### PR TITLE
fix(skills): refuse long-running tools when no long_running_ctx available

### DIFF
--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -127,6 +127,30 @@ pub async fn execute_skill_tool(
         .await;
     }
 
+    // Refuse long-running tools when no long-running context is available
+    // (callback turns, silent mode, CLI test). The sync exec path does not
+    // inject __mika_task_id/__mika_agent, so the handler would crash with
+    // a cryptic error. Return an explicit error instead (#537).
+    if matches!(
+        &skill_tool.handler,
+        ToolHandler::Exec {
+            long_running: true,
+            ..
+        }
+    ) && long_running_ctx.is_none()
+    {
+        warn!(
+            tool = %skill_tool.definition.name,
+            "long-running tool invoked without long_running_ctx"
+        );
+        return ToolOutput::error(format!(
+            "Tool '{}' is declared long_running but cannot run in the current context \
+             (callback turn, silent mode, or CLI test). Long-running tools require a \
+             conversation-mode turn with an active task engine.",
+            skill_tool.definition.name
+        ));
+    }
+
     let timeout = Duration::from_secs(timeout_secs);
     match tokio::time::timeout(timeout, execute_inner(skill_tool, input, github_token)).await {
         Ok(Ok(output)) => output,
@@ -1569,6 +1593,47 @@ mod tests {
         assert!(
             !output.content.contains("GH_TOKEN=ghp_"),
             "expected GH_TOKEN to not contain a token when github_token is None, got: {}",
+            output.content
+        );
+    }
+
+    /// Regression test for #537: a long_running tool with no long_running_ctx
+    /// must return an explicit error instead of silently falling through to
+    /// the sync exec path (which lacks __mika_task_id injection).
+    #[tokio::test]
+    async fn test_long_running_tool_without_context_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "Long-running test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            handler: ToolHandler::Exec {
+                command: "./handlers/run.sh".to_string(),
+                long_running: true,
+                estimated_duration_secs: Some(300),
+            },
+            skill_dir: tmp.path().to_path_buf(),
+        };
+
+        // Pass None for long_running_ctx — simulates callback turn / silent mode / CLI test
+        let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
+
+        assert!(output.is_error, "expected error, got: {}", output.content);
+        assert!(
+            output.content.contains("run_claude_pilot"),
+            "error should name the tool: {}",
+            output.content
+        );
+        assert!(
+            output.content.contains("long_running"),
+            "error should mention long_running: {}",
+            output.content
+        );
+        assert!(
+            output.content.contains("cannot run in the current context"),
+            "error should explain the context restriction: {}",
             output.content
         );
     }

