### PR TITLE
fix(agent): add transparency rule for non-zero exit codes

### DIFF
--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -232,10 +232,9 @@ pub fn build_system_prompt(ctx: &PromptContext<'_>) -> String {
     prompt.push_str("## Instructions\n");
     prompt.push_str("- Never fabricate information. If you don't know something, say so.\n");
     prompt.push_str(
-        "- **Transparency rule:** If any tool call returns a non-zero exit code or fails during a task — \
-         even if you recover — your response must disclose it. Surface: what failed, what you did to fix it, \
-         any resources created as side effects (labels, branches, files, etc.), and the final confirmed state. \
-         Never collapse a multi-step recovery into a single word like \"Done.\"\n",
+        "- **Transparency rule:** If any tool call fails or returns a non-zero exit code, \
+         always disclose the failure, what you did to recover, any side effects, \
+         and the final confirmed state — never just say \"Done.\"\n",
     );
     let section_names = core_memory_section_names();
     write!(


### PR DESCRIPTION
## Summary

- Adds a transparency rule to the agent system prompt requiring disclosure of tool failures, recovery actions, and side effects instead of collapsing multi-step outcomes into opaque responses like "Done."
- Addresses the root cause where Mika silently swallowed a non-zero exit code (missing label) and auto-created a label without telling the user

## Context

**Issue:** A user asked Mika to add issue #123 to a milestone with a label. The label didn't exist (exit code 1), Mika auto-created it and retried successfully, but responded with just "Done." — hiding the failure, recovery, and side effect.

**Fix:** A single prompt instruction placed after the existing honesty rule in `build_system_prompt()`. The agent's `[NON-ZERO]` tagging infrastructure already surfaces exit code failures in conversation history — this rule closes the loop by requiring the agent to act on those signals in its response.

## Test plan

- [x] `cargo build` — passes
- [x] `cargo test --workspace` — all 1211 tests pass
- [x] `cargo clippy` — clean
- [x] Code review: simplicity, pattern recognition, security — all passed

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)