### PR TITLE
fix(trace): fix broken trace messages endpoint and missing trace_id propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 ## Commands
 
 - `cargo build` — Build all crates
-- `cargo test` — Run all tests (~1209 tests)
+- `cargo test` — Run all tests (~1211 tests)
 - `cargo run --bin mika` — Run TUI CLI (default: chat, or `mika status`, `mika memory`, etc.)
 - `cargo run --bin mika-server` — Run HTTP server (requires `MIKA_ROUTING_URL` and `MIKA_INTERNAL_TOKEN`)
 - `VITE_MIKA_DASHBOARD_TOKEN=<token> npm run dev --prefix dashboard` — Run dashboard dev server (requires mika-server on :8080)

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -120,6 +120,7 @@ pub struct Task {
     pub input_context: Option<String>,
     pub result: Option<String>,
     pub created_by_session: Option<String>,
+    pub created_trace_id: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
     pub fired_at: Option<i64>,
@@ -1513,12 +1514,13 @@ impl Database {
             input_context: r.get(17)?,
             result: r.get(18)?,
             created_by_session: r.get(19)?,
-            created_at: r.get(20)?,
-            updated_at: r.get(21)?,
-            fired_at: r.get(22)?,
-            completed_at: r.get(23)?,
-            reference_url: r.get(24)?,
-            source: r.get(25)?,
+            created_trace_id: r.get(20)?,
+            created_at: r.get(21)?,
+            updated_at: r.get(22)?,
+            fired_at: r.get(23)?,
+            completed_at: r.get(24)?,
+            reference_url: r.get(25)?,
+            source: r.get(26)?,
         })
     }
 
