### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1](https://github.com/senara-solutions/mika/releases/tag/v0.3.1) — 2026-03-31
+
+### Fixed
+
+- remove remaining fallback references in config field doc and reference table
+- remove MIKA_INVESTIGATE_GITHUB_TOKEN fallback from agent_github_token()
+
 ## [0.3.0](https://github.com/senara-solutions/mika/releases/tag/v0.3.0) — 2026-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mika-a2a"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "mika-agent"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "mika-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "mika-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "mika-gateway"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 description = "AI executive assistant with persistent memory"
@@ -139,9 +139,9 @@ serial_test = "3"
 dashmap = "6"
 
 # Workspace crates
-mika-common = { path = "crates/mika-common", version = "0.3.0" }
-mika-agent = { path = "crates/mika-agent", version = "0.3.0" }
-mika-a2a = { path = "crates/mika-a2a", version = "0.3.0" }
+mika-common = { path = "crates/mika-common", version = "0.3.1" }
+mika-agent = { path = "crates/mika-agent", version = "0.3.1" }
+mika-a2a = { path = "crates/mika-a2a", version = "0.3.1" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION



## 🤖 New release

* `mika-a2a`: 0.3.0 -> 0.3.1
* `mika-common`: 0.3.0 -> 0.3.1
* `mika-agent`: 0.3.0 -> 0.3.1
* `mika-cli`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `mika-common`

<blockquote>

## [0.3.1](https://github.com/senara-solutions/mika/releases/tag/v0.3.1) — 2026-03-31

### Fixed

- remove remaining fallback references in config field doc and reference table
- remove MIKA_INVESTIGATE_GITHUB_TOKEN fallback from agent_github_token()
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).