### PR TITLE
fix: [#144] set success=false when non_zero_exit is true

### DIFF
--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -141,8 +141,8 @@ pub struct ToolCallSummary {
     pub output_summary: String,
     pub success: bool,
     /// True when the tool output starts with a non-zero exit code prefix
-    /// (e.g. "Exit code: 1" or "Killed by signal: 9"). These are not errors
-    /// (`success` is still true) but indicate the subprocess exited non-zero.
+    /// (e.g. "Exit code: 1" or "Killed by signal: 9"). When set, `success`
+    /// is `false`. This field provides additional detail about *why* it failed.
     #[serde(default)]
     pub non_zero_exit: bool,
 }
@@ -271,10 +271,10 @@ pub fn format_tool_summary_block(metadata_json: &str) -> Option<String> {
                 .get("non_zero_exit")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let status = if !success {
-                " [FAILED]"
-            } else if non_zero_exit {
+            let status = if non_zero_exit {
                 " [NON-ZERO]"
+            } else if !success {
+                " [FAILED]"
             } else {
                 ""
             };
@@ -302,10 +302,10 @@ fn format_step_exceeded_fallback(summaries: &[ToolCallSummary]) -> String {
     let mut msg = String::from("I ran out of steps working on that. Here's what I did:\n");
     let start = summaries.len().saturating_sub(5);
     for s in &summaries[start..] {
-        let status = if !s.success {
-            "failed"
-        } else if s.non_zero_exit {
+        let status = if s.non_zero_exit {
             "non-zero exit"
+        } else if !s.success {
+            "failed"
         } else {
             "done"
         };
@@ -1014,7 +1014,7 @@ async fn process_tool_calls(
                 name: name.clone(),
                 input_summary,
                 output_summary,
-                success: !output.is_error,
+                success: !output.is_error && !non_zero_exit,
                 non_zero_exit,
             });
 
@@ -2288,8 +2288,21 @@ mod tests {
     }
 
     #[test]
-    fn test_format_tool_summary_block_non_zero_exit() {
+    fn test_format_tool_summary_block_non_zero_exit_old_format() {
+        // Backward compat: old metadata had success: true with non_zero_exit: true
         let json = r#"{"tool_calls":[{"step":0,"name":"shell_exec","input_summary":"grep foo","output_summary":"Exit code: 1\nno matches","success":true,"non_zero_exit":true}]}"#;
+        let block = format_tool_summary_block(json).unwrap();
+        assert!(
+            block.contains("[NON-ZERO]"),
+            "expected [NON-ZERO] tag in: {block}"
+        );
+        assert!(!block.contains("[FAILED]"));
+    }
+
+    #[test]
+    fn test_format_tool_summary_block_non_zero_exit_new_format() {
+        // New format: success is false when non_zero_exit is true
+        let json = r#"{"tool_calls":[{"step":0,"name":"shell_exec","input_summary":"grep foo","output_summary":"Exit code: 1\nno matches","success":false,"non_zero_exit":true}]}"#;
         let block = format_tool_summary_block(json).unwrap();
         assert!(
             block.contains("[NON-ZERO]"),
@@ -2318,13 +2331,32 @@ mod tests {
     }
 
     #[test]
-    fn test_format_step_exceeded_fallback_non_zero_exit() {
+    fn test_format_step_exceeded_fallback_non_zero_exit_old_format() {
+        // Backward compat: old metadata had success: true with non_zero_exit: true
         let summaries = vec![ToolCallSummary {
             step: 0,
             name: "shell_exec".to_string(),
             input_summary: "grep foo".to_string(),
             output_summary: "Exit code: 1".to_string(),
             success: true,
+            non_zero_exit: true,
+        }];
+        let result = format_step_exceeded_fallback(&summaries);
+        assert!(
+            result.contains("- shell_exec (non-zero exit)"),
+            "expected non-zero exit status in: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_step_exceeded_fallback_non_zero_exit_new_format() {
+        // New format: success is false when non_zero_exit is true
+        let summaries = vec![ToolCallSummary {
+            step: 0,
+            name: "shell_exec".to_string(),
+            input_summary: "grep foo".to_string(),
+            output_summary: "Exit code: 1".to_string(),
+            success: false,
             non_zero_exit: true,
         }];
         let result = format_step_exceeded_fallback(&summaries);

--- a/docs/plans/2026-03-13-001-fix-tool-call-success-contradicts-non-zero-exit-plan.md
+++ b/docs/plans/2026-03-13-001-fix-tool-call-success-contradicts-non-zero-exit-plan.md
@@ -1,0 +1,90 @@
+---
+title: "fix: tool call success flag contradicts non_zero_exit"
+type: fix
+status: completed
+date: 2026-03-13
+---
+
+# fix: tool call success flag contradicts non_zero_exit
+
+## Overview
+
+`ToolCallSummary.success` is set to `true` even when `non_zero_exit` is `true`, creating contradictory metadata. This affects **all tools using exec handlers** (shell-exec, github CLI, file-reader, and any marketplace skill with exec handlers) — not just `read_file`.
+
+**Root cause:** In `process_tool_calls()` (`agent.rs:1017`), `success` was derived solely from `!output.is_error`. Exec handlers deliberately return `ToolOutput::success()` for non-zero exits (because tools like grep use exit code 1 for non-error conditions), so `is_error` is always `false` for subprocess results.
+
+**GitHub Issue:** #144
+
+## Proposed Solution
+
+Three-part fix:
+1. **Write side** — make `success` consider `non_zero_exit` (already done in working tree)
+2. **Read side** — reorder conditionals in both formatting functions to check `non_zero_exit` before `!success`, preserving the `[NON-ZERO]` vs `[FAILED]` distinction
+3. **Tests** — update existing tests and add backward-compatibility coverage
+
+## System-Wide Impact
+
+- **Affected code paths:** `process_tool_calls` (write), `format_tool_summary_block` (history context injection), `format_step_exceeded_fallback` (max-steps fallback). All in `crates/mika-agent/src/agent.rs`.
+- **Affected tools:** All exec-handler-based tools — shell-exec, github CLI (`builtin_handlers.rs:386`), file-reader, and any skill with `handler = "exec"`.
+- **Silent/heartbeat mode:** Uses same `process_tool_calls` — fix propagates automatically.
+- **Team engine:** Delegates to same tool loop — fix propagates automatically.
+- **Backward compatibility:** Old DB rows may have `success: true, non_zero_exit: true`. Reordering the read-side conditionals handles both old and new data correctly.
+- **Dashboard:** Frontend `parseToolCalls()` reads `success` and `non_zero_exit` independently — no dashboard changes needed.
+
+## Acceptance Criteria
+
+- [x] `success` is `false` whenever `non_zero_exit` is `true` in newly-written metadata (`agent.rs:1017`)
+- [x] `format_tool_summary_block` shows `[NON-ZERO]` (not `[FAILED]`) for non-zero exit entries — both old format (`success: true, non_zero_exit: true`) and new format (`success: false, non_zero_exit: true`)
+- [x] `format_step_exceeded_fallback` shows `"non-zero exit"` (not `"failed"`) for non-zero exit entries — both formats
+- [x] Doc comment on `non_zero_exit` field updated to reflect new semantics
+- [x] Tests cover both old-format and new-format metadata
+- [x] `cargo test` passes
+- [x] `cargo clippy` clean
+
+## MVP
+
+### 1. Write side — `process_tool_calls` (`agent.rs:1017`)
+
+Already done in working tree:
+
+```rust
+success: !output.is_error && !non_zero_exit,
+```
+
+### 2. Read side — `format_tool_summary_block` (`agent.rs:274-280`)
+
+Reorder to check `non_zero_exit` first:
+
+```rust
+let status = if non_zero_exit {
+    " [NON-ZERO]"
+} else if !success {
+    " [FAILED]"
+} else {
+    ""
+};
+```
+
+### 3. Read side — `format_step_exceeded_fallback` (`agent.rs:305-311`)
+
+Same reorder:
+
+```rust
+let status = if s.non_zero_exit {
+    "non-zero exit"
+} else if !s.success {
+    "failed"
+} else {
+    "done"
+};
+```
+
+### 4. Tests (`agent.rs:~2292, ~2321`)
+
+Update existing test JSON to use new-format data (`success: false, non_zero_exit: true`) and add backward-compat tests with old-format data (`success: true, non_zero_exit: true`). Both should assert `[NON-ZERO]` appears.
+
+## Sources
+
+- Related issue: #144
+- Institutional learning: `docs/solutions/logic-errors/exec-handler-stdout-discarded-on-nonzero-exit.md`
+- Institutional learning: `docs/solutions/ui-bugs/dashboard-tool-calls-tabular-ux.md`

--- a/docs/solutions/logic-errors/tool-call-success-contradicts-non-zero-exit.md
+++ b/docs/solutions/logic-errors/tool-call-success-contradicts-non-zero-exit.md
@@ -1,0 +1,57 @@
+---
+title: "ToolCallSummary success flag contradicts non_zero_exit"
+category: logic-errors
+date: 2026-03-13
+severity: medium
+module: crates/mika-agent/src/agent.rs
+issue: "#144"
+tags: [tool-metadata, non-zero-exit, exec-handler, observability]
+---
+
+## Problem
+
+`ToolCallSummary` reported `success: true` alongside `non_zero_exit: true` — a contradictory state. Any tool using exec handlers (shell-exec, github CLI, file-reader, marketplace skills) could produce this combination because exec handlers return `ToolOutput::success()` for non-zero exits (by design — grep uses exit code 1 for "no matches").
+
+The `success` field in `ToolCallSummary` was derived solely from `!output.is_error`, ignoring the `non_zero_exit` heuristic.
+
+## Root Cause
+
+In `process_tool_calls()` (agent.rs:1017), `success` was set to `!output.is_error` without considering `non_zero_exit`. Since exec handlers deliberately return `ToolOutput::success()` for non-zero exits (the exit code is data for the agent to interpret, not an execution error), `is_error` was always `false` for subprocess results — even when the process exited non-zero.
+
+Additionally, two reading functions (`format_tool_summary_block` and `format_step_exceeded_fallback`) checked `!success` before `non_zero_exit`, meaning after fixing the write side, non-zero exits would display as `[FAILED]` instead of `[NON-ZERO]`.
+
+## Solution
+
+Three-part fix in `crates/mika-agent/src/agent.rs`:
+
+**1. Write side** — make `success` consider `non_zero_exit`:
+```rust
+// Before
+success: !output.is_error,
+// After
+success: !output.is_error && !non_zero_exit,
+```
+
+**2. Read side** — reorder conditionals to check `non_zero_exit` first (preserves `[NON-ZERO]` vs `[FAILED]` distinction for both old and new metadata):
+```rust
+// Before: !success checked first, non_zero_exit unreachable for new data
+let status = if !success { " [FAILED]" } else if non_zero_exit { " [NON-ZERO]" } else { "" };
+// After: non_zero_exit checked first, works for both old and new data
+let status = if non_zero_exit { " [NON-ZERO]" } else if !success { " [FAILED]" } else { "" };
+```
+
+Applied to both `format_tool_summary_block` (history context injection) and `format_step_exceeded_fallback` (max-steps fallback).
+
+**3. Tests** — added backward-compat tests (old format: `success: true, non_zero_exit: true`) alongside new-format tests (`success: false, non_zero_exit: true`). Both assert `[NON-ZERO]` appears.
+
+## Prevention
+
+- When adding boolean flags to serialized structs, consider all consumers (write path + every read path) and ensure invariants are maintained across all of them.
+- When a derived field (`success`) depends on multiple inputs (`is_error`, `non_zero_exit`), encode the full derivation at the construction site — don't leave it to readers to combine fields.
+- Test backward compatibility with old serialized data whenever changing field semantics on persisted structs.
+
+## Related
+
+- `docs/solutions/logic-errors/exec-handler-stdout-discarded-on-nonzero-exit.md` — the original fix that introduced `non_zero_exit` and the `ToolOutput::success()` pattern for non-zero exits
+- `docs/solutions/logic-errors/tool-calls-metadata-tail-drop-loses-entries.md` — metadata serialization pipeline
+- `docs/solutions/ui-bugs/dashboard-tool-calls-tabular-ux.md` — dashboard consumption of `ToolCallSummary`


### PR DESCRIPTION
## Summary

- **Bug:** `ToolCallSummary` reported `success: true` alongside `non_zero_exit: true` — contradictory metadata affecting all exec-handler-based tools (shell-exec, github CLI, file-reader, marketplace skills)
- **Root cause:** `success` was derived solely from `!output.is_error`, ignoring the `non_zero_exit` heuristic
- **Fix:** Include `non_zero_exit` in success derivation, reorder read-side conditionals to preserve `[NON-ZERO]` vs `[FAILED]` distinction, add backward-compat tests

## Changes

1. **Write side** (`process_tool_calls`): `success: !output.is_error` → `success: !output.is_error && !non_zero_exit`
2. **Read side** (`format_tool_summary_block`, `format_step_exceeded_fallback`): Check `non_zero_exit` before `!success` so both old-format (`success: true, non_zero_exit: true`) and new-format (`success: false, non_zero_exit: true`) metadata correctly displays `[NON-ZERO]`
3. **Tests:** Backward-compat tests for old DB metadata + new-format tests

## Test plan

- [x] All 14 related tests pass (old-format, new-format, missing-field backward compat)
- [x] `cargo test -p mika-agent` passes
- [x] `cargo clippy -p mika-agent` clean
- [ ] Verify dashboard shows tool call status correctly with existing DB data

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)