### PR TITLE
feat(llm): add first-class MiniMax, Qwen, and Kimi provider prefixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,17 @@ MIKA_LLM_API_KEY=sk-ant-...
 # MIKA_BRAVE_API_KEY=BSA...
 
 # Optional: Override defaults (see ~/.mika/config.toml for non-secret settings)
-# MIKA_LLM_MODEL=claude-sonnet-4-6     # or use provider prefix: openai/gpt-4o, ollama/llama3
+# MIKA_LLM_MODEL=claude-sonnet-4-6     # default (Anthropic)
+# Provider prefixes with built-in base URLs:
+#   openai/gpt-4o              — OpenAI
+#   ollama/llama3              — Ollama (local)
+#   groq/llama-3.1-70b         — Groq
+#   minimax/MiniMax-M2.5       — MiniMax ($0.25/$1.20 per 1M tokens, best tool calling)
+#   qwen/qwen3.5-plus          — Qwen ($0.26/$1.56 per 1M tokens, best open-source agentic)
+#   kimi/kimi-k2.5             — Kimi ($0.60/$2.50 per 1M tokens, best coding)
+#   openai-compatible/<model>  — any OpenAI-compatible API (requires MIKA_LLM_BASE_URL)
 # MIKA_LLM_MAX_TOKENS=4096
-# MIKA_LLM_BASE_URL=http://localhost:11434/v1  # Override base URL for OpenAI-compatible providers
+# MIKA_LLM_BASE_URL=http://localhost:11434/v1  # Override base URL (only needed for openai-compatible/)
 # MIKA_DB_PATH=mika.db
 # MIKA_LOG_LEVEL=info
 # MIKA_LOG_FORMAT=json                  # json (default) or pretty (human-readable, for local dev)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 
 - **Language:** Rust (edition 2024)
 - **Agent engine:** Explicit Rust loop (no framework) — retrieve context → build prompt → LLM API → match stop_reason → execute tools or respond
-- **LLM:** Multi-provider via `LlmProvider` trait — Anthropic (default, Claude Sonnet 4.6), OpenAI-compatible (OpenAI, Ollama, vLLM, Groq, Together). Provider selected by `llm_model` config with `provider/model` prefix (e.g., `openai/gpt-4o`, `ollama/llama3`). No prefix defaults to Anthropic.
+- **LLM:** Multi-provider via `LlmProvider` trait — Anthropic (default, Claude Sonnet 4.6), OpenAI-compatible (OpenAI, Ollama, vLLM, Groq, Together), plus first-class MiniMax (`minimax/`), Qwen (`qwen/`), and Kimi (`kimi/`) with built-in base URLs. Provider selected by `llm_model` config with `provider/model` prefix (e.g., `openai/gpt-4o`, `minimax/MiniMax-M2.5`, `ollama/llama3`). No prefix defaults to Anthropic.
 - **Database:** SQLite via rusqlite (single DB per container at `~/.mika/data/mika.db`)
 - **HTTP server:** Axum 0.8 (mika-server binary) with tower-http middleware
 - **HTTP client:** reqwest 0.12 with rustls-tls (Claude API client with typed errors and retry)

--- a/crates/mika-cli/src/cli.rs
+++ b/crates/mika-cli/src/cli.rs
@@ -537,6 +537,9 @@ pub const MODEL_ALIASES: &[(&str, &str, &str)] = &[
     ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
     ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
     ("haiku", "claude-haiku-4-5", "Claude Haiku 4.5"),
+    ("minimax", "minimax/MiniMax-M2.5", "MiniMax M2.5"),
+    ("qwen", "qwen/qwen3.5-plus", "Qwen 3.5 Medium"),
+    ("kimi", "kimi/kimi-k2.5", "Kimi K2.5"),
 ];
 
 /// Resolve a model alias (e.g., "sonnet") to its full model ID (e.g., "claude-sonnet-4-6").

