### PR TITLE
fix: work item session cap only counts active items (#233)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -2534,13 +2534,16 @@ impl Database {
         Ok(rows)
     }
 
-    /// Count agent-created work items in a session (for per-session cap enforcement).
+    /// Count **active** agent-created work items in a session (for per-session cap enforcement).
+    /// Only pending/in_progress/blocked items count — completed/cancelled/failed/delivered
+    /// items are terminal and should not block new work item creation (sprint mode).
     /// Scoped to agent_id for defense-in-depth.
     pub fn count_session_work_items(&self, agent_id: &str, session_id: &str) -> Result<i64> {
         let n: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM tasks
              WHERE agent_id = ?1 AND created_by_session = ?2 AND trigger_type = 'manual'
-               AND (source IS NULL OR source != 'user_request')",
+               AND (source IS NULL OR source != 'user_request')
+               AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')",
             params![agent_id, session_id],
             |r| r.get(0),
         )?;

--- a/crates/mika-agent/src/tools/create_work_item.rs
+++ b/crates/mika-agent/src/tools/create_work_item.rs
@@ -307,21 +307,48 @@ mod tests {
         let tool = CreateWorkItemTool;
 
         // Create MAX_WORK_ITEMS_PER_SESSION items
+        let mut item_ids = Vec::new();
         for i in 0..MAX_WORK_ITEMS_PER_SESSION {
             let result = tool
                 .execute(serde_json::json!({"label": format!("Item {i}")}), &ctx)
                 .await
                 .unwrap();
             assert!(!result.is_error, "item {i} failed: {}", result.content);
+            let id = result
+                .content
+                .lines()
+                .next()
+                .unwrap()
+                .strip_prefix("Work item created: ")
+                .unwrap()
+                .to_string();
+            item_ids.push(id);
         }
 
-        // 6th should be rejected
+        // 6th should be rejected (all 5 are active)
         let result = tool
             .execute(serde_json::json!({"label": "One too many"}), &ctx)
             .await
             .unwrap();
         assert!(result.is_error);
         assert!(result.content.contains("Maximum"));
+
+        // Complete one item — should free up a slot
+        ctx.db
+            .update_task_status(&item_ids[0], "completed")
+            .await
+            .unwrap();
+
+        // Now creating a 6th should succeed (only 4 active)
+        let result = tool
+            .execute(serde_json::json!({"label": "After completing one"}), &ctx)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "should succeed after completing one: {}",
+            result.content
+        );
     }
 
     #[tokio::test]

--- a/docs/plans/2026-03-22-fix-233-work-item-session-cap-plan.md
+++ b/docs/plans/2026-03-22-fix-233-work-item-session-cap-plan.md
@@ -1,0 +1,26 @@
+---
+date: 2026-03-22
+issue: 233
+type: fix
+---
+
+# Fix: Work item per-session cap counts terminal items
+
+## Problem
+
+`count_session_work_items` counts ALL manual work items in a session regardless of status. After a sprint creates 5 work items (all completed), the agent can't create new ones.
+
+## Fix
+
+Add status filter to the SQL query in `db.rs:count_session_work_items()`:
+
+```sql
+AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
+```
+
+Update the test `test_create_work_item_session_cap` to verify that completing items frees up slots.
+
+## Files
+
+- `crates/mika-agent/src/db.rs` — `count_session_work_items()` query
+- `crates/mika-agent/src/tools/create_work_item.rs` — update test


### PR DESCRIPTION
## Summary

- Fix `count_session_work_items` to exclude terminal items (`completed`, `cancelled`, `failed`, `delivered`) from the per-session cap
- Only active items (`pending`, `in_progress`, `blocked`) count against the limit of 5
- Unblocks sprint mode: mika-dev can now work through unlimited sequential issues in a single session

## Root cause

The SQL query counted ALL manual work items in the session regardless of status. After a sprint created 5 work items (all completed), the agent couldn't create new ones.

## Test plan

- [x] Updated `test_create_work_item_session_cap` verifies that completing an item frees up a slot
- [x] All 10 create_work_item tests pass
- [ ] Sprint mode can create >5 sequential work items (each completed before the next)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)