### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.1](https://github.com/senara-solutions/mika/releases/tag/v0.1.1) — 2026-03-01
+
+### Added
+
+- add automated release system with GitHub binary downloads
+
+### Documentation
+
+- update documentation for release system and rustls migration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mika-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "mika-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "mika-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "mika-gateway"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 description = "AI executive assistant with persistent memory"
@@ -113,8 +113,8 @@ tempfile = "3"
 serial_test = "3"
 
 # Workspace crates
-mika-common = { path = "crates/mika-common", version = "0.1.0" }
-mika-agent = { path = "crates/mika-agent", version = "0.1.0" }
+mika-common = { path = "crates/mika-common", version = "0.1.1" }
+mika-agent = { path = "crates/mika-agent", version = "0.1.1" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION



## 🤖 New release

* `mika-common`: 0.1.0 -> 0.1.1
* `mika-agent`: 0.1.0 -> 0.1.1
* `mika-cli`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `mika-common`

<blockquote>

## [0.1.1](https://github.com/senara-solutions/mika/releases/tag/v0.1.1) — 2026-03-01

### Added

- add automated release system with GitHub binary downloads

### Documentation

- update documentation for release system and rustls migration
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).