### PR TITLE
chore: remove obsolete auto-merge label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -81,8 +81,3 @@
 - name: dashboard
   color: "7057ff"
   description: Observability dashboard (React SPA)
-
-# ── Automation ──────────────────────────────────────────────────────────────
-- name: auto-merge
-  color: "0e8a16"
-  description: QA can merge PR after PASS verdict


### PR DESCRIPTION
## Summary
- Remove the `auto-merge` label from `.github/labels.yml`
- mika-qa now calls `gh pr merge --auto` directly on every pass verdict — label-based merge decisions were removed
- EndBug/label-sync will auto-delete the label from GitHub on next sync

## Companion PRs
- senara-solutions/mika-cloud (same branch)
- senara-solutions/mika-skills (same branch)

Closes senara-solutions/mika-platform#11

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: label config change only, no runtime impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)