@@ -1526,7 +1528,7 @@ impl Database {
          trigger_type, cron_expr, event_source, event_offset_secs, condition_expr,
          next_fire_at, timeout_at, action_type, action_config,
          status, process_id, input_context, result, created_by_session,
-         created_at, updated_at, fired_at, completed_at,
+         created_trace_id, created_at, updated_at, fired_at, completed_at,
          reference_url, source";
 
     pub fn get_task(&self, id: &str, agent_id: &str) -> Result<Option<Task>> {
@@ -1666,7 +1668,7 @@ impl Database {
     }
 
     /// Number of columns in TASK_COLUMNS (used for child_count ordinal in list_manual_tasks).
-    const TASK_COLUMN_COUNT: usize = 26;
+    const TASK_COLUMN_COUNT: usize = 27;
 
     /// List manual (work item) tasks for an agent with optional filters.
     /// Uses parameterized NULL checks to avoid dynamic SQL construction.
@@ -2117,6 +2119,8 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
+    const SESSION_MESSAGE_COLUMNS: &'static str = "m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at";
+
     fn row_to_session_message(r: &rusqlite::Row<'_>) -> rusqlite::Result<SessionMessage> {
         Ok(SessionMessage {
             id: r.get(0)?,
@@ -2136,12 +2140,13 @@ impl Database {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.agent_id = ?1 AND m.role != 'summary' AND s.channel_type != 'team'
               ORDER BY m.created_at DESC, m.id DESC LIMIT ?2",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let mut messages = stmt
             .query_map(
                 params![agent_id, limit as i64],
@@ -2155,10 +2160,12 @@ impl Database {
     pub fn load_conversation_summary(&self, agent_id: &str) -> Result<Option<SessionMessage>> {
         self.conn
             .query_row(
-                "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-                  FROM messages m JOIN sessions s ON m.session_id = s.id
-                  WHERE m.agent_id = ?1 AND m.role = 'summary'
-                  ORDER BY m.created_at DESC LIMIT 1",
+                &format!(
+                    "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
+                      WHERE m.agent_id = ?1 AND m.role = 'summary'
+                      ORDER BY m.created_at DESC LIMIT 1",
+                    Self::SESSION_MESSAGE_COLUMNS
+                ),
                 params![agent_id],
                 Self::row_to_session_message,
             )
@@ -2193,12 +2200,13 @@ impl Database {
             Some(id) => id,
             None => return Ok(vec![]),
         };
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.agent_id = ?1 AND m.role != 'summary' AND m.id <= ?2
               ORDER BY m.created_at ASC, m.id ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(params![agent_id, cutoff_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
@@ -2224,7 +2232,7 @@ impl Database {
             "DELETE FROM messages WHERE agent_id = ?1 AND role = 'summary'",
             params![agent_id],
         )?;
-        // Insert new summary
+        // Insert new summary (no trace_id — summaries span multiple traces)
         self.conn.execute(
             "INSERT INTO messages (session_id, agent_id, role, content, compacted_through_id)
              VALUES (?1, ?2, 'summary', ?3, ?4)",
@@ -2240,12 +2248,13 @@ impl Database {
         agent_id: &str,
         after_id: i64,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.agent_id = ?1 AND m.id > ?2
               ORDER BY m.created_at ASC, m.id ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(params![agent_id, after_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
@@ -2263,11 +2272,12 @@ impl Database {
 
     /// Load a single message by its row ID.
     pub fn get_message_by_id(&self, message_id: i64) -> Result<Option<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.id = ?1",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt
             .query_map(params![message_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -2283,14 +2293,15 @@ impl Database {
         before: u32,
         after: u32,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.session_id = ?1
                 AND (m.id >= (SELECT id FROM (SELECT id FROM messages WHERE session_id = ?1 AND id <= ?2 ORDER BY id DESC LIMIT ?3) sub ORDER BY id ASC LIMIT 1))
                 AND m.id <= (SELECT id FROM (SELECT id FROM messages WHERE session_id = ?1 AND id >= ?2 ORDER BY id ASC LIMIT ?4) sub ORDER BY id DESC LIMIT 1)
               ORDER BY m.created_at ASC, m.id ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(
                 params![session_id, target_id, before + 1, after + 1],
@@ -2305,12 +2316,13 @@ impl Database {
         agent_id: &str,
         since_unix: i64,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.agent_id = ?1 AND m.created_at >= ?2 AND m.role != 'summary'
               ORDER BY m.created_at ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(params![agent_id, since_unix], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
@@ -2920,12 +2932,13 @@ impl Database {
         session_id: &str,
         after_id: i64,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.agent_id = ?1 AND m.session_id = ?2 AND m.id > ?3
               ORDER BY m.id ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(
                 params![agent_id, session_id, after_id],
@@ -4034,12 +4047,13 @@ impl Database {
 
     /// Get full messages for a specific trace_id (for rich trace detail rendering).
     pub fn get_messages_by_trace_id(&self, trace_id: &str) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.trace_id = ?1
               ORDER BY m.created_at ASC, m.id ASC",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(params![trace_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
@@ -4230,12 +4244,13 @@ impl Database {
         limit: u32,
         offset: u32,
     ) -> Result<Vec<SessionMessage>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at
-              FROM messages m JOIN sessions s ON m.session_id = s.id
+        let sql = format!(
+            "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
               WHERE m.session_id = ?1
               ORDER BY m.created_at ASC, m.id ASC LIMIT ?2 OFFSET ?3",
-        )?;
+            Self::SESSION_MESSAGE_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(
                 params![session_id, limit as i64, offset as i64],
@@ -4582,6 +4597,24 @@ mod tests {
         let msgs = db.get_messages_since("mika", 1500).unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].content, "new");
+    }
+
+    #[test]
+    fn test_get_messages_by_trace_id() {
+        let (db, sid) = db_with_session();
+        let trace = "aaaa0000bbbb1111cccc2222dddd3333";
+        db.save_message_with_metadata("mika", &sid, "user", "traced msg", None, Some(trace))
+            .unwrap();
+        db.save_message("mika", &sid, "assistant", "no trace", None)
+            .unwrap();
+
+        let msgs = db.get_messages_by_trace_id(trace).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "traced msg");
+        assert_eq!(msgs[0].trace_id.as_deref(), Some(trace));
+
+        let empty = db.get_messages_by_trace_id("nonexistent").unwrap();
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -1654,6 +1654,44 @@ mod tests {
         assert!(json.as_array().unwrap().is_empty());
     }
 
+    #[tokio::test]
+    async fn test_trace_messages_returns_matching_messages() {
+        let state = test_state();
+        state.ready.store(true, Ordering::Release);
+        let db = state.agents.get("mika").unwrap().db.clone();
+
+        let trace_id = "aabb0011ccddeeff0011223344556677";
+        db.save_message_with_metadata(
+            "test-session",
+            "user",
+            "traced message",
+            None,
+            Some(trace_id),
+        )
+        .await
+        .unwrap();
+
+        let app = test_app(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/timeline/trace/{trace_id}/messages"))
+                    .header("authorization", "Bearer test-token-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.len(), 1);
+        assert_eq!(json[0]["content"], "traced message");
+        assert_eq!(json[0]["role"], "user");
+    }
+
     // ===== Auth split tests =====
 
     #[tokio::test]

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -281,6 +281,7 @@ async fn spawn_agent_worker(
                     task_id,
                     label,
                     result,
+                    trace_id,
                 } => {
                     // Save the callback result as a tool_result message
                     let metadata = serde_json::json!({
@@ -294,7 +295,7 @@ async fn spawn_agent_worker(
                             "tool_result",
                             &result,
                             Some(&metadata),
-                            None,
+                            trace_id.as_deref(),
                         )
                         .await;
 

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -182,6 +182,7 @@ pub enum AgentRequest {
         task_id: String,
         label: String,
         result: String,
+        trace_id: Option<String>,
     },
     SetModel {
         model: String,
@@ -1270,6 +1271,7 @@ impl<'a> App<'a> {
                 task_id: task.id,
                 label: task.label,
                 result,
+                trace_id: task.created_trace_id,
             });
 
             self.status = AgentStatus::Thinking;

--- a/dashboard/src/pages/TraceDetail.tsx
+++ b/dashboard/src/pages/TraceDetail.tsx
@@ -429,7 +429,7 @@ function EventCard({ event }: { event: { event_type: string; event_subtype: stri
 export default function TraceDetail() {
   const { traceId } = useParams<{ traceId: string }>()
   const { data: events, isLoading: eventsLoading, error: eventsError } = useTraceDetail(traceId ?? '')
-  const { data: messages, isLoading: messagesLoading } = useTraceMessages(traceId ?? '')
+  const { data: messages, isLoading: messagesLoading, error: messagesError } = useTraceMessages(traceId ?? '')
   const [investigationCtx, setInvestigationCtx] = useState<InvestigationContext | null>(null)
 
   const openInvestigation = (
@@ -449,7 +449,7 @@ export default function TraceDetail() {
   }
 
   const isLoading = eventsLoading || messagesLoading
-  const error = eventsError
+  const error = eventsError || messagesError
 
   // Non-message events (audit, task)
   const nonMessageEvents = events?.filter((e) => e.event_type !== 'message') ?? []

--- a/docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md
+++ b/docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md
@@ -1,0 +1,155 @@
+---
+title: "Fix trace messages endpoint — missing column, silent errors, lost trace IDs"
+date: 2026-03-12
+module: mika-agent (db, server, CLI), dashboard
+tags: [bug, dashboard, trace, sqlite, column-mismatch, error-handling, observability]
+severity: high
+symptoms:
+  - "Message 685 has no trace_id in database"
+  - "Trace f221c4ea... shows nothing in Trace Detail view"
+  - "Trace e5e8996e... shows audit logs instead of expected messages"
+  - "Trace 64834561... shows no message when it should show message 677"
+root_cause: >
+  get_messages_by_trace_id() SELECT listed 8 columns but row_to_session_message()
+  expects 9 (m.trace_id was missing), causing a rusqlite column-count error on every
+  call. The dashboard swallowed the resulting HTTP error because TraceDetail.tsx
+  discarded the messagesError from the query hook. Additionally, CLI callback
+  tool_result messages were saved without propagating the task's created_trace_id,
+  so those messages could never be found by trace. The Task struct also omitted the
+  created_trace_id field that exists in the DB, preventing trace_id propagation
+  through the callback pipeline.
+resolution: >
+  Introduced SESSION_MESSAGE_COLUMNS constant to centralize the 9-column SELECT list
+  across all 10+ message queries, eliminating column-count drift. Added created_trace_id
+  to the Task struct and adjusted column ordinals. Propagated trace_id through
+  AgentRequest::CallbackResult into save_message_with_metadata. Surfaced messagesError in
+  TraceDetail.tsx. Added unit and integration tests for the fixed paths.
+---
+
+# SQL Column Mismatch Breaks Trace Detail View
+
+## Problem
+
+The dashboard's "Trace Detail" view was completely non-functional for displaying messages. Four symptoms were reported:
+
+1. Message 685 had no `trace_id` in the database
+2. Trace `f221c4ea...` showed nothing
+3. Trace `e5e8996e...` showed audit logs instead of expected messages
+4. Trace `64834561...` showed no message when it should show message 677
+
+## Root Cause Analysis
+
+The `get_messages_by_trace_id()` query in `crates/mika-agent/src/db.rs` selected **8 columns** but was passed to `row_to_session_message()`, which reads **9 columns** by positional index (0 through 8).
+
+The query was:
+```sql
+SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.created_at
+```
+
+Missing: `m.trace_id` at index 7.
+
+The `row_to_session_message` mapper expects:
+- 0: `id`, 1: `session_id`, 2: `agent_id`, 3: `role`, 4: `content`, 5: `channel_type`, 6: `metadata`, **7: `trace_id`**, 8: `created_at`
+
+**Cascade failure:** Because `m.trace_id` was omitted, `m.created_at` (an integer timestamp) landed at index 7 where `trace_id` (`Option<String>`) was expected. SQLite's dynamic typing allowed the integer-to-string coercion to silently succeed. However, `r.get::<_, i64>(8)` for `created_at` was out of bounds (only 8 columns, indices 0-7), causing a **runtime error on every call**. The dashboard endpoint returned 500 errors, and `TraceDetail.tsx` silently swallowed them because it only checked `eventsError`, not `messagesError`.
+
+Three secondary issues compounded the problem:
+
+- **`Task` struct missing `created_trace_id`**: The field existed in the DB schema (added in v4-v5 migration) and in `NewTask`, but `Task` (the read-back struct) and `row_to_task` omitted it, causing all subsequent column indices to be off by one.
+- **CLI callback trace_id not propagated**: `AgentRequest::CallbackResult` had no `trace_id` field, so callback result messages were saved with `trace_id: None`, making them invisible in trace views.
+- **Duplicated column lists**: The 9-column SELECT was hand-written across 10+ queries with no shared constant, making it easy for one query to drift.
+
+## Fixes Applied
+
+### 1. SQL column fix (`db.rs`)
+
+All queries using `row_to_session_message` now reference `SESSION_MESSAGE_COLUMNS`:
+
+```rust
+const SESSION_MESSAGE_COLUMNS: &'static str =
+    "m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at";
+```
+
+This follows the existing `TASK_COLUMNS` pattern. 10 queries updated.
+
+### 2. `Task` struct `created_trace_id` (`db.rs`)
+
+```rust
+pub struct Task {
+    // ...
+    pub created_by_session: Option<String>,
+    pub created_trace_id: Option<String>,  // added
+    pub created_at: i64,
+    // ...
+}
+```
+
+`row_to_task` updated with `created_trace_id` at index 20, shifting subsequent fields. `TASK_COLUMNS` and `TASK_COLUMN_COUNT` (26 -> 27) updated.
+
+### 3. CLI callback trace_id threading (`app.rs`, `chat.rs`)
+
+```rust
+// app.rs — enum variant
+AgentRequest::CallbackResult {
+    task_id: String,
+    label: String,
+    result: String,
+    trace_id: Option<String>,  // added
+}
+
+// app.rs — dispatch site
+trace_id: task.created_trace_id,  // propagate from task
+
+// chat.rs — message save
+save_message_with_metadata(..., trace_id.as_deref())  // was: None
+```
+
+### 4. Dashboard error surfacing (`TraceDetail.tsx`)
+
+```tsx
+const { data: messages, isLoading: messagesLoading, error: messagesError } = useTraceMessages(...)
+const error = eventsError || messagesError  // was: eventsError only
+```
+
+### 5. Clarifying comment (`db.rs`)
+
+Added `// no trace_id — summaries span multiple traces` on `replace_with_summary` to prevent future "fixes".
+
+## Prevention Strategies
+
+### Column constant pattern
+
+`SESSION_MESSAGE_COLUMNS` centralizes the column list. Any future column changes are single-point edits. The constant and mapper live adjacent in the code, making drift obvious during review. This mirrors `TASK_COLUMNS` which already existed for `row_to_task`.
+
+### Testing strategy
+
+Every new `pub` DB function returning a struct must have a roundtrip test. The missing test for `get_messages_by_trace_id` allowed this bug to ship. Two tests were added:
+
+- `test_get_messages_by_trace_id` in `db.rs` — unit test verifying query + deserialization
+- `test_trace_messages_returns_matching_messages` in `server/mod.rs` — integration test for the HTTP endpoint
+
+### Code review checklist
+
+When reviewing DB query changes:
+
+- [ ] Does the SELECT use the column constant (`SESSION_MESSAGE_COLUMNS`, `TASK_COLUMNS`)?
+- [ ] If hand-written, does it use a different mapper?
+- [ ] Is there a roundtrip test?
+- [ ] If a column was added/removed, was `*_COLUMN_COUNT` updated?
+
+### Future consideration: named column access
+
+`row.get("column_name")` instead of `row.get(N)` would eliminate positional mismatch entirely. `rusqlite` supports this. Recommended for new mappers; migrate existing ones opportunistically.
+
+## Test Coverage
+
+- `test_get_messages_by_trace_id` — insert message with trace_id, verify roundtrip, verify empty for nonexistent trace
+- `test_trace_messages_returns_matching_messages` — HTTP endpoint returns 200 with correct message data
+
+## Related Documentation
+
+- [trace-id-correlation-unified-observability.md](../architecture-patterns/trace-id-correlation-unified-observability.md) — Trace_id propagation architecture (v4-v5 schema migration)
+- [sqlite-datetime-format-mismatch.md](./sqlite-datetime-format-mismatch.md) — Similar class of silent query failure due to column type assumptions
+- [callback-resume-agent-lifecycle.md](../architecture/callback-resume-agent-lifecycle.md) — Callback task lifecycle and delivery paths
+- [callback-tui-delivery-polling.md](../architecture-patterns/callback-tui-delivery-polling.md) — TUI callback polling mechanism
+- [team-task-child-wrong-agent-id.md](./team-task-child-wrong-agent-id.md) — Related pattern: column/query mismatch causing silent failures

--- a/todos/643-complete-p2-session-message-columns-constant.md
+++ b/todos/643-complete-p2-session-message-columns-constant.md
@@ -1,0 +1,52 @@
+---
+status: complete
+priority: p2
+issue_id: 643
+tags: [code-review, architecture, database]
+dependencies: []
+---
+
+# Add SESSION_MESSAGE_COLUMNS constant to prevent SQL column mismatch bugs
+
+## Problem Statement
+
+The `row_to_session_message` function expects a 9-column SELECT in a specific order, but there is no shared constant like `TASK_COLUMNS` to enforce it. The 9-column SELECT string is repeated across 12+ call sites. The root-cause bug fixed in this PR (missing `m.trace_id` in `get_messages_by_trace_id`) was a direct consequence of this repetition — one query out of 12 had a typo.
+
+## Findings
+
+- `TASK_COLUMNS` constant + `TASK_COLUMN_COUNT` already solves this for the `Task` struct (27 columns, centralized)
+- `SessionMessage` has no equivalent — each call site manually writes `SELECT m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at`
+- 12+ queries use `row_to_session_message`: `load_recent_messages`, `load_conversation_summary`, `load_messages_before_window`, `load_messages_after`, `get_message_by_id`, `get_surrounding_messages`, `get_messages_since`, `get_messages_after_id`, `load_session_messages_paginated`, `get_messages_by_trace_id`, etc.
+- Flagged by: architecture-strategist, performance-oracle, pattern-recognition-specialist
+
+## Proposed Solutions
+
+### Option A: Add SESSION_MESSAGE_COLUMNS constant (Recommended)
+Add a `const SESSION_MESSAGE_COLUMNS: &str` similar to `TASK_COLUMNS`, and use it across all 12+ call sites.
+- Pros: Eliminates entire class of column mismatch bugs, follows existing `TASK_COLUMNS` pattern
+- Cons: Requires updating all 12+ call sites (mechanical change)
+- Effort: Medium
+- Risk: Low
+
+### Option B: Keep as-is with comment convention
+Add a comment above `row_to_session_message` documenting the expected column order.
+- Pros: Zero code change
+- Cons: Comments drift, doesn't prevent the bug class
+- Effort: Small
+- Risk: Medium (bug can recur)
+
+## Technical Details
+
+- **Affected files:** `crates/mika-agent/src/db.rs`
+- **Pattern to follow:** `TASK_COLUMNS` / `TASK_COLUMN_COUNT` / `row_to_task` triple
+
+## Acceptance Criteria
+
+- [ ] `SESSION_MESSAGE_COLUMNS` constant defined alongside `row_to_session_message`
+- [ ] All queries using `row_to_session_message` use the constant (with table alias prefix where needed)
+- [ ] All existing tests pass
+- [ ] No new queries can accidentally omit a column
+
+## Work Log
+
+- 2026-03-12: Created from code review of fix/trace-messages-endpoint branch

--- a/todos/644-pending-p3-message-response-missing-trace-id.md
+++ b/todos/644-pending-p3-message-response-missing-trace-id.md
@@ -1,0 +1,44 @@
+---
+status: pending
+priority: p3
+issue_id: 644
+tags: [code-review, dashboard, api]
+dependencies: []
+---
+
+# Add trace_id to MessageResponse and TraceMessage TypeScript type
+
+## Problem Statement
+
+The `MessageResponse` struct in `dashboard.rs` and the `TraceMessage` TypeScript interface in `timeline.ts` do not include a `trace_id` field. The DB query now correctly fetches `m.trace_id` (fixed in this PR), but it is dropped during `From<SessionMessage>` conversion. Not a functional issue today (the trace_id is in the URL path), but keeps API types incomplete.
+
+## Findings
+
+- `MessageResponse` struct at `crates/mika-agent/src/server/dashboard.rs:324-333` has no `trace_id`
+- `From<SessionMessage>` impl at line 335 silently drops `trace_id`
+- `TraceMessage` interface at `dashboard/src/api/timeline.ts:51-60` also lacks `trace_id`
+- Flagged by: architecture-strategist, agent-native-reviewer, security-sentinel, pattern-recognition-specialist
+
+## Proposed Solutions
+
+### Option A: Add trace_id to both (Recommended)
+Add `trace_id: Option<String>` to `MessageResponse` and `trace_id?: string` to `TraceMessage`.
+- Pros: API contract matches DB schema, enables future per-message trace linking
+- Cons: Slightly larger JSON payloads
+- Effort: Small
+- Risk: Low
+
+## Technical Details
+
+- **Affected files:** `crates/mika-agent/src/server/dashboard.rs`, `dashboard/src/api/timeline.ts`
+
+## Acceptance Criteria
+
+- [ ] `MessageResponse` includes `trace_id: Option<String>`
+- [ ] `From<SessionMessage>` maps `trace_id`
+- [ ] `TraceMessage` TypeScript interface includes `trace_id?: string`
+- [ ] Dashboard builds cleanly
+
+## Work Log
+
+- 2026-03-12: Created from code review of fix/trace-messages-endpoint branch

--- a/todos/645-pending-p3-get-session-messages-trace-id.md
+++ b/todos/645-pending-p3-get-session-messages-trace-id.md
@@ -1,0 +1,42 @@
+---
+status: pending
+priority: p3
+issue_id: 645
+tags: [code-review, agent-native, tools]
+dependencies: []
+---
+
+# Add trace_id to get_session_messages tool output
+
+## Problem Statement
+
+The `get_session_messages` tool formats messages as `[timestamp] role: content` but does not include the `trace_id`. The agent can cross-reference via `query_timeline` with trace_id filtering, but when browsing a session's messages, it cannot see which trace each message belongs to.
+
+## Findings
+
+- Tool at `crates/mika-agent/src/tools/get_session_messages.rs:98-107` formats output without trace_id
+- Agent has `query_timeline` for trace-based queries, so this is a convenience improvement
+- Flagged by: agent-native-reviewer
+
+## Proposed Solutions
+
+### Option A: Include trace_id in output when present
+Format as `[timestamp] role (trace:abcd...): content` when trace_id is Some.
+- Pros: Full introspection parity, helps agent correlate messages to traces
+- Cons: Slightly longer output
+- Effort: Small
+- Risk: Low
+
+## Technical Details
+
+- **Affected files:** `crates/mika-agent/src/tools/get_session_messages.rs`
+
+## Acceptance Criteria
+
+- [ ] Messages with trace_id show it in the output
+- [ ] Messages without trace_id display as before
+- [ ] Existing tests pass
+
+## Work Log
+
+- 2026-03-12: Created from code review of fix/trace-messages-endpoint branch


### PR DESCRIPTION
## Summary

- Fix `get_messages_by_trace_id()` SQL SELECT missing `m.trace_id` column — caused runtime error on every call, making the dashboard Trace Detail view non-functional
- Add `SESSION_MESSAGE_COLUMNS` constant to centralize the 9-column SELECT across 10+ queries, preventing this class of column mismatch bug
- Add `created_trace_id` to `Task` struct (was in DB schema but not read back), fix column index alignment
- Thread `trace_id` through CLI callback path so callback result messages are properly correlated
- Surface `messagesError` in dashboard `TraceDetail.tsx` (was silently swallowed)
- Add unit test for `get_messages_by_trace_id` and integration test for the trace messages endpoint

## Test plan

- [x] `cargo test` — all 1211 tests pass (867 mika-agent + 174 mika-common + 118 mika-cli + 52 mika-gateway)
- [x] `cargo clippy` — no warnings
- [x] `npm run build --prefix dashboard` — builds cleanly
- [ ] Manual: start mika-server + dashboard, send a message, click trace_id in timeline → messages should appear
- [x] New `test_get_messages_by_trace_id` verifies DB roundtrip
- [x] New `test_trace_messages_returns_matching_messages` verifies HTTP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)