### PR TITLE
fix: [#185] fix broken "View Full Logs" link on dashboard

### DIFF
--- a/dashboard/src/pages/AgentDetail.tsx
+++ b/dashboard/src/pages/AgentDetail.tsx
@@ -189,9 +189,12 @@ export default function AgentDetail() {
             ))}
             {audit.total > 5 && (
               <div className="text-center pt-2">
-                <span className="text-xs text-accent hover:text-accent-light cursor-pointer">
+                <Link
+                  to={`/?event_type=audit&agent_id=${agentId}`}
+                  className="text-xs text-accent hover:text-accent-light transition-colors"
+                >
                   View Full Logs ({audit.total} total)
-                </span>
+                </Link>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Replace non-functional `<span>` with a React Router `<Link>` in the Recent Audit Events card on the Agent Detail page
- Clicking "View Full Logs (N total)" now navigates to the Timeline page (`/`) pre-filtered to `event_type=audit` and the current `agent_id`
- The Timeline page already supports these filters with full pagination, search, and agent/event-type dropdowns

## What was broken

The "View Full Logs" element was a `<span>` with `cursor-pointer` styling but no `onClick` handler or navigation — purely decorative.

## Fix

Replaced with `<Link to={...}>` using existing React Router infrastructure. No new routes, components, or API changes needed.

Closes #185

## Test plan

- [ ] Navigate to Agent Detail page for an agent with >5 audit events
- [ ] Verify "View Full Logs (N total)" link appears
- [ ] Click the link — should navigate to Timeline page
- [ ] Verify Timeline shows audit events filtered to that agent (both dropdowns pre-selected)
- [ ] Verify the link has proper hover styling and cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)