### PR TITLE
fix: [#321] restore dashboard endpoints in OpenAPI spec

### DIFF
--- a/crates/mika-agent/docs/openapi/mika-server.yaml
+++ b/crates/mika-agent/docs/openapi/mika-server.yaml
@@ -7,6 +7,62 @@ info:
     identifier: MIT
   version: 0.1.0
 paths:
+  /api/v1/dashboard/disable:
+    post:
+      tags:
+      - embedded_dashboard
+      summary: Disable the embedded dashboard at runtime.
+      operationId: handle_disable
+      responses:
+        '200':
+          description: Dashboard disabled
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: false
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
+  /api/v1/dashboard/enable:
+    post:
+      tags:
+      - embedded_dashboard
+      summary: Enable the embedded dashboard at runtime.
+      operationId: handle_enable
+      responses:
+        '200':
+          description: Dashboard enabled
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: true
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
+  /api/v1/dashboard/status:
+    get:
+      tags:
+      - embedded_dashboard
+      summary: Return the current dashboard status.
+      operationId: handle_status
+      responses:
+        '200':
+          description: Dashboard status
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: true
+                has_assets: true
+                has_token: true
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
   /health:
     get:
       tags:

--- a/crates/mika-agent/src/server/embedded_dashboard.rs
+++ b/crates/mika-agent/src/server/embedded_dashboard.rs
@@ -41,18 +41,48 @@ pub async fn handle_root(State(state): State<AppState>) -> Response {
 }
 
 /// Enable the embedded dashboard at runtime.
+#[utoipa::path(
+    post,
+    path = "/api/v1/dashboard/enable",
+    responses(
+        (status = 200, description = "Dashboard enabled", body = inline(serde_json::Value),
+            example = json!({"enabled": true})),
+        (status = 401, description = "Missing or invalid Bearer token"),
+    ),
+    security(("bearer" = []))
+)]
 pub async fn handle_enable(State(state): State<AppState>) -> Json<serde_json::Value> {
     state.dashboard_enabled.store(true, Ordering::Relaxed);
     Json(serde_json::json!({ "enabled": true }))
 }
 
 /// Disable the embedded dashboard at runtime.
+#[utoipa::path(
+    post,
+    path = "/api/v1/dashboard/disable",
+    responses(
+        (status = 200, description = "Dashboard disabled", body = inline(serde_json::Value),
+            example = json!({"enabled": false})),
+        (status = 401, description = "Missing or invalid Bearer token"),
+    ),
+    security(("bearer" = []))
+)]
 pub async fn handle_disable(State(state): State<AppState>) -> Json<serde_json::Value> {
     state.dashboard_enabled.store(false, Ordering::Relaxed);
     Json(serde_json::json!({ "enabled": false }))
 }
 
 /// Return the current dashboard status.
+#[utoipa::path(
+    get,
+    path = "/api/v1/dashboard/status",
+    responses(
+        (status = 200, description = "Dashboard status", body = inline(serde_json::Value),
+            example = json!({"enabled": true, "has_assets": true, "has_token": true})),
+        (status = 401, description = "Missing or invalid Bearer token"),
+    ),
+    security(("bearer" = []))
+)]
 pub async fn handle_status(State(state): State<AppState>) -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "enabled": state.dashboard_enabled.load(Ordering::Relaxed),

--- a/crates/mika-agent/src/server/openapi.rs
+++ b/crates/mika-agent/src/server/openapi.rs
@@ -3,6 +3,7 @@
 use utoipa::OpenApi;
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 
+use super::embedded_dashboard;
 use super::handlers;
 use super::types;
 
