### PR TITLE
fix: pin CI Rust toolchain to rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Install Rust toolchain
+        run: rustup show  # reads rust-toolchain.toml
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
         with:
           prefix-key: v1-rust
@@ -93,7 +94,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Install Rust toolchain
+        run: rustup show  # reads rust-toolchain.toml
       - name: Install security tools
         run: cargo install cargo-audit cargo-deny --locked
       - name: Run cargo-audit

--- a/docs/plans/2026-03-28-001-fix-ci-rust-toolchain-pin-plan.md
+++ b/docs/plans/2026-03-28-001-fix-ci-rust-toolchain-pin-plan.md
@@ -1,0 +1,45 @@
+---
+title: "fix: Pin CI Rust toolchain to rust-toolchain.toml"
+type: fix
+status: active
+date: 2026-03-28
+---
+
+# fix: Pin CI Rust toolchain to rust-toolchain.toml
+
+## Overview
+
+CI uses `dtolnay/rust-toolchain@stable` which installs the latest stable Rust (currently 1.94.1), but `rust-toolchain.toml` pins to 1.93. Different rustfmt versions produce different formatting — code formatted locally with 1.93 fails CI's 1.94.1 `cargo fmt --check`. This affects both mika and mika-cloud repos.
+
+## Acceptance Criteria
+
+- [x] CI reads Rust version from `rust-toolchain.toml` (single source of truth)
+- [x] No version duplication between CI workflow and `rust-toolchain.toml`
+- [x] `cargo fmt`, `cargo clippy`, `cargo test` all use the pinned toolchain in CI
+
+## Solution
+
+Replace `dtolnay/rust-toolchain@...  # stable` with `rustup show` which reads `rust-toolchain.toml` and installs the specified toolchain. The `Swatinem/rust-cache` action continues to work since the toolchain is installed before it runs.
+
+### Before
+```yaml
+- uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+```
+
+### After
+```yaml
+- name: Install Rust toolchain
+  run: rustup show  # reads rust-toolchain.toml
+```
+
+### Files to modify
+
+1. `.github/workflows/ci.yml` — replace dtolnay action with `rustup show` (both Check and Security jobs)
+
+Cross-repo: same change in mika-cloud.
+
+## Sources
+
+- mika-cloud PR #61 CI failure: cargo fmt mismatch between local 1.93 and CI 1.94.1
+- `rust-toolchain.toml`: pins to `channel = "1.93"`
+- Dockerfiles: already pin to `rust:1.93`

--- a/docs/solutions/ci-cd/ci-rust-toolchain-version-mismatch.md
+++ b/docs/solutions/ci-cd/ci-rust-toolchain-version-mismatch.md
@@ -1,0 +1,58 @@
+---
+title: "CI Rust toolchain version mismatch with rust-toolchain.toml"
+category: ci-cd
+date: 2026-03-28
+tags:
+  - ci
+  - rust
+  - rustfmt
+  - toolchain
+  - cross-repo
+severity: high
+affected_components:
+  - .github/workflows/ci.yml
+  - rust-toolchain.toml
+related_issues:
+  - mika-cloud#61
+---
+
+# CI Rust Toolchain Version Mismatch
+
+## Problem
+
+PR #61 on mika-cloud failed CI's `cargo fmt --all -- --check` step even though the code was formatted locally. Different Rust versions produce different rustfmt output.
+
+**Local:** `rust-toolchain.toml` pins to 1.93 → rustfmt 1.8.0
+**CI:** `dtolnay/rust-toolchain@stable` installs latest stable (1.94.1) → different rustfmt
+
+## Root Cause
+
+Both mika and mika-cloud CI workflows used `dtolnay/rust-toolchain@631a55b...  # stable` which always installs the latest stable Rust, ignoring the `rust-toolchain.toml` file. This created a version split:
+
+| Component | Version |
+|-----------|---------|
+| `rust-toolchain.toml` | 1.93 |
+| Dockerfiles | rust:1.93 |
+| CI workflow | latest stable (1.94.1) |
+| Local dev | 1.93 (from rust-toolchain.toml) |
+
+## Solution
+
+Replaced the `dtolnay/rust-toolchain` action with `rustup show` which reads `rust-toolchain.toml` and installs the pinned toolchain. This makes `rust-toolchain.toml` the single source of truth for all environments.
+
+```yaml
+# Before
+- uses: dtolnay/rust-toolchain@631a55b...  # stable
+
+# After
+- name: Install Rust toolchain
+  run: rustup show  # reads rust-toolchain.toml
+```
+
+Applied to both mika and mika-cloud CI workflows.
+
+## Prevention
+
+When upgrading Rust version, update in one place: `rust-toolchain.toml`. CI, local dev, and lefthook all derive from it automatically. Dockerfiles still need manual updates (`FROM rust:X.YZ`).
+
+Never use `dtolnay/rust-toolchain@stable` in repos that have `rust-toolchain.toml` — they will diverge over time.


### PR DESCRIPTION
## Summary

- Replace `dtolnay/rust-toolchain@stable` with `rustup show` in CI workflow
- `rustup show` reads `rust-toolchain.toml`, making it the single source of truth for Rust version
- Fixes version mismatch: CI was using Rust 1.94.1 (latest stable) while `rust-toolchain.toml` pins to 1.93

## Context

Both mika and mika-cloud CI used `dtolnay/rust-toolchain@stable` which always installs the latest stable Rust, ignoring `rust-toolchain.toml`. When stable moved to 1.94.1, rustfmt formatting rules changed, causing CI `cargo fmt --check` to fail on code formatted locally with 1.93's rustfmt (mika-cloud PR #61).

| Component | Before | After |
|-----------|--------|-------|
| `rust-toolchain.toml` | 1.93 | 1.93 (unchanged) |
| Dockerfiles | rust:1.93 | rust:1.93 (unchanged) |
| CI | latest stable (1.94.1) | reads `rust-toolchain.toml` (1.93) |

Companion PR: senara-solutions/mika-cloud#63

## Test plan

- [ ] CI passes with `rustup show` reading `rust-toolchain.toml`
- [ ] `cargo fmt`, `cargo clippy`, `cargo test` all run with 1.93

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)