--- a/crates/mika-common/src/llm/mod.rs
+++ b/crates/mika-common/src/llm/mod.rs
@@ -77,6 +77,9 @@ pub enum ProviderKind {
     OpenAi,
     Ollama,
     Groq,
+    MiniMax,
+    Qwen,
+    Kimi,
     /// Generic OpenAI-compatible provider with a custom base URL.
     OpenAiCompatible,
 }
@@ -88,6 +91,9 @@ impl std::fmt::Display for ProviderKind {
             ProviderKind::OpenAi => write!(f, "openai"),
             ProviderKind::Ollama => write!(f, "ollama"),
             ProviderKind::Groq => write!(f, "groq"),
+            ProviderKind::MiniMax => write!(f, "minimax"),
+            ProviderKind::Qwen => write!(f, "qwen"),
+            ProviderKind::Kimi => write!(f, "kimi"),
             ProviderKind::OpenAiCompatible => write!(f, "openai-compatible"),
         }
     }
@@ -118,10 +124,13 @@ impl ModelSpec {
                 "openai" => ProviderKind::OpenAi,
                 "ollama" => ProviderKind::Ollama,
                 "groq" => ProviderKind::Groq,
+                "minimax" => ProviderKind::MiniMax,
+                "qwen" => ProviderKind::Qwen,
+                "kimi" => ProviderKind::Kimi,
                 "openai-compatible" => ProviderKind::OpenAiCompatible,
                 _ => bail!(
                     "unknown provider prefix '{prefix}'. \
-                     Known prefixes: anthropic, openai, ollama, groq, openai-compatible"
+                     Known prefixes: anthropic, openai, ollama, groq, minimax, qwen, kimi, openai-compatible"
                 ),
             };
             (provider, model.to_string())
@@ -157,6 +166,9 @@ impl ModelSpec {
             ProviderKind::OpenAi => Some("https://api.openai.com/v1"),
             ProviderKind::Ollama => Some("http://localhost:11434/v1"),
             ProviderKind::Groq => Some("https://api.groq.com/openai/v1"),
+            ProviderKind::MiniMax => Some("https://api.minimax.chat/v1"),
+            ProviderKind::Qwen => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+            ProviderKind::Kimi => Some("https://api.moonshot.ai/v1"),
             ProviderKind::OpenAiCompatible => None, // requires explicit base_url
         }
     }
@@ -187,6 +199,9 @@ pub fn create_provider(spec: &ModelSpec, max_tokens: u32) -> Result<Arc<dyn LlmP
         ProviderKind::OpenAi
         | ProviderKind::Ollama
         | ProviderKind::Groq