@@ -16,6 +17,9 @@ use super::types;
     paths(
         handlers::handle_health,
         handlers::handle_message,
+        embedded_dashboard::handle_enable,
+        embedded_dashboard::handle_disable,
+        embedded_dashboard::handle_status,
     ),
     components(schemas(
         types::MessageRequest,
@@ -62,6 +66,18 @@ mod tests {
         let yaml = agent_openapi_yaml();
         assert!(yaml.contains("/health"), "missing /health endpoint");
         assert!(yaml.contains("/message"), "missing /message endpoint");
+        assert!(
+            yaml.contains("/api/v1/dashboard/enable"),
+            "missing /api/v1/dashboard/enable endpoint"
+        );
+        assert!(
+            yaml.contains("/api/v1/dashboard/disable"),
+            "missing /api/v1/dashboard/disable endpoint"
+        );
+        assert!(
+            yaml.contains("/api/v1/dashboard/status"),
+            "missing /api/v1/dashboard/status endpoint"
+        );
     }
 
     #[test]

--- a/docs/openapi/mika-server.yaml
+++ b/docs/openapi/mika-server.yaml
@@ -7,6 +7,62 @@ info:
     identifier: MIT
   version: 0.1.0
 paths:
+  /api/v1/dashboard/disable:
+    post:
+      tags:
+      - embedded_dashboard
+      summary: Disable the embedded dashboard at runtime.
+      operationId: handle_disable
+      responses:
+        '200':
+          description: Dashboard disabled
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: false
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
+  /api/v1/dashboard/enable:
+    post:
+      tags:
+      - embedded_dashboard
+      summary: Enable the embedded dashboard at runtime.
+      operationId: handle_enable
+      responses:
+        '200':
+          description: Dashboard enabled
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: true
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
+  /api/v1/dashboard/status:
+    get:
+      tags:
+      - embedded_dashboard
+      summary: Return the current dashboard status.
+      operationId: handle_status
+      responses:
+        '200':
+          description: Dashboard status
+          content:
+            application/json:
+              schema: {}
+              example:
+                enabled: true
+                has_assets: true
+                has_token: true
+        '401':
+          description: Missing or invalid Bearer token
+      security:
+      - bearer: []
   /health:
     get:
       tags:

--- a/docs/plans/2026-03-29-004-fix-restore-dashboard-openapi-endpoints-plan.md
+++ b/docs/plans/2026-03-29-004-fix-restore-dashboard-openapi-endpoints-plan.md
@@ -1,0 +1,69 @@
+# Fix: Restore Dashboard Endpoints in OpenAPI Spec via utoipa Annotations
+
+**Issue:** #321
+**Date:** 2026-03-29
+**Type:** Bug fix
+
+## Problem
+
+PR #319 (commit c602d98) regenerated `docs/openapi/mika-server.yaml`, removing 3 dashboard toggle endpoints that were previously manually added. The handlers in `embedded_dashboard.rs` lack `#[utoipa::path]` annotations, so code generation doesn't include them.
+
+### Removed Endpoints
+
+- `POST /api/v1/dashboard/enable` — enable embedded dashboard at runtime
+- `POST /api/v1/dashboard/disable` — disable embedded dashboard at runtime
+- `GET /api/v1/dashboard/status` — return dashboard state (enabled, has_assets, has_token)
+
+### Impact
+
+The `self-knowledge` skill serves the OpenAPI spec via `get_documentation("api-spec")`. Agents asked about the dashboard API get incomplete documentation.
+
+## Implementation Plan
+
+### Step 1: Add utoipa annotations to `embedded_dashboard.rs`
+
+**File:** `crates/mika-agent/src/server/embedded_dashboard.rs`
+
+Add `#[utoipa::path]` annotations to the 3 handler functions:
+
+- `handle_enable` — POST, `/api/v1/dashboard/enable`, 200 + 401 responses, bearer security
+- `handle_disable` — POST, `/api/v1/dashboard/disable`, 200 + 401 responses, bearer security
+- `handle_status` — GET, `/api/v1/dashboard/status`, 200 + 401 responses, bearer security
+
+Use `body = inline(serde_json::Value)` with `example` values matching actual handler output. Full path prefix required — utoipa doesn't know about Axum's `nest()` routing.
+
+### Step 2: Register paths in `openapi.rs`
+
+**File:** `crates/mika-agent/src/server/openapi.rs`
+
+- Add `use super::embedded_dashboard;` import
+- Add 3 paths to `AgentApiDoc`'s `#[openapi(paths(...))]`
+- Add test assertion for dashboard endpoints
+
+### Step 3: Regenerate the OpenAPI spec
+
+```bash
+cargo test -p mika-agent server::openapi::tests::write_agent_openapi_yaml -- --ignored
+```
+
+### Step 4: Sync crate-local copy
+
+```bash
+./scripts/sync-agent-docs.sh
+```
+
+## Verification
+
+```bash
+cargo test -p mika-agent -- openapi         # OpenAPI tests pass (including spec currency check)
+cargo build                                 # workspace compiles
+cargo clippy                                # no warnings
+```
+
+## Acceptance Criteria
+
+- All 3 dashboard endpoints appear in `docs/openapi/mika-server.yaml`
+- Each endpoint has correct HTTP method, path, response schema, and security
+- `test_committed_spec_is_current` passes
+- No new security schemes added (reuses `bearer`)
+- No new dependencies added

--- a/docs/plans/2026-03-29-004-fix-restore-dashboard-openapi-endpoints-plan.md
+++ b/docs/plans/2026-03-29-004-fix-restore-dashboard-openapi-endpoints-plan.md
@@ -1,12 +1,19 @@
-# Fix: Restore Dashboard Endpoints in OpenAPI Spec via utoipa Annotations
+---
+title: "fix: Restore dashboard endpoints in OpenAPI spec via utoipa annotations"
+type: fix
+status: active
+date: 2026-03-29
+---
 
-**Issue:** #321
-**Date:** 2026-03-29
-**Type:** Bug fix
+# fix: Restore Dashboard Endpoints in OpenAPI Spec via utoipa Annotations
 
-## Problem
+## Overview
 
 PR #319 (commit c602d98) regenerated `docs/openapi/mika-server.yaml`, removing 3 dashboard toggle endpoints that were previously manually added. The handlers in `embedded_dashboard.rs` lack `#[utoipa::path]` annotations, so code generation doesn't include them.
+
+## Problem Statement / Motivation
+
+The `self-knowledge` skill serves the OpenAPI spec via `get_documentation("api-spec")`. With the dashboard endpoints missing, agents asked about the dashboard API get incomplete documentation. The root cause is that the endpoints were originally hand-added to the YAML but never backed by utoipa annotations — any spec regeneration removes them.
 
 ### Removed Endpoints
 
@@ -14,9 +21,16 @@ PR #319 (commit c602d98) regenerated `docs/openapi/mika-server.yaml`, removing 3
 - `POST /api/v1/dashboard/disable` — disable embedded dashboard at runtime
 - `GET /api/v1/dashboard/status` — return dashboard state (enabled, has_assets, has_token)
 
-### Impact
+## Proposed Solution
 
-The `self-knowledge` skill serves the OpenAPI spec via `get_documentation("api-spec")`. Agents asked about the dashboard API get incomplete documentation.
+Add `#[utoipa::path]` annotations to the 3 handler functions in `embedded_dashboard.rs` and register them in `AgentApiDoc` in `openapi.rs`. This makes them first-class generated endpoints that survive future spec regeneration.
+
+## Technical Considerations
+
+- **Annotation pattern:** Follow the existing convention from `handlers.rs` — `#[utoipa::path]` with HTTP method, full path, responses, and bearer security
+- **Response schema:** Use `body = inline(serde_json::Value)` with `example = json!(...)` since these handlers return ad-hoc JSON (no dedicated response struct). The `json!` macro is resolved by utoipa's proc macro internally — no explicit `use serde_json::json` import needed
+- **Full path required:** utoipa doesn't know about Axum's `nest()` routing, so paths must include the full prefix (e.g., `/api/v1/dashboard/enable` not just `/dashboard/enable`)
+- **Two-copy sync:** Both `docs/openapi/mika-server.yaml` (canonical) and `crates/mika-agent/docs/openapi/mika-server.yaml` (crate-local for crates.io) must be updated. `scripts/sync-agent-docs.sh` handles the copy
 
 ## Implementation Plan
 
@@ -30,20 +44,18 @@ Add `#[utoipa::path]` annotations to the 3 handler functions:
 - `handle_disable` — POST, `/api/v1/dashboard/disable`, 200 + 401 responses, bearer security
 - `handle_status` — GET, `/api/v1/dashboard/status`, 200 + 401 responses, bearer security
 
-Use `body = inline(serde_json::Value)` with `example` values matching actual handler output. Full path prefix required — utoipa doesn't know about Axum's `nest()` routing.
-
 ### Step 2: Register paths in `openapi.rs`
 
 **File:** `crates/mika-agent/src/server/openapi.rs`
 
 - Add `use super::embedded_dashboard;` import
 - Add 3 paths to `AgentApiDoc`'s `#[openapi(paths(...))]`
-- Add test assertion for dashboard endpoints
+- Add test assertions for dashboard endpoints in `test_agent_openapi_yaml_contains_endpoints`
 
 ### Step 3: Regenerate the OpenAPI spec
 
 ```bash
-cargo test -p mika-agent server::openapi::tests::write_agent_openapi_yaml -- --ignored
+cargo test -p mika-agent --lib -- write_agent_openapi_yaml --ignored
 ```
 
 ### Step 4: Sync crate-local copy
@@ -52,18 +64,28 @@ cargo test -p mika-agent server::openapi::tests::write_agent_openapi_yaml -- --i
 ./scripts/sync-agent-docs.sh
 ```
 
+## Acceptance Criteria
+
+- [x] All 3 dashboard endpoints appear in `docs/openapi/mika-server.yaml`
+- [x] Each endpoint has correct HTTP method, path, response schema, and security
+- [x] `test_committed_spec_is_current` passes
+- [x] `test_agent_openapi_yaml_contains_endpoints` covers all 3 new paths
+- [x] No new security schemes added (reuses `bearer`)
+- [x] No new dependencies added
+- [x] `cargo clippy` clean
+
 ## Verification
 
 ```bash
-cargo test -p mika-agent -- openapi         # OpenAPI tests pass (including spec currency check)
-cargo build                                 # workspace compiles
-cargo clippy                                # no warnings
+cargo test -p mika-agent --lib -- openapi     # OpenAPI tests pass (including spec currency check)
+cargo build -p mika-agent                     # crate compiles
+cargo clippy -p mika-agent                    # no warnings
 ```
 
-## Acceptance Criteria
+## Sources & References
 
-- All 3 dashboard endpoints appear in `docs/openapi/mika-server.yaml`
-- Each endpoint has correct HTTP method, path, response schema, and security
-- `test_committed_spec_is_current` passes
-- No new security schemes added (reuses `bearer`)
-- No new dependencies added
+- Similar implementation: `crates/mika-agent/src/server/handlers.rs` — existing utoipa annotations on `handle_health`, `handle_message`, `handle_task_complete`
+- Learning: `docs/solutions/integration-issues/gateway-monorepo-migration.md` — documents the `test_committed_spec_is_current` pattern
+- Learning: `docs/solutions/architecture-patterns/embed-dashboard-spa-rust-embed.md` — documents dashboard route architecture
+- Related issue: #321
+- Related PR: #319 (caused the regression)

--- a/docs/solutions/integration-issues/openapi-spec-drift-missing-utoipa-annotations.md
+++ b/docs/solutions/integration-issues/openapi-spec-drift-missing-utoipa-annotations.md
@@ -1,0 +1,75 @@
+---
+title: "OpenAPI spec drift from missing utoipa annotations"
+category: integration-issues
+date: 2026-03-29
+tags: [openapi, utoipa, spec-generation, dashboard, regression]
+issue: "#321"
+pr: "#326"
+modules: [mika-agent/server]
+---
+
+# OpenAPI Spec Drift from Missing utoipa Annotations
+
+## Problem
+
+After PR #319 regenerated `docs/openapi/mika-server.yaml`, 3 dashboard toggle endpoints (`/api/v1/dashboard/enable`, `/disable`, `/status`) disappeared from the spec. The endpoints were originally hand-added to the YAML but never backed by `#[utoipa::path]` annotations — any spec regeneration silently removed them.
+
+**Symptom:** The `self-knowledge` skill serves the OpenAPI spec via `get_documentation("api-spec")`. Agents asked about the dashboard API got incomplete documentation.
+
+## Root Cause
+
+The handlers in `embedded_dashboard.rs` lacked `#[utoipa::path]` proc macro annotations. The `AgentApiDoc` struct in `openapi.rs` only generates spec entries for functions listed in its `paths(...)` attribute — functions without annotations and registration are invisible to the generator.
+
+## Solution
+
+1. **Add `#[utoipa::path]` annotations** to each handler in `embedded_dashboard.rs`:
+
+```rust
+#[utoipa::path(
+    post,
+    path = "/api/v1/dashboard/enable",
+    responses(
+        (status = 200, description = "Dashboard enabled", body = inline(serde_json::Value),
+            example = json!({"enabled": true})),
+        (status = 401, description = "Missing or invalid Bearer token"),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn handle_enable(State(state): State<AppState>) -> Json<serde_json::Value> { ... }
+```
+
+2. **Register in `AgentApiDoc`** in `openapi.rs`:
+
+```rust
+paths(
+    handlers::handle_health,
+    handlers::handle_message,
+    embedded_dashboard::handle_enable,
+    embedded_dashboard::handle_disable,
+    embedded_dashboard::handle_status,
+),
+```
+
+3. **Add regression test assertions** in `test_agent_openapi_yaml_contains_endpoints`.
+
+4. **Regenerate spec:** `cargo test -p mika-agent --lib -- write_agent_openapi_yaml --ignored`
+
+5. **Sync crate-local copy:** `./scripts/sync-agent-docs.sh`
+
+### Key Details
+
+- **Full paths required:** utoipa doesn't know about Axum's `nest()` routing — use `/api/v1/dashboard/enable`, not `/dashboard/enable`.
+- **`json!` macro in attributes:** utoipa's proc macro resolves `json!(...)` internally — no `use serde_json::json` import needed in the handler file.
+- **`inline(serde_json::Value)`:** Use for ad-hoc JSON responses without a dedicated struct. Generates `schema: {}` in YAML but the `example` compensates.
+- **Two-copy sync:** Both `docs/openapi/mika-server.yaml` (canonical) and `crates/mika-agent/docs/openapi/mika-server.yaml` (crate-local for crates.io) must match. `scripts/sync-agent-docs.sh` handles the copy. The `test_committed_spec_is_current` test only validates the canonical copy.
+
+## Prevention
+
+- **Always add `#[utoipa::path]` when creating new Axum handlers.** If a handler should appear in the OpenAPI spec, annotate it at creation time — not after the fact.
+- **The `test_committed_spec_is_current` test** catches drift between generated and committed specs, but only for endpoints that have annotations. It cannot detect missing annotations.
+- **The `test_agent_openapi_yaml_contains_endpoints` test** serves as an explicit endpoint inventory — add a new assertion whenever a new endpoint is annotated.
+
+## Related
+
+- [Gateway monorepo migration](gateway-monorepo-migration.md) — documents the same `test_committed_spec_is_current` pattern for mika-gateway
+- [Embed dashboard SPA](../architecture-patterns/embed-dashboard-spa-rust-embed.md) — documents the dashboard route architecture


### PR DESCRIPTION
## Summary

- Add `#[utoipa::path]` annotations to the 3 dashboard toggle handlers (`handle_enable`, `handle_disable`, `handle_status`) in `embedded_dashboard.rs`
- Register the 3 new paths in `AgentApiDoc` in `openapi.rs` and extend endpoint test coverage
- Regenerate `docs/openapi/mika-server.yaml` and sync the crate-local copy

Closes #321

## Test plan

- [x] `cargo test -p mika-agent --lib -- openapi` — all 3 OpenAPI tests pass (including `test_committed_spec_is_current`)
- [x] `cargo clippy -p mika-agent` — no warnings
- [x] `cargo build` — workspace compiles
- [x] No new security schemes added (reuses existing `bearer`)
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)