### PR TITLE
fix(skills): inject GH_TOKEN into exec handler child processes (#515 #517)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Optional (GitHub — investigation panel):
 - `MIKA_GITHUB_REPO` — Target repository in `owner/repo` format (e.g. `senara-solutions/mika`). Both `MIKA_INVESTIGATE_GITHUB_TOKEN` and this must be set to enable the `create_github_issue` investigation tool.
 
 Optional (gh CLI in agent sessions):
-- `GH_TOKEN` — GitHub PAT for `gh` CLI in Claude Code sessions spawned via claude-pilot. Without this, `gh` falls back to the host user's personal `~/.config/gh/hosts.yml`. Do NOT set in `~/.mika/.env` — if detected there, `check_env_warnings()` actively removes it from the process environment at startup (#380). `scrub_mika_env_vars()` also scrubs `GH_TOKEN` from exec handler child processes via `EXTRA_SCRUB_VARS` (defense-in-depth). Agent `run_gh` operations inject `MIKA_GITHUB_TOKEN` as `GH_TOKEN` AFTER the scrub for platform identity separation.
+- `GH_TOKEN` — GitHub PAT for `gh` CLI in Claude Code sessions spawned via claude-pilot. Without this, `gh` falls back to the host user's personal `~/.config/gh/hosts.yml`. Do NOT set in `~/.mika/.env` — if detected there, `check_env_warnings()` actively removes it from the process environment at startup (#380). `scrub_mika_env_vars()` also scrubs `GH_TOKEN` from exec handler child processes via `EXTRA_SCRUB_VARS` (defense-in-depth). The builtin `run_gh` and `pr_merge_with_gate` handlers, along with all exec handler skill subprocesses, re-inject `MIKA_GITHUB_TOKEN` as `GH_TOKEN` AFTER the scrub for platform identity separation (#515).
 
 Server mode additionally requires:
 - `MIKA_ROUTING_URL` — Gateway URL for outbound message delivery

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -215,6 +215,10 @@ Without it, `gh` falls back to the host user's `~/.config/gh/hosts.yml` (persona
 Additionally, `scrub_mika_env_vars()` scrubs `GH_TOKEN` from exec handler child processes
 via `EXTRA_SCRUB_VARS` as defense-in-depth. The `run_gh` builtin handler re-injects
 `MIKA_GITHUB_TOKEN` as `GH_TOKEN` AFTER the scrub for correct platform identity separation.
+The same scrub-then-inject pattern is applied to all exec handler subprocesses spawned by
+skills — `MIKA_GITHUB_TOKEN` is re-injected as `GH_TOKEN` after the env scrub, so any `gh`
+CLI invocation inside a skill handler runs as the agent's configured GitHub identity (not
+the host user).
 
 | Layer | Identity | Purpose |
 |-------|----------|---------|

--- a/crates/mika-agent/docs/skills.md
+++ b/crates/mika-agent/docs/skills.md
@@ -205,6 +205,7 @@ Execution details:
 - Stdout is captured as the successful tool result.
 - Stderr is included in the error message on non-zero exit.
 - The command is **not** passed the tool name as an argument — all dispatch context is in the JSON on stdin.
