### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [v0.4.0](https://github.com/senara-solutions/mika/releases/tag/vv0.4.0) — 2026-04-03
+## [v0.4.0](https://github.com/senara-solutions/mika/releases/tag/v0.4.0) — 2026-04-03
 
 ### Added
 
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file.
 - *(ci)* declare only mika-common in release-plz.toml
 - *(ci)* replace release-plz with git-cliff release workflow
 - *(ci)* fix YAML syntax in release workflow
-## [v0.3.2](https://github.com/senara-solutions/mika/releases/tag/vv0.3.2) — 2026-04-02
+- *(ci)* fix double-v in changelog release URL
+- *(ci)* exclude release/* branches from pipeline artifact checks
+## [v0.3.2](https://github.com/senara-solutions/mika/releases/tag/v0.3.2) — 2026-04-02
 
 ### Added
 
@@ -56,7 +58,7 @@ All notable changes to this project will be documented in this file.
 - *(ci)* use pinned Rust toolchain in release-plz workflow (#394)
 - *(ci)* revert release-plz to crates.io comparison mode
 - *(ci)* remove dist from dashboard/.gitignore
-## [v0.3.1](https://github.com/senara-solutions/mika/releases/tag/vv0.3.1) — 2026-03-31
+## [v0.3.1](https://github.com/senara-solutions/mika/releases/tag/v0.3.1) — 2026-03-31
 
 ### Added
 
@@ -78,7 +80,7 @@ All notable changes to this project will be documented in this file.
 - *(gateway)* match on_response log level to span level for health probes
 - remove MIKA_INVESTIGATE_GITHUB_TOKEN fallback from agent_github_token()
 - remove remaining fallback references in config field doc and reference table
-## [v0.3.0](https://github.com/senara-solutions/mika/releases/tag/vv0.3.0) — 2026-03-30
+## [v0.3.0](https://github.com/senara-solutions/mika/releases/tag/v0.3.0) — 2026-03-30
 
 ### Added
 
@@ -404,7 +406,7 @@ All notable changes to this project will be documented in this file.
 - use per-agent LLM provider in server mode (#323)
 - [#350] add timezone support to reminders to prevent off-by-one day errors
 - [#350] address QA HOLD-2 and HOLD-3 on timezone reminder PR
-## [v0.1.6](https://github.com/senara-solutions/mika/releases/tag/vv0.1.6) — 2026-03-13
+## [v0.1.6](https://github.com/senara-solutions/mika/releases/tag/v0.1.6) — 2026-03-13
 
 ### Added
 
@@ -602,7 +604,7 @@ All notable changes to this project will be documented in this file.
 ### Security
 
 - *(server)* separate dashboard token from mutation endpoints
-## [v0.1.4](https://github.com/senara-solutions/mika/releases/tag/vv0.1.4) — 2026-03-07
+## [v0.1.4](https://github.com/senara-solutions/mika/releases/tag/v0.1.4) — 2026-03-07
 
 ### Added
 
@@ -763,7 +765,7 @@ All notable changes to this project will be documented in this file.
 - remove agent_id filtering from task tree traversal queries
 - don't load agent chat history in team mode TUI
 - use orchestrator agent_id for invoke_orchestrator parent task
-## [v0.1.1](https://github.com/senara-solutions/mika/releases/tag/vv0.1.1) — 2026-03-01
+## [v0.1.1](https://github.com/senara-solutions/mika/releases/tag/v0.1.1) — 2026-03-01
 
 ### Added
 


### PR DESCRIPTION
## Release v0.4.0
## [v0.4.0](https://github.com/senara-solutions/mika/releases/tag/v0.4.0) — 2026-04-03

### Added

- *(ui)* add semantic color tokens and flexible EmptyState (#393)
- [#381] github_app module — JWT signing, installation token caching (#396)
- *(gateway)* GitHub webhook endpoint — POST /webhook/github (#399)
- *(cli)* HTTPS git push with installation token — credential helper and mika token CLI (#400)

### Fixed

- *(gateway)* remove bot self-event filter — blocks webhook-driven dev loop (#401) (#402)
- *(agent)* give SilentTrigger::Reminder 20-step budget matching Callback (#404)
- *(gateway,agent)* unblock webhook-driven dev loop (#407)
- worktree lefthook install and cost_usd numeric type (#406) (#408)
- *(ci)* switch release-plz to git_only mode for tag-based comparison
- *(ci)* set release = false on all crates except mika-common
- *(ci)* remove version from workspace dep specs for publish = false crates
- *(ci)* declare only mika-common in release-plz.toml
- *(ci)* replace release-plz with git-cliff release workflow
- *(ci)* fix YAML syntax in release workflow
- *(ci)* fix double-v in changelog release URL
- *(ci)* exclude release/* branches from pipeline artifact checks

---
Merging this PR will trigger tag creation and GitHub release.