--- a/docs/plans/2026-04-12-001-fix-long-running-handler-silent-fallthrough-plan.md
+++ b/docs/plans/2026-04-12-001-fix-long-running-handler-silent-fallthrough-plan.md
@@ -1,0 +1,116 @@
+---
+title: "fix: execute_skill_tool silently falls through long-running handler to sync exec"
+type: fix
+status: completed
+date: 2026-04-12
+issue: "#537"
+---
+
+# fix: execute_skill_tool silently falls through long-running handler to sync exec
+
+## Overview
+
+When a skill tool declares `handler.long_running = true` but `long_running_ctx` is `None` (callback turns, silent mode, CLI test), `execute_skill_tool` silently falls through to the synchronous `execute_exec` path. The sync path does not inject `__mika_task_id` / `__mika_agent`, causing handlers that expect long-running metadata to exit 1 with a cryptic error that looks like a handler bug, not an engine bug.
+
+## Problem Statement
+
+The `if let` guard at `executor.rs:112-128` matches on **both** `long_running: true` AND `Some(ctx) = long_running_ctx`. When the context is `None`, the entire block is skipped and execution falls through to the timeout-wrapped `execute_inner`, which calls `execute_exec` — a sync path that doesn't provide the long-running metadata the handler expects.
+
+This was introduced intentionally in commit `04ae084c` to block recursion during callback turns, but the implementation chose "silently fall through" instead of "refuse with a clear error".
+
+## Proposed Solution
+
+Add an explicit guard after the long-running dispatch block: if the handler is `ToolHandler::Exec { long_running: true, .. }` and `long_running_ctx` is `None`, return `ToolOutput::error(...)` with a descriptive message naming the tool and explaining the context restriction.
+
+### Implementation
+
+**File: `crates/mika-agent/src/skills/executor.rs`** (`execute_skill_tool` function, ~line 128)
+
+After the existing `if let` block (lines 112-128), add:
+
+```rust
+// Refuse long-running tools when no long-running context is available
+// (callback turns, silent mode, CLI test). The sync exec path does not
+// inject __mika_task_id/__mika_agent, so the handler would crash with
+// a cryptic error. Return an explicit error instead.
+if matches!(
+    &skill_tool.handler,
+    ToolHandler::Exec { long_running: true, .. }
+) && long_running_ctx.is_none()
+{
+    warn!(
+        tool = %skill_tool.definition.name,
+        "long-running tool invoked without long_running_ctx"
+    );
+    return ToolOutput::error(format!(
+        "Tool '{}' is declared long_running but cannot run in the current context \
+         (callback turn, silent mode, or CLI test). Long-running tools require a \
+         conversation-mode turn with an active task engine.",
+        skill_tool.definition.name
+    ));
+}
+```
+
+**File: `crates/mika-cli/src/commands/skills.rs`** (~line 639-645)
+
+No code change needed here — the CLI already passes `None` for `long_running_ctx`, so after the executor fix, `mika skills test <skill> <tool>` for a long-running tool will naturally receive the new error message instead of silently falling through. The existing error display at line 648-649 will print it correctly.
+
+### Unit Test
+
+**File: `crates/mika-agent/src/skills/executor.rs`** (in `mod tests`)
+
+```rust
+#[tokio::test]
+async fn test_long_running_tool_without_context_returns_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tool = ResolvedSkillTool {
+        definition: ToolDefinition {
+            name: "run_claude_pilot".to_string(),
+            description: "Long-running test tool".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        },
+        handler: ToolHandler::Exec {
+            command: "./handlers/run.sh".to_string(),
+            long_running: true,
+            estimated_duration_secs: Some(300),
+        },
+        skill_dir: tmp.path().to_path_buf(),
+    };
+
+    // Pass None for long_running_ctx — simulates callback turn / silent mode / CLI test
+    let output = execute_skill_tool(&tool, serde_json::json!({}), 30, None, None).await;
+
+    assert!(output.is_error, "expected error, got: {}", output.content);
+    assert!(
+        output.content.contains("run_claude_pilot"),
+        "error should name the tool: {}",
+        output.content
+    );
+    assert!(
+        output.content.contains("long_running"),
+        "error should mention long_running: {}",
+        output.content
+    );
+}
+```
+
+## Acceptance Criteria
+
+- [x] `execute_skill_tool` returns `ToolOutput::error` when handler is `Exec { long_running: true }` and `long_running_ctx` is `None`
+- [x] Error message names the tool and explains the context restriction
+- [x] Unit test: `long_running: true` + `long_running_ctx = None` → `is_error == true` with expected message
+- [x] `mika skills test <skill> <tool>` for a long-running tool produces the same clear error (via the executor fix, no separate CLI change needed)
+
+## Context
+
+- **Key file:** `crates/mika-agent/src/skills/executor.rs:104-153` — `execute_skill_tool` function
+- **CLI caller:** `crates/mika-cli/src/commands/skills.rs:639-645` — passes `None` for `long_running_ctx`
+- **ToolHandler enum:** `crates/mika-agent/src/skills/manifest.rs:154-170`
+- **LongRunningContext:** `crates/mika-agent/src/skills/executor.rs:92-97`
+- **Callback turn lr_ctx=None:** `crates/mika-agent/src/agent.rs:1395-1404`
+- **Original commit:** `04ae084c` — introduced `lr_ctx = None` for callback turns
+
+## Sources
+
+- GitHub issue: #537
+- Related: #520 (GH_TOKEN injection that triggered the discovery)

