### PR TITLE
fix: load per-agent .env for token and credential-helper (#427)

### DIFF
--- a/crates/mika-cli/src/main.rs
+++ b/crates/mika-cli/src/main.rs
@@ -22,20 +22,28 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Commands::Token(args)) => {
             let global_home = home::resolve_home_dir()?;
-            mika_common::dotenv::load_dotenv(&global_home);
             let agent_home = cli
                 .agent
                 .as_deref()
                 .map(|name| home::resolve_agent_home(&global_home, name));
+            // Load per-agent .env first (dotenvy won't override), then global as fallback
+            if let Some(ref ah) = agent_home {
+                mika_common::dotenv::load_dotenv(ah);
+            }
+            mika_common::dotenv::load_dotenv(&global_home);
             return commands::token::run(&args.command, &global_home, agent_home.as_deref()).await;
         }
         Some(Commands::CredentialHelper(args)) => {
             let global_home = home::resolve_home_dir()?;
-            mika_common::dotenv::load_dotenv(&global_home);
             let agent_home = cli
                 .agent
                 .as_deref()
                 .map(|name| home::resolve_agent_home(&global_home, name));
+            // Load per-agent .env first (dotenvy won't override), then global as fallback
+            if let Some(ref ah) = agent_home {
+                mika_common::dotenv::load_dotenv(ah);
+            }
+            mika_common::dotenv::load_dotenv(&global_home);
             return commands::credential_helper::run(
                 &args.operation,
                 &global_home,

--- a/docs/plans/2026-04-03-007-fix-per-agent-dotenv-loading-plan.md
+++ b/docs/plans/2026-04-03-007-fix-per-agent-dotenv-loading-plan.md
@@ -1,0 +1,58 @@
+---
+title: "fix: per-agent .env loading for token and credential-helper"
+type: fix
+status: completed
+date: 2026-04-03
+---
+
+# fix: per-agent .env loading for token and credential-helper
+
+## Overview
+
+`mika token github` and `mika credential-helper` only load `~/.mika/.env` (global). When `--agent` is passed, the per-agent `~/.mika/agents/<name>/.env` is never loaded into the process environment. Since PR #426 moved GitHub App credentials to per-agent `.env`, these commands fail.
+
+## Root Cause
+
+In `main.rs` lines 23-30 and 32-39: `load_dotenv(&global_home)` is called, but `load_dotenv(&agent_home)` is never called. The `agent_home` is correctly resolved and passed to `token.rs`/`credential_helper.rs`, but `Settings::load_for_agent()` reads from process env vars — which were never populated from the agent's `.env` file.
+
+## Fix
+
+Load per-agent `.env` BEFORE global `.env` when `--agent` is specified. dotenvy does not override existing vars, so the first load wins. Per-agent credentials take precedence.
+
+### `crates/mika-cli/src/main.rs`
+
+For both `Token` and `CredentialHelper` branches:
+
+```rust
+// Before (broken):
+let global_home = home::resolve_home_dir()?;
+mika_common::dotenv::load_dotenv(&global_home);
+let agent_home = cli.agent.as_deref()
+    .map(|name| home::resolve_agent_home(&global_home, name));
+
+// After (fixed):
+let global_home = home::resolve_home_dir()?;
+let agent_home = cli.agent.as_deref()
+    .map(|name| home::resolve_agent_home(&global_home, name));
+// Load per-agent .env first (wins on conflict), then global as fallback
+if let Some(ref ah) = agent_home {
+    mika_common::dotenv::load_dotenv(ah);
+}
+mika_common::dotenv::load_dotenv(&global_home);
+```
+
+## Acceptance Criteria
+
+- [ ] `mika --agent mika-dev token github` loads per-agent `.env` and prints a token
+- [ ] `mika --agent mika-qa token github` loads per-agent `.env` and prints a token
+- [ ] `mika token github` (no agent) still works with global `.env`
+- [ ] `mika --agent mika-dev credential-helper get` uses per-agent App credentials
+- [ ] Per-agent vars take precedence over global vars
+- [ ] `cargo test` passes
+
+## Sources
+
+- Issue: #427
+- Per-agent `.env` introduced in: PR #426
+- dotenv module: `crates/mika-common/src/dotenv.rs`
+- CLI entry point: `crates/mika-cli/src/main.rs:22-39`


### PR DESCRIPTION
## Summary

- `mika token github` and `mika credential-helper` now load per-agent `.env` when `--agent` is passed
- Per-agent `.env` is loaded BEFORE global `.env` so agent-specific GitHub App credentials take precedence
- Fixes the chicken-and-egg problem: per-agent App credentials (PR #426) were unreachable by CLI subcommands

Closes #427

## Changes

`crates/mika-cli/src/main.rs` — for both `Token` and `CredentialHelper` early-return branches: resolve `agent_home` first, load its `.env`, then load global `.env`. dotenvy does not override existing vars, so first load wins.

## Test plan

- [x] `cargo test -p mika-cli` — 238 passed
- [x] `cargo clippy` — clean
- [x] lefthook pre-commit — all pass
- [ ] Manual: `mika --agent mika-dev token github` prints installation token
- [ ] Manual: `mika --agent mika-qa token github` prints installation token

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)