### PR TITLE
chore: add auto-merge label to label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -81,3 +81,8 @@
 - name: dashboard
   color: "7057ff"
   description: Observability dashboard (React SPA)
+
+# ── Automation ──────────────────────────────────────────────────────────────
+- name: auto-merge
+  color: "0e8a16"
+  description: QA can merge PR after PASS verdict


### PR DESCRIPTION
## Summary

- Adds `auto-merge` label to `.github/labels.yml` for QA-driven autonomous merge

Companion PRs: senara-solutions/mika-cloud (label sync setup), senara-solutions/mika-skills (label sync setup)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>