### PR TITLE
fix(config): rename github_token to investigate_github_token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,10 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_OTLP_ENDPOINT=http://localhost:4318/v1/traces                       (Jaeger)
 # MIKA_OTLP_AUTH_HEADER=publicKey:secretKey  (raw or base64-encoded, Langfuse only)
 
-# Optional: GitHub token + repo for dashboard investigation issue creation
+# Optional: Investigation panel GitHub token + repo for dashboard issue creation
 # The investigation agent can create GitHub issues when both are set.
 # Token needs `repo` scope (private repos) or `public_repo` scope (public repos).
-# MIKA_GITHUB_TOKEN=ghp_...
+# MIKA_INVESTIGATE_GITHUB_TOKEN=ghp_...
 # MIKA_GITHUB_REPO=owner/repo
 
 # Optional: Dashboard CORS origin (default: http://localhost:5173)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,8 @@ Optional (Layer 3 vector search):
 Optional (web search):
 - `MIKA_BRAVE_API_KEY` — Brave Search API key for `web_search` builtin skill (get free key at https://brave.com/search/api/)
 
-Optional (dashboard investigation agent — GitHub issue creation):
-- `MIKA_GITHUB_TOKEN` — GitHub Personal Access Token (needs `repo` scope for private repos, `public_repo` for public)
+Optional (investigation panel — GitHub issue creation):
+- `MIKA_INVESTIGATE_GITHUB_TOKEN` — GitHub Personal Access Token for investigation panel issue creation (needs `repo` scope for private repos, `public_repo` for public)
 - `MIKA_GITHUB_REPO` — Target repository in `owner/repo` format (e.g. `senara-solutions/mika`). Both must be set to enable the `create_github_issue` investigation tool.
 
 Server mode additionally requires:

--- a/crates/mika-agent/src/server/investigate.rs
+++ b/crates/mika-agent/src/server/investigate.rs
@@ -547,7 +547,7 @@ impl Tool for CreateGithubIssueTool {
 pub struct InvestigationToolsConfig {
     pub agents: Arc<std::collections::HashMap<String, Arc<super::state::AgentState>>>,
     pub http_client: reqwest::Client,
-    pub github_token: Option<String>,
+    pub investigate_github_token: Option<String>,
     pub github_repo: Option<String>,
 }
 
@@ -563,7 +563,7 @@ fn build_investigation_tools(config: InvestigationToolsConfig) -> ToolRegistry {
     }));
 
     // Conditionally register GitHub issue creation tool
