### PR TITLE
feat: add /mika dev workflow command with documentation audit

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -1,0 +1,26 @@
+---
+name: mika
+description: Mika development workflow with quality gates and documentation audit
+argument-hint: "[feature description]"
+disable-model-invocation: true
+---
+
+Run these slash commands in order. Do not do anything else. Do not stop between steps — complete every step through to the end.
+
+1. `/ralph-loop "finish all slash commands" --completion-promise "DONE"`
+2. `/workflows:plan $ARGUMENTS`
+3. `/workflows:work`
+4. `/workflows:review`
+5. `/compound-engineering:resolve_todo_parallel`
+6. **Documentation audit** — Review the git diff (`git diff main...HEAD`) and update all affected documentation:
+   - **Always**: Review `CLAUDE.md` for accuracy (architecture, conventions, commands, env vars, test count, schema version, pending work)
+   - **If new env vars**: Update `.env.example` and `docs/configuration.md`
+   - **If schema/DB changes**: Update `docs/architecture.md` and CLAUDE.md Architecture section
+   - **If new CLI commands or tools**: Update `README.md`, `docs/getting-started.md`, `docs/slash-commands.md`
+   - **If skill changes**: Update `docs/skills.md`
+   - **If infra changes** (Helm, Docker, K8s): Update `docs/deployment.md`
+   - **If new config fields**: Update `docs/configuration.md`
+7. `/workflows:compound`
+8. Output `<promise>DONE</promise>` when complete
+
+Start with step 1 now.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - `docs/brainstorms/` — Decision brainstorm documents
 - `docs/plans/` — Implementation plans
 - `todos/` — Code review findings (tracked as markdown files)
+- `.claude/commands/` — Claude Code slash commands (`/mika` — full dev workflow with doc audit)
 
 ## Conventions
 
@@ -44,7 +45,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 ## Commands
 
 - `cargo build` — Build all crates
-- `cargo test` — Run all tests (~236 tests)
+- `cargo test` — Run all tests (~475 tests)
 - `cargo run --bin mika` — Run TUI CLI (default: chat, or `mika status`, `mika memory`, etc.)
 - `cargo run --bin mika-server` — Run HTTP server (requires `MIKA_ROUTING_URL` and `MIKA_INTERNAL_TOKEN`)
 - `cargo clippy` — Lint

