### PR TITLE
feat: out-of-sandbox file writes and task completeness prompts

### DIFF
--- a/crates/mika-agent/src/bundled_skills.rs
+++ b/crates/mika-agent/src/bundled_skills.rs
@@ -373,4 +373,21 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_shell_exec_prompt_contains_sandbox_guidance() {
+        let content = include_str!("../templates/skills/shell-exec/system_prompt.md");
+        assert!(
+            content.contains("Writing files outside your home directory"),
+            "shell-exec prompt missing out-of-sandbox section"
+        );
+        assert!(
+            content.contains("Tracing references after rename"),
+            "shell-exec prompt missing reference-tracing section"
+        );
+        assert!(
+            content.contains("write_file` tool is sandboxed"),
+            "shell-exec prompt missing sandbox explanation"
+        );
+    }
 }

--- a/crates/mika-agent/src/tools/write_file.rs
+++ b/crates/mika-agent/src/tools/write_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use mika_common::claude::ToolDefinition;
@@ -60,7 +62,16 @@ impl Tool for WriteFileTool {
 
         let full_path = match validate_and_resolve_path(path, ctx.home_dir, true).await {
             Ok(p) => p,
-            Err(e) => return Ok(e),
+            Err(e) => {
+                // If the path was absolute, hint that run_shell can write outside the home dir
+                if Path::new(path).is_absolute() {
+                    return Ok(ToolOutput::error(format!(
+                        "{} For paths outside your home directory, use run_shell instead.",
+                        e.content
+                    )));
+                }
+                return Ok(e);
+            }
         };
 
         // Check if file already exists
@@ -408,6 +419,46 @@ mod tests {
                 .contains(&expected_path.display().to_string()),
             "expected absolute path '{}' in confirmation: {}",
             expected_path.display(),
+            output.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_absolute_path_hints_run_shell() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        let tool = WriteFileTool;
+        let harness = TestHarness::new();
+        let ctx = harness.ctx_with_home(&home);
+        let input = serde_json::json!({ "path": "/tmp/outside.txt", "content": "data" });
+
+        let output = tool.execute(input, &ctx).await.unwrap();
+        assert!(output.is_error);
+        assert!(
+            output.content.contains("use run_shell instead"),
+            "expected run_shell hint, got: {}",
+            output.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_traversal_path_does_not_hint_run_shell() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        let tool = WriteFileTool;
+        let harness = TestHarness::new();
+        let ctx = harness.ctx_with_home(&home);
+        let input = serde_json::json!({ "path": "../escape.txt", "content": "data" });
+
+        let output = tool.execute(input, &ctx).await.unwrap();
+        assert!(output.is_error);
+        assert!(
+            !output.content.contains("run_shell"),
+            "traversal error should not mention run_shell, got: {}",
             output.content
         );
     }

--- a/crates/mika-agent/templates/skills/shell-exec/system_prompt.md
+++ b/crates/mika-agent/templates/skills/shell-exec/system_prompt.md
@@ -18,8 +18,30 @@ When modifying config files (hyprland.conf, waybar config, bashrc, etc.):
 
 Before writing to any file via shell (cat >, tee, sed -i, echo >, heredoc, etc.):
 - ALWAYS read the file first if it exists, to understand what you're replacing.
-- Prefer the `write_file` tool over shell writes when the content fits — it enforces read-before-overwrite automatically.
+- For files inside your home directory, prefer `write_file` over shell writes — it enforces read-before-overwrite automatically.
 - When shell writes are necessary (e.g., binary data, piping, large files), use `cat <file>` or `head <file>` first.
+
+## Writing files outside your home directory
+
+Your `write_file` tool is sandboxed to your home directory — it cannot reach paths like `~/.local/bin/`, `~/.config/`, etc. For file operations outside your home directory (and outside any team workspace), use `run_shell`.
+
+Before writing via shell, check whether the target already exists:
+- **Target exists:** Show the user the exact command you'll run and what it overwrites. Wait for explicit confirmation before executing. Example: "~/.config/hypr/hyprland.conf exists and contains a quickclaw keybinding. I'll replace it with quickmika. Here's the change: [show diff]. Shall I proceed?"
+- **Target does not exist:** Tell the user what you're creating, then execute immediately. Example: "I'll create ~/.local/bin/quickmika with the adapted script." Then write the file and set permissions in the same turn. Exception: always confirm writes to sensitive locations (`~/.ssh/`, `~/.config/autostart/`, shell rc files, cron/systemd paths) even if the file is new.
+
+After writing, verify success (`ls -la` for existence/permissions, `head` for content spot-check).
+
+## Tracing references after rename or adaptation
+
+When you adapt, rename, or replace a script, config, or binary, trace references to the original:
+- `grep -rl "original_name" ~/.config/` — find config files (keybindings, WM configs, autostart)
+- Check shell configs (`~/.bashrc`, `~/.zshrc`, `~/.profile`) for aliases or PATH references
+- Check systemd units, cron entries, desktop files if relevant
+- Update each reference found and verify with a follow-up grep
+
+If a location requires access you don't have, or the search returns no results and you're uncertain coverage was complete, list what you could not verify so the user can check manually.
+
+When scanning config files, do not echo file contents containing secrets, tokens, or credentials in your responses. Report only the file path and the specific line that needs updating.
 
 ## Writing shell scripts
 

--- a/crates/mika-common/src/home.rs
+++ b/crates/mika-common/src/home.rs
@@ -272,6 +272,7 @@ You protect the user's time fiercely.
 - Never pretend to have done something you haven't
 - Say "I don't know" when you don't know
 - Ask for clarification rather than guess on high-stakes decisions
+- When you adapt, replace, or rename something, you own the full outcome — not just the artifact. Trace all references and update them. The job isn't done until the system works end-to-end.
 "#;
 
 pub const DEFAULT_HEARTBEAT: &str = r#"# Heartbeat Checklist

--- a/docs/brainstorms/2026-03-11-out-of-sandbox-writes-brainstorm.md
+++ b/docs/brainstorms/2026-03-11-out-of-sandbox-writes-brainstorm.md
@@ -1,0 +1,108 @@
+# Brainstorm: Out-of-Sandbox File Writes & Task Completeness
+
+**Date:** 2026-03-11
+**Status:** Ready for planning
+**Triggered by:** Mika failed to adapt `~/.local/bin/quickclaw` — wrote to wrong path, didn't update Hyprland keybinding config
+
+---
+
+## What We're Building
+
+Two prompt-level improvements (zero Rust code changes) that fix a class of agent failure where Mika:
+
+1. **Cannot write files outside `~/.mika/`** — `write_file` is sandboxed by design, but Mika defaults to it instead of using `run_shell` for user filesystem operations.
+2. **Stops short of completing multi-step tasks** — treats "adapt this script" as "draft a replacement" rather than "make the system work end-to-end."
+
+## Why This Approach
+
+**Prompt-only fix, no new tools.** The reasoning:
+
+- `run_shell` already solves out-of-sandbox writes — it just needs prompt guidance steering Mika toward it for the right cases.
+- A new `write_user_file` Rust tool adds maintenance surface for a problem the shell already handles.
+- Expanding `write_file` to accept absolute paths silently erodes the sandbox invariant — future features that should be restricted may accidentally inherit expanded permissions.
+- The confirmation step (not the filesystem restriction) is the real security boundary. This matches the industry pattern: Cursor, Claude Code, and Aider all use shell for out-of-sandbox writes with per-operation confirmation.
+
+## Key Decisions
+
+### Decision 1: Prompt-only, no new Rust code
+
+Keep `write_file` sandboxed to `~/.mika/`. Add system prompt guidance that explicitly directs Mika to use `run_shell` for file operations outside her home directory. The shell-exec skill's existing `system_prompt.md` is the right place for the technical guidance.
+
+### Decision 2: Two-layer guidance (soul + skill)
+
+The task completeness failure has two layers that map to different parts of the prompt system:
+
+| Layer | Where | What |
+|-------|-------|------|
+| **Disposition** ("want to finish") | `soul.md` | Core principle: "When asked to adapt or replace something, you own the outcome, not just the artifact. The job isn't done until the system works." |
+| **Technique** ("know how to finish") | `shell-exec/system_prompt.md` | Concrete pattern: grep for references, locate dependent configs (keybindings, aliases, systemd units), update them, verify the change landed. |
+
+Soul alone is too abstract to catch the Hyprland case. Shell-exec alone can't install the disposition — it only fires when Mika already suspects there's a config to update.
+
+### Decision 3: Context-dependent confirmation
+
+Not all out-of-sandbox writes carry the same risk. The heuristic:
+
+**Confirm before executing when:**
+- The target path already exists (overwrite risk)
+- The operation is destructive or irreversible (`rm`, `mv`, `chmod` on system files)
+- The write touches a config controlling a running system (dotfiles, systemd units, WM configs)
+
+**Narrate and execute immediately when:**
+- Creating a net-new file at a path that doesn't exist
+- Appending to a log or history file
+- The operation is trivially reversible
+
+**Rationale:** Uniform confirmation causes approval fatigue — rubber-stamping defeats the purpose. The two-line encoding: *"For out-of-sandbox writes, check if the target exists. If it does, confirm first and show the exact command. If it doesn't, narrate what you're creating and proceed."*
+
+## Changes Required
+
+### 1. `soul.md` (default soul / personality)
+
+Location: `crates/mika-common/src/home.rs` → `DEFAULT_SOUL` constant
+
+Add a principle about task ownership. Something like:
+> When you adapt, replace, or rename something, you own the full outcome — not just the artifact. Trace all references (configs, keybindings, aliases, imports) and update them. The job isn't done until the system works end-to-end. Don't leave manual steps for the user.
+
+### 2. `shell-exec/system_prompt.md`
+
+Location: `crates/mika-agent/templates/skills/shell-exec/system_prompt.md`
+
+Two additions:
+
+**a) Out-of-sandbox write guidance:**
+> For file operations outside `~/.mika/` (the user's filesystem), use `run_shell`. The `write_file` tool is sandboxed to your home directory — it cannot reach paths like `~/.local/bin/`, `~/.config/`, etc.
+>
+> For out-of-sandbox writes, check if the target exists first. If it does, show the exact command and confirm before executing. If it doesn't, narrate what you're creating and proceed.
+
+**b) Reference-tracing technique:**
+> When adapting, replacing, or renaming a script/config/binary, trace all references to the original:
+> - `grep -rl "original_name" ~/.config/` to find config files that reference it
+> - Check keybinding configs, shell aliases, systemd units, cron entries
+> - Update each reference and verify with a follow-up grep
+
+### 3. Existing shell-exec guidance update
+
+The current line *"Prefer the `write_file` tool over shell writes when the content fits"* needs to be scoped: it should only apply to writes within `~/.mika/`. For user filesystem paths, `run_shell` is the correct tool.
+
+## What Success Looks Like
+
+Replay the quickclaw scenario:
+1. User: "Adapt `~/.local/bin/quickclaw` to work with mika ask"
+2. Mika reads the script, adapts the content
+3. Mika writes to `~/.local/bin/quickmika` via `run_shell` (new file, narrate-and-execute)
+4. Mika runs `chmod +x` immediately
+5. Mika greps `~/.config/hypr/` for `quickclaw`, finds the keybinding
+6. Mika shows the config change (existing file, confirm before executing)
+7. Mika verifies with `ls -la` and `grep`
+8. Zero manual steps for the user
+
+## Resolved Questions
+
+- **Q: Should we add a new Rust tool?** No. `run_shell` already handles this; adding tools creates maintenance surface for a solved problem.
+- **Q: Where does the "finish the job" principle go?** Split: soul.md for disposition, shell-exec for technique.
+- **Q: Confirm every out-of-sandbox write?** No — context-dependent. New files proceed with narration; existing files require confirmation. Avoids approval fatigue.
+
+## Open Questions
+
+None — all decisions resolved during brainstorming.

--- a/docs/plans/2026-03-11-feat-out-of-sandbox-writes-task-completeness-plan.md
+++ b/docs/plans/2026-03-11-feat-out-of-sandbox-writes-task-completeness-plan.md
@@ -1,0 +1,116 @@
+---
+title: "feat: Out-of-sandbox file writes and task completeness"
+type: feat
+status: active
+date: 2026-03-11
+origin: docs/brainstorms/2026-03-11-out-of-sandbox-writes-brainstorm.md
+---
+
+# feat: Out-of-sandbox file writes and task completeness
+
+Prompt-level fix (+ one error message string change) for a class of agent failure where Mika writes files to the wrong location (sandbox instead of user filesystem) and stops short of completing multi-step tasks.
+
+## Acceptance Criteria
+
+- [ ] Soul.md contains a task ownership principle about owning outcomes end-to-end
+- [ ] Shell-exec system prompt directs agent to `run_shell` for paths outside home/workspace
+- [ ] Shell-exec system prompt includes context-dependent confirmation heuristic (confirm overwrites, narrate new files)
+- [ ] Shell-exec system prompt includes reference-tracing technique (grep configs after rename/adapt)
+- [ ] Existing "prefer write_file" line is scoped to home directory only
+- [ ] `validate_and_resolve_path` error message hints at `run_shell` for out-of-sandbox paths
+- [ ] Existing tests pass (`cargo test`)
+- [ ] Build succeeds (shell-exec templates are `include_str!` compiled)
+
+## Changes
+
+### 1. `crates/mika-common/src/home.rs` — DEFAULT_SOUL
+
+Add a task ownership principle to the Boundaries section (see brainstorm: Decision 2, Layer 1):
+
+```
+## Boundaries
+...
+- When you adapt, replace, or rename something, you own the full outcome — not just the artifact.
+  Trace all references (configs, keybindings, aliases, imports) and update them.
+  The job isn't done until the system works end-to-end. Don't leave manual steps for the user.
+```
+
+This is a dispositional directive — it tells the agent *why* to trace references. The *how* lives in the shell-exec skill.
+
+### 2. `crates/mika-agent/templates/skills/shell-exec/system_prompt.md`
+
+Three edits to the existing file:
+
+**a) Scope the existing write_file preference (line 21):**
+
+Change:
+```
+- Prefer the `write_file` tool over shell writes when the content fits — it enforces read-before-overwrite automatically.
+```
+To:
+```
+- For files inside your home directory, prefer `write_file` over shell writes — it enforces read-before-overwrite automatically.
+```
+
+**b) Add out-of-sandbox write guidance (new section after "File writing"):**
+
+```
+## Writing files outside your home directory
+
+Your `write_file` tool is sandboxed to your home directory — it cannot reach paths like `~/.local/bin/`, `~/.config/`, etc. For file operations outside your home directory (and outside any team workspace), use `run_shell`.
+
+Before writing via shell, check whether the target already exists:
+- **Target exists:** Show the user the exact command you'll run and what it overwrites. Wait for explicit confirmation before executing. Example: "~/.config/hypr/hyprland.conf exists and contains a quickclaw keybinding. I'll replace it with quickmika. Here's the change: [show diff]. Shall I proceed?"
+- **Target does not exist:** Tell the user what you're creating, then execute immediately. Example: "I'll create ~/.local/bin/quickmika with the adapted script." Then write the file and set permissions in the same turn.
+
+After writing, verify success (`ls -la` for existence/permissions, `head` for content spot-check).
+```
+
+**c) Add reference-tracing technique (new section):**
+
+```
+## Tracing references after rename or adaptation
+
+When you adapt, rename, or replace a script, config, or binary, trace references to the original:
+- `grep -rl "original_name" ~/.config/` — find config files (keybindings, WM configs, autostart)
+- Check shell configs (`~/.bashrc`, `~/.zshrc`, `~/.profile`) for aliases or PATH references
+- Check systemd units, cron entries, desktop files if relevant
+- Update each reference found and verify with a follow-up grep
+
+If a location requires access you don't have, or the search returns no results and you're uncertain coverage was complete, list what you could not verify so the user can check manually.
+```
+
+### 3. `crates/mika-agent/src/tools/mod.rs` — error message hint
+
+One-line string change in `validate_and_resolve_path` (line ~288). Change the absolute-path rejection message from:
+
+```
+"Absolute paths are not allowed. Use a relative path within the directory."
+```
+
+To:
+
+```
+"Absolute paths are not allowed. Use a relative path within your home directory, or use run_shell for paths outside it."
+```
+
+Last line of defense when prompt guidance isn't enough — prevents the agent from retrying with a wrong relative path instead of switching tools. String literal only, no logic change.
+
+## SpecFlow Findings Incorporated
+
+From the spec-flow analysis (see brainstorm for full context):
+
+| Finding | Resolution |
+|---|---|
+| `write_workspace` interaction | Guidance says "outside your home directory and any team workspace" |
+| "Narrate-and-execute" undefined | Added concrete examples in section 2b |
+| Silent/team mode interaction | Soul principle is aspirational; agents do their best with available tools. Shell-exec excluded from silent mode already |
+| Privilege escalation (`sudo`) | Not addressed in prompts — existing "confirm destructive commands" covers it. Agent should never `sudo` unprompted |
+| Rewind can't undo filesystem changes | Acceptable limitation — out of scope for prompt fix |
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-11-out-of-sandbox-writes-brainstorm.md](docs/brainstorms/2026-03-11-out-of-sandbox-writes-brainstorm.md) — key decisions: prompt-only fix, two-layer guidance (soul + skill), context-dependent confirmation
+- **Existing pattern:** `write_file` overwrite confirmation flow (`docs/solutions/integration-issues/write-file-tool-overwrite-confirmation-flow.md`)
+- **Existing pattern:** Tool path reporting — resolved absolute paths (`docs/solutions/logic-errors/tool-path-reporting-misbehavior.md`)
+- **Current files:** `crates/mika-common/src/home.rs:252-275` (DEFAULT_SOUL), `crates/mika-agent/templates/skills/shell-exec/system_prompt.md` (full file), `crates/mika-agent/src/prompt.rs:390-420` (home_dir in system prompt)


