### PR TITLE
feat: hot-reload skill registry via AtomicBool dirty flag

### DIFF
--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -456,6 +456,8 @@ pub struct AgentParams<'a> {
     pub user_images: &'a [mika_common::claude::ImageSource],
     /// Brave Search API key (optional; enables web_search builtin skill).
     pub brave_api_key: Option<&'a str>,
+    /// Shared dirty flag for skill hot-reload.
+    pub skills_dirty: &'a AtomicBool,
 }
 
 /// Run the agent loop for a single inbound message.
@@ -612,6 +614,7 @@ async fn run_agent_inner(params: &AgentParams<'_>) -> Result<AgentOutput> {
         message_sender: params.message_sender.clone(),
         embedding_client: params.embedding_client,
         brave_api_key: params.brave_api_key,
+        skills_dirty: params.skills_dirty,
     };
 
     // Auto-adjust max_tokens when thinking is enabled
@@ -862,6 +865,8 @@ pub struct SilentAgentParams<'a> {
     pub message_sender: Option<Arc<dyn MessageSender>>,
     pub embedding_client: Option<&'a EmbeddingClient>,
     pub brave_api_key: Option<&'a str>,
+    /// Shared dirty flag for skill hot-reload.
+    pub skills_dirty: &'a AtomicBool,
 }
 
 /// Run a silent-mode agent loop for background tasks (heartbeat, reminders).
@@ -984,6 +989,7 @@ async fn run_silent_inner(params: &SilentAgentParams<'_>, channel_type: &str) ->
         message_sender: params.message_sender.clone(),
         embedding_client: params.embedding_client,
         brave_api_key: params.brave_api_key,
+        skills_dirty: params.skills_dirty,
     };
 
     let mut request = MessagesRequest {
@@ -1029,6 +1035,8 @@ pub struct TeamAgentParams<'a> {
     pub session_id: &'a str,
     pub embedding_client: Option<&'a EmbeddingClient>,
     pub brave_api_key: Option<&'a str>,
+    /// Shared dirty flag for skill hot-reload.
+    pub skills_dirty: &'a AtomicBool,
 }
 
 /// Run an agent within a team execution context.
