### PR TITLE
Enforce pipeline artifacts with verification before PR creation

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -33,11 +33,12 @@ Before running the pipeline, set up an isolated worktree:
 5. `/compound-engineering:resolve_todo_parallel`
 6. `/mika-doc-audit`
 7. `/ce:compound`
-8. Create a PR if one doesn't already exist. If a GitHub issue was referenced, include `Closes #<number>` in the PR body.
+8. Run `bash scripts/verify-pipeline.sh` to verify pipeline artifacts exist. If it fails, read the error messages to identify missing artifacts, go back and produce them (run `/ce:plan` if no plan doc, `/ce:work` if no source changes), then re-run verification until it passes.
+9. Create a PR if one doesn't already exist. If a GitHub issue was referenced, include `Closes #<number>` in the PR body.
 
 ## Cleanup
 
-9. If `CREATED_WORKTREE=true`: cd back to `ORIGINAL_DIR`, then run `git worktree remove --force <WORKTREE>`.
-10. Output `<promise>DONE</promise>` when complete
+10. Do NOT remove the worktree. Worktrees persist until the PR is merged — needed for CI fixes, review feedback, and acceptance testing. Cleanup happens post-merge.
+11. Output `<promise>DONE</promise>` when complete
 
 Start with worktree isolation, then step 1.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  pipeline-artifacts:
+    name: Pipeline Artifacts
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+      - name: Verify pipeline artifacts
+        run: bash scripts/verify-pipeline.sh origin/main
+
   security:
     name: Security
     runs-on: ubuntu-22.04

--- a/scripts/verify-pipeline.sh
+++ b/scripts/verify-pipeline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify that the /mika pipeline produced required artifacts before PR creation.
+#
+# Checks:
+#   1. A plan doc exists in docs/plans/*.md (in the branch diff)
+#   2. Source code changes exist beyond the plan doc
+#
+# Usage:
+#   ./scripts/verify-pipeline.sh              # local (compares to main)
+#   ./scripts/verify-pipeline.sh origin/main  # CI (compares to origin/main)
+#
+# Exit codes:
+#   0 - all checks passed
+#   1 - missing artifacts
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BASE_REF="${1:-main}"
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")
+
+# Collect all changed files: committed + staged + unstaged
+COMMITTED=$(git diff "$MERGE_BASE" HEAD --name-only 2>/dev/null || true)
+STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+UNSTAGED=$(git diff --name-only 2>/dev/null || true)
+ALL=$(printf '%s\n%s\n%s' "$COMMITTED" "$STAGED" "$UNSTAGED" | sort -u | grep -v '^$' || true)
+
+ERRORS=0
+
+# Check 1: Plan doc in docs/plans/
+PLAN=$(echo "$ALL" | grep '^docs/plans/.*\.md$' || true)
+if [[ -z "$PLAN" ]]; then
+  echo "MISSING: No plan doc in docs/plans/. Run /ce:plan." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check 2: Source changes beyond plan doc and .claude/ config
+CODE=$(echo "$ALL" | grep -v '^docs/plans/' | grep -v '^\.claude/' || true)
+if [[ -z "$CODE" ]]; then
+  echo "MISSING: No source changes beyond plan doc. Run /ce:work." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo "Verification FAILED: $ERRORS missing artifact(s)." >&2
+  exit 1
+fi
+
+echo "Pipeline verification passed. Plan: $PLAN"


### PR DESCRIPTION
## Summary

- Add `scripts/verify-pipeline.sh` that checks for required pipeline artifacts (plan doc in `docs/plans/`, source changes) before PR creation
- Insert verification step 8 in the `/mika` pipeline command — blocks PR creation if artifacts are missing
- Add `pipeline-artifacts` CI job as defense-in-depth
- Stop removing worktrees after PR creation — persist until PR is merged for CI fixes, review feedback, and acceptance testing

## Context

PR #227 ran the `/mika` pipeline but did everything inline without invoking `/ce:plan`, `/ce:work`, etc. No plan doc was committed. Pipeline enforcement was instruction-driven (Claude can skip steps). This change makes it artifact-driven: each step must produce a verifiable output checked before PR creation.

## Test plan

- [ ] On a test branch with no plan doc, `verify-pipeline.sh` exits 1 with "MISSING: No plan doc"
- [ ] Add a plan doc only → still fails with "MISSING: No source changes"
- [ ] Add source changes → passes
- [ ] CI `pipeline-artifacts` job runs on PRs and catches missing artifacts
- [ ] Worktree persists after PR creation (no automatic cleanup)

Companion PR: senara-solutions/mika-skills#5
Closes senara-solutions/mika-platform#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)