### PR TITLE
fix(tui): display callback task results as system messages instead of 'You:'

### DIFF
--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -576,20 +576,24 @@ pub struct AgentParams<'a> {
 pub async fn run_agent(params: &AgentParams<'_>) -> Result<AgentOutput> {
     let trace_id = mika_common::trace::generate_trace_id();
 
-    // Save the user message (with image annotation if images attached)
-    let save_text = if params.user_images.is_empty() {
-        params.user_message.to_string()
-    } else {
-        format!(
-            "[{} image(s) attached]\n{}",
-            params.user_images.len(),
-            params.user_message
-        )
-    };
-    params
-        .db
-        .save_message(params.session_id, "user", &save_text, Some(&trace_id))
-        .await?;
+    // Save the user message (with image annotation if images attached).
+    // Skip for callback turns — the raw result is already persisted as role='tool_result'
+    // by the caller, and the framing wrapper is an internal prompt construct.
+    if !params.is_callback_turn {
+        let save_text = if params.user_images.is_empty() {
+            params.user_message.to_string()
+        } else {
+            format!(
+                "[{} image(s) attached]\n{}",
+                params.user_images.len(),
+                params.user_message
+            )
+        };
+        params
+            .db
+            .save_message(params.session_id, "user", &save_text, Some(&trace_id))
+            .await?;
+    }
 
     let agent_name = params
         .home_dir

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -15,7 +15,10 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::init::{self, AppContext};
-use crate::tui::app::{AgentRequest, AgentResponse, App, ChatMessage, ChatRole, TeamRequest};
+use crate::tui::app::{
+    AgentRequest, AgentResponse, App, ChatMessage, ChatRole, TeamRequest,
+    callback_label_from_metadata,
+};
 use crate::tui::event::{AppEvent, EventReader};
 use crate::tui::input;
 use crate::tui::ui;
@@ -393,8 +396,15 @@ pub async fn run(agent_name: &str) -> Result<()> {
     if let Ok(history) = worker._ctx.async_db.load_recent_messages(20).await {
         for msg in history {
             let role = match msg.role.as_str() {
-                "user" => ChatRole::User,
+                "user" => {
+                    // Skip stale framing messages saved before the callback save fix
+                    if msg.content.starts_with("A background task has completed.") {
+                        continue;
+                    }
+                    ChatRole::User
+                }
                 "assistant" => ChatRole::Assistant,
+                "tool_result" => ChatRole::System,
                 _ => continue,
             };
             let channel = if msg.channel_type == "cli" {
@@ -402,9 +412,16 @@ pub async fn run(agent_name: &str) -> Result<()> {
             } else {
                 Some(msg.channel_type.clone())
             };
+            // For tool_result, show a brief summary with label from metadata
+            let content = if msg.role == "tool_result" {
+                let label = callback_label_from_metadata(&msg.metadata);
+                format!("[Task: {}] Result received", label)
+            } else {
+                msg.content
+            };
             app.messages.push(ChatMessage {
                 role,
-                content: msg.content,
+                content,
                 rendered: None,
                 channel,
             });

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -50,6 +50,15 @@ pub enum ChatRole {
     Thinking,
 }
 
+/// Extract callback task label from message metadata JSON.
+pub fn callback_label_from_metadata(metadata: &Option<String>) -> String {
+    metadata
+        .as_ref()
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| v.get("label")?.as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| "background task".to_string())
+}
+
 /// Messages flowing between the TUI and the agent worker.
 pub enum AgentRequest {
     Message {
@@ -1037,8 +1046,15 @@ impl<'a> App<'a> {
 
         for msg in &new_msgs {
             let role = match msg.role.as_str() {
-                "user" => ChatRole::User,
+                "user" => {
+                    // Skip stale framing messages saved before the callback save fix
+                    if msg.content.starts_with("A background task has completed.") {
+                        continue;
+                    }
+                    ChatRole::User
+                }
                 "assistant" => ChatRole::Assistant,
+                "tool_result" => ChatRole::System,
                 _ => continue,
             };
             // CLI messages from other processes don't need a channel badge
@@ -1048,9 +1064,16 @@ impl<'a> App<'a> {
             } else {
                 Some(msg.channel_type.clone())
             };
+            // For tool_result, show a brief summary with label from metadata
+            let content = if msg.role == "tool_result" {
+                let label = callback_label_from_metadata(&msg.metadata);
+                format!("[Task: {}] Result received", label)
+            } else {
+                msg.content.clone()
+            };
             self.messages.push(ChatMessage {
                 role,
-                content: msg.content.clone(),
+                content,
                 rendered: None,
                 channel,
             });
@@ -1337,5 +1360,30 @@ mod tests {
     fn test_visual_line_rows_zero_width() {
         use crate::tui::ui::visual_line_rows;
         assert_eq!(visual_line_rows("hello", 0), 1);
+    }
+
+    // === callback_label_from_metadata tests ===
+
+    #[test]
+    fn test_callback_label_with_valid_metadata() {
+        let meta = Some(r#"{"callback_task_id":"abc","label":"analyze_codebase"}"#.to_string());
+        assert_eq!(callback_label_from_metadata(&meta), "analyze_codebase");
+    }
+
+    #[test]
+    fn test_callback_label_with_missing_label() {
+        let meta = Some(r#"{"callback_task_id":"abc"}"#.to_string());
+        assert_eq!(callback_label_from_metadata(&meta), "background task");
+    }
+
+    #[test]
+    fn test_callback_label_with_none_metadata() {
+        assert_eq!(callback_label_from_metadata(&None), "background task");
+    }
+
+    #[test]
+    fn test_callback_label_with_invalid_json() {
+        let meta = Some("not json".to_string());
+        assert_eq!(callback_label_from_metadata(&meta), "background task");
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause:** `run_agent()` saved the callback framing wrapper (with `<callback_result>` XML) as `role='user'`, which loaded as "You:" on TUI restart
- **Fix:** Skip saving framing on callback turns (raw result already persisted as `tool_result`), map `tool_result` to system messages with task label, and detect/skip stale framing from before the fix
- **3 files changed:** `agent.rs` (guard user message save), `chat.rs` (history loading), `app.rs` (cross-channel polling + helper + tests)

## Testing
- 4 unit tests added for `callback_label_from_metadata` (valid, missing label, None, invalid JSON)
- All 987 existing tests pass
- Clippy clean, fmt clean

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required: display-only change affecting TUI rendering of callback results. No server-side behavior change.

Closes #83

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)