### PR DESCRIPTION
## Summary

- **Shell-exec prompt**: Added "Writing files outside your home directory" and "Tracing references after rename" sections to guide the agent to use `run_shell` for paths outside `~/.mika/` and trace all references when adapting scripts
- **Soul.md**: Added task ownership principle — "own the full outcome, not just the artifact"
- **write_file hint**: When `write_file` rejects an absolute path, the error now suggests `run_shell` as an alternative
- **3 new tests**: `run_shell` hint assertion, traversal-path negative test, shell-exec prompt content verification

## Motivation

Mika botched a quickclaw→quickmika script adaptation: wrote to `~/.mika/agents/mika/scripts/` instead of `~/.local/bin/`, and completely ignored the Hyprland config keybinding. Root cause: `write_file` is sandboxed + the old prompt said "prefer write_file over shell writes" without explaining what to do for paths outside the sandbox.

## Manual test results

Ran "The Quickmika Redemption" — rewound the original botched conversation, then re-asked the same question:

| Phase | Result |
|-------|--------|
| Cross-session rewind of botched attempt | PASS — 4 msgs deleted |
| Re-ask quickclaw with new prompts | PASS — `run_shell` used, correct path, executable, Hyprland config updated |
| Same-session rewind (`/undo` + `/rewind`) | PASS — accumulation guard works, no confabulation |

## Test plan

- [x] `cargo test` — 1200 tests pass (including 22 rewind + 3 new)
- [x] `cargo clippy` — clean
- [x] Manual TUI test: rewind → re-ask → verify script + config → rewind again
- [x] Script content verified against original quickclaw


🤖 Generated with [Claude Code](https://claude.com/claude-code)