### PR TITLE
fix: worktree lefthook install and cost_usd numeric type (#406)

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -17,13 +17,14 @@ Before running the pipeline, set up an isolated worktree:
 
 1. **Parse branch:** If `$ARGUMENTS` starts with `branch:<name>`, extract `<name>` as the branch name and strip the `branch:<name>` prefix from `$ARGUMENTS`. Otherwise, derive the branch name from args (issue → `feat|fix|chore/<number>/<kebab-title>`, free-text → `feat/<kebab>`).
 2. **Skip if no branch or no args:** If there are no arguments (backlog eval mode), skip worktree creation and run the pipeline in the current directory.
-3. **Detect existing worktree (MANDATORY):** Run `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, you are ALREADY inside a worktree. **STOP worktree setup immediately** — set `CREATED_WORKTREE=false` and proceed directly to the Pipeline section below. Do NOT attempt to create, remove, or modify any worktree. Do NOT clean up or recreate. Just use the current directory as-is.
+3. **Detect existing worktree (MANDATORY):** Run `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, you are ALREADY inside a worktree. **STOP worktree setup immediately** — set `CREATED_WORKTREE=false`, run `command -v lefthook >/dev/null 2>&1 && lefthook install` (non-blocking — skip silently if lefthook is not installed), and proceed directly to the Pipeline section below. Do NOT attempt to create, remove, or modify any worktree. Do NOT clean up or recreate. Just use the current directory as-is.
 4. **Sync main:** Run `git fetch origin main:main` to fast-forward local `main` to match remote. This ensures the worktree branches from the latest code. If it fails (e.g., `main` is checked out with uncommitted changes), fall back to `git fetch origin` and use `origin/main` as the base ref in the next step.
 5. **Create worktree:** Set `WORKTREE=../.claude/worktrees/<sanitized-branch>/mika/` (sanitize branch name: replace `/` with `-`). Record `ORIGINAL_DIR=$(pwd)`.
    - If the worktree path already exists, remove it first: `git worktree remove --force <WORKTREE>` (ignore errors).
    - Try: `git worktree add -b <branch> <WORKTREE> main`
    - If that fails (branch already exists): `git worktree add <WORKTREE> <branch>`
    - cd into the worktree. Set `CREATED_WORKTREE=true`.
+6. **Install lefthook hooks:** Run `command -v lefthook >/dev/null 2>&1 && lefthook install` to ensure pre-commit hooks (fmt, clippy, secrets scan) are active in the worktree. Non-blocking — skip silently if lefthook is not installed.
 
 ## Pipeline
 

--- a/crates/mika-agent/src/server/dashboard_dev_runs.rs
+++ b/crates/mika-agent/src/server/dashboard_dev_runs.rs
@@ -59,7 +59,10 @@ impl From<Task> for DevRunResponse {
                     cp.get("pr_url")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string()),
-                    cp.get("cost_usd").and_then(|v| v.as_f64()),
+                    cp.get("cost_usd").and_then(|v| {
+                        v.as_f64()
+                            .or_else(|| v.as_str().and_then(|s| s.parse::<f64>().ok()))
+                    }),
                     cp.get("duration_ms").and_then(|v| v.as_u64()),
                     cp.get("turns").and_then(|v| v.as_u64()).map(|n| n as u32),
                     cp.get("session_id")

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -897,8 +897,15 @@ fn extract_callback_fields(result: &str) -> serde_json::Value {
         map.insert("turns".into(), serde_json::Value::Number(n.into()));
     }
     if let Some(cap) = RE_COST.captures(result) {
-        // Regex already rejects non-numeric input (e.g. "$unknown")
-        map.insert("cost_usd".into(), serde_json::Value::String(cap[1].into()));
+        // Parse as f64 and store as JSON number (consistent with turns/duration_ms).
+        // from_f64 returns None for NaN/Infinity — impossible from the regex but handled defensively.
+        if let Some(n) = cap[1]
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+        {
+            map.insert("cost_usd".into(), serde_json::Value::Number(n));
+        }
     }
     if let Some(cap) = RE_DURATION.captures(result)
         && let Ok(n) = cap[1].parse::<u64>()
@@ -1148,7 +1155,7 @@ mod tests {
         let cp = &extracted["claude_pilot"];
         assert_eq!(cp["session_id"], "abc-123-def");
         assert_eq!(cp["turns"], 91);
-        assert_eq!(cp["cost_usd"], "7.07");
+        assert_eq!(cp["cost_usd"], 7.07);
         assert_eq!(cp["duration_ms"], 996000);
     }
 
@@ -1163,7 +1170,7 @@ mod tests {
         let cp = &extracted["claude_pilot"];
         assert_eq!(cp["session_id"], "sess-456");
         assert_eq!(cp["turns"], 45);
-        assert_eq!(cp["cost_usd"], "3.50");
+        assert_eq!(cp["cost_usd"], 3.5);
         assert_eq!(cp["duration_ms"], 500000);
     }
 
@@ -1175,7 +1182,7 @@ mod tests {
         let extracted = extract_callback_fields(result);
         let cp = &extracted["claude_pilot"];
         assert_eq!(cp["session_id"], "my-session");
-        assert_eq!(cp["cost_usd"], "1.23");
+        assert_eq!(cp["cost_usd"], 1.23);
         assert!(cp.get("turns").is_none());
         assert!(cp.get("duration_ms").is_none());
     }
@@ -1288,7 +1295,7 @@ mod tests {
         let cp = &metadata["claude_pilot"];
         assert_eq!(cp["session_id"], "test-session-id");
         assert_eq!(cp["turns"], 91);
-        assert_eq!(cp["cost_usd"], "7.07");
+        assert_eq!(cp["cost_usd"], 7.07);
         assert_eq!(cp["duration_ms"], 996000);
     }
 

--- a/docs/plans/2026-04-03-002-fix-dev-loop-reliability-worktree-metadata-plan.md
+++ b/docs/plans/2026-04-03-002-fix-dev-loop-reliability-worktree-metadata-plan.md
@@ -1,0 +1,123 @@
+---
+title: "fix: dev loop reliability — worktree hooks and metadata cleanup"
+type: fix
+status: completed
+date: 2026-04-03
+issues: [406, 398, 385]
+---
+
+# Dev Loop Reliability — Worktree Hooks and Metadata Cleanup
+
+## Overview
+
+Two reliability improvements for the autonomous dev loop: (1) ensure lefthook pre-commit hooks run in worktrees created by the `/mika` pipeline, and (2) normalize `cost_usd` callback metadata to numeric JSON type so the dashboard can display it.
+
+## Task 1: lefthook install in worktrees (#398)
+
+### Problem
+
+The `/mika` pipeline creates git worktrees but never runs `lefthook install` in them. Lefthook hooks (fmt, clippy, secrets scan — 7 checks total) are silently bypassed. Evidence: PR #396 was created with `cargo fmt` violations and `cargo clippy` errors, requiring two manual fix commits.
+
+### Fix
+
+Add `lefthook install` after worktree creation in two files:
+
+1. **`mika/.claude/commands/mika.md`** — per-repo pipeline (after step 5 "cd into the worktree")
+2. **`mika-platform/.claude/commands/mika.md`** — meta-repo dispatcher (after worktree creation in self-targeting pipeline)
+
+**Failure policy:** Non-blocking. Use `command -v lefthook >/dev/null 2>&1 && lefthook install` to silently skip when lefthook is not installed (Docker containers, CI environments may lack it).
+
+**Idempotency:** `lefthook install` is idempotent — safe to run on fresh or reused worktrees.
+
+**Existing worktree detection:** When step 3 detects an already-existing worktree (`CREATED_WORKTREE=false`), still run `lefthook install` before the pipeline starts. An existing worktree may lack hooks.
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `.claude/commands/mika.md` | Add `lefthook install` after worktree cd (line ~26), and after existing worktree detection (line ~20) |
+
+### Out of scope (follow-up)
+
+- `mika-skills/claude-pilot/handlers/run.sh` — autonomous handler creates worktrees too, but lives in a different repo. File a follow-up issue.
+- `mika-platform/.claude/commands/mika.md` — meta-repo dispatcher. Separate repo, separate PR.
+
+## Task 2: normalize cost_usd to numeric type (#385)
+
+### Problem
+
+In `extract_callback_fields()` (`dispatcher.rs` line 901), `cost_usd` is stored as a JSON string (`"7.07"`) while `turns` and `duration_ms` are stored as numbers. Downstream, `dashboard_dev_runs.rs` line 62 calls `as_f64()` which returns `None` for strings — **cost_usd is always null in the dashboard**.
+
+### Fix — Write path
+
+```rust
+// dispatcher.rs, extract_callback_fields(), line 899-901
+// BEFORE:
+if let Some(cap) = RE_COST.captures(result) {
+    map.insert("cost_usd".into(), serde_json::Value::String(cap[1].into()));
+}
+
+// AFTER:
+if let Some(cap) = RE_COST.captures(result) {
+    if let Some(n) = cap[1].parse::<f64>().ok().and_then(serde_json::Number::from_f64) {
+        map.insert("cost_usd".into(), serde_json::Value::Number(n));
+    }
+}
+```
+
+Pattern matches `turns` and `duration_ms` handling. `from_f64()` returns `None` for NaN/Infinity (impossible from the regex `r"Cost:\s*\$([0-9]+(?:\.[0-9]+)?)"` but handled defensively).
+
+### Fix — Read path (backward compatibility)
+
+Update `dashboard_dev_runs.rs` line 62 to parse both string and number types for historical data:
+
+```rust
+// BEFORE:
+cp.get("cost_usd").and_then(|v| v.as_f64()),
+
+// AFTER:
+cp.get("cost_usd").and_then(|v| v.as_f64().or_else(|| v.as_str().and_then(|s| s.parse::<f64>().ok()))),
+```
+
+This fixes both old (string) and new (number) data without a migration.
+
+### Tests to update
+
+5 assertions in `dispatcher.rs` that compare `cost_usd` as string:
+
+| Test | Line | Current | Expected |
+|------|------|---------|----------|
+| `test_extract_success_format` | ~1151 | `assert_eq!(cp["cost_usd"], "7.07")` | `assert_eq!(cp["cost_usd"], 7.07)` |
+| `test_extract_pipeline_failure_format` | ~1166 | `assert_eq!(cp["cost_usd"], "3.50")` | `assert_eq!(cp["cost_usd"], 3.5)` |
+| `test_extract_partial_fields` | ~1178 | `assert_eq!(cp["cost_usd"], "1.23")` | `assert_eq!(cp["cost_usd"], 1.23)` |
+| `test_extract_unknown_values_skipped` | ~1196 | `assert!(cp.get("cost_usd").is_none())` | No change |
+| `test_try_extract_callback_metadata_writes_to_parent` | ~1291 | `assert_eq!(cp["cost_usd"], "7.07")` | `assert_eq!(cp["cost_usd"], 7.07)` |
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/task_engine/dispatcher.rs` | Fix `extract_callback_fields()` cost_usd to numeric; update 4 test assertions |
+| `crates/mika-agent/src/server/dashboard_dev_runs.rs` | Add dual-parse for backward compatibility |
+
+### Out of scope (follow-up)
+
+- `mika-skills/self-dev/system_prompt.md` — prompt example shows `"cost_usd": "..."` (string). Should be updated to show numeric value and note engine pre-writes these fields. Separate repo.
+
+## Acceptance Criteria
+
+- [x] `lefthook install` runs after worktree creation in `mika/.claude/commands/mika.md`
+- [x] `lefthook install` runs for detected existing worktrees too
+- [x] lefthook failure is non-blocking (silent skip if binary not found)
+- [x] `cost_usd` stored as JSON number in callback metadata
+- [x] Dashboard reads both string and number `cost_usd` (backward compat)
+- [x] All tests pass (`cargo test -p mika-agent`)
+
+## Sources
+
+- Issue #406 (umbrella), #398 (lefthook), #385 (cost_usd)
+- Learnings: `docs/solutions/build-errors/lefthook-not-installed-worktree-ci-failure.md`
+- Learnings: `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md`
+- `crates/mika-agent/src/task_engine/dispatcher.rs:878` — `extract_callback_fields()`
+- `crates/mika-agent/src/server/dashboard_dev_runs.rs:62` — `DevRunResponse` read path
+- `.claude/commands/mika.md:14-26` — worktree setup section


### PR DESCRIPTION
## Summary

- **lefthook install in worktrees:** Added `lefthook install` to `.claude/commands/mika.md` in both existing worktree detection (step 3) and new worktree creation (step 6). Non-blocking — uses `command -v lefthook` guard.
- **cost_usd numeric type:** `extract_callback_fields()` in `dispatcher.rs` now stores `cost_usd` as `serde_json::Value::Number` instead of `Value::String`. Dashboard `dev_runs` endpoint handles both types for backward compat.

Closes #406

## Test plan

- [x] 15 callback metadata tests pass (including updated numeric assertions)
- [x] `cargo clippy` clean
- [x] lefthook pre-commit hooks pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: lefthook install is a dev-time change, cost_usd type change is backward compatible.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)