--- a/docs/plans/2026-02-27-feat-mika-development-workflow-command-plan.md
+++ b/docs/plans/2026-02-27-feat-mika-development-workflow-command-plan.md
@@ -1,0 +1,148 @@
+---
+title: Mika-specific development workflow slash command
+type: feat
+status: completed
+date: 2026-02-27
+---
+
+# Mika-specific development workflow slash command
+
+## Overview
+
+Create a project-level `/letsgo` Claude Code slash command at `.claude/commands/letsgo.md` that extends the global workflow with Mika-specific quality gates and documentation update steps. Also update the global `/letsgo` to unconditionally start ralph-loop.
+
+## Problem Statement / Motivation
+
+The current global `/letsgo` command at `~/.claude/commands/letsgo.md` has two gaps:
+
+1. **Conditional ralph-loop**: Says "Start with step 2 now (or step 1 if ralph-wiggum is available)" — ralph-wiggum is always installed, so this conditional is unnecessary
+2. **No documentation updates**: The workflow produces code changes but never audits documentation. This has already caused real drift (see `docs/solutions/documentation-gaps/oauth-subscription-auth-docs.md` where OAuth support was implemented but user-facing docs were not updated)
+3. **No Rust quality gates**: `cargo fmt`, `cargo clippy`, and `cargo test` are not part of the automated pipeline — quality checks are manual
+
+## Proposed Solution
+
+### Two changes:
+
+**1. Update global `/letsgo`** — Remove the conditional; always start with ralph-loop as step 1.
+
+**2. Create project-level `/letsgo`** at `/data/workspace/senara-solutions/mika/.claude/commands/letsgo.md` with this pipeline:
+
+```
+Step 1:  /ralph-loop (unconditional)
+Step 2:  /workflows:plan $ARGUMENTS
+Step 3:  /workflows:work
+Step 4:  Quality gate — cargo fmt && cargo clippy && cargo test
+Step 5:  /workflows:review
+Step 6:  /compound-engineering:resolve_todo_parallel
+Step 7:  Quality gate re-run (same as step 4, catches regressions from fixes)
+Step 8:  Documentation audit (CLAUDE.md + user-facing docs based on diff analysis)
+Step 9:  /workflows:compound
+Step 10: Output <promise>DONE</promise>
+```
+
+### Documentation audit step (Step 8) details
+
+This step operationalizes the "Documentation-first checklist" pattern from `docs/solutions/documentation-gaps/oauth-subscription-auth-docs.md`. The agent should:
+
+1. **Always review CLAUDE.md** — Check that Architecture, Stack, Conventions, Commands, and Environment Variables sections reflect the current code. Update test count, schema version, and Pending Work as needed.
+2. **Check git diff for triggers** and update the corresponding files:
+   - New `MIKA_*` env vars → `.env.example`, `docs/configuration.md`
+   - Schema/DB changes → `docs/architecture.md`, CLAUDE.md Architecture section
+   - New CLI commands or tools → `README.md`, `docs/getting-started.md`, `docs/slash-commands.md`
+   - New skills or skill changes → `docs/skills.md`
+   - Infrastructure changes (Helm, Docker, K8s) → `docs/deployment.md`
+   - New config fields → `docs/configuration.md`
+3. **Update Claude Code memory** — If significant patterns, conventions, or debugging insights were discovered during the session, update `/home/samidarko/.claude/projects/-data-workspace-senara-solutions-mika/memory/MEMORY.md`.
+
+## Acceptance Criteria
+
+- [x] Global `/letsgo` updated: ralph-loop starts unconditionally (step 1 always), conditional text removed
+- [x] Project-level `.claude/commands/mika.md` created with full pipeline (named `/mika` instead of `/letsgo`)
+- [x] Quality gates handled by `/workflows:work` and `/workflows:review` (no explicit cargo commands needed)
+- [x] Pipeline includes documentation audit step between resolve_todos and compound
+- [x] Documentation audit step covers: CLAUDE.md, .env.example, README.md, docs/getting-started.md, docs/configuration.md, docs/architecture.md, docs/skills.md, docs/deployment.md, docs/slash-commands.md
+- [x] Memory/learnings handled by `/workflows:compound` step
+- [x] `disable-model-invocation: true` set so steps execute without prompting
+
+## Technical Considerations
+
+### Command precedence
+Claude Code uses project-level commands with precedence over global ones when the name matches. Creating `.claude/commands/letsgo.md` at the project level will override the global `/letsgo` when working in the Mika repo. The global command remains available for other projects.
+
+### Quality gate design
+- `cargo fmt` — auto-fixes formatting (not `--check`, since we want it fixed)
+- `cargo clippy` — linting with default settings (project already uses this convention)
+- `cargo test` — runs all ~236 tests
+- Chained with `&&` so failures halt the pipeline and the agent can fix them before proceeding
+
+### Documentation audit is agent-driven
+Since `disable-model-invocation: true` means the command runs as literal steps, the documentation audit step needs to be written as an explicit instruction to the agent. The agent reads the git diff, applies the checklist, and updates files as needed.
+
+## MVP
+
+### `.claude/commands/letsgo.md` (project-level)
+
+```markdown
+---
+name: letsgo
+description: Mika full autonomous workflow with quality gates and docs
+argument-hint: "[feature description]"
+disable-model-invocation: true
+---
+
+Run these slash commands in order. Do not do anything else. Do not stop between steps — complete every step through to the end.
+
+1. `/ralph-loop "finish all slash commands" --completion-promise "DONE"`
+2. `/workflows:plan $ARGUMENTS`
+3. `/workflows:work`
+4. Run `cargo fmt 2>&1 && cargo clippy 2>&1 && cargo test 2>&1` to verify code quality. If any step fails, fix the issues and re-run until clean.
+5. `/workflows:review`
+6. `/compound-engineering:resolve_todo_parallel`
+7. Run `cargo fmt 2>&1 && cargo clippy 2>&1 && cargo test 2>&1` again to catch regressions from review fixes. Fix any issues.
+8. **Documentation audit** — Review the git diff (`git diff main...HEAD`) and update all affected documentation:
+   - **Always**: Review `CLAUDE.md` for accuracy (architecture, conventions, commands, env vars, test count, schema version, pending work)
+   - **If new env vars**: Update `.env.example` and `docs/configuration.md`
+   - **If schema/DB changes**: Update `docs/architecture.md` and CLAUDE.md Architecture section
+   - **If new CLI commands or tools**: Update `README.md`, `docs/getting-started.md`, `docs/slash-commands.md`
+   - **If skill changes**: Update `docs/skills.md`
+   - **If infra changes** (Helm, Docker, K8s): Update `docs/deployment.md`
+   - **If new config fields**: Update `docs/configuration.md`
+   - **If significant patterns or insights discovered**: Update memory at `~/.claude/projects/-data-workspace-senara-solutions-mika/memory/MEMORY.md`
+9. `/workflows:compound`
+10. Output `<promise>DONE</promise>` when complete
+
+Start with step 1 now.
+```
+
+### Global `~/. claude/commands/letsgo.md` (updated)
+
+```markdown
+---
+name: letsgo
+description: Full autonomous workflow
+argument-hint: "[feature description]"
+disable-model-invocation: true
+---
+
+Run these slash commands in order. Do not do anything else. Do not stop between steps — complete every step through to the end.
+
+1. `/ralph-loop "finish all slash commands" --completion-promise "DONE"`
+2. `/workflows:plan $ARGUMENTS`
+3. `/workflows:work`
+4. `/workflows:review`
+5. `/compound-engineering:resolve_todo_parallel`
+6. `/workflows:compound`
+7. Output `<promise>DONE</promise>` when complete
+
+Start with step 1 now.
+```
+
+Only change: removed the conditional "Start with step 2 now (or step 1 if ralph-wiggum is available)" and replaced with "Start with step 1 now."
+
+## References
+
+- Global `/letsgo`: `/home/samidarko/.claude/commands/letsgo.md`
+- Documentation-first checklist pattern: `docs/solutions/documentation-gaps/oauth-subscription-auth-docs.md`
+- Claude Code memory directory: `/home/samidarko/.claude/projects/-data-workspace-senara-solutions-mika/memory/`
+- Project settings: `.claude/settings.local.json` (already allows `cargo fmt`, `cargo clippy`, `cargo test`)
+- CLAUDE.md staleness tracking precedent: `todos/066-complete-p2-stale-claude-md.md`, `todos/107-complete-p3-claudemd-stale-async-db.md`