@@ -1107,6 +1115,7 @@ async fn run_team_agent_inner(params: &TeamAgentParams<'_>) -> Result<Option<Str
         message_sender: None,
         embedding_client: params.embedding_client,
         brave_api_key: params.brave_api_key,
+        skills_dirty: params.skills_dirty,
     };
 
     let mut request = MessagesRequest {

--- a/crates/mika-agent/src/scheduler.rs
+++ b/crates/mika-agent/src/scheduler.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use mika_common::claude::ClaudeClient;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tracing::{info, warn};
 
 use mika_common::embedding::EmbeddingClient;
@@ -159,6 +160,7 @@ impl ReminderScheduler {
                 "firing past-due reminder"
             );
             let session_id = format!("reminder-recovery-{}", reminder.id);
+            let skills_dirty = AtomicBool::new(false);
             let params = SilentAgentParams {
                 db: &self.db,
                 claude: &self.claude,
@@ -173,6 +175,7 @@ impl ReminderScheduler {
                 message_sender: self.message_sender.clone(),
                 embedding_client: self.embedding_client.as_ref(),
                 brave_api_key: self.brave_api_key.as_deref(),
+                skills_dirty: &skills_dirty,
             };
 
             if let Err(e) = run_silent_agent(&params).await {

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -181,6 +181,18 @@ pub async fn handle_message(
         async move {
             let _lock = lock; // Hold lock for duration of agent loop
 
+            // Hot-reload skills if the dirty flag was set by a previous turn
+            let skills = if a.skills_dirty.load(Ordering::Acquire) {
+                a.skills_dirty.store(false, Ordering::Release);
+                let new = Arc::new(crate::skills::SkillRegistry::from_dir(
+                    &a.home_dir.join("skills"),
+                ));
+                *a.skills.lock().unwrap() = new.clone();
+                new
+            } else {
+                a.skills.lock().unwrap().clone()
+            };
+
             let session_id = uuid::Uuid::new_v4().to_string();
             let is_onboarding = check_onboarding(&a.db).await;
 
@@ -197,7 +209,7 @@ pub async fn handle_message(
                 db: &a.db,
                 claude: &s.claude,
                 tools: &s.tools,
-                skills: &a.skills,
+                skills: &skills,
                 user_message: &req.text,
                 channel_type: &req.channel,
                 session_id: &session_id,
@@ -209,6 +221,7 @@ pub async fn handle_message(
                 thinking: None,
                 user_images: &user_images,
                 brave_api_key: s.brave_api_key.as_deref(),
+                skills_dirty: &a.skills_dirty,
             };
 
             match agent::run_agent(&params).await {
@@ -303,6 +316,19 @@ pub async fn handle_heartbeat(
     let a = agent_state.clone();
     tokio::spawn(async move {
         let _lock = lock;
+
+        // Hot-reload skills if the dirty flag was set by a previous turn
+        let skills = if a.skills_dirty.load(Ordering::Acquire) {
+            a.skills_dirty.store(false, Ordering::Release);
+            let new = Arc::new(crate::skills::SkillRegistry::from_dir(
+                &a.home_dir.join("skills"),
+            ));
+            *a.skills.lock().unwrap() = new.clone();
+            new
+        } else {
+            a.skills.lock().unwrap().clone()
+        };
+
         let session_id = uuid::Uuid::new_v4().to_string();
 
         let sender = GatewayMessageSender::new(
@@ -318,13 +344,14 @@ pub async fn handle_heartbeat(
             db: &a.db,
             claude: &s.claude,
             tools: &s.tools,
-            skills: &a.skills,
+            skills: &skills,
             trigger: SilentTrigger::Heartbeat,
             home_dir: &a.home_dir,
             session_id: &session_id,
             message_sender: Some(sender_arc),
             embedding_client: a.embedding_client.as_ref(),
             brave_api_key: s.brave_api_key.as_deref(),
+            skills_dirty: &a.skills_dirty,
         };
 
         if let Err(e) = run_silent_agent(&params).await {

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -95,7 +95,8 @@ fn init_agent(
 
     let agent_state = AgentState {
         db: async_db,
-        skills: skill_registry,
+        skills: std::sync::Mutex::new(skill_registry),
+        skills_dirty: Arc::new(AtomicBool::new(false)),
         scheduler: scheduler.clone(),
         agent_lock: Arc::new(tokio::sync::Mutex::new(())),
         home_dir: agent_home.to_path_buf(),
@@ -295,7 +296,8 @@ mod tests {
 
         let agent_state = AgentState {
             db,
-            skills: skills_reg,
+            skills: std::sync::Mutex::new(skills_reg),
+            skills_dirty: Arc::new(AtomicBool::new(false)),
             scheduler,
             agent_lock: Arc::new(tokio::sync::Mutex::new(())),
             home_dir: std::path::PathBuf::from("/tmp/mika-test"),

--- a/crates/mika-agent/src/server/state.rs
+++ b/crates/mika-agent/src/server/state.rs
@@ -14,10 +14,11 @@ use crate::skills::SkillRegistry;
 use crate::tools::ToolRegistry;
 
 /// Per-agent state bundle. Each agent gets its own DB, skills, scheduler, and lock.
-#[derive(Clone)]
+/// Always used behind `Arc<AgentState>` — does not need Clone.
 pub struct AgentState {
     pub db: AsyncDatabase,
-    pub skills: Arc<SkillRegistry>,
+    pub skills: std::sync::Mutex<Arc<SkillRegistry>>,
+    pub skills_dirty: Arc<AtomicBool>,
     pub scheduler: Arc<ReminderScheduler>,
     pub agent_lock: Arc<tokio::sync::Mutex<()>>,
     pub home_dir: PathBuf,

--- a/crates/mika-agent/src/teams/engine.rs
+++ b/crates/mika-agent/src/teams/engine.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tracing::{info, warn};
 
 use mika_common::agent;
@@ -317,6 +318,7 @@ impl TeamEngine {
                 let result: Result<String> = match resources {
                     Ok(resources) => {
                         let session_id = format!("team-{}-{}", run_id, agent_name);
+                        let skills_dirty = AtomicBool::new(false);
                         let params = TeamAgentParams {
                             db: &resources.db,
                             claude: &claude,
@@ -328,6 +330,7 @@ impl TeamEngine {
                             session_id: &session_id,
                             embedding_client: resources.embedding_client.as_ref(),
                             brave_api_key: brave_api_key.as_deref(),
+                            skills_dirty: &skills_dirty,
                         };
                         crate::agent::run_team_agent(&params)
                             .await
@@ -443,6 +446,7 @@ impl TeamEngine {
 
         // Use the pre-built tool registry (#255)
         let session_id = format!("team-{}-{}", self.run.run_id, agent_name);
+        let skills_dirty = AtomicBool::new(false);
         let params = TeamAgentParams {
             db: &resources.db,
             claude: &self.claude,
@@ -454,6 +458,7 @@ impl TeamEngine {
             session_id: &session_id,
             embedding_client: resources.embedding_client.as_ref(),
             brave_api_key: self.brave_api_key.as_deref(),
+            skills_dirty: &skills_dirty,
         };
 
         Ok(crate::agent::run_team_agent(&params)

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -3,7 +3,7 @@ pub mod test_helpers {
     use crate::async_db::AsyncDatabase;
     use crate::db::Database;
     use crate::tools::ToolContext;
-    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::{AtomicBool, AtomicU32};
 
     /// Create an in-memory database for tests (sync — for db module tests).
     pub fn test_db() -> Database {
@@ -30,6 +30,7 @@ pub mod test_helpers {
         is_onboarding: bool,
     ) -> ToolContext<'a> {
         static HOME_DIR: &str = "/tmp/mika-test";
+        static SKILLS_DIRTY: AtomicBool = AtomicBool::new(false);
         ToolContext {
             db,
             session_id: "test-session",
@@ -39,6 +40,7 @@ pub mod test_helpers {
             message_sender: None,
             embedding_client: None,
             brave_api_key: None,
+            skills_dirty: &SKILLS_DIRTY,
         }
     }
 
@@ -70,6 +72,7 @@ pub mod test_helpers {
 
         /// Create a ToolContext with a custom home directory.
         pub fn ctx_with_home<'a>(&'a self, home: &'a std::path::Path) -> ToolContext<'a> {
+            static SKILLS_DIRTY: AtomicBool = AtomicBool::new(false);
             ToolContext {
                 db: &self.db,
                 session_id: "test-session",
@@ -79,6 +82,7 @@ pub mod test_helpers {
                 message_sender: None,
                 embedding_client: None,
                 brave_api_key: None,
+                skills_dirty: &SKILLS_DIRTY,
             }
         }
     }

--- a/crates/mika-agent/src/tools/create_skill.rs
+++ b/crates/mika-agent/src/tools/create_skill.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use mika_common::claude::ToolDefinition;
 use serde_json::{Value, json};
+use std::sync::atomic::Ordering;
 
 use std::path::Path;
 
@@ -113,8 +114,8 @@ impl Tool for CreateSkillTool {
             name: "create_skill".to_string(),
             description: "Create a new skill with a manifest and system prompt snippet. \
                 Skills extend your capabilities by injecting context into your system prompt \
-                when triggered by keywords. The skill will be available after restarting \
-                the conversation. Note: this creates the skill scaffold only (manifest + prompt). \
+                when triggered by keywords. The skill will be available immediately on \
+                the next turn. Note: this creates the skill scaffold only (manifest + prompt). \
                 To add custom tools with executable handlers, the user must edit the files manually."
                 .to_string(),
             input_schema: json!({
@@ -244,10 +245,12 @@ impl Tool for CreateSkillTool {
             )));
         }
 
+        ctx.skills_dirty.store(true, Ordering::Release);
+
         Ok(ToolOutput::success(format!(
             "Created skill '{name}'.\n\
              Files: skill.toml, system_prompt.md\n\
-             The skill will be available after restarting the conversation.\n\
+             The skill will be available immediately on the next turn.\n\
              To add custom tools, create a tools.json file in the skill directory.",
         )))
     }

--- a/crates/mika-agent/src/tools/delete_skill.rs
+++ b/crates/mika-agent/src/tools/delete_skill.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use mika_common::claude::ToolDefinition;
 use serde_json::Value;
+use std::sync::atomic::Ordering;
 
 use super::create_skill::{validate_skill_name, verify_skill_path};
 use super::{Tool, ToolContext, ToolOutput};
@@ -20,8 +21,8 @@ impl Tool for DeleteSkillTool {
             name: "delete_skill".to_string(),
             description: "Permanently delete a custom skill. Removes the skill directory and \
                 all its files (manifest, prompt, tools, handlers). Built-in skills cannot be \
-                deleted — use toggle_skill to disable them instead. Changes take effect after \
-                restarting the conversation."
+                deleted — use toggle_skill to disable them instead. Changes take effect \
+                immediately on the next turn."
                 .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -69,8 +70,10 @@ impl Tool for DeleteSkillTool {
             return Ok(ToolOutput::error(format!("Failed to delete skill: {e}")));
         }
 
+        ctx.skills_dirty.store(true, Ordering::Release);
+
         Ok(ToolOutput::success(format!(
-            "Deleted skill '{name}'.\nChanges take effect after restarting the conversation."
+            "Deleted skill '{name}'.\nChanges take effect immediately on the next turn."
         )))
     }
 }
@@ -115,7 +118,7 @@ keywords = ["test"]
             .unwrap();
         assert!(!result.is_error, "Got: {}", result.content);
         assert!(result.content.contains("Deleted skill 'my-skill'"));
-        assert!(result.content.contains("restarting the conversation"));
+        assert!(result.content.contains("immediately"));
 
         // Verify directory is gone
         assert!(!tmp.path().join("skills/my-skill").exists());

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -26,7 +26,7 @@ use mika_common::config::Settings;
 use serde_json::Value;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 
 use crate::async_db::AsyncDatabase;
 use crate::messaging::MessageSender;
@@ -45,6 +45,10 @@ pub struct ToolContext<'a> {
     pub message_sender: Option<Arc<dyn MessageSender>>,
     pub embedding_client: Option<&'a EmbeddingClient>,
     pub brave_api_key: Option<&'a str>,
+    /// Shared flag: set to `true` by skill-modifying tools after successful writes.
+    /// The agent loop coordinator checks this before each turn and rebuilds the
+    /// SkillRegistry if set, enabling hot-reload without restart.
+    pub skills_dirty: &'a AtomicBool,
 }
 
 /// A tool that the agent can invoke via Claude's tool_use.

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -121,6 +121,7 @@ mod tests {
     async fn test_send_message_with_sender() {
         let harness = TestHarness::new();
         let mock = Arc::new(MockSender::new());
+        let skills_dirty = std::sync::atomic::AtomicBool::new(false);
         let ctx = crate::tools::ToolContext {
             db: &harness.db,
             session_id: "test",
@@ -130,6 +131,7 @@ mod tests {
             message_sender: Some(mock.clone()),
             embedding_client: None,
             brave_api_key: None,
+            skills_dirty: &skills_dirty,
         };
         let tool = SendMessageTool;
 

--- a/crates/mika-agent/src/tools/toggle_skill.rs
+++ b/crates/mika-agent/src/tools/toggle_skill.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use mika_common::claude::ToolDefinition;
 use serde_json::Value;
+use std::sync::atomic::Ordering;
 
 use super::create_skill::{validate_skill_name, verify_skill_path};
 use super::{Tool, ToolContext, ToolOutput};
@@ -18,7 +19,7 @@ impl Tool for ToggleSkillTool {
         ToolDefinition {
             name: "toggle_skill".to_string(),
             description: "Enable or disable a skill. Disabled skills are not loaded on startup. \
-                Changes take effect after restarting the conversation."
+                Changes take effect immediately on the next turn."
                 .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -77,8 +78,9 @@ impl Tool for ToggleSkillTool {
                     "Failed to enable skill '{name}': {e}"
                 )));
             }
+            ctx.skills_dirty.store(true, Ordering::Release);
             Ok(ToolOutput::success(format!(
-                "Skill '{name}' enabled. Changes take effect after restarting the conversation."
+                "Skill '{name}' enabled. Changes take effect immediately on the next turn."
             )))
         } else {
             // Create .disabled marker
@@ -87,8 +89,9 @@ impl Tool for ToggleSkillTool {
                     "Failed to disable skill '{name}': {e}"
                 )));
             }
+            ctx.skills_dirty.store(true, Ordering::Release);
             Ok(ToolOutput::success(format!(
-                "Skill '{name}' disabled. Changes take effect after restarting the conversation."
+                "Skill '{name}' disabled. Changes take effect immediately on the next turn."
             )))
         }
     }

--- a/crates/mika-agent/src/tools/update_skill.rs
+++ b/crates/mika-agent/src/tools/update_skill.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use mika_common::claude::ToolDefinition;
 use serde_json::{Value, json};
+use std::sync::atomic::Ordering;
 
 use super::create_skill::{
     validate_description, validate_keywords, validate_skill_name, validate_system_prompt,
@@ -23,7 +24,7 @@ impl Tool for UpdateSkillTool {
             name: "update_skill".to_string(),
             description: "Update an existing skill's manifest or system prompt. \
                 At least one optional field must be provided. \
-                Changes take effect after restarting the conversation."
+                Changes take effect immediately on the next turn."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -186,9 +187,11 @@ impl Tool for UpdateSkillTool {
             updated.push("system_prompt");
         }
 
+        ctx.skills_dirty.store(true, Ordering::Release);
+
         Ok(ToolOutput::success(format!(
             "Updated skill '{name}': changed {fields}.\n\
-             Changes take effect after restarting the conversation.",
+             Changes take effect immediately on the next turn.",
             fields = updated.join(", ")
         )))
     }

--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::io::Read;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use uuid::Uuid;
 
 use mika_agent::agent::{self, AgentParams, check_onboarding};
@@ -33,6 +34,7 @@ pub async fn run(message: &str, agent_name: &str) -> Result<()> {
     }
 
     let is_onboarding = check_onboarding(&ctx.async_db).await;
+    let skills_dirty = AtomicBool::new(false);
 
     let output = agent::run_agent(&AgentParams {
         db: &ctx.async_db,
@@ -50,6 +52,7 @@ pub async fn run(message: &str, agent_name: &str) -> Result<()> {
         thinking: None,
         user_images: &[],
         brave_api_key: ctx.settings.brave_api_key.as_deref(),
+        skills_dirty: &skills_dirty,
     })
     .await?;
 

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -8,6 +8,7 @@ use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -49,6 +50,7 @@ async fn spawn_agent_worker(
     let session_id = Uuid::new_v4().to_string();
     let tool_registry = Arc::new(tools::default_tools());
     let skill_registry = Arc::new(SkillRegistry::from_dir(&ctx.home_dir.join("skills")));
+    let skills_dirty = Arc::new(AtomicBool::new(false));
     let embedding_client = ctx.settings.make_embedding_client();
     let message_sender =
         crate::init::make_message_sender(&ctx.settings, &ctx.async_db, http_client);
@@ -78,12 +80,13 @@ async fn spawn_agent_worker(
     let worker_db = ctx.async_db.clone();
     let mut worker_claude = ctx.claude.clone();
     let worker_tools = tool_registry.clone();
-    let worker_skills = skill_registry.clone();
+    let mut worker_skills = skill_registry.clone();
     let worker_home = ctx.home_dir.clone();
     let worker_session = session_id.clone();
     let worker_embedding = embedding_client;
     let worker_brave_key = brave_api_key;
     let worker_sender = message_sender;
+    let worker_dirty = skills_dirty.clone();
     let handle = tokio::spawn(async move {
         while let Some(request) = user_rx.recv().await {
             match request {
@@ -92,6 +95,15 @@ async fn spawn_agent_worker(
                     images,
                     thinking_budget,
                 } => {
+                    // Hot-reload skills if the dirty flag was set by a previous turn
+                    let mut skills_reloaded = false;
+                    if worker_dirty.load(Ordering::Acquire) {
+                        worker_dirty.store(false, Ordering::Release);
+                        worker_skills =
+                            Arc::new(SkillRegistry::from_dir(&worker_home.join("skills")));
+                        skills_reloaded = true;
+                    }
+
                     let thinking = thinking_budget.map(|budget| ThinkingConfig::Enabled {
                         budget_tokens: budget,
                     });
@@ -123,8 +135,24 @@ async fn spawn_agent_worker(
                         thinking,
                         user_images: &image_sources,
                         brave_api_key: worker_brave_key.as_deref(),
+                        skills_dirty: &worker_dirty,
                     })
                     .await;
+
+                    // If the dirty flag is set after this turn, rebuild now so we
+                    // can send the updated registry to the TUI for autocomplete.
+                    if worker_dirty.load(Ordering::Acquire) {
+                        worker_dirty.store(false, Ordering::Release);
+                        worker_skills =
+                            Arc::new(SkillRegistry::from_dir(&worker_home.join("skills")));
+                        skills_reloaded = true;
+                    }
+
+                    let updated_skills = if skills_reloaded {
+                        Some(worker_skills.clone())
+                    } else {
+                        None
+                    };
 
                     let response = match result {
                         Ok(output) => AgentResponse {
@@ -132,12 +160,14 @@ async fn spawn_agent_worker(
                             is_error: false,
                             thinking: output.thinking,
                             input_tokens: output.usage.as_ref().map(|u| u.input_tokens),
+                            updated_skills,
                         },
                         Err(e) => AgentResponse {
                             content: format!("{e}"),
                             is_error: true,
                             thinking: None,
                             input_tokens: None,
+                            updated_skills,
                         },
                     };
                     if agent_tx.send(response).is_err() {

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -61,6 +61,8 @@ pub struct AgentResponse {
     pub is_error: bool,
     pub thinking: Option<String>,
     pub input_tokens: Option<u32>,
+    /// If skills were hot-reloaded during this turn, contains the new registry.
+    pub updated_skills: Option<Arc<SkillRegistry>>,
 }
 
 /// Shell-like input history with draft saving.
@@ -374,6 +376,11 @@ impl<'a> App<'a> {
         // Check for agent response
         match self.agent_rx.try_recv() {
             Ok(response) => {
+                // Update skills if hot-reloaded during this turn
+                if let Some(new_skills) = response.updated_skills {
+                    self.skills = new_skills;
+                }
+
                 // Update context token tracking
                 if let Some(tokens) = response.input_tokens {
                     self.context_tokens = Some(tokens);


### PR DESCRIPTION
## Summary

- Adds a shared `AtomicBool` dirty flag to `ToolContext` so skill-modifying tools (`create_skill`, `update_skill`, `delete_skill`, `toggle_skill`) can signal "skills changed on disk"
- Agent loop coordinators (CLI worker, server handlers) check the flag before each turn and rebuild the `SkillRegistry` from disk if set — skill changes take effect immediately without restart
- CLI worker sends the updated `SkillRegistry` back to the TUI via `AgentResponse.updated_skills` so `/skills` autocomplete stays current

No new crate dependencies — uses `std::sync::atomic::AtomicBool`.

## Test plan

- [x] `cargo build` — all crates compile
- [x] `cargo test` — all 432+ tests pass (0 failures)
- [x] `cargo clippy` — no new warnings
- [ ] Manual TUI test: create a skill, verify it triggers on the next message without restart
- [ ] Manual TUI test: delete a skill, verify it stops triggering on the next message without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)