+        | ProviderKind::MiniMax
+        | ProviderKind::Qwen
+        | ProviderKind::Kimi
         | ProviderKind::OpenAiCompatible => {
             if matches!(spec.provider, ProviderKind::OpenAiCompatible) {
                 tracing::warn!(
@@ -310,13 +325,69 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_minimax_prefix() {
+        let spec = ModelSpec::parse("minimax/MiniMax-M2.5").unwrap();
+        assert_eq!(spec.provider, ProviderKind::MiniMax);
+        assert_eq!(spec.model, "MiniMax-M2.5");
+    }
+
+    #[test]
+    fn test_parse_qwen_prefix() {
+        let spec = ModelSpec::parse("qwen/qwen3.5-plus").unwrap();
+        assert_eq!(spec.provider, ProviderKind::Qwen);
+        assert_eq!(spec.model, "qwen3.5-plus");
+    }
+
+    #[test]
+    fn test_parse_kimi_prefix() {
+        let spec = ModelSpec::parse("kimi/kimi-k2.5").unwrap();
+        assert_eq!(spec.provider, ProviderKind::Kimi);
+        assert_eq!(spec.model, "kimi-k2.5");
+    }
+
+    #[test]
+    fn test_default_base_urls_new_providers() {
+        let spec = ModelSpec::parse("minimax/MiniMax-M2.5").unwrap();
+        assert_eq!(spec.default_base_url(), Some("https://api.minimax.chat/v1"));
+
+        let spec = ModelSpec::parse("qwen/qwen3.5-plus").unwrap();
+        assert_eq!(
+            spec.default_base_url(),
+            Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
+        );
+
+        let spec = ModelSpec::parse("kimi/kimi-k2.5").unwrap();
+        assert_eq!(spec.default_base_url(), Some("https://api.moonshot.ai/v1"));
+    }
+
+    #[test]
+    fn test_openai_compatible_still_works() {
+        let spec = ModelSpec::parse("openai-compatible/custom-model").unwrap();
+        assert_eq!(spec.provider, ProviderKind::OpenAiCompatible);
+        assert_eq!(spec.model, "custom-model");
+        assert_eq!(spec.default_base_url(), None);
+    }
+
+    #[test]
     fn test_provider_kind_display() {
         assert_eq!(ProviderKind::Anthropic.to_string(), "anthropic");
         assert_eq!(ProviderKind::OpenAi.to_string(), "openai");
         assert_eq!(ProviderKind::Ollama.to_string(), "ollama");
+        assert_eq!(ProviderKind::MiniMax.to_string(), "minimax");
+        assert_eq!(ProviderKind::Qwen.to_string(), "qwen");
+        assert_eq!(ProviderKind::Kimi.to_string(), "kimi");
         assert_eq!(
             ProviderKind::OpenAiCompatible.to_string(),
             "openai-compatible"
         );
+    }
+
+    #[test]
+    fn test_unknown_prefix_lists_new_providers() {
+        let err = ModelSpec::parse("unknown/model").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("minimax"), "error should list minimax");
+        assert!(msg.contains("qwen"), "error should list qwen");
+        assert!(msg.contains("kimi"), "error should list kimi");
     }
 }

--- a/crates/mika-common/src/llm/openai.rs
+++ b/crates/mika-common/src/llm/openai.rs
@@ -268,6 +268,9 @@ impl LlmProvider for OpenAiCompatibleProvider {
             ProviderKind::OpenAi => "openai",
             ProviderKind::Ollama => "ollama",
             ProviderKind::Groq => "groq",
+            ProviderKind::MiniMax => "minimax",
+            ProviderKind::Qwen => "qwen",
+            ProviderKind::Kimi => "kimi",
             _ => "openai-compatible",
         }
     }