--- a/docs/solutions/documentation-gaps/workflow-documentation-audit-automation.md
+++ b/docs/solutions/documentation-gaps/workflow-documentation-audit-automation.md
@@ -1,0 +1,152 @@
+---
+title: Automated documentation audit step in development workflow
+date: 2026-02-27
+category: documentation-gaps
+severity: medium
+component:
+  - .claude/commands/mika.md (project-level slash command)
+  - ~/.claude/commands/letsgo.md (global slash command)
+  - CLAUDE.md (project instructions)
+tags:
+  - documentation-drift
+  - workflow-automation
+  - slash-commands
+  - claude-code
+  - developer-experience
+symptoms: |
+  Documentation drifted from code reality because the automated development workflow
+  (plan -> work -> review -> resolve -> compound) had no documentation audit step.
+  Real example: OAuth subscription token support was fully implemented but three
+  user-facing docs (README, getting-started, configuration) were never updated.
+  CLAUDE.md test count was stale (~236 vs actual ~475).
+root_cause: >
+  Documentation updates were treated as optional post-implementation polish rather
+  than an integral part of the development workflow. The automated pipeline had no
+  enforcement mechanism to validate that project metadata, user-facing guides, and
+  architecture docs stayed synchronized with code changes.
+---
+
+# Automated documentation audit step in development workflow
+
+## Problem
+
+The Mika project's development workflow (global `/letsgo` Claude Code command) chained
+plan -> work -> review -> resolve -> compound but had no documentation audit step.
+This caused documentation to drift from code reality.
+
+**Real-world example:** OAuth subscription token support was fully implemented in code
+(commit `44916b5`) with auto-detection logic, but three user-facing documentation files
+were never updated (fixed reactively in commit `749b6db`):
+- `README.md` — Quick Start only mentioned API keys
+- `docs/getting-started.md` — No mention of OAuth tokens
+- `docs/configuration.md` — Settings tables only referenced API keys
+
+Additionally, `CLAUDE.md` had a stale test count (~236 tests, actual was ~475 after
+the skills system, Layer 3 vector search, and other additions).
+
+## Root Cause
+
+Documentation updates were treated as optional polish rather than a feature deliverable.
+The automated pipeline had no enforcement mechanism. Developer discipline alone is
+insufficient because:
+- Developers juggle competing priorities
+- A feature "works" without docs — no immediate penalty for skipping
+- Documentation debt compounds silently until discovered by new users
+
+## Solution
+
+### 1. Created project-level `/mika` command
+
+File: `.claude/commands/mika.md`
+
+8-step pipeline with documentation audit between resolve-todos and compound:
+
+```
+1. /ralph-loop (unconditional)
+2. /workflows:plan $ARGUMENTS
+3. /workflows:work
+4. /workflows:review
+5. /compound-engineering:resolve_todo_parallel
+6. Documentation audit (NEW — checks git diff, updates affected docs)
+7. /workflows:compound
+8. Output completion promise
+```
+
+### 2. Documentation audit checklist (Step 6)
+
+The audit is conditional and systematic:
+
+- **Always audit:** `CLAUDE.md` for accuracy (architecture, conventions, commands,
+  env vars, test count, schema version, pending work)
+- **If new env vars:** Update `.env.example` and `docs/configuration.md`
+- **If schema/DB changes:** Update `docs/architecture.md` and CLAUDE.md Architecture
+- **If new CLI commands or tools:** Update `README.md`, `docs/getting-started.md`,
+  `docs/slash-commands.md`
+- **If skill changes:** Update `docs/skills.md`
+- **If infra changes** (Helm, Docker, K8s): Update `docs/deployment.md`
+- **If new config fields:** Update `docs/configuration.md`
+
+### 3. Updated global `/letsgo`
+
+Removed stale conditional ("Start with step 2 now (or step 1 if ralph-wiggum is
+available)") since ralph-wiggum is always installed. Now unconditionally starts
+with ralph-loop as step 1.
+
+### 4. Caught stale metadata during first audit
+
+Test count in CLAUDE.md: ~236 -> ~475. Directory structure updated to include
+`.claude/commands/`.
+
+## Verification
+
+- `.claude/commands/mika.md` created with correct frontmatter and pipeline steps
+- Global `~/.claude/commands/letsgo.md` updated (conditional removed)
+- `CLAUDE.md` test count corrected, directory structure updated
+- `cargo fmt && cargo clippy && cargo test` — all 475 tests pass
+
+## Prevention
+
+### The "Documentation-first checklist" pattern
+
+Treat documentation as a first-class feature component, not optional polish:
+
+1. **Design phase:** Document intended behavior in plans
+2. **Implementation phase:** Update internal docs (CLAUDE.md, .env.example, code comments)
+3. **Audit phase:** Run the automated checklist against git diff
+4. **Review gate:** Documentation audit results are part of the workflow pipeline
+5. **Compound phase:** Only after audit passes does the agent document the solution
+
+### Key insight: enforcement via workflow automation
+
+Manual reminders ("remember to update docs") fail because there is no immediate
+penalty for skipping. Automated enforcement works because:
+- Friction is applied at the right moment (after code review, before shipping)
+- No judgment required — the checklist is objective
+- Scalable — applies the same logic to every change
+- Feedback is specific — reports which files are likely affected
+
+### When to extend the checklist
+
+Update the audit step in `/mika` when:
+- New documentation files are added to the project
+- New crates or binaries are introduced
+- New public APIs or configuration fields are created
+- New deployment targets or infrastructure components are added
+
+### Known limitations
+
+- Agent-driven, so quality depends on diff analysis heuristics
+- Cannot determine developer intent from code alone
+- Large multi-file diffs are harder to reason about
+- Checklist coverage is point-in-time — new doc files need manual addition
+
+## Related
+
+- `docs/solutions/documentation-gaps/oauth-subscription-auth-docs.md` — The original
+  documentation drift incident that motivated this solution
+- `todos/066-complete-p2-stale-claude-md.md` — CLAUDE.md staleness tracking
+- `todos/107-complete-p3-claudemd-stale-async-db.md` — CLAUDE.md stale async DB refs
+- `todos/058-complete-p2-stale-readme-encryption-refs.md` — README stale encryption refs
+- `todos/233-complete-p2-deduplicate-content-across-docs.md` — Documentation duplication
+  as a drift vector
+- `docs/plans/2026-02-27-feat-mika-development-workflow-command-plan.md` — Implementation plan


### PR DESCRIPTION
## Summary

- Adds a project-level `/mika` Claude Code slash command with a documentation audit step baked into the pipeline (plan → work → review → resolve → **doc audit** → compound)
- Updates the global `/letsgo` to unconditionally start ralph-loop (was conditional on ralph-wiggum availability)
- Fixes stale CLAUDE.md: test count ~236 → ~475, added `.claude/commands/` to directory structure

## Motivation

The global `/letsgo` workflow had no documentation audit step. This caused real drift — e.g., OAuth subscription token support was fully implemented but three user-facing docs were never updated (#22). The `/mika` command prevents this by embedding a checklist-driven documentation audit into every development cycle.

## Test plan

- [x] `cargo fmt && cargo clippy && cargo test` — all 475 tests pass
- [x] Verified `.claude/commands/mika.md` has correct frontmatter and pipeline steps
- [x] Verified global `~/.claude/commands/letsgo.md` conditional removed
- [x] CLAUDE.md test count and directory structure updated

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a Claude Code workflow configuration change (markdown files only), no runtime code affected.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)