+- All `MIKA_*` environment variables are scrubbed from the child process. The agent's `MIKA_GITHUB_TOKEN` is then re-injected as `GH_TOKEN` so `gh` CLI calls in the handler run as the agent's GitHub identity. Note that `git push` / `git clone` over HTTPS does **not** receive credential helper injection — those operations fall back to host credentials or fail. Skill authors who need git over HTTPS should use SSH remotes instead, or open an issue to request `GIT_ASKPASS` injection.
 
 Exec handlers require a `tools.json` file in the skill directory to define the tool schemas sent to Claude.
 

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1698,6 +1698,7 @@ async fn execute_tool(
             input,
             dispatch.skill_timeout,
             dispatch.long_running_ctx,
+            dispatch.ctx.github_token,
         )
         .await;
     }

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -106,6 +106,7 @@ pub async fn execute_skill_tool(
     input: serde_json::Value,
     timeout_secs: u64,
     long_running_ctx: Option<&LongRunningContext>,
+    github_token: Option<&str>,
 ) -> ToolOutput {
     // Check for long-running exec handler
     if let ToolHandler::Exec {
@@ -115,12 +116,19 @@ pub async fn execute_skill_tool(
     } = &skill_tool.handler
         && let Some(ctx) = long_running_ctx
     {
-        return execute_long_running(skill_tool, command, input, *estimated_duration_secs, ctx)
-            .await;
+        return execute_long_running(
+            skill_tool,
+            command,
+            input,
+            *estimated_duration_secs,
+            ctx,
+            github_token,
+        )
+        .await;
     }
 
     let timeout = Duration::from_secs(timeout_secs);
-    match tokio::time::timeout(timeout, execute_inner(skill_tool, input)).await {
+    match tokio::time::timeout(timeout, execute_inner(skill_tool, input, github_token)).await {
         Ok(Ok(output)) => output,
         Ok(Err(e)) => {
             warn!(
@@ -147,6 +155,7 @@ pub async fn execute_skill_tool(
 async fn execute_inner(
     skill_tool: &ResolvedSkillTool,
     input: serde_json::Value,
+    github_token: Option<&str>,
 ) -> Result<ToolOutput> {
     tracing::info!(
         tool = %skill_tool.definition.name,
@@ -160,6 +169,7 @@ async fn execute_inner(
                 &skill_tool.skill_dir,
                 &skill_tool.definition.name,
                 input,
+                github_token,
             )
             .await
         }
@@ -306,6 +316,7 @@ async fn execute_exec(
     skill_dir: &std::path::Path,
     tool_name: &str,
     input: serde_json::Value,
+    github_token: Option<&str>,
 ) -> Result<ToolOutput> {
     // Resolve command relative to skill directory
     let cmd_path = skill_dir.join(command);
@@ -328,6 +339,11 @@ async fn execute_exec(
             .env_remove("TMUX_PANE")
             .kill_on_drop(true);
         scrub_mika_env_vars(&mut cmd);
+        // Re-inject agent's GitHub token for platform identity separation.
+        // Same pattern as builtin run_gh handler (builtin_handlers.rs).
+        if let Some(token) = github_token {
+            cmd.env("GH_TOKEN", token);
+        }
         match cmd.spawn() {
             Ok(child) => break child,
             Err(e) if e.raw_os_error() == Some(26 /* ETXTBSY */) => {
@@ -515,6 +531,7 @@ async fn execute_long_running(
     input: serde_json::Value,
     estimated_duration_secs: Option<u64>,
     ctx: &LongRunningContext,
+    github_token: Option<&str>,
 ) -> ToolOutput {
     // Validate work_item_id — long-running tasks require tracked work items
     let work_item_id = input
@@ -602,6 +619,7 @@ async fn execute_long_running(
         enriched_input,
         task_id.clone(),
         ctx.db.clone(),
+        github_token.map(|s| s.to_string()),
     );
 
     ToolOutput::success(format!(
@@ -622,6 +640,7 @@ fn spawn_long_running_exec(
     input: serde_json::Value,
     task_id: String,
     db: AsyncDatabase,
+    github_token: Option<String>,
 ) {
     tokio::spawn(async move {
         let mut cmd = tokio::process::Command::new(&cmd_path);
@@ -633,6 +652,9 @@ fn spawn_long_running_exec(
             .env_remove("TMUX_PANE")
             .kill_on_drop(false);
         scrub_mika_env_vars(&mut cmd);
+        if let Some(ref token) = github_token {
+            cmd.env("GH_TOKEN", token);
+        }
         let mut child = match cmd.spawn() {
             Ok(child) => child,
             Err(e) => {
@@ -790,7 +812,7 @@ mod tests {
 
         let tool = make_exec_tool(tmp.path(), "handlers/handler.sh");
         let output =
-            execute_skill_tool(&tool, serde_json::json!({"query": "test"}), 30, None).await;
+            execute_skill_tool(&tool, serde_json::json!({"query": "test"}), 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(output.content.contains("hello from handler"));
     }
@@ -804,7 +826,7 @@ mod tests {
         );
 
         let tool = make_exec_tool(tmp.path(), "fail.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         // Non-zero exit is NOT a tool error — the process ran to completion
         assert!(!output.is_error, "non-zero exit should not be is_error");
         assert!(
@@ -828,7 +850,7 @@ mod tests {
         );
 
         let tool = make_exec_tool(tmp.path(), "status.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(
             !output.is_error,
             "non-zero exit should not be is_error, got: {}",
@@ -852,7 +874,7 @@ mod tests {
         write_script(&tmp.path().join("silent_fail.sh"), "#!/bin/sh\nexit 3");
 
         let tool = make_exec_tool(tmp.path(), "silent_fail.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error, "non-zero exit should not be is_error");
         assert!(
             output.content.contains("Exit code: 3"),
@@ -867,7 +889,7 @@ mod tests {
         // via 2>&1, so on non-zero exit the executor must read stdout (not stderr).
         let (_tmp, tool) = setup_shell_exec_handler();
         let input = serde_json::json!({"command": "echo 'health check output' && exit 2"});
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(
             !output.is_error,
             "non-zero exit via run.sh should not be is_error, got: {}",
@@ -892,7 +914,7 @@ mod tests {
         write_script(&tmp.path().join("ok.sh"), "#!/bin/sh\necho 'all good'");
 
         let tool = make_exec_tool(tmp.path(), "ok.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error);
         assert!(
             !output.content.contains("Exit code:"),
@@ -912,7 +934,7 @@ mod tests {
         );
 
         let tool = make_exec_tool(tmp.path(), "both.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error);
         assert!(output.content.contains("Exit code: 1"));
         assert!(
@@ -931,7 +953,7 @@ mod tests {
     async fn test_exec_handler_missing_command() {
         let tmp = tempfile::tempdir().unwrap();
         let tool = make_exec_tool(tmp.path(), "nonexistent.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(output.is_error);
         assert!(output.content.contains("not found"));
     }
@@ -945,7 +967,7 @@ mod tests {
         );
 
         let tool = make_exec_tool(tmp.path(), "slow.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 2, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 2, None, None).await;
         assert!(
             output.is_error,
             "expected timeout error, got: {}",
@@ -961,7 +983,7 @@ mod tests {
 
         let tool = make_exec_tool(tmp.path(), "echo_input.sh");
         let input = serde_json::json!({"query": "hello world"});
-        let output = execute_skill_tool(&tool, input.clone(), 30, None).await;
+        let output = execute_skill_tool(&tool, input.clone(), 30, None, None).await;
         assert!(!output.is_error);
         // The output should contain the JSON input
         let parsed: serde_json::Value = serde_json::from_str(&output.content).unwrap();
@@ -972,7 +994,7 @@ mod tests {
     async fn test_exec_handler_command_with_quotes() {
         let (_tmp, tool) = setup_shell_exec_handler();
         let input = serde_json::json!({"command": "echo \"hello world\""});
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("hello world"),
@@ -999,7 +1021,7 @@ mod tests {
         let (_tmp, tool) = setup_shell_exec_handler();
         // CSS selectors and hex colors contain # which must survive JSON → jq → eval
         let input = serde_json::json!({"command": "echo '#custom-relay { color: #a6e3a1; }'"});
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("#custom-relay"),
@@ -1020,7 +1042,7 @@ mod tests {
         let input = serde_json::json!({
             "command": "cat << 'EOF'\n#selector { color: #fff; }\nEOF"
         });
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("#selector"),
@@ -1045,7 +1067,7 @@ mod tests {
             css_file.display()
         );
         let input = serde_json::json!({"command": cmd});
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("#new-selector"),
@@ -1059,7 +1081,7 @@ mod tests {
         let (_tmp, tool) = setup_shell_exec_handler();
         // printf with \n format specifiers: backslashes must survive JSON → jq → eval → printf
         let input = serde_json::json!({"command": "printf 'line1\\nline2\\n'"});
-        let output = execute_skill_tool(&tool, input, 30, None).await;
+        let output = execute_skill_tool(&tool, input, 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("line1"),
@@ -1097,7 +1119,7 @@ mod tests {
             },
             skill_dir: PathBuf::from("/tmp"),
         };
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 5, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 5, None, None).await;
         assert!(output.is_error);
         assert!(output.content.contains("unsupported HTTP method"));
     }
@@ -1263,7 +1285,7 @@ mod tests {
         write_script(&handler_dir.join("screenshot.sh"), &script);
 
         let tool = make_exec_tool(tmp.path(), "handlers/screenshot.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(output.content.contains("Screenshot taken."));
         assert_eq!(output.images.len(), 1);
@@ -1280,7 +1302,7 @@ mod tests {
         );
 
         let tool = make_exec_tool(tmp.path(), "plain.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error);
         assert!(output.content.contains("just plain text"));
         assert!(output.images.is_empty());
@@ -1303,7 +1325,7 @@ mod tests {
         }
 
         let tool = make_exec_tool(tmp.path(), "check_env.sh");
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         // Both vars should be empty because env_remove strips them
         assert_eq!(output.content.trim(), "TMUX= TMUX_PANE=");
@@ -1333,8 +1355,14 @@ mod tests {
             trace_id: "00000000000000000000000000000000".to_string(),
         };
 
-        let output =
-            execute_skill_tool(&tool, serde_json::json!({"query": "test"}), 30, Some(&ctx)).await;
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"query": "test"}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
 
         assert!(output.is_error);
         assert!(
@@ -1384,6 +1412,7 @@ mod tests {
             serde_json::json!({"query": "test", "work_item_id": wi_id}),
             30,
             Some(&ctx),
+            None,
         )
         .await;
 
@@ -1447,7 +1476,7 @@ mod tests {
             trace_id: "00000000000000000000000000000000".to_string(),
         };
 
-        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, Some(&ctx)).await;
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, Some(&ctx), None).await;
         assert!(!output.is_error, "unexpected error: {}", output.content);
         assert!(
             output.content.contains("sync result"),
@@ -1481,6 +1510,7 @@ mod tests {
             serde_json::json!({"work_item_id": wi_id}),
             30,
             Some(&ctx),
+            None,
         )
         .await;
 
@@ -1504,6 +1534,42 @@ mod tests {
         assert!(
             result_text.contains("Exit code: 1"),
             "expected 'Exit code: 1' in result, got: {result_text}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_exec_handler_receives_gh_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(
+            &tmp.path().join("check_token.sh"),
+            "#!/bin/sh\necho \"GH_TOKEN=$GH_TOKEN\"",
+        );
+
+        let tool = make_exec_tool(tmp.path(), "check_token.sh");
+
+        // With github_token provided — should appear in child env
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({}),
+            30,
+            None,
+            Some("ghp_test_token_123"),
+        )
+        .await;
+        assert!(!output.is_error, "unexpected error: {}", output.content);
+        assert!(
+            output.content.contains("GH_TOKEN=ghp_test_token_123"),
+            "expected GH_TOKEN to be injected, got: {}",
+            output.content
+        );
+
+        // Without github_token — GH_TOKEN should be absent (scrubbed)
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
+        assert!(!output.is_error, "unexpected error: {}", output.content);
+        assert!(
+            !output.content.contains("GH_TOKEN=ghp_"),
+            "expected GH_TOKEN to not contain a token when github_token is None, got: {}",
+            output.content
         );
     }
 }

--- a/crates/mika-cli/src/commands/skills.rs
+++ b/crates/mika-cli/src/commands/skills.rs
@@ -636,9 +636,14 @@ async fn test_skill_tool(
 
     println!("\n  Testing {skill_name}/{tool_name}...\n");
 
-    let output =
-        executor::execute_skill_tool(skill_tool, input, entry.manifest.skill.timeout_secs, None)
-            .await;
+    let output = executor::execute_skill_tool(
+        skill_tool,
+        input,
+        entry.manifest.skill.timeout_secs,
+        None,
+        None,
+    )
+    .await;
 
     if output.is_error {
         println!("  [ERROR] {}", output.content);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,10 @@ Without it, `gh` falls back to the host user's `~/.config/gh/hosts.yml` (persona
 Additionally, `scrub_mika_env_vars()` scrubs `GH_TOKEN` from exec handler child processes
 via `EXTRA_SCRUB_VARS` as defense-in-depth. The `run_gh` builtin handler re-injects
 `MIKA_GITHUB_TOKEN` as `GH_TOKEN` AFTER the scrub for correct platform identity separation.
+The same scrub-then-inject pattern is applied to all exec handler subprocesses spawned by
+skills — `MIKA_GITHUB_TOKEN` is re-injected as `GH_TOKEN` after the env scrub, so any `gh`
+CLI invocation inside a skill handler runs as the agent's configured GitHub identity (not
+the host user).
 
 | Layer | Identity | Purpose |
 |-------|----------|---------|

--- a/docs/plans/2026-04-11-001-fix-exec-handler-github-identity-and-retry-plan.md
+++ b/docs/plans/2026-04-11-001-fix-exec-handler-github-identity-and-retry-plan.md
@@ -1,0 +1,94 @@
+---
+title: "fix: exec handler GitHub identity and required_tools retry on terminal errors"
+type: fix
+status: active
+date: 2026-04-11
+---
+
+# fix: exec handler GitHub identity and required_tools retry on terminal errors
+
+## Overview
+
+Two related fixes surfaced during mika-qa PR review audits (mika-skills#124, 2026-04-10):
+1. Exec skill handlers can't authenticate as the agent's GitHub identity (#515)
+2. The required_tools retry gate wastes LLM calls retrying unrecoverable errors (#516)
+
+Both are in `crates/mika-agent/`.
+
+## Part 1: GH_TOKEN injection into exec handlers (#515)
+
+### Problem
+
+`execute_exec()` at `executor.rs:304-341` scrubs `GH_TOKEN` via `scrub_mika_env_vars()` (line 330) but never re-injects the agent's `github_token`. The builtin `run_gh` handler (`builtin_handlers.rs:831-838`) already does this correctly:
+
+```rust
+scrub_mika_env_vars(&mut cmd);
+if let Some(token) = ctx.github_token {
+    cmd.env("GH_TOKEN", token);
+}
+```
+
+### Fix
+
+Thread `github_token: Option<&str>` through the exec handler call chain:
+
+1. **`execute_skill_tool()`** (`executor.rs:104`) — add `github_token: Option<&str>` parameter
+2. **`execute_exec()`** (`executor.rs:304`) — add `github_token: Option<&str>`, inject after scrub at line 330
+3. **`execute_long_running()`** (`executor.rs:~635`) — same injection after its `scrub_mika_env_vars()` call
+4. **Call site** (`agent.rs:1696-1702`) — pass `dispatch.ctx.github_token` from the `ToolDispatchCtx`
+
+### Files
+
+- `crates/mika-agent/src/skills/executor.rs` — `execute_skill_tool()`, `execute_exec()`, `execute_long_running()`
+- `crates/mika-agent/src/agent.rs` — call site at `execute_tool()` (~line 1696)
+
+### Constraints
+
+- Never silently fall back between tokens (per `docs/solutions/architecture-patterns/dedicated-github-token-agent-operations.md`)
+- Follow scrub-then-inject ordering (per `docs/solutions/security-issues/gh-token-identity-collision-dotenv-leak.md`)
+- `github_token: None` means no injection — exec handler falls back to host auth (existing behavior, acceptable)
+
+## Part 2: required_tools retry on terminal errors (#516)
+
+### Problem
+
+The required_tools gate (`agent.rs:735-772`) retries when the agent responds with text on EndTurn without calling all required tools. But if a required tool WAS called and failed with a terminal error (e.g., GitHub "Can not approve your own pull request"), the agent correctly explains the failure in text. The gate sees text without a successful required tool call and retries — wasting LLM calls.
+
+### Fix
+
+The gate already tracks `tools_called: HashSet<String>` across all steps. It should also consider a required tool "called" even if the call failed, since the agent attempted it.
+
+Change the tracking: insert the tool name into `tools_called` regardless of success/failure. The gate's purpose is to prevent the agent from *fabricating results without trying* — if the agent called the tool and it failed, the agent is not fabricating.
+
+### File
+
+- `crates/mika-agent/src/agent.rs` — where `tools_called` is populated (~line 920-923) and the required_tools check (~line 735-772)
+
+### Edge cases
+
+- Tool called and failed transiently → agent may retry on its own (existing behavior, unaffected)
+- Tool called and failed terminally → agent responds with text → gate sees tool was called → no retry (desired)
+- Tool never called → gate retries once (existing behavior, preserved)
+
+## Acceptance Criteria
+
+- [x] `GH_TOKEN` is injected into exec handler child processes when `github_token` is `Some`
+- [x] `GH_TOKEN` is injected into long-running exec handler child processes
+- [x] `GH_TOKEN` is NOT injected when `github_token` is `None` (no fallback)
+- [x] Required tools gate already tracks tool calls before dispatch (no code change needed — see note below)
+- [x] Existing required_tools retry behavior preserved for tools never called
+- [x] `cargo clippy` clean
+- [x] `cargo test` passes
+- [x] Add test: exec handler receives `GH_TOKEN` when `github_token` is provided
+- [ ] ~~Add test: required_tools gate does not retry when required tool was called but failed~~ (not needed — tracking was already correct)
+
+**Note on #516:** Investigation revealed that `tools_called` is populated from the LLM's ToolCall blocks **before** dispatch (agent.rs:919-923). Tool names are inserted regardless of execution outcome. The retry in the audit was caused by `run_shell` never being requested by the LLM (not applicable for that review), not by a failed tool being missed. The real fix is to remove `run_shell` from qa-review's `required_tools` config (mika-skills concern, not engine).
+
+## Sources & References
+
+- ADR-008: `docs/adr/008-github-identity-separation.md`
+- Builtin pattern: `crates/mika-agent/src/skills/builtin_handlers.rs:831-838`
+- Env scrub: `docs/solutions/security-issues/gh-token-identity-collision-dotenv-leak.md`
+- Env isolation tiers: `docs/solutions/security-issues/env-var-leakage-exec-handler-child-processes.md`
+- Required tools gate: `docs/solutions/prompt-engineering/required-tools-enforcement-gate.md`
+- mika#515, mika#516, mika#517

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -205,6 +205,7 @@ Execution details:
 - Stdout is captured as the successful tool result.
 - Stderr is included in the error message on non-zero exit.
 - The command is **not** passed the tool name as an argument — all dispatch context is in the JSON on stdin.
+- All `MIKA_*` environment variables are scrubbed from the child process. The agent's `MIKA_GITHUB_TOKEN` is then re-injected as `GH_TOKEN` so `gh` CLI calls in the handler run as the agent's GitHub identity. Note that `git push` / `git clone` over HTTPS does **not** receive credential helper injection — those operations fall back to host credentials or fail. Skill authors who need git over HTTPS should use SSH remotes instead, or open an issue to request `GIT_ASKPASS` injection.
 
 Exec handlers require a `tools.json` file in the skill directory to define the tool schemas sent to Claude.
 

--- a/docs/solutions/security-issues/exec-handler-gh-token-injection.md
+++ b/docs/solutions/security-issues/exec-handler-gh-token-injection.md
@@ -1,0 +1,139 @@
+---
+title: "Exec handler GitHub identity gap — GH_TOKEN injection asymmetry"
+category: security-issues
+date: 2026-04-11
+severity: high
+tags: [identity-separation, GH_TOKEN, exec-handler, scrub, defense-in-depth, agent-parity]
+issue: "#515"
+umbrella: "#517"
+modules: [executor, agent, skills, qa-review]
+related:
+  - docs/solutions/security-issues/gh-token-identity-collision-dotenv-leak.md
+  - docs/solutions/security-issues/env-var-leakage-exec-handler-child-processes.md
+  - docs/solutions/architecture-patterns/dedicated-github-token-agent-operations.md
+  - docs/adr/008-github-identity-separation.md
+---
+
+# Exec handler GitHub identity gap — GH_TOKEN injection asymmetry
+
+## Problem
+
+The Mika engine had two parallel paths for invoking the `gh` CLI from agent context, with **inconsistent** identity handling:
+
+| Path | Token re-injected? | Resulting identity |
+|------|--------------------|--------------------|
+| Builtin `run_gh` (Rust) | Yes — `cmd.env("GH_TOKEN", token)` after scrub | Agent's `MIKA_GITHUB_TOKEN` (e.g., `mika-platform-dev`) |
+| Builtin `pr_merge_with_gate` (Rust) | Yes — same pattern | Agent's `MIKA_GITHUB_TOKEN` |
+| **Exec handler skills** (`run_gh.sh`, etc.) | **No** | Host `~/.config/gh/hosts.yml` (typically the developer's personal account) |
+
+The gap manifested during mika-qa's PR review on mika-skills#124 (2026-04-10):
+
+```
+$ gh pr review 124 --approve --body '...'
+failed to create review: GraphQL: Review Can not approve your own pull request
+```
+
+mika-qa's `MIKA_GITHUB_TOKEN` mapped to the `mika-platform-qa` machine user — but its `qa-review` skill uses an **exec handler** (`handlers/run_gh.sh`), not the builtin. The handler subprocess inherited zero credentials after `scrub_mika_env_vars()` ran, so `gh` fell back to the host's active account (`samidarko`). Since `samidarko` was also the PR author, GitHub refused the approval as a self-review.
+
+## Root cause
+
+`scrub_mika_env_vars()` (`crates/mika-agent/src/skills/executor.rs:38-47`) is intentionally aggressive — it strips all `MIKA_*` env vars plus a small allowlist (`EXTRA_SCRUB_VARS = ["GH_TOKEN"]`) as defense-in-depth against credential leakage from `~/.mika/.env` into child processes (see [gh-token-identity-collision-dotenv-leak.md](./gh-token-identity-collision-dotenv-leak.md)).
+
+The builtin `run_gh` handler at `crates/mika-agent/src/skills/builtin_handlers.rs:831-838` re-injects the agent's token immediately after scrubbing:
+
+```rust
+scrub_mika_env_vars(&mut cmd);
+if let Some(token) = ctx.github_token {
+    cmd.env("GH_TOKEN", token);
+}
+```
+
+But `execute_exec()` and `execute_long_running()` (the generic exec handler dispatchers in `executor.rs`) **never received `github_token`** — `execute_skill_tool()` had no parameter for it, and the call site in `agent.rs` didn't pass `dispatch.ctx.github_token` even though `ToolDispatchCtx.ctx` had it available.
+
+Result: defense-in-depth scrubbing was working correctly, but only the builtin path knew how to recover from it. Skill-level exec handlers were silently downgraded to host identity.
+
+## Solution
+
+Thread `github_token: Option<&str>` from `ToolDispatchCtx.ctx.github_token` through the exec handler call chain and re-inject after scrubbing — same pattern as the builtins.
+
+**Files changed (commit `859c2dd`):**
+
+- `crates/mika-agent/src/skills/executor.rs`:
+  - Add `github_token: Option<&str>` parameter to `execute_skill_tool()`, `execute_inner()`, `execute_exec()`, `execute_long_running()`
+  - Add `github_token: Option<String>` parameter to `spawn_long_running_exec()` (owned because the spawned task needs `'static`)
+  - In both `execute_exec()` and `spawn_long_running_exec()`: inject `GH_TOKEN` after `scrub_mika_env_vars()`
+
+- `crates/mika-agent/src/agent.rs`: pass `dispatch.ctx.github_token` to `execute_skill_tool()` at the call site
+
+- `crates/mika-cli/src/commands/skills.rs`: CLI `mika skills test` passes `None` (no agent identity context in standalone CLI invocation)
+
+**Injection code (mirrors builtin `run_gh`):**
+
+```rust
+scrub_mika_env_vars(&mut cmd);
+// Re-inject agent's GitHub token for platform identity separation.
+// Same pattern as builtin run_gh handler (builtin_handlers.rs).
+if let Some(token) = github_token {
+    cmd.env("GH_TOKEN", token);
+}
+```
+
+**`None` semantics preserved:** when `github_token` is `None` (CLI test mode, agent without `MIKA_GITHUB_TOKEN` configured), no injection happens. The handler's `gh` calls fall back to host auth — existing behavior, no silent token substitution. This honors the [dedicated-github-token-agent-operations](../architecture-patterns/dedicated-github-token-agent-operations.md) principle: never silently fall back between token scopes.
+
+## Verification
+
+New unit test `test_exec_handler_receives_gh_token` in `executor.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_exec_handler_receives_gh_token() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_script(
+        &tmp.path().join("check_token.sh"),
+        "#!/bin/sh\necho \"GH_TOKEN=$GH_TOKEN\"",
+    );
+
+    let tool = make_exec_tool(tmp.path(), "check_token.sh");
+
+    // With github_token provided — should appear in child env
+    let output = execute_skill_tool(
+        &tool, serde_json::json!({}), 30, None, Some("ghp_test_token_123"),
+    ).await;
+    assert!(output.content.contains("GH_TOKEN=ghp_test_token_123"));
+
+    // Without github_token — GH_TOKEN should be absent (scrubbed)
+    let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
+    assert!(!output.content.contains("GH_TOKEN=ghp_"));
+}
+```
+
+`cargo test --workspace`: 2159 tests pass. `cargo clippy --workspace --all-targets`: clean. Pre-commit lefthook hooks pass (rust-fmt, rust-clippy).
+
+## Prevention
+
+1. **Pattern audit:** When adding any new subprocess spawn site that calls `scrub_mika_env_vars()`, verify it also re-injects required platform credentials (`GH_TOKEN` today, possibly more tomorrow). The `pr_merge_with_gate` builtin tool followed this pattern correctly; the generic exec handler did not. Asymmetry like this is the canonical sign of a parity gap.
+
+2. **Test the scrub-then-inject contract:** Tests that exercise child env vars (like the new `test_exec_handler_receives_gh_token`) catch regressions where someone adds a new spawn site without the inject step. Worth replicating for any future credential.
+
+3. **Architectural rule (per [ADR-008](../../adr/008-github-identity-separation.md)):** Agents never hold GitHub App credentials. They only ever receive a `GH_TOKEN` injected by the engine. Any new agent-spawned subprocess that talks to GitHub must go through this single inject point.
+
+4. **Known remaining gap (P3):** Exec handler subprocesses can also invoke `git push` / `git clone` over HTTPS, which authenticates via git credential helpers — not `GH_TOKEN`. This commit does not address that path. Self-dev currently uses SSH for git, so impact is low. See `todos/751-complete-p3-extend-gh-token-injection-to-git-https-exec-handlers.md` for the documented limitation. The fix would set `GIT_ASKPASS` to a helper that emits the token; deferred until a real use case arises.
+
+## Cross-references
+
+- Companion doc audit: extended `docs/configuration.md` and `docs/skills.md` to document exec handler `GH_TOKEN` injection (commit `95be4a5`)
+- ADR-008 (`docs/adr/008-github-identity-separation.md`) — the architectural decision behind why machine user PATs (not GitHub App bots) handle action authorship in the self-dev loop
+- Related security solutions:
+  - [gh-token-identity-collision-dotenv-leak](./gh-token-identity-collision-dotenv-leak.md) — why `GH_TOKEN` is in `EXTRA_SCRUB_VARS` in the first place
+  - [env-var-leakage-exec-handler-child-processes](./env-var-leakage-exec-handler-child-processes.md) — the three-tier env isolation model that exec handlers participate in
+- Related architecture pattern:
+  - [dedicated-github-token-agent-operations](../architecture-patterns/dedicated-github-token-agent-operations.md) — never silently fall back between token scopes
+- Audit traces:
+  - mika-qa session `8c0d7827` (2026-04-10T22:21) — the failing review attempt where this was detected
+  - PR mika#518 — the PR mika-qa was trying to approve when the failure occurred (eventually merged manually)
+
+## Lessons
+
+- **Defense-in-depth that works asymmetrically is worse than no defense.** Scrubbing `GH_TOKEN` from child processes was correct; the bug was that not all subprocess spawn sites knew how to re-inject the agent's token after the scrub. The resulting silent fallback to host identity is exactly the failure mode the scrubbing was trying to prevent.
+- **A new identity model surfaces hidden parity gaps.** Once mika-dev and mika-qa got separate PAT identities (per ADR-008), the `samidarko`-as-fallback bug instantly became visible — both PR author and reviewer resolved to the same human user, and GitHub's self-approval check caught it. Before identity separation, this gap was invisible because everything ran as the developer anyway.
+- **Single-line config gaps cause multi-week debugging cycles.** The fix is 4 lines of Rust. Finding it required: (1) noticing the failed review, (2) tracing through the executor scrub path, (3) comparing against the builtin handler, (4) understanding why threads of `github_token` stopped at `execute_skill_tool()`. The doc audit (`docs/configuration.md`) now calls this out for the next person.

--- a/todos/751-complete-p3-extend-gh-token-injection-to-git-https-exec-handlers.md
+++ b/todos/751-complete-p3-extend-gh-token-injection-to-git-https-exec-handlers.md
@@ -1,0 +1,93 @@
+---
+status: complete
+priority: p3
+issue_id: 751
+tags:
+  - code-review
+  - security
+  - identity
+  - exec-handlers
+dependencies:
+  - "#515"
+  - "#517"
+---
+
+# Extend GH_TOKEN identity threading to git HTTPS in exec handlers
+
+## Problem Statement
+
+Commit `859c2dd` (#515) re-injects `GH_TOKEN` into exec handler child processes after `scrub_mika_env_vars()`, fixing the identity collision for `gh` CLI calls inside skills. This closes the parity gap for `gh pr review`, `gh pr create`, etc.
+
+However, the same exec handler subprocess can also invoke `git push` / `git clone` over HTTPS, which authenticates via git credential helpers — not `GH_TOKEN`. After the scrub, no credential helper config is injected, so HTTPS git operations still fall back to host identity (or fail outright).
+
+A `crates/mika-agent/src/skills/git.rs::inject_github_token` helper exists for the skill install path (clone-from-github) but is not applied to general exec handler subprocesses.
+
+**Practical impact:** Low. The current self-dev loop uses SSH for git operations (per `gh auth status` showing `Git operations protocol: ssh`). HTTPS git ops in exec skills are uncommon. But it's a real parity gap if someone writes a skill that does `git push https://github.com/...`.
+
+## Findings
+
+- **Source:** `compound-engineering:review:agent-native-reviewer` review of commit `859c2dd`
+- **Existing helper:** `crates/mika-agent/src/skills/git.rs::inject_github_token` — used only for skill install clone path
+- **Missing:** Same injection in `execute_exec()` and `spawn_long_running_exec()` for any subprocess that may invoke `git`
+- **Equivalent for `gh`:** Just-merged in #515 — sets `GH_TOKEN` env var
+- **For `git`:** Would need to set `GIT_ASKPASS` to a helper that returns the token, or write a temporary credential file with `git credential store --file=...`
+
+## Proposed Solutions
+
+### Option A: Set credential helper via env var (preferred)
+
+Set `GIT_ASKPASS=<helper-script>` in exec handler env when `github_token` is `Some`. The helper script (already exists for `mika credential-helper get`) prints the token on stdout. This requires:
+- Bundling or generating an askpass shim that calls `mika credential-helper get`
+- Or pointing `GIT_ASKPASS` directly at `mika credential-helper get` if its CLI shape allows
+
+**Pros:** No filesystem writes, scoped to subprocess, no leftover state
+**Cons:** Adds a runtime dependency on `mika credential-helper get` being on PATH inside skills
+**Effort:** Small
+**Risk:** Low
+
+### Option B: Wait for a real use case
+
+The current self-dev loop uses SSH. No skill currently does HTTPS git ops. Document the gap and address when it bites.
+
+**Pros:** Zero work, no speculative complexity
+**Cons:** Latent gap; first user to hit it gets a confusing failure
+**Effort:** None
+**Risk:** Low
+
+### Option C: Document the limitation in skills.md
+
+Add a one-line note in `docs/skills.md` warning skill authors that exec handlers can use `gh` (with agent identity) but `git push https://...` falls back to host credentials.
+
+**Pros:** Sets expectations
+**Cons:** Doesn't fix the gap, just hides it
+**Effort:** Small
+**Risk:** None
+
+## Recommended Action
+
+(Triage)
+
+## Technical Details
+
+- **Affected files:** `crates/mika-agent/src/skills/executor.rs` (sync + long-running exec paths)
+- **Reference:** `crates/mika-agent/src/skills/git.rs::inject_github_token` (existing helper)
+- **Related:** ADR-008 (`docs/adr/008-github-identity-separation.md`)
+
+## Acceptance Criteria
+
+- [ ] Decision documented (fix vs defer vs note)
+- [ ] If fixing: exec handler subprocesses have working git HTTPS auth as agent identity
+- [ ] If fixing: test asserts `git push` works as agent's `MIKA_GITHUB_TOKEN` identity
+- [ ] If deferring: limitation documented in `docs/skills.md`
+
+## Work Log
+
+- 2026-04-11: Created from `/ce:review` of commit `859c2dd` (mika#515)
+- 2026-04-11: Resolved via Option C (document the limitation). Added a bullet to the "Execution details" list in `docs/skills.md` explaining that exec handler subprocesses receive `MIKA_GITHUB_TOKEN` as `GH_TOKEN` for `gh` CLI but do not receive credential helper injection for `git` over HTTPS — skill authors should use SSH remotes or open an issue for `GIT_ASKPASS` support. Option A (full `GIT_ASKPASS` fix) intentionally deferred: practical impact is low because self-dev uses SSH for git operations, and no current skill needs HTTPS git ops.
+
+## Resources
+
+- Commit: `859c2dd` (fix(skills): inject GH_TOKEN into exec handler child processes)
+- Related issues: mika#515, mika#517
+- ADR: `docs/adr/008-github-identity-separation.md`
+- Existing pattern: `crates/mika-agent/src/skills/git.rs`

--- a/todos/752-complete-p3-document-exec-handler-gh-token-injection.md
+++ b/todos/752-complete-p3-document-exec-handler-gh-token-injection.md
@@ -1,0 +1,60 @@
+---
+status: complete
+priority: p3
+issue_id: 752
+tags:
+  - code-review
+  - documentation
+  - exec-handlers
+dependencies:
+  - "#515"
+---
+
+# Document exec handler GH_TOKEN injection in configuration.md
+
+## Problem Statement
+
+`docs/configuration.md` already documents that the builtin `run_gh` handler scrubs and re-injects `GH_TOKEN` for platform identity separation. After commit `859c2dd` (#515), the same scrub-then-inject behavior applies to **all exec handler skills** — not just `run_gh`.
+
+A skill author reading `docs/configuration.md` today would not know that exec handlers automatically receive the agent's `MIKA_GITHUB_TOKEN` as `GH_TOKEN`. They might still think they need to write their own token plumbing.
+
+## Findings
+
+- **Source:** `compound-engineering:review:agent-native-reviewer` review of commit `859c2dd`
+- **Current docs:** `docs/configuration.md:217` describes `run_gh` token injection only
+- **Gap:** No mention of exec handler token injection
+- **Affected audience:** Skill authors writing `gh`-using exec handlers
+
+## Proposed Solution
+
+Add a one-line addendum at `docs/configuration.md:217` (the existing `run_gh` injection note) extending it to cover exec handlers:
+
+> The same scrub-then-inject pattern is applied to all exec handler subprocesses spawned by skills — `MIKA_GITHUB_TOKEN` is re-injected as `GH_TOKEN` after the env scrub, so any `gh` CLI invocation inside a skill handler runs as the agent's configured GitHub identity (not the host user).
+
+Optionally, also note this in `docs/skills.md` where exec handlers are documented.
+
+## Recommended Action
+
+(Triage)
+
+## Technical Details
+
+- **Affected files:** `docs/configuration.md`, optionally `docs/skills.md`
+- **Effort:** Small (1-2 sentences)
+- **Risk:** None
+
+## Acceptance Criteria
+
+- [ ] `docs/configuration.md` mentions exec handler `GH_TOKEN` injection
+- [ ] Optionally: `docs/skills.md` mentions the agent identity guarantee for `gh` calls in exec handlers
+
+## Work Log
+
+- 2026-04-11: Created from `/ce:review` of commit `859c2dd` (mika#515)
+- 2026-04-11: Completed — extended the existing `run_gh` injection note in `docs/configuration.md` (lines 217-221) with a 3-sentence addendum covering all exec handler subprocesses.
+
+## Resources
+
+- Commit: `859c2dd`
+- Related issues: mika#515, mika#517
+- ADR: `docs/adr/008-github-identity-separation.md`


### PR DESCRIPTION
## Summary

Fixes the exec handler GitHub identity gap that caused mika-qa to hit \"Can not approve your own pull request\" on mika-skills#124. The builtin \`run_gh\` and \`pr_merge_with_gate\` handlers already re-injected the agent's \`MIKA_GITHUB_TOKEN\` as \`GH_TOKEN\` after \`scrub_mika_env_vars()\` — but exec handler skill subprocesses didn't, so they silently fell back to the host user's \`~/.config/gh/hosts.yml\` identity.

This commit threads \`github_token: Option<&str>\` from \`ToolDispatchCtx.ctx.github_token\` through \`execute_skill_tool()\` → \`execute_exec()\` and \`execute_long_running()\` → \`spawn_long_running_exec()\`, and re-injects \`GH_TOKEN\` after the scrub using the same pattern as the builtins.

## Changes

- **\`crates/mika-agent/src/skills/executor.rs\`** — signature changes + injection at both sync and long-running spawn points + new test \`test_exec_handler_receives_gh_token\`
- **\`crates/mika-agent/src/agent.rs\`** — single call site change to pass \`dispatch.ctx.github_token\`
- **\`crates/mika-cli/src/commands/skills.rs\`** — CLI \`mika skills test\` passes \`None\` (no agent identity context in standalone CLI)
- **\`docs/configuration.md\`** + **\`docs/skills.md\`** — document the new contract; call out the remaining HTTPS git limitation
- **\`CLAUDE.md\`** — update GH_TOKEN env var note to reflect that all exec handlers (not just \`run_gh\`) do the re-injection
- **\`docs/adr/008-github-identity-separation.md\`** — already merged, this PR implements the architectural decision
- **\`docs/plans/2026-04-11-001-fix-exec-handler-github-identity-and-retry-plan.md\`** — implementation plan with #516 investigation note
- **\`docs/solutions/security-issues/exec-handler-gh-token-injection.md\`** — compound doc capturing root cause and lessons

## On #516 (required_tools retry on terminal errors)

Investigation determined no engine code change is needed. The required_tools gate at \`agent.rs:919-923\` already inserts tool names into \`tools_called\` from LLM ToolCall blocks **before dispatch**, so a tool that was called and failed terminally is correctly tracked. The retry observed in the audit was caused by \`run_shell\` never being requested by the LLM (not applicable for that review path), not by a failed tool being missed. The real fix is at the skill level — remove \`run_shell\` from qa-review's \`required_tools\` config — and is out of scope for this PR.

## Testing

- New test \`test_exec_handler_receives_gh_token\` asserts both \`Some\` (injects \`GH_TOKEN\`) and \`None\` (scrubbed, no fallback) branches
- \`cargo test --workspace\` — 2159 tests pass
- \`cargo clippy --workspace --all-targets\` — clean
- \`cargo fmt --check\` — clean
- Pre-commit lefthook hooks pass on all 4 commits

## Architectural context

Per ADR-008 (\`docs/adr/008-github-identity-separation.md\`):
- GitHub Apps handle event ingestion only (webhooks)
- Machine user PATs (\`mika-platform-dev\`, \`mika-platform-qa\`) handle action authorship
- \`MIKA_GITHUB_TOKEN\` is injected as \`GH_TOKEN\` into exec handler child processes
- Self-approval is structurally impossible: dev opens PR, qa reviews it — different GitHub accounts

This PR is the implementation half of that decision.

## Pipeline artifacts

- ✅ Plan: \`docs/plans/2026-04-11-001-fix-exec-handler-github-identity-and-retry-plan.md\`
- ✅ Source changes: 4 commits across executor, agent, cli, docs
- ✅ Solution doc: \`docs/solutions/security-issues/exec-handler-gh-token-injection.md\`
- ✅ Doc audit: CLAUDE.md + docs/configuration.md + docs/skills.md + crate-local copies synced
- ✅ Code review: 0 P1, 0 P2, 2 P3 follow-ups (both already resolved in this PR)
- ✅ \`scripts/verify-pipeline.sh\`: passed

## Post-deploy validation

- **What to test:** Trigger a mika-qa review on a PR authored by mika-platform-dev. Expected: \`gh pr review --approve\` succeeds, \`pull_request_review.submitted\` webhook fires, mika-dev receives the verdict.
- **Failure signal:** \"Can not approve your own pull request\" returns → token not injected; check \`MIKA_GITHUB_TOKEN\` is set in \`~/.mika/agents/mika-qa/.env\`
- **Rollback:** \`git revert 859c2dd\` (the doc commits are independent and safe to keep)

Closes #515
Refs #517