@@ -285,9 +288,10 @@ impl LlmProvider for OpenAiCompatibleProvider {
     }
 
     fn supports_vision(&self) -> bool {
-        // Most OpenAI-compatible providers support vision for their multimodal models.
-        // Conservative default; can be made configurable later.
-        matches!(self.provider_kind, ProviderKind::OpenAi)
+        matches!(
+            self.provider_kind,
+            ProviderKind::OpenAi | ProviderKind::MiniMax | ProviderKind::Qwen | ProviderKind::Kimi
+        )
     }
 
     fn supports_extended_thinking(&self) -> bool {

--- a/docs/brainstorms/2026-03-18-openai-migration-brainstorm.md
+++ b/docs/brainstorms/2026-03-18-openai-migration-brainstorm.md
@@ -1,0 +1,119 @@
+# Brainstorm: Migrating from Anthropic OAuth to Alternative LLM Providers
+
+**Date:** 2026-03-18
+**Status:** Decided
+
+## Context
+
+Anthropic blocked OAuth tokens (`sk-ant-oat*`) for third-party applications on January 9, 2026 — they now only work with Claude Code and Claude.ai. This is a server-side policy enforcement with no workaround. The user needs a cost-effective alternative that supports Mika's full agent features (memory, tasks, skills, team delegation) with reliable tool calling.
+
+## What We're Building
+
+No code changes initially. This is a configuration migration guide and provider evaluation. First-class provider prefixes (e.g., `minimax/`, `qwen/`, `kimi/`) will be considered after hands-on testing validates tool calling quality.
+
+## Provider Comparison
+
+### MiniMax M2.5
+
+- **Pricing:** $0.25/M input, $1.20/M output (~$3-7/month for daily use)
+- **Tool calling:** BFCL score 76.8 — #1 in multi-turn function calling, outperforms Claude 4.6 and Gemini 3 Pro
+- **Context window:** 197K tokens
+- **Vision:** Yes
+- **OpenAI-compatible:** Yes
+- **Standout:** Best multi-turn tool calling reliability. ~20% fewer rounds than predecessors for same results.
+
+**Mika config:**
+```bash
+MIKA_LLM_MODEL=openai-compatible/MiniMax-M2.5
+MIKA_LLM_BASE_URL=https://api.minimax.chat/v1
+MIKA_LLM_API_KEY=<minimax-key>
+```
+
+### Qwen 3.5 Medium (122B-A10B)
+
+- **Pricing:** $0.26/M input, $1.56/M output (~$3-8/month for daily use)
+- **Tool calling:** BFCL-V4 score 72.2 — outperforms GPT-5 mini by 30%
+- **Context window:** 128K+ tokens
+- **Vision:** Yes
+- **OpenAI-compatible:** Yes
+- **Standout:** Best open-source agentic benchmarks. Alibaba-backed with strong ecosystem (Qwen-Agent framework).
+
+**Mika config:**
+```bash
+MIKA_LLM_MODEL=openai-compatible/qwen3.5-plus
+MIKA_LLM_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+MIKA_LLM_API_KEY=<dashscope-key>
+```
+
+### Kimi K2.5
+
+- **Pricing:** $0.60/M input, $2.50/M output (~$5-12/month for daily use)
+- **Tool calling:** Strong (SWE-bench Verified 76.8%, competitive with Claude Opus 4.5)
+- **Context window:** 128K+ tokens
+- **Vision:** Yes (native multimodal — trained on 15T mixed visual+text tokens)
+- **OpenAI-compatible:** Yes
+- **Standout:** Best coding/SWE benchmarks. Native visual agentic intelligence. Agent swarm paradigm.
+
+**Mika config:**
+```bash
+MIKA_LLM_MODEL=openai-compatible/kimi-k2.5
+MIKA_LLM_BASE_URL=https://api.moonshot.ai/v1
+MIKA_LLM_API_KEY=<moonshot-key>
+```
+
+### Reference: OpenAI GPT-4o-mini
+
+- **Pricing:** $0.15/M input, $0.60/M output (~$2-5/month)
+- **Tool calling:** Good but not top-tier on recent BFCL
+- **Context window:** 128K tokens
+- **Vision:** No (use gpt-4o for vision)
+- **Standout:** Cheapest option, already first-class in Mika (`openai/gpt-4o-mini`)
+
+## Recommendation Matrix
+
+| Priority | Best Pick | Why |
+|----------|-----------|-----|
+| **Tool calling reliability** | MiniMax M2.5 | #1 BFCL multi-turn score (76.8), critical for Mika's 10-tool agent loop |
+| **Cheapest** | OpenAI GPT-4o-mini | $0.15/$0.60 per 1M tokens, already first-class support |
+| **Best all-rounder** | Qwen 3.5 Medium | Strong agentic benchmarks + vision + reasonable price |
+| **Best for coding tasks** | Kimi K2.5 | SWE-bench leader, strong visual coding |
+
+**Primary recommendation: MiniMax M2.5** — Mika's value comes from its tool-heavy agent loop (memory, tasks, skills, delegation). The #1 multi-turn tool calling score directly maps to what matters most. Price is competitive.
+
+**Fallback: Qwen 3.5 Medium** — If MiniMax has availability issues or regional restrictions, Qwen is the next best for agentic tool use with Alibaba's infrastructure backing.
+
+## Known Limitations (All Non-Claude Providers)
+
+- **No extended thinking** — Claude-only feature, silently skipped
+- **No prompt caching** — Full token cost every turn (mitigated by cheaper token prices)
+- **System prompt adherence** — Mika's system prompt is large and complex; may need testing
+- **Team orchestration risk** — Multi-agent delegation requires precise structured output; test thoroughly before relying on it
+
+## Testing Plan
+
+1. Sign up for MiniMax API at https://platform.minimax.io/
+2. Configure Mika with the `openai-compatible/` prefix (see config above)
+3. Test these scenarios in order of criticality:
+   - Basic chat conversation
+   - Memory operations: `store_fact`, `update_core_memory`, `search_memory`
+   - Reminder creation and delivery
+   - Skill execution (web search, file operations)
+   - Multi-step tool chains (3+ sequential tool calls)
+   - Team delegation (if applicable)
+4. If MiniMax passes, repeat with Qwen as backup option
+5. After testing, decide whether to add first-class provider prefixes (`minimax/`, `qwen/`, `kimi/`)
+
+## Open Questions
+
+None — all questions resolved during brainstorming.
+
+## Sources
+
+- [Qwen API Platform](https://qwen.ai/apiplatform)
+- [Qwen API Pricing Guide 2026](https://deepinfra.com/blog/qwen-api-pricing-2026-guide)
+- [MiniMax M2.5 Official Announcement](https://www.minimax.io/news/minimax-m25)
+- [MiniMax OpenAI-Compatible API Docs](https://platform.minimax.io/docs/api-reference/text-openai-api)
+- [Kimi K2.5 Tech Blog](https://www.kimi.com/blog/kimi-k2-5)
+- [Kimi API Pricing](https://costgoat.com/pricing/kimi-api)
+- [MiniMax M2.5 BFCL Benchmarks](https://vertu.com/ai-tools/minimax-m2-5-officially-released-comprehensive-benchmarks-comparison/)
+- [Qwen 3.5 Agentic Benchmarks](https://www.buildmvpfast.com/blog/alibaba-qwen-3-5-agentic-ai-benchmark-2026)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,7 +237,7 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | Field | Type | Default | Env Var | Description |
 |-------|------|---------|---------|-------------|
 | `llm_api_key` | `Option<String>` | None | `MIKA_LLM_API_KEY` | LLM API key. Supports Anthropic API keys (`sk-ant-api03-...`), OAuth subscription tokens (`sk-ant-oat01-...`), and third-party provider keys. Auto-detected from prefix for auth scheme selection. Required for any command that calls an LLM. |
-| `llm_model` | `String` | `claude-sonnet-4-6` | `MIKA_LLM_MODEL` | Model ID for inference. Supports provider prefix: `openai/gpt-4o`, `ollama/llama3`, `groq/llama-3.1-70b`. No prefix defaults to Anthropic. CLI: `--model <model>` on `mika ask` / `mika chat` overrides for a single invocation without persisting. Aliases: `sonnet`, `opus`, `haiku`. |
+| `llm_model` | `String` | `claude-sonnet-4-6` | `MIKA_LLM_MODEL` | Model ID for inference. Supports provider prefix: `openai/gpt-4o`, `ollama/llama3`, `groq/llama-3.1-70b`, `minimax/MiniMax-M2.5`, `qwen/qwen3.5-plus`, `kimi/kimi-k2.5`. No prefix defaults to Anthropic. CLI: `--model <model>` on `mika ask` / `mika chat` overrides for a single invocation without persisting. Aliases: `sonnet`, `opus`, `haiku`, `minimax`, `qwen`, `kimi`. |
 | `llm_base_url` | `Option<String>` | None | `MIKA_LLM_BASE_URL` | Override base URL for OpenAI-compatible providers (e.g., `http://localhost:11434/v1` for Ollama). Each known provider has a default; only needed for `openai-compatible` or custom endpoints. |
 | `llm_max_tokens` | `u32` | `4096` | `MIKA_LLM_MAX_TOKENS` | Maximum tokens for Claude responses. |
 | `db_path` | `PathBuf` | `~/.mika/data/mika.db` | `MIKA_DB_PATH` | Path to the SQLite database file. If not explicitly set, resolves to `{home_dir}/data/mika.db`. |
@@ -501,6 +501,9 @@ is present, Anthropic is used by default.
 | OpenAI | `openai/` | `https://api.openai.com/v1` | `MIKA_LLM_API_KEY` |
 | Ollama | `ollama/` | `http://localhost:11434/v1` | Optional |
 | Groq | `groq/` | `https://api.groq.com/openai/v1` | `MIKA_LLM_API_KEY` |
+| MiniMax | `minimax/` | `https://api.minimax.chat/v1` | `MIKA_LLM_API_KEY` |
+| Qwen | `qwen/` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` | `MIKA_LLM_API_KEY` |
+| Kimi | `kimi/` | `https://api.moonshot.ai/v1` | `MIKA_LLM_API_KEY` |
 | OpenAI-compatible | `openai-compatible/` | None (requires `MIKA_LLM_BASE_URL`) | `MIKA_LLM_API_KEY` |
 
 ### Anthropic models
@@ -541,6 +544,27 @@ export MIKA_LLM_MODEL=groq/llama-3.1-70b
 export MIKA_LLM_API_KEY=gsk_...
 ```
 
+**MiniMax** (best tool calling, cost-effective Claude alternative):
+
+```sh
+export MIKA_LLM_MODEL=minimax/MiniMax-M2.5
+export MIKA_LLM_API_KEY=<minimax-key>  # Get key at https://platform.minimax.io/
+```
+
+**Qwen** (best open-source agentic):
+
+```sh
+export MIKA_LLM_MODEL=qwen/qwen3.5-plus
+export MIKA_LLM_API_KEY=<dashscope-key>  # Get key at https://qwen.ai/apiplatform
+```
+
+**Kimi** (best coding):
+
+```sh
+export MIKA_LLM_MODEL=kimi/kimi-k2.5
+export MIKA_LLM_API_KEY=<moonshot-key>  # Get key at https://api.moonshot.ai/
+```
+
 **Custom OpenAI-compatible endpoint:**
 
 ```sh
@@ -573,11 +597,11 @@ next message.
 
 Not all providers support all features. The `LlmProvider` trait reports capabilities:
 
-| Feature | Anthropic | OpenAI | Ollama | Groq |
-|---------|-----------|--------|--------|------|
-| Tool calling | Yes | Yes | Varies by model | Varies by model |
-| Vision/images | Yes | Yes | Varies by model | No |
-| Extended thinking | Yes | No | No | No |
+| Feature | Anthropic | OpenAI | MiniMax | Qwen | Kimi | Ollama | Groq |
+|---------|-----------|--------|---------|------|------|--------|------|
+| Tool calling | Yes | Yes | Yes | Yes | Yes | Varies | Varies |
+| Vision/images | Yes | Yes | Yes | Yes | Yes | Varies | No |
+| Extended thinking | Yes | No | No | No | No | No | No |
 
 When using a provider that doesn't support tool calling, Mika's agent tools
 (memory, reminders, etc.) will not be available. The agent will operate in

--- a/docs/plans/2026-03-21-001-feat-first-class-alternative-llm-providers-plan.md
+++ b/docs/plans/2026-03-21-001-feat-first-class-alternative-llm-providers-plan.md
@@ -1,0 +1,137 @@
+---
+title: "feat: Add first-class provider prefixes for MiniMax, Qwen, and Kimi"
+type: feat
+status: completed
+date: 2026-03-21
+origin: docs/brainstorms/2026-03-18-openai-migration-brainstorm.md (on branch docs/openai-migration-brainstorm)
+---
+
+# feat: Add first-class provider prefixes for MiniMax, Qwen, and Kimi
+
+## Overview
+
+After Anthropic blocked OAuth tokens (`sk-ant-oat*`) for third-party apps on Jan 9 2026, Mika users need cost-effective alternative LLM providers. The multi-provider infrastructure already exists (`LlmProvider` trait, `OpenAiCompatibleProvider`, `ModelSpec::parse()`). This adds first-class `minimax/`, `qwen/`, and `kimi/` prefixes with built-in default base URLs so users don't need the generic `openai-compatible/` prefix + manual `MIKA_LLM_BASE_URL` configuration.
+
+## Acceptance Criteria
+
+- [x] `MIKA_LLM_MODEL=minimax/MiniMax-M2.5` works without setting `MIKA_LLM_BASE_URL`
+- [x] `MIKA_LLM_MODEL=qwen/qwen3.5-plus` works without setting `MIKA_LLM_BASE_URL`
+- [x] `MIKA_LLM_MODEL=kimi/kimi-k2.5` works without setting `MIKA_LLM_BASE_URL`
+- [x] All three providers report `supports_vision() -> true`
+- [x] `mika doctor` validates connectivity for the configured provider
+- [x] `.env.example` documents the new prefixes with example configs
+- [x] `docs/configuration.md` updated with provider migration guide
+- [x] `CLAUDE.md` Stack section updated with new provider prefixes
+- [x] Unknown prefix error message lists the new providers
+- [x] Existing `openai-compatible/` path still works (no regression)
+- [x] All tests pass (`cargo test`)
+
+## Implementation
+
+### 1. Add `ProviderKind` variants
+
+**File:** `crates/mika-common/src/llm/mod.rs`
+
+Add three new variants to the `ProviderKind` enum (line ~74):
+
+```rust
+pub enum ProviderKind {
+    Anthropic,
+    OpenAi,
+    Ollama,
+    Groq,
+    MiniMax,        // NEW
+    Qwen,           // NEW
+    Kimi,           // NEW
+    OpenAiCompatible,
+}
+```
+
+### 2. Add prefix matching in `ModelSpec::parse()`
+
+**File:** `crates/mika-common/src/llm/mod.rs` (line ~116)
+
+Add to the match arm:
+
+```rust
+"minimax" => ProviderKind::MiniMax,
+"qwen" => ProviderKind::Qwen,
+"kimi" => ProviderKind::Kimi,
+```
+
+### 3. Add default base URLs
+
+**File:** `crates/mika-common/src/llm/mod.rs` (line ~154)
+
+```rust
+ProviderKind::MiniMax => Some("https://api.minimax.chat/v1"),
+ProviderKind::Qwen => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+ProviderKind::Kimi => Some("https://api.moonshot.ai/v1"),
+```
+
+### 4. Add dispatch in `create_provider()`
+
+**File:** `crates/mika-common/src/llm/mod.rs` (line ~176)
+
+Add `MiniMax | Qwen | Kimi` to the same match arm as `OpenAi | Ollama | Groq` — they all create `OpenAiCompatibleProvider`. No special handling needed.
+
+### 5. Enable vision support
+
+**File:** `crates/mika-common/src/llm/openai.rs` (line ~290)
+
+Update `supports_vision()` to return `true` for the new providers:
+
+```rust
+fn supports_vision(&self) -> bool {
+    matches!(self.provider_kind, ProviderKind::OpenAi | ProviderKind::MiniMax | ProviderKind::Qwen | ProviderKind::Kimi)
+}
+```
+
+### 6. Update error message
+
+**File:** `crates/mika-common/src/llm/mod.rs` — the unknown-prefix error (line ~127)
+
+Add `minimax`, `qwen`, `kimi` to the list of known prefixes in the error message.
+
+### 7. Add CLI model aliases (optional convenience)
+
+**File:** `crates/mika-cli/src/cli.rs` (line ~536)
+
+```rust
+("minimax", "minimax/MiniMax-M2.5"),
+("qwen", "qwen/qwen3.5-plus"),
+("kimi", "kimi/kimi-k2.5"),
+```
+
+### 8. Update `.env.example`
+
+Add example configurations for each provider with comments explaining which to choose.
+
+### 9. Create `docs/configuration.md` — provider migration guide
+
+New file documenting:
+- All supported providers with prefix, default base URL, vision support
+- Migration guide: switching from Anthropic to MiniMax/Qwen/Kimi
+- Known limitations of non-Claude providers (no extended thinking, no prompt caching)
+- Cost comparison table (from brainstorm)
+
+### 10. Update `CLAUDE.md`
+
+Update the Stack section's LLM line to mention the new provider prefixes.
+
+### 11. Add/update tests
+
+**File:** `crates/mika-common/src/llm/mod.rs` (test module)
+
+- Test `ModelSpec::parse("minimax/MiniMax-M2.5")` → `ProviderKind::MiniMax` + model `MiniMax-M2.5`
+- Test `ModelSpec::parse("qwen/qwen3.5-plus")` → `ProviderKind::Qwen` + model `qwen3.5-plus`
+- Test `ModelSpec::parse("kimi/kimi-k2.5")` → `ProviderKind::Kimi` + model `kimi-k2.5`
+- Test default base URLs are set correctly
+- Test `openai-compatible/` still works (regression guard)
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-18-openai-migration-brainstorm.md](docs/brainstorms/2026-03-18-openai-migration-brainstorm.md) (on branch `docs/openai-migration-brainstorm`) — MiniMax M2.5 as primary recommendation, Qwen 3.5 Medium as fallback, Kimi K2.5 for coding tasks
+- **Multi-provider architecture:** [docs/solutions/architecture-patterns/multi-provider-llm-trait-abstraction.md](docs/solutions/architecture-patterns/multi-provider-llm-trait-abstraction.md)
+- **API key consolidation:** [docs/solutions/architecture-patterns/unified-llm-api-key-consolidation.md](docs/solutions/architecture-patterns/unified-llm-api-key-consolidation.md)
+- Related issue: #197


### PR DESCRIPTION
## Summary

After Anthropic blocked OAuth tokens (`sk-ant-oat*`) for third-party apps (Jan 9 2026), Mika users need cost-effective alternative LLM providers. This adds first-class `minimax/`, `qwen/`, and `kimi/` prefixes with built-in default base URLs.

- **MiniMax M2.5** — `minimax/MiniMax-M2.5` — $0.25/$1.20 per 1M tokens, #1 BFCL tool calling
- **Qwen 3.5 Medium** — `qwen/qwen3.5-plus` — $0.26/$1.56 per 1M tokens, best open-source agentic
- **Kimi K2.5** — `kimi/kimi-k2.5` — $0.60/$2.50 per 1M tokens, best coding

Users no longer need `openai-compatible/` prefix + manual `MIKA_LLM_BASE_URL`. Just set `MIKA_LLM_MODEL=minimax/MiniMax-M2.5` and `MIKA_LLM_API_KEY`.

### Changes

- Add `MiniMax`, `Qwen`, `Kimi` variants to `ProviderKind` enum
- Add prefix matching and default base URLs in `ModelSpec::parse()`
- Enable vision support for all three providers
- Add CLI model aliases (`minimax`, `qwen`, `kimi`)
- Update `.env.example`, `docs/configuration.md`, `CLAUDE.md`
- Include brainstorm from `docs/openai-migration-brainstorm` branch
- Add tests for new prefixes, base URLs, and regression guard

Closes #197

## Testing

- All 46 LLM module tests pass including 6 new tests
- Regression test confirms `openai-compatible/` still works
- `cargo clippy` clean on changed crates

### Manual testing needed

- [ ] Sign up for MiniMax API at https://platform.minimax.io/
- [ ] Test `MIKA_LLM_MODEL=minimax/MiniMax-M2.5` with full tool suite
- [ ] Test `MIKA_LLM_MODEL=qwen/qwen3.5-plus` as backup
- [ ] Verify multi-step tool chains (3+ sequential tool calls)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a configuration-level change that adds new provider routing options. Existing providers are unaffected. New providers will show up in Langfuse traces with their `gen_ai.provider.name` attribute when users switch to them.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)