### PR TITLE
fix: add dashboard dist placeholder to release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,6 +23,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Create dashboard dist placeholder
+        run: mkdir -p dashboard/dist && touch dashboard/dist/.gitkeep
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040  # v0.5
         with:
           command: release-pr
@@ -44,6 +46,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Create dashboard dist placeholder
+        run: mkdir -p dashboard/dist && touch dashboard/dist/.gitkeep
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040  # v0.5
         with:
           command: release


### PR DESCRIPTION
## Summary

- Adds `mkdir -p dashboard/dist && touch dashboard/dist/.gitkeep` to both `release-plz-pr` and `release-plz-release` jobs, matching the existing pattern in `ci.yml`
- Fixes the Release job failure where `rust-embed` could not derive the `Embed` trait on `DashboardAssets` because `dashboard/dist/` doesn't exist in CI

**Root cause:** `cargo publish --verify` compiles `mika-agent`, which uses `#[derive(Embed)]` on a struct pointing at `../../dashboard/dist/`. Without this directory, the derive macro fails to generate trait methods (`get`, `iter`), causing compilation errors.

**Failed run:** https://github.com/senara-solutions/mika/actions/runs/23821694057/job/69435254984

## Test plan

- [ ] Verify the `Release-plz` workflow passes on this PR's merge to main
- [ ] Re-run the release workflow via `workflow_dispatch` if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)