--- a/docs/solutions/logic-errors/long-running-handler-silent-fallthrough.md
+++ b/docs/solutions/logic-errors/long-running-handler-silent-fallthrough.md
@@ -1,0 +1,61 @@
+---
+title: "Long-running handler silently falls through to sync exec path"
+category: logic-errors
+date: 2026-04-12
+tags: [skills, executor, long-running, callback, silent-mode]
+issue: "#537"
+---
+
+# Long-running handler silently falls through to sync exec path
+
+## Problem
+
+When `execute_skill_tool` dispatches a skill tool with `handler.long_running = true` but `long_running_ctx` is `None` (callback turns, silent mode, CLI test), the function silently falls through to the synchronous `execute_exec` path. The sync path does not inject `__mika_task_id` / `__mika_agent` env vars, so handlers expecting long-running metadata crash with a cryptic exit-code error (`no __mika_task_id in input`) that looks like a handler bug, not an engine dispatch bug.
+
+## Root Cause
+
+The `if let` guard at `executor.rs:112-128` uses a compound pattern matching **both** `long_running: true` AND `Some(ctx) = long_running_ctx`. When `long_running_ctx` is `None`, the entire block is skipped and control falls through to the timeout-wrapped `execute_inner` -> `execute_exec` — which runs the handler in sync mode without the long-running metadata injection that only happens in `execute_long_running`.
+
+The `lr_ctx = None` for callback turns was introduced intentionally in commit `04ae084c` to prevent recursion, but the implementation chose "silently fall through" instead of "refuse with a clear error".
+
+## Solution
+
+Added an explicit guard in `execute_skill_tool` (after the existing long-running dispatch block) that checks if the handler is `ToolHandler::Exec { long_running: true, .. }` and `long_running_ctx` is `None`. When both conditions are true, it returns `ToolOutput::error(...)` with a message that:
+
+1. Names the tool
+2. Explains that long-running tools cannot run in the current context
+3. Lists the contexts where this restriction applies (callback turn, silent mode, CLI test)
+
+```rust
+if matches!(
+    &skill_tool.handler,
+    ToolHandler::Exec { long_running: true, .. }
+) && long_running_ctx.is_none()
+{
+    return ToolOutput::error(format!(
+        "Tool '{}' is declared long_running but cannot run in the current context \
+         (callback turn, silent mode, or CLI test). Long-running tools require a \
+         conversation-mode turn with an active task engine.",
+        skill_tool.definition.name
+    ));
+}
+```
+
+**Key file:** `crates/mika-agent/src/skills/executor.rs`
+
+## Prevention
+
+When adding compound pattern guards that match on both a data variant AND an `Option`, always add an explicit else-branch for the `None` case rather than relying on fall-through behavior. The fall-through path should be reserved for genuinely compatible alternatives, not for incompatible dispatch modes that will fail downstream.
+
+**Pattern to follow:**
+```rust
+// Match on (variant, Some(ctx)) -> dispatch
+if let Variant { flag: true } = &item && let Some(ctx) = optional_ctx {
+    return dispatch_with_ctx(ctx);
+}
+// Explicit guard for (variant, None) -> refuse
+if matches!(&item, Variant { flag: true, .. }) && optional_ctx.is_none() {
+    return error("cannot dispatch without context");
+}
+// Fall through for non-matching variants
+```


### PR DESCRIPTION
## Summary

- **Fixes #537** — `execute_skill_tool` silently fell through long-running handler to sync exec path when `long_running_ctx` was `None` (callback turns, silent mode, CLI test)
- Added explicit guard that returns `ToolOutput::error` naming the tool and explaining the context restriction
- Added regression test `test_long_running_tool_without_context_returns_error`

## What Changed

**`crates/mika-agent/src/skills/executor.rs`** — After the existing `if let` block that dispatches long-running tools with context, added a second guard that catches the `(long_running: true, ctx: None)` case and returns an explicit error instead of silently falling through to `execute_exec` (which lacks `__mika_task_id` injection).

The error message names the tool, explains the constraint, and lists the contexts where it applies.

**No CLI change needed** — `mika skills test` already passes `None` for `long_running_ctx`, so it naturally receives the new clear error.

## Test Plan

- [x] New unit test: `test_long_running_tool_without_context_returns_error` — constructs `long_running: true` tool, passes `None` for context, asserts error with tool name and explanation
- [x] All 42 existing executor tests pass
- [x] `cargo clippy -p mika-agent -- -D warnings` clean

## Post-Deploy Monitoring & Validation

- **What to monitor**: Agent logs for `long-running tool invoked without long_running_ctx` warn messages
- **Expected healthy behavior**: The warning appears instead of cryptic `Exit code: 1 / Error: no __mika_task_id` errors from handlers
- **No additional operational monitoring required**: This converts a crash into an explicit error — strictly improved observability

Closes #537

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)