### PR TITLE
fix: use per-agent LLM provider in server mode

### DIFF
--- a/crates/mika-agent/src/server/a2a.rs
+++ b/crates/mika-agent/src/server/a2a.rs
@@ -136,7 +136,7 @@ async fn run_a2a_agent(
 
     let params = AgentParams {
         db: &agent_state.db,
-        llm: state.llm.as_ref(),
+        llm: agent_state.llm.as_ref(),
         tools: &state.tools,
         skills: &skills,
         user_message: input_text,
@@ -155,7 +155,7 @@ async fn run_a2a_agent(
         mcp_manager: agent_state.mcp_manager.as_ref(),
         global_home_dir: Some(&state.global_home_dir),
         is_callback_turn: false,
-        settings: Some(&state.settings),
+        settings: Some(&agent_state.settings),
         trace_id: Some(task_id.to_string()),
     };
 

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -222,7 +222,7 @@ pub async fn handle_message(
 
             let params = AgentParams {
                 db: &a.db,
-                llm: s.llm.as_ref(),
+                llm: a.llm.as_ref(),
                 tools: &s.tools,
                 skills: &skills,
                 user_message: &req.text,
@@ -241,7 +241,7 @@ pub async fn handle_message(
                 mcp_manager: a.mcp_manager.as_ref(),
                 global_home_dir: Some(&s.global_home_dir),
                 is_callback_turn: false,
-                settings: Some(&s.settings),
+                settings: Some(&a.settings),
                 trace_id: Some(req.request_id.clone()),
             };
 
@@ -270,7 +270,7 @@ pub async fn handle_message(
             // Spawn compaction outside the lock
             drop(_lock);
             let db = a.db.clone();
-            let llm = s.llm.clone();
+            let llm = a.llm.clone();
             tokio::spawn(
                 async move {
                     if let Err(e) = compaction::maybe_compact(&db, llm.as_ref()).await {

--- a/crates/mika-agent/src/server/investigate.rs
+++ b/crates/mika-agent/src/server/investigate.rs
@@ -1070,7 +1070,13 @@ pub async fn handle_investigate(
 
     // --- Start SSE stream ---
     let (tx, rx) = mpsc::channel::<Result<sse::Event, Infallible>>(64);
-    let llm = state.llm.clone();
+    // Investigation panel is not agent-scoped — use the default agent's LLM provider.
+    // The default agent is guaranteed to exist (validated in run_server).
+    let llm = state
+        .resolve_agent(&state.default_agent)
+        .expect("default agent must exist")
+        .llm
+        .clone();
     let db = state.dashboard_db.clone();
     let agents = state.agents.clone();
     let lock = state.investigation_lock.clone();

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -29,7 +29,6 @@ use mika_common::agent;
 use mika_common::config::Settings;
 use mika_common::embedding::EmbeddingClient;
 use mika_common::home;
-use mika_common::llm::LlmProvider;
 
 use crate::async_db::AsyncDatabase;
 use crate::db::Database;
@@ -209,12 +208,13 @@ fn build_router(state: AppState) -> Router {
 /// Initialize a single agent and return its AgentState with a running TaskEngine.
 ///
 /// Uses the shared container database at `{global_home}/data/mika.db`.
+/// Loads per-agent settings via `Settings::load_for_agent()` so each agent gets
+/// its own LLM provider (respecting per-agent `config.toml` overrides). See #323.
 #[allow(clippy::too_many_arguments)]
 async fn init_agent(
     agent_name: &str,
     agent_home: &std::path::Path,
     global_home: &std::path::Path,
-    llm: &Arc<dyn LlmProvider>,
     tool_registry: &Arc<crate::tools::ToolRegistry>,
     gateway_url: &str,
     internal_token: &secrecy::SecretString,
@@ -224,6 +224,9 @@ async fn init_agent(
     github_token: Option<String>,
     disable_bundled_skills: bool,
 ) -> Result<AgentState> {
+    // Load per-agent settings (global config.toml → agent config.toml → env vars)
+    let agent_settings = Settings::load_for_agent(global_home, agent_home)?;
+    let agent_llm = agent_settings.make_llm_provider()?;
     let db_path = home::container_db_path(global_home);
     std::fs::create_dir_all(db_path.parent().unwrap())?;
     let db = Database::open(&db_path)?;
@@ -259,7 +262,7 @@ async fn init_agent(
 
     let dispatcher = Arc::new(TaskDispatcher {
         db: async_db.clone(),
-        llm: llm.clone(),
+        llm: agent_llm.clone(),
         tools: tool_registry.clone(),
         skills: skill_registry.clone(),
         home_dir: agent_home.to_path_buf(),
@@ -272,6 +275,7 @@ async fn init_agent(
         // Server mode: engine dispatches callbacks via dispatch_undelivered_callbacks().
         // The agent_lock serializes concurrent dispatch attempts.
         cli_mode: false,
+        settings: agent_settings.clone(),
     });
 
     let task_engine = Arc::new(tokio::sync::Mutex::new(TaskEngine::new(
@@ -302,6 +306,8 @@ async fn init_agent(
         home_dir: agent_home.to_path_buf(),
         embedding_client,
         mcp_manager,
+        settings: agent_settings,
+        llm: agent_llm,
     };
 
     debug!(agent = agent_name, home = %agent_home.display(), "initialized agent");
@@ -388,7 +394,6 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         );
     }
 
-    let llm = settings.make_llm_provider()?;
     let http_client = reqwest::Client::new();
     let mut tool_registry = tools::default_tools();
     for tool in tools::management_tools_if_needed(global_home, settings, http_client.clone()) {
@@ -442,7 +447,6 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 agent::DEFAULT_AGENT,
                 &default_home,
                 global_home,
-                &llm,
                 &tool_registry,
                 &gateway_url,
                 &internal_token,
@@ -462,7 +466,6 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 name,
                 &agent_home,
                 global_home,
-                &llm,
                 &tool_registry,
                 &gateway_url,
                 &internal_token,
@@ -519,7 +522,6 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
     let state = AppState {
         agents: Arc::new(agents),
         default_agent,
-        llm,
         tools: tool_registry,
         ready: ready.clone(),
         internal_token,
@@ -652,6 +654,11 @@ mod tests {
     use secrecy::SecretString;
     use tower::ServiceExt;
 
+    fn test_settings() -> Settings {
+        let tmp = tempfile::tempdir().unwrap();
+        Settings::load(tmp.path()).unwrap()
+    }
+
     fn test_task_engine(
         db: AsyncDatabase,
     ) -> (Arc<tokio::sync::Mutex<TaskEngine>>, Arc<TaskDispatcher>) {
@@ -669,6 +676,7 @@ mod tests {
             skills_dirty: Arc::new(AtomicBool::new(false)),
             agent_lock: None,
             cli_mode: false,
+            settings: test_settings(),
         });
         let engine = Arc::new(tokio::sync::Mutex::new(TaskEngine::new(
             db,
@@ -697,6 +705,8 @@ mod tests {
             home_dir: std::path::PathBuf::from("/tmp/mika-test"),
             embedding_client: None,
             mcp_manager: None,
+            settings: test_settings(),
+            llm: llm.clone(),
         };
 
         let mut agents = HashMap::new();
@@ -705,7 +715,6 @@ mod tests {
         AppState {
             agents: Arc::new(agents),
             default_agent: "mika".to_string(),
-            llm,
             tools: tools_reg,
             ready: Arc::new(AtomicBool::new(false)),
             internal_token: SecretString::from("test-token-secret"),
@@ -716,67 +725,7 @@ mod tests {
             brave_api_key: None,
             github_token: None,
             global_home_dir: std::path::PathBuf::from("/tmp/mika-test"),
-            settings: Settings {
-                llm_provider: mika_common::llm::ProviderKind::Anthropic,
-                llm_max_tokens: 4096,
-                anthropic_model: None,
-                anthropic_api_key: Some("test-key".to_string()),
-                anthropic_base_url: None,
-                openai_model: None,
-                openai_base_url: None,
-                openrouter_model: None,
-                openrouter_api_key: None,
-                openrouter_base_url: None,
-                groq_model: None,
-                groq_api_key: None,
-                groq_base_url: None,
-                ollama_model: None,
-                ollama_api_key: None,
-                ollama_base_url: None,
-                mistral_model: None,
-                mistral_api_key: None,
-                mistral_base_url: None,
-                google_model: None,
-                google_api_key: None,
-                google_base_url: None,
-                deepseek_model: None,
-                deepseek_api_key: None,
-                deepseek_base_url: None,
-                minimax_model: None,
-                minimax_api_key: None,
-                minimax_base_url: None,
-                kimi_model: None,
-                kimi_api_key: None,
-                kimi_base_url: None,
-                qwen_model: None,
-                qwen_api_key: None,
-                qwen_base_url: None,
-                db_path: std::path::PathBuf::from("/tmp/mika-test/data/mika.db"),
-                log_level: "info".to_string(),
-                log_format: "json".to_string(),
-                routing_url: None,
-                customer_id: None,
-                server_port: 8080,
-                internal_token: None,
-                dashboard_token: None,
-                openai_api_key: None,
-                embedding_model: "text-embedding-3-small".to_string(),
-                embedding_dimensions: 512,
-                brave_api_key: None,
-                github_token: None,
-                investigate_github_token: None,
-                github_repo: None,
-                home_dir: std::path::PathBuf::from("/tmp/mika-test"),
-                server_log_file: None,
-                dashboard_enabled: false,
-                disable_bundled_skills: false,
-                telemetry_enabled: false,
-                otlp_endpoint: None,
-                otlp_auth_header: None,
-                store_llm_calls: true,
-                store_tool_calls: true,
-                log_llm_bodies: false,
-            },
+            settings: test_settings(),
             dashboard_db,
             investigation_lock: Arc::new(tokio::sync::Mutex::new(())),
             investigation_tools: Arc::new(tokio::sync::OnceCell::new()),

--- a/crates/mika-agent/src/server/state.rs
+++ b/crates/mika-agent/src/server/state.rs
@@ -30,6 +30,12 @@ pub struct AgentState {
     pub home_dir: PathBuf,
     pub embedding_client: Option<EmbeddingClient>,
     pub mcp_manager: Option<McpManager>,
+    /// Per-agent settings loaded via `Settings::load_for_agent(global_home, agent_home)`.
+    /// Ensures callback/heartbeat/reflection turns use the agent's LLM provider config,
+    /// not the global default. See #323.
+    pub settings: Settings,
+    /// Per-agent LLM provider built from `self.settings`.
+    pub llm: Arc<dyn LlmProvider>,
 }
 
 /// Shared application state for the Axum HTTP server.
@@ -44,7 +50,6 @@ pub struct AppState {
     pub agents: Arc<HashMap<String, Arc<AgentState>>>,
     /// Default agent name (resolved from active_agent file).
     pub default_agent: String,
-    pub llm: Arc<dyn LlmProvider>,
     pub tools: Arc<ToolRegistry>,
     pub ready: Arc<AtomicBool>,
     pub internal_token: SecretString,

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use chrono::Timelike;
+use mika_common::config::Settings;
 use mika_common::embedding::EmbeddingClient;
 use mika_common::llm::LlmProvider;
 use std::path::PathBuf;
@@ -48,6 +49,10 @@ pub struct TaskDispatcher {
     /// CLI/TUI mode handles callbacks via `poll_callback_tasks()` instead,
     /// preventing a race where the engine steals callbacks from the TUI.
     pub cli_mode: bool,
+    /// Per-agent settings for constructing per-skill LLM overrides in silent mode.
+    /// Passed as `settings: Some(&self.settings)` to all `SilentAgentParams` constructions.
+    /// See #323.
+    pub settings: Settings,
 }
 
 impl TaskDispatcher {
@@ -242,7 +247,7 @@ impl TaskDispatcher {
             brave_api_key: self.brave_api_key.as_deref(),
             github_token: self.github_token.as_deref(),
             skills_dirty: &self.skills_dirty,
-            settings: None,
+            settings: Some(&self.settings),
             trace_id: Some(trace_id.clone()),
         };
 
@@ -330,7 +335,7 @@ impl TaskDispatcher {
             brave_api_key: self.brave_api_key.as_deref(),
             github_token: self.github_token.as_deref(),
             skills_dirty: &self.skills_dirty,
-            settings: None,
+            settings: Some(&self.settings),
             trace_id: Some(trace_id.clone()),
         };
 
@@ -510,7 +515,7 @@ impl TaskDispatcher {
             brave_api_key: self.brave_api_key.as_deref(),
             github_token: self.github_token.as_deref(),
             skills_dirty: &self.skills_dirty,
-            settings: None,
+            settings: Some(&self.settings),
             trace_id: Some(trace_id.clone()),
         };
 
@@ -650,7 +655,7 @@ impl TaskDispatcher {
             brave_api_key: self.brave_api_key.as_deref(),
             github_token: self.github_token.as_deref(),
             skills_dirty: &self.skills_dirty,
-            settings: None,
+            settings: Some(&self.settings),
             trace_id: Some(trace_id.clone()),
         };
 
@@ -757,6 +762,8 @@ mod tests {
     }
 
     fn test_dispatcher(db: AsyncDatabase) -> TaskDispatcher {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
         TaskDispatcher {
             db,
             llm: mika_common::llm::dummy_provider(),
@@ -770,6 +777,7 @@ mod tests {
             skills_dirty: Arc::new(AtomicBool::new(false)),
             agent_lock: None,
             cli_mode: false,
+            settings,
         }
     }
 

--- a/crates/mika-agent/src/task_engine/engine.rs
+++ b/crates/mika-agent/src/task_engine/engine.rs
@@ -608,6 +608,8 @@ mod tests {
     }
 
     fn test_dispatcher(db: AsyncDatabase) -> Arc<TaskDispatcher> {
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = mika_common::config::Settings::load(tmp.path()).unwrap();
         Arc::new(TaskDispatcher {
             db,
             llm: mika_common::llm::dummy_provider(),
@@ -621,6 +623,7 @@ mod tests {
             skills_dirty: Arc::new(AtomicBool::new(false)),
             agent_lock: None,
             cli_mode: false,
+            settings,
         })
     }
 
@@ -1004,6 +1007,8 @@ mod tests {
     async fn test_cli_mode_skips_callback_dispatch() {
         let db = test_db();
         // Create dispatcher with cli_mode: true
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = mika_common::config::Settings::load(tmp.path()).unwrap();
         let dispatcher = Arc::new(TaskDispatcher {
             db: db.clone(),
             llm: mika_common::llm::dummy_provider(),
@@ -1017,6 +1022,7 @@ mod tests {
             skills_dirty: Arc::new(AtomicBool::new(false)),
             agent_lock: None,
             cli_mode: true,
+            settings,
         });
         let mut engine = TaskEngine::new(db.clone(), dispatcher);
 

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -137,6 +137,7 @@ async fn spawn_agent_worker(
         // session-scoped queries and atomic claiming. Skip engine dispatch to prevent
         // the engine from stealing callbacks. See #264.
         cli_mode: true,
+        settings: ctx.settings.clone(),
     });
     let task_engine = Arc::new(tokio::sync::Mutex::new(TaskEngine::new(
         ctx.async_db.clone(),

--- a/docs/plans/2026-03-30-004-fix-callback-turns-use-global-llm-provider-plan.md
+++ b/docs/plans/2026-03-30-004-fix-callback-turns-use-global-llm-provider-plan.md
@@ -1,0 +1,166 @@
+---
+title: "fix: callback turns use global LLM provider instead of agent config"
+type: fix
+status: completed
+date: 2026-03-30
+issue: "#323"
+---
+
+# fix: callback turns use global LLM provider instead of agent config
+
+## Overview
+
+Callback sessions (and all silent agent runs — heartbeat, reflection, skill_run) in server mode use the global `config.toml` LLM provider instead of the per-agent `config.toml` override. An agent configured with `deepseek/deepseek-chat` gets `minimax/MiniMax-M2.7` (the global default) during callback turns.
+
+This is the same bug class as the team engine fix (#285, see `docs/solutions/logic-errors/team-engine-ignores-per-agent-llm-config.md`), now manifesting in the server dispatcher and HTTP handler paths.
+
+## Problem Statement
+
+### Root Cause
+
+Two compounding issues:
+
+1. **Server loads global-only Settings:** `mika-server.rs` calls `Settings::load(&home_dir)` which internally calls `Settings::load_for_agent(home_dir, home_dir)` — since `global_home == agent_home`, the per-agent config layer is never applied. The single `LlmProvider` built from this is shared across ALL agents.
+
+2. **TaskDispatcher passes `settings: None`:** All four `SilentAgentParams` construction sites in `dispatcher.rs` set `settings: None`, blocking `resolve_skill_llm_override()` for per-skill `[llm]` overrides in silent mode.
+
+### Affected Paths (Server Mode)
+
+| Path | `llm` source | `settings` | Status |
+|------|-------------|------------|--------|
+| `handle_message` (Telegram inbound) | Global `AppState.llm` | Global `AppState.settings` | **Broken** |
+| `run_a2a_agent` (A2A inbound) | Global `AppState.llm` | Global `AppState.settings` | **Broken** |
+| `dispatch_resume_agent` (callback) | Global `TaskDispatcher.llm` | `None` | **Broken** |
+| `dispatch_heartbeat` | Global `TaskDispatcher.llm` | `None` | **Broken** |
+| `dispatch_reflection` | Global `TaskDispatcher.llm` | `None` | **Broken** |
+| `dispatch_skill_by_name` | Global `TaskDispatcher.llm` | `None` | **Broken** |
+| `dispatch_invoke_orchestrator` (team) | Per-agent (team engine fix) | Per-agent | OK |
+
+### Affected Paths (CLI Mode)
+
+| Path | `llm` source | `settings` | Status |
+|------|-------------|------------|--------|
+| CLI `chat`/`ask` (foreground) | Per-agent via `AppContext` | `Some(&settings)` | OK |
+| CLI `TaskDispatcher` (heartbeat/reflection/callback) | Per-agent via `AppContext` | `None` | **Partial** — provider correct, per-skill override broken |
+
+## Proposed Solution
+
+Follow the team engine fix pattern (`AgentResources` with per-agent `Settings` + `LlmProvider`):
+
+### Phase 1: Per-agent state on `AgentState`
+
+Add `settings: Settings` and `llm: Arc<dyn LlmProvider>` fields to `AgentState` (`server/state.rs`).
+
+**`crates/mika-agent/src/server/state.rs`:**
+```rust
+pub struct AgentState {
+    pub db: AsyncDatabase,
+    pub skills: Vec<SkillEntry>,
+    pub dispatcher: Arc<TaskDispatcher>,
+    pub settings: Settings,                    // NEW
+    pub llm: Arc<dyn LlmProvider>,             // NEW
+}
+```
+
+### Phase 2: Refactor `init_agent()` to build per-agent LLM
+
+**`crates/mika-agent/src/server/mod.rs`:**
+
+Change `init_agent()` to accept `global_home: &Path` and `global_settings: &Settings` instead of `llm: &Arc<dyn LlmProvider>`. Internally:
+
+```rust
+fn init_agent(
+    global_home: &Path,
+    global_settings: &Settings,
+    agent_home: &Path,
+    // ... other params unchanged
+) -> Result<AgentState> {
+    let agent_settings = Settings::load_for_agent(global_home, agent_home)?;
+    let agent_llm = agent_settings.make_llm_provider()?;
+    // ... build TaskDispatcher with agent_llm and agent_settings
+}
+```
+
+### Phase 3: Thread `settings` through `TaskDispatcher`
+
+Add `pub settings: Settings` to `TaskDispatcher`. Update all four `SilentAgentParams` construction sites:
+
+- `dispatch_resume_agent` (line ~333)
+- `dispatch_skill_by_name` (line ~245)
+- `dispatch_heartbeat` (line ~513)
+- `dispatch_reflection` (line ~654)
+
+Change `settings: None` → `settings: Some(&self.settings)` in each.
+
+### Phase 4: Update HTTP handlers to use per-agent state
+
+**`crates/mika-agent/src/server/handlers.rs` — `handle_message`:**
+```rust
+// Before: llm: s.llm.as_ref(), settings: Some(&s.settings)
+// After:  llm: agent_state.llm.as_ref(), settings: Some(&agent_state.settings)
+```
+
+**`crates/mika-agent/src/server/a2a.rs` — `run_a2a_agent`:**
+```rust
+// Before: llm: state.llm.as_ref(), settings: Some(&state.settings)
+// After:  llm: agent_state.llm.as_ref(), settings: Some(&agent_state.settings)
+```
+
+### Phase 5: Keep `AppState.settings` for global values, remove `AppState.llm`
+
+`AppState.settings` is legitimately used for global values (`brave_api_key`, `github_token`, `gateway_url`, `internal_token`, `dashboard_token`). Keep it.
+
+Remove `AppState.llm` to prevent accidental misuse. Any remaining non-agent-scoped LLM usage (investigation panel) should construct its own provider from global settings.
+
+### Phase 6: Fix CLI `TaskDispatcher` settings
+
+**`crates/mika-cli/src/commands/chat.rs`:**
+
+Add `settings` to `TaskDispatcher` construction (line ~120). The CLI already has correct per-agent settings in `AppContext` — just thread it through.
+
+## System-Wide Impact
+
+- **Interaction graph:** `handle_message` → `run_agent()` → LLM call now uses per-agent provider. `TaskDispatcher.dispatch_*` → `run_silent_agent()` → LLM call now uses per-agent provider. No new callbacks or side effects introduced.
+- **Error propagation:** `Settings::load_for_agent()` failure during `init_agent()` triggers existing error path — agent is skipped with warning log. No change to error handling.
+- **State lifecycle risks:** None — `Settings` and `LlmProvider` are immutable after construction. No partial-failure orphan risk.
+- **API surface parity:** All six server dispatch paths + two HTTP handler paths share the same fix pattern. CLI gets the `settings` threading fix.
+- **Integration test scenarios:** (1) Multi-agent server with different `llm_provider` configs — verify callback uses correct provider. (2) Per-skill `[llm]` override in a callback turn. (3) Malformed per-agent config does not crash server startup.
+
+## Acceptance Criteria
+
+- [x] Server callback turns use the agent's `llm_provider`/`llm_model` config, not the global default
+- [x] Server heartbeat/reflection/skill_run turns use per-agent LLM provider
+- [x] Server `handle_message` and `run_a2a_agent` use per-agent LLM provider
+- [x] `SilentAgentParams.settings` is `Some(...)` in all server and CLI dispatch paths
+- [x] Per-skill `[llm]` overrides work in silent/callback mode
+- [x] `AppState.llm` removed (or scoped to non-agent use only)
+- [x] `AppState.settings` retained for global config values
+- [x] Malformed per-agent config.toml skips agent with warning, does not crash server
+- [x] CLI `TaskDispatcher` passes settings through
+- [x] Existing tests pass (`cargo test`)
+- [x] `cargo clippy` clean
+
+## Dependencies & Risks
+
+- **Low risk:** `Settings` already derives `Clone` (line 460 of `config.rs`), so storing owned copies in `AgentState` and `TaskDispatcher` is trivial.
+- **Precedent:** Team engine fix (#285) successfully applied this exact pattern. The same solution structure applies here.
+- **Breaking changes:** `init_agent()` signature changes (internal API, not public). `AppState.llm` removal requires updating all call sites. Both are contained within `mika-agent` crate.
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/server/state.rs` | Add `settings`, `llm` to `AgentState` |
+| `crates/mika-agent/src/server/mod.rs` | Refactor `init_agent()`, remove global `llm` construction |
+| `crates/mika-agent/src/server/handlers.rs` | Use `agent_state.llm`/`agent_state.settings` |
+| `crates/mika-agent/src/server/a2a.rs` | Use `agent_state.llm`/`agent_state.settings` |
+| `crates/mika-agent/src/task_engine/dispatcher.rs` | Add `settings: Settings`, pass `Some(&self.settings)` |
+| `crates/mika-cli/src/commands/chat.rs` | Pass `settings` to `TaskDispatcher` |
+| `crates/mika-common/src/config.rs` | No changes (already has `load_for_agent`) |
+
+## Sources
+
+- **Precedent fix:** `docs/solutions/logic-errors/team-engine-ignores-per-agent-llm-config.md` — exact same bug pattern in team engine
+- **Per-skill LLM doc:** `docs/solutions/architecture-patterns/per-skill-llm-override-via-toml-section.md` — flagged `settings: None` as known tech debt
+- **Config cascade:** `docs/solutions/architecture-patterns/simplified-config-4-source-model.md`
+- Related issue: #323

--- a/docs/solutions/logic-errors/server-dispatch-uses-global-llm-provider.md
+++ b/docs/solutions/logic-errors/server-dispatch-uses-global-llm-provider.md
@@ -1,0 +1,120 @@
+---
+title: "Server dispatch uses global LLM provider instead of per-agent config"
+category: logic-errors
+date: 2026-03-30
+tags: [llm-provider, per-agent-config, server-mode, callback, heartbeat, silent-agent, settings]
+issue: "#323"
+related:
+  - docs/solutions/logic-errors/team-engine-ignores-per-agent-llm-config.md
+  - docs/solutions/architecture-patterns/per-skill-llm-override-via-toml-section.md
+  - docs/solutions/architecture-patterns/simplified-config-4-source-model.md
+---
+
+# Server dispatch uses global LLM provider instead of per-agent config
+
+## Problem
+
+In server mode, all agent execution paths — message handling, A2A requests, and all silent dispatch paths (callback, heartbeat, reflection, skill_run) — used a single global `LlmProvider` constructed from `Settings::load(&home_dir)`. This ignored per-agent `config.toml` overrides entirely.
+
+An agent configured with `llm_provider = "deepseek"` in its `config.toml` would still use the global default (e.g., `minimax/MiniMax-M2.7`) for all callback and background turns.
+
+Additionally, all four `SilentAgentParams` construction sites in `TaskDispatcher` passed `settings: None`, which blocked per-skill `[llm]` overrides via `resolve_skill_llm_override()`.
+
+**Symptom:** LLM call logs for callback sessions showed the wrong provider/model compared to the agent's configured values.
+
+## Root cause
+
+Two compounding issues:
+
+1. **`run_server()` built one global LLM provider.** `Settings::load(&home_dir)` calls `Settings::load_for_agent(home_dir, home_dir)` — since `global_home == agent_home`, the per-agent config layer was never applied. The single `Arc<dyn LlmProvider>` was stored on `AppState` and shared across all agents.
+
+2. **`TaskDispatcher` passed `settings: None`.** All four dispatch methods (`dispatch_resume_agent`, `dispatch_skill_by_name`, `dispatch_heartbeat`, `dispatch_reflection`) constructed `SilentAgentParams` with `settings: None`, blocking per-skill LLM overrides.
+
+This is the same bug class as the team engine fix (#285), now manifesting in the server dispatcher and HTTP handler paths.
+
+## Solution
+
+Moved LLM provider ownership from shared `AppState` to per-agent `AgentState`, following the team engine fix pattern:
+
+### 1. Added per-agent state to `AgentState`
+
+```rust
+// server/state.rs
+pub struct AgentState {
+    // ... existing fields ...
+    pub settings: Settings,           // NEW: per-agent config
+    pub llm: Arc<dyn LlmProvider>,    // NEW: per-agent provider
+}
+```
+
+### 2. Refactored `init_agent()` to build per-agent LLM
+
+```rust
+async fn init_agent(
+    agent_name: &str,
+    agent_home: &Path,
+    global_home: &Path,
+    // removed: llm: &Arc<dyn LlmProvider>,
+    // ...
+) -> Result<AgentState> {
+    let agent_settings = Settings::load_for_agent(global_home, agent_home)?;
+    let agent_llm = agent_settings.make_llm_provider()?;
+    // ... uses agent_llm for TaskDispatcher and AgentState
+}
+```
+
+### 3. Added `settings` to `TaskDispatcher`
+
+```rust
+pub struct TaskDispatcher {
+    // ... existing fields ...
+    pub settings: Settings,
+}
+```
+
+All four `SilentAgentParams` sites changed from `settings: None` to `settings: Some(&self.settings)`.
+
+### 4. Updated HTTP handlers
+
+- `handle_message`: `s.llm` → `a.llm`, `s.settings` → `a.settings`
+- `run_a2a_agent`: `state.llm` → `agent_state.llm`, `state.settings` → `agent_state.settings`
+- Compaction: `s.llm` → `a.llm`
+
+### 5. Removed `AppState.llm`
+
+The global `llm` field was removed from `AppState` to prevent accidental misuse. The investigation panel now uses the default agent's LLM provider directly.
+
+### 6. Fixed CLI `TaskDispatcher`
+
+Added `settings: ctx.settings.clone()` to the CLI `TaskDispatcher` construction, enabling per-skill LLM overrides in CLI background tasks.
+
+## Affected paths
+
+| Path | Before | After |
+|------|--------|-------|
+| `handle_message` | Global `AppState.llm` | Per-agent `AgentState.llm` |
+| `run_a2a_agent` | Global `AppState.llm` | Per-agent `AgentState.llm` |
+| `dispatch_resume_agent` (callback) | Global LLM, `settings: None` | Per-agent LLM, `settings: Some(...)` |
+| `dispatch_heartbeat` | Global LLM, `settings: None` | Per-agent LLM, `settings: Some(...)` |
+| `dispatch_reflection` | Global LLM, `settings: None` | Per-agent LLM, `settings: Some(...)` |
+| `dispatch_skill_by_name` | Global LLM, `settings: None` | Per-agent LLM, `settings: Some(...)` |
+| CLI `TaskDispatcher` | Correct LLM, `settings: None` | Correct LLM, `settings: Some(...)` |
+
+## Prevention
+
+1. **Config resolution rule:** All agent execution contexts (CLI, server, silent, team, callback) must use `Settings::load_for_agent(global_home, agent_home)` — never `Settings::load(home_dir)` alone.
+
+2. **No shared `LlmProvider` across agents.** Each agent constructs its own provider from its own settings. Shared state (`AppState`) should only hold non-agent-scoped values.
+
+3. **`settings: None` is tech debt.** When adding `Option<&T>` params for new features, decide upfront whether all code paths will supply it. If not, document the limitation.
+
+4. **Grep for the pattern:** When fixing a provider resolution bug in one execution context, search for the same pattern in all other contexts (CLI, server, team engine, silent dispatch).
+
+## Key files
+
+- `crates/mika-agent/src/server/state.rs` — `AgentState` struct (added `settings`, `llm`; removed `llm` from `AppState`)
+- `crates/mika-agent/src/server/mod.rs` — `init_agent()` (per-agent settings loading), `run_server()` (removed global LLM)
+- `crates/mika-agent/src/server/handlers.rs` — `handle_message` (switched to per-agent)
+- `crates/mika-agent/src/server/a2a.rs` — `run_a2a_agent` (switched to per-agent)
+- `crates/mika-agent/src/task_engine/dispatcher.rs` — All four `SilentAgentParams` sites
+- `crates/mika-cli/src/commands/chat.rs` — CLI `TaskDispatcher` settings threading


### PR DESCRIPTION
## Summary

- **Bug:** Callback, heartbeat, reflection, and skill_run turns in server mode used the global `config.toml` LLM provider instead of per-agent overrides. `handle_message` and A2A requests were also affected.
- **Fix:** Move `llm` and `settings` from shared `AppState` to per-agent `AgentState`. Each agent now loads its own config via `Settings::load_for_agent()` and builds its own `LlmProvider`.
- **Also fixed:** `TaskDispatcher` now passes `settings: Some(&self.settings)` to all `SilentAgentParams` constructions, enabling per-skill `[llm]` overrides in silent mode. CLI `TaskDispatcher` also gets settings threading.

Closes #323

## Test plan

- [x] All existing tests pass (`cargo test` — 1847+ tests)
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass (fmt, clippy, no-secrets, no-large-files)
- [ ] Manual: Deploy with multi-agent setup where agents have different `llm_provider` configs — verify callback sessions use the correct provider

## Post-Deploy Monitoring & Validation

- **What to monitor:** LLM call logs (`llm_calls` table) for callback/heartbeat sessions — verify `provider` and `model` columns match the agent's `config.toml`, not the global default
- **Validation query:** `SELECT session_id, provider, model FROM llm_calls WHERE session_id LIKE 'callback-%' ORDER BY created_at DESC LIMIT 10;`
- **Expected healthy behavior:** Each agent's background turns show the agent's configured provider/model
- **Failure signal:** Background sessions show the global default provider instead of the agent's override

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)