-    if let (Some(token), Some(repo)) = (config.github_token, config.github_repo)
+    if let (Some(token), Some(repo)) = (config.investigate_github_token, config.github_repo)
         && !token.is_empty()
         && !repo.is_empty()
     {
@@ -973,7 +973,8 @@ pub async fn handle_investigate(
     }
 
     // --- Check GitHub tool availability ---
-    let has_github = state.settings.github_token.is_some() && state.settings.github_repo.is_some();
+    let has_github =
+        state.settings.investigate_github_token.is_some() && state.settings.github_repo.is_some();
 
     // --- Build context ---
     let system_prompt = build_investigation_context(
@@ -996,14 +997,14 @@ pub async fn handle_investigate(
     // --- Lazy-init investigation tools ---
     // NOTE: Tool registry is immutable after first initialization. GitHub tool
     // availability is determined at the first investigation request. Config changes
-    // (e.g., setting MIKA_GITHUB_TOKEN) require a server restart to take effect.
+    // (e.g., setting MIKA_INVESTIGATE_GITHUB_TOKEN) require a server restart to take effect.
     let tools = state
         .investigation_tools
         .get_or_init(|| async {
             Arc::new(build_investigation_tools(InvestigationToolsConfig {
                 agents: state.agents.clone(),
                 http_client: state.http_client.clone(),
-                github_token: state.settings.github_token.clone(),
+                investigate_github_token: state.settings.investigate_github_token.clone(),
                 github_repo: state.settings.github_repo.clone(),
             }))
         })

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -632,7 +632,7 @@ mod tests {
                 embedding_model: "text-embedding-3-small".to_string(),
                 embedding_dimensions: 512,
                 brave_api_key: None,
-                github_token: None,
+                investigate_github_token: None,
                 github_repo: None,
                 home_dir: std::path::PathBuf::from("/tmp/mika-test"),
                 server_log_file: None,

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -183,7 +183,7 @@ pub mod test_helpers {
             embedding_model: "text-embedding-3-small".to_string(),
             embedding_dimensions: 512,
             brave_api_key: None,
-            github_token: None,
+            investigate_github_token: None,
             github_repo: None,
             home_dir: PathBuf::from("/tmp"),
             server_log_file: None,

--- a/crates/mika-agent/templates/skills/github/handlers/run.sh
+++ b/crates/mika-agent/templates/skills/github/handlers/run.sh
@@ -12,7 +12,7 @@ set -f  # Disable globbing for safe word splitting
 export GH_PROMPT_DISABLED=1
 
 # Scrub sensitive env vars so gh subprocesses cannot leak them
-unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY
+unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY MIKA_INVESTIGATE_GITHUB_TOKEN
 
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.command // empty')

--- a/crates/mika-agent/templates/skills/shell-exec/handlers/run.sh
+++ b/crates/mika-agent/templates/skills/shell-exec/handlers/run.sh
@@ -10,7 +10,7 @@ command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed
 INPUT=$(cat)
 
 # Scrub sensitive env vars so subprocesses cannot leak them
-unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY
+unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY MIKA_INVESTIGATE_GITHUB_TOKEN
 
 # Parse JSON fields
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.command // empty')

--- a/crates/mika-cli/src/commands/config.rs
+++ b/crates/mika-cli/src/commands/config.rs
@@ -138,33 +138,59 @@ async fn run_set(agent_name: &str, key: &str, value: Option<String>) -> Result<(
             println!("Set {key} = {val}");
         }
         ConfigBackend::Env => {
-            // Secret keys: never accept value from CLI args
-            if value.is_some() {
-                eprintln!("Warning: secret keys should not be passed as CLI arguments.");
-                eprintln!("The value argument will be ignored. You will be prompted securely.");
-            }
-
-            // Require TTY for interactive prompt
-            if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-                anyhow::bail!(
-                    "Secret keys require an interactive terminal.\n\
-                     Set {} as an environment variable instead.",
-                    info.env_var.unwrap_or("the corresponding MIKA_* var")
-                );
-            }
-
-            let secret = dialoguer::Password::new()
-                .with_prompt(format!("Enter value for {key}"))
-                .interact()?;
-
-            if secret.trim().is_empty() {
-                anyhow::bail!("Value cannot be empty");
-            }
-
             let env_key = info
                 .env_var
                 .ok_or_else(|| anyhow::anyhow!("No env var mapping for {key}"))?;
-            mika_common::dotenv::set_env_var(&ctx.global_home, env_key, &secret)?;
+
+            if info.secret {
+                // Secret keys: never accept value from CLI args
+                if value.is_some() {
+                    eprintln!("Warning: secret keys should not be passed as CLI arguments.");
+                    eprintln!("The value argument will be ignored. You will be prompted securely.");
+                }
+
+                if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                    anyhow::bail!(
+                        "Secret keys require an interactive terminal.\n\
+                         Set {} as an environment variable instead.",
+                        env_key
+                    );
+                }
+
+                let secret = dialoguer::Password::new()
+                    .with_prompt(format!("Enter value for {key}"))
+                    .interact()?;
+
+                if secret.trim().is_empty() {
+                    anyhow::bail!("Value cannot be empty");
+                }
+
+                mika_common::dotenv::set_env_var(&ctx.global_home, env_key, &secret)?;
+            } else {
+                // Non-secret env keys: accept CLI value or prompt with visible input
+                let val = match value {
+                    Some(v) => v,
+                    None => {
+                        if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                            anyhow::bail!(
+                                "Usage: mika config set {key} <value>\n\
+                                 Or set {} as an environment variable.",
+                                env_key
+                            );
+                        }
+                        dialoguer::Input::<String>::new()
+                            .with_prompt(format!("Enter value for {key}"))
+                            .interact_text()?
+                    }
+                };
+
+                if val.trim().is_empty() {
+                    anyhow::bail!("Value cannot be empty");
+                }
+
+                mika_common::dotenv::set_env_var(&ctx.global_home, env_key, val.trim())?;
+            }
+
             println!("Set {key} in ~/.mika/.env");
         }
         ConfigBackend::Database => {

--- a/crates/mika-cli/src/commands/doctor.rs
+++ b/crates/mika-cli/src/commands/doctor.rs
@@ -61,6 +61,18 @@ pub async fn run(args: DoctorArgs, agent_name: &str) -> Result<()> {
             &global_home,
             "web search disabled",
         ),
+        check_optional_key(
+            "GitHub token",
+            "MIKA_INVESTIGATE_GITHUB_TOKEN",
+            &global_home,
+            "dashboard issue creation disabled",
+        ),
+        check_optional_key(
+            "GitHub repo",
+            "MIKA_GITHUB_REPO",
+            &global_home,
+            "dashboard issue creation disabled",
+        ),
         check_jq(),
         check_mcp(&agent_home),
         check_skills(&agent_home),

--- a/crates/mika-cli/src/commands/setup.rs
+++ b/crates/mika-cli/src/commands/setup.rs
@@ -128,7 +128,23 @@ fn run_cli_prompts(
         )?;
     }
 
-    // 3. Telemetry
+    // 3. GitHub integration (optional)
+    if interactive && !secret_is_set("MIKA_INVESTIGATE_GITHUB_TOKEN") {
+        *env_written |= prompt_optional_secret(
+            home_dir,
+            "MIKA_INVESTIGATE_GITHUB_TOKEN",
+            "  GitHub token for dashboard issue creation (optional, press Enter to skip)",
+        )?;
+    }
+    if interactive && !secret_is_set("MIKA_GITHUB_REPO") {
+        *env_written |= prompt_optional_value(
+            home_dir,
+            "MIKA_GITHUB_REPO",
+            "  GitHub repo for dashboard issues, e.g. owner/repo (optional, press Enter to skip)",
+        )?;
+    }
+
+    // 4. Telemetry
     if interactive && !config_key_is_set(home_dir, "telemetry_enabled") {
         let enable = Confirm::new()
             .with_prompt("  Enable telemetry?")
@@ -161,7 +177,7 @@ fn run_cli_prompts(
         }
     }
 
-    // 4. Internal token (auto-generate, no prompt)
+    // 5. Internal token (auto-generate, no prompt)
     if !secret_is_set("MIKA_INTERNAL_TOKEN") {
         let token = generate_token();
         mika_common::dotenv::set_env_var(home_dir, "MIKA_INTERNAL_TOKEN", &token)?;
@@ -272,6 +288,20 @@ fn run_compose_generation() -> Result<()> {
         .interact()?;
     let openai_key = openai_key.trim();
 
+    let github_token = Password::new()
+        .with_prompt("  GitHub token for dashboard issue creation (optional, press Enter to skip)")
+        .allow_empty_password(true)
+        .interact()?;
+    let github_token = github_token.trim();
+
+    let github_repo: String = Input::new()
+        .with_prompt(
+            "  GitHub repo for dashboard issues, e.g. owner/repo (optional, press Enter to skip)",
+        )
+        .allow_empty(true)
+        .interact_text()?;
+    let github_repo = github_repo.trim().to_string();
+
     // --- Auto-generate tokens ---
     let internal_token = generate_token();
     let webhook_secret = generate_token();
@@ -291,6 +321,12 @@ fn run_compose_generation() -> Result<()> {
     }
     if !openai_key.is_empty() {
         lines.push(format!("MIKA_OPENAI_API_KEY={openai_key}"));
+    }
+    if !github_token.is_empty() {
+        lines.push(format!("MIKA_INVESTIGATE_GITHUB_TOKEN={github_token}"));
+    }
+    if !github_repo.is_empty() {
+        lines.push(format!("MIKA_GITHUB_REPO={github_repo}"));
     }
     lines.push(String::new());
 
@@ -363,6 +399,20 @@ fn prompt_optional_secret(home_dir: &Path, env_key: &str, prompt: &str) -> Resul
         .with_prompt(prompt)
         .allow_empty_password(true)
         .interact()?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(false);
+    }
+    mika_common::dotenv::set_env_var(home_dir, env_key, value)?;
+    Ok(true)
+}
+
+/// Prompt for an optional non-secret value with visible input. Returns true if a value was written.
+fn prompt_optional_value(home_dir: &Path, env_key: &str, prompt: &str) -> Result<bool> {
+    let value: String = Input::new()
+        .with_prompt(prompt)
+        .allow_empty(true)
+        .interact_text()?;
     let value = value.trim();
     if value.is_empty() {
         return Ok(false);

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -105,11 +105,11 @@ pub static CONFIG_KEYS: &[ConfigKeyInfo] = &[
         description: "Server internal auth token",
     },
     ConfigKeyInfo {
-        key: "github_token",
+        key: "investigate_github_token",
         backend: ConfigBackend::Env,
-        env_var: Some("MIKA_GITHUB_TOKEN"),
+        env_var: Some("MIKA_INVESTIGATE_GITHUB_TOKEN"),
         secret: true,
-        description: "GitHub token for dashboard issue creation",
+        description: "GitHub token for investigation panel issue creation",
     },
     ConfigKeyInfo {
         key: "github_repo",
@@ -168,7 +168,7 @@ pub fn get_effective_value(key: &str, settings: &Settings) -> Option<String> {
         "anthropic_api_key" => settings.anthropic_api_key.clone(),
         "openai_api_key" => settings.openai_api_key.clone(),
         "brave_api_key" => settings.brave_api_key.clone(),
-        "github_token" => settings.github_token.clone(),
+        "investigate_github_token" => settings.investigate_github_token.clone(),
         "github_repo" => settings.github_repo.clone(),
         "internal_token" => settings
             .internal_token
@@ -246,9 +246,9 @@ pub struct Settings {
     #[serde(default)]
     pub server_log_file: Option<PathBuf>,
 
-    /// GitHub Personal Access Token for dashboard investigation issue creation (optional)
+    /// GitHub Personal Access Token for investigation panel issue creation (optional)
     #[serde(default)]
-    pub github_token: Option<String>,
+    pub investigate_github_token: Option<String>,
 
     /// GitHub repository in owner/repo format for issue creation (optional)
     #[serde(default)]
@@ -418,8 +418,8 @@ impl std::fmt::Debug for Settings {
                 &self.brave_api_key.as_ref().map(|_| "[REDACTED]"),
             )
             .field(
-                "github_token",
-                &self.github_token.as_ref().map(|_| "[REDACTED]"),
+                "investigate_github_token",
+                &self.investigate_github_token.as_ref().map(|_| "[REDACTED]"),
             )
             .field("github_repo", &self.github_repo)
             .field("server_log_file", &self.server_log_file)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,12 +121,32 @@ existing shell environment variables. File permissions are set to `0600`.
 MIKA_ANTHROPIC_API_KEY=sk-ant-api03-...
 MIKA_OPENAI_API_KEY=sk-...
 MIKA_BRAVE_API_KEY=BSA...
+MIKA_INVESTIGATE_GITHUB_TOKEN=ghp_...
+MIKA_GITHUB_REPO=owner/repo
 ```
 
 Run `mika setup` to interactively configure secrets (API keys, tokens) and
 preferences (telemetry) — secrets are written to `~/.mika/.env`, config to
 `~/.mika/config.toml`. The wizard auto-generates `MIKA_INTERNAL_TOKEN` for
 server mode.
+
+### GitHub issue creation (dashboard investigation)
+
+The investigation panel can create GitHub issues when both `MIKA_INVESTIGATE_GITHUB_TOKEN`
+and `MIKA_GITHUB_REPO` are set. Steps:
+
+1. Create a GitHub Personal Access Token:
+   - **Fine-grained token** (recommended): Settings → Developer settings →
+     Fine-grained tokens → select your repo → Permissions → Issues: Read and Write
+   - **Classic token**: select `repo` scope (private repos) or `public_repo`
+     (public repos)
+2. Add to `~/.mika/.env`:
+   ```sh
+   MIKA_INVESTIGATE_GITHUB_TOKEN=ghp_your_token_here
+   MIKA_GITHUB_REPO=owner/repo
+   ```
+3. Restart mika-server (tool registry is lazily initialized on first
+   investigation request)
 
 ### Example: Override model in home config
 
@@ -183,7 +203,7 @@ Behavior depends on the key's backend:
 | Backend | Behavior |
 |---------|----------|
 | `File` | Writes to `{agent_home}/config.toml` (preserves comments, atomic write). Validates value format. |
-| `Env` | Prompts for value interactively (never accepts secrets as CLI arguments). Writes to `~/.mika/.env`. |
+| `Env` | Writes to `~/.mika/.env`. Secret keys prompt interactively via masked input (never accepts CLI arguments). Non-secret keys accept a CLI value or prompt with visible input. |
 | `Database` | Writes to the `customer_config` table in SQLite. |
 | `ReadOnly` | Rejected with an error. |
 
@@ -223,7 +243,7 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `embedding_model` | `String` | `text-embedding-3-small` | `MIKA_EMBEDDING_MODEL` | OpenAI embedding model ID. |
 | `embedding_dimensions` | `u32` | `512` | `MIKA_EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `brave_api_key` | `Option<String>` | None | `MIKA_BRAVE_API_KEY` | Brave Search API key for `web_search` builtin skill. Get a free key at https://brave.com/search/api/. |
-| `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for the dashboard investigation agent's issue creation tool. Needs `repo` scope for private repos or `public_repo` for public. Both `github_token` and `github_repo` must be set to enable the tool. |
+| `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
 | `internal_token` | `Option<SecretString>` | None | `MIKA_INTERNAL_TOKEN` | Shared bearer token for gateway-to-container auth. Must be exactly 64 hex characters (32 bytes hex-encoded). Required in server mode. Accepted on all routes (superuser). |
 | `dashboard_token` | `Option<SecretString>` | None | `MIKA_DASHBOARD_TOKEN` | Separate bearer token for read-only dashboard API routes (`/api/v1/*`). If unset, dashboard routes accept `internal_token` (backwards compatible). Only grants access to read-only routes — mutation endpoints (`/message`, `/tasks/{id}/complete`) still require `internal_token`. |
@@ -239,7 +259,7 @@ defaults to `~/.mika/`.
 
 ### Security notes
 
-- `anthropic_api_key`, `internal_token`, `dashboard_token`, `brave_api_key`, `github_token`, and `otlp_auth_header` are redacted in
+- `anthropic_api_key`, `internal_token`, `dashboard_token`, `brave_api_key`, `investigate_github_token`, and `otlp_auth_header` are redacted in
   `Debug` output (printed as `[REDACTED]`). The `mika config` command
   distinguishes between credential types: `OAuth token [REDACTED]` or
   `API key [REDACTED]`.
@@ -390,7 +410,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |
 | `MIKA_OPENAI_API_KEY` | No | OpenAI API key for Layer 3 vector search |
 | `MIKA_BRAVE_API_KEY` | No | Brave Search API key for web search skill |
-| `MIKA_GITHUB_TOKEN` | No | GitHub token for dashboard investigation issue creation |
+| `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |
 | `MIKA_DISABLE_BUNDLED_SKILLS` | No | Skip bundled skill re-sync on startup (default: false) |
 | `MIKA_TELEMETRY_ENABLED` | No | Enable OTel trace export (requires `--features telemetry` build) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,8 +160,10 @@ launches a guided wizard to configure secrets and preferences:
 The wizard prompts for:
 1. **Anthropic API key** (masked input)
 2. **Brave Search API key** (optional, masked)
-3. **Telemetry configuration** (OTLP endpoint and auth header if enabled)
-4. **Internal token** (auto-generated 64-char hex token for server mode)
+3. **GitHub token for investigation** (optional, masked — enables dashboard issue creation)
+4. **GitHub repo** (optional, visible — `owner/repo` format for issue creation)
+5. **Telemetry configuration** (OTLP endpoint and auth header if enabled)
+6. **Internal token** (auto-generated 64-char hex token for server mode)
 
 Each prompt is skipped if the value is already set (via environment variable or
 `~/.mika/.env`). Secrets are written to `~/.mika/.env` (0600 permissions);
@@ -182,7 +184,7 @@ configuration and only prompts for missing values.
 
 | Mode | Command | Purpose |
 |------|---------|---------|
-| `cli` (default) | `mika setup` | Configure API keys, telemetry, internal token |
+| `cli` (default) | `mika setup` | Configure API keys, GitHub config, telemetry, internal token |
 | `server` | `mika setup --mode server` | CLI config + routing URL, dashboard token |
 | `compose` | `mika setup --mode compose` | Generate a `.env` for docker-compose in CWD |
 

--- a/docs/solutions/architecture-patterns/conditional-investigation-tool-registration.md
+++ b/docs/solutions/architecture-patterns/conditional-investigation-tool-registration.md
@@ -6,7 +6,7 @@ category: architecture-patterns
 tags: [investigation, tools, conditional-registration, github-api, config-struct]
 modules:
   - mika-agent (server/investigate.rs — CreateGithubIssueTool, InvestigationToolsConfig, InvestigationParams)
-  - mika-common (config.rs — github_token, github_repo Settings fields)
+  - mika-common (config.rs — investigate_github_token, github_repo Settings fields)
 severity: low
 symptoms:
   - Investigation agent is purely read-only with no write actions
@@ -33,7 +33,7 @@ into `InvestigationToolsConfig`:
 ```rust
 struct InvestigationToolsConfig {
     http_client: reqwest::Client,
-    github_token: Option<String>,
+    investigate_github_token: Option<String>,
     github_repo: Option<String>,
 }
 ```
@@ -55,7 +55,7 @@ struct InvestigationParams<'a> {
 The GitHub issue tool is only registered when both env vars are set and valid:
 
 ```rust
-if let (Some(token), Some(repo)) = (config.github_token, config.github_repo)
+if let (Some(token), Some(repo)) = (config.investigate_github_token, config.github_repo)
     && !token.is_empty()
     && !repo.is_empty()
 {


### PR DESCRIPTION
## Summary

Closes #120

The investigation panel couldn't create GitHub issues because the config key `github_token` didn't match the env var `MIKA_INVESTIGATE_GITHUB_TOKEN`. This PR aligns the naming across all layers and adds setup/diagnostic support.

- **Config key rename:** `github_token` → `investigate_github_token` in Settings struct, config registry (`ConfigKeyInfo`), `investigate.rs`, and test utils
- **Env var scrubbing:** Updated `shell-exec` and `github` handler scripts to scrub `MIKA_INVESTIGATE_GITHUB_TOKEN`
- **Setup wizard:** Added GitHub token + repo prompts to both CLI (`--mode cli`) and compose (`--mode compose`) setup flows
- **Doctor command:** Added checks for `investigate_github_token` and `github_repo` configuration
- **Config set fix:** `ConfigBackend::Env` now uses visible input for non-secret keys (e.g. `github_repo`) instead of masked password prompt
- **Docs:** Updated `getting-started.md`, `configuration.md`, and solution doc with correct env var names
- **`.env.example`:** Renamed `MIKA_GITHUB_TOKEN` → `MIKA_INVESTIGATE_GITHUB_TOKEN`

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo test` passes
- [ ] `mika setup --mode cli` prompts for GitHub token and repo
- [ ] `mika doctor` shows GitHub token/repo check results
- [ ] `mika config set github_repo owner/repo` uses visible (not masked) input
- [ ] Investigation panel creates GitHub issues with correct env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)