### PR TITLE
fix(ci): use pinned Rust toolchain in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Install Rust toolchain
+        run: rustup show  # reads rust-toolchain.toml
       - name: Create dashboard dist placeholder
         run: mkdir -p dashboard/dist
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040  # v0.5
@@ -45,7 +46,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+      - name: Install Rust toolchain
+        run: rustup show  # reads rust-toolchain.toml
       - name: Create dashboard dist placeholder
         run: mkdir -p dashboard/dist
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040  # v0.5


### PR DESCRIPTION
## Summary

- Replace `dtolnay/rust-toolchain@stable` (Rust 1.94.1) with `rustup show` (reads `rust-toolchain.toml` → Rust 1.93) in both release-plz jobs
- Fixes `cargo package --verify` failure where `#[derive(Embed)]` with `$OUT_DIR` interpolation + `#[allow_missing = true]` fails to generate the `Embed` trait impl on Rust 1.94, causing `E0599` errors on `DashboardAssets::get()` and `::iter()`
- Matches the toolchain installation pattern already used in `ci.yml`

## Context

The Release-plz workflow has been failing on every push to `main` since April 1st (10+ consecutive failures). The root cause is a Rust version mismatch: `release-plz.yml` installed `stable` (1.94.1) while the repo pins 1.93. Locally with Rust 1.93, `cargo package -p mika-agent --allow-dirty` compiles fine — the `DashboardAssets` derive generates a valid empty impl. Under Rust 1.94, the derive silently fails to generate the impl in the `cargo package --verify` context.

## Test plan

- [ ] CI passes on this PR (validates `rustup show` works in GitHub Actions)
- [ ] After merge, the Release-plz workflow succeeds on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)