### PR TITLE
feat(tui): silence internal dev questions in TUI inbox mode (#494)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - **Grounding rule:** The system prompt prohibits the agent from claiming downstream system state unless a tool result confirms it. Reinforced in `format_callback_framing` and `SilentTrigger::Callback`.
 - **Confirmation before action:** The system prompt instructs the agent to answer informational questions directly without starting multi-step workflows.
 - **Context priority:** current user message > core memory > active skill context > conversation summary > conversation history > search results. See `docs/memory-classification.md`.
-- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v21. See `crates/mika-agent/CLAUDE.md` for schema details.
+- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v22. See `crates/mika-agent/CLAUDE.md` for schema details.
 - **Secrets:** `Settings` has manual `Debug` impl that redacts API key and OTLP auth header. Exec handler executor scrubs all MIKA_* env vars from child processes. MCP child processes use `env_clear()` + allowlist. Git subprocesses scrub MIKA_* vars and set `GIT_TERMINAL_PROMPT=0`.
 - **Labels:** `.github/labels.yml` is the canonical label taxonomy (type, priority, component). All issue-creation paths reference it.
 - **Async DB:** `AsyncDatabase` wraps sync `Database` with dedicated OS thread + `sync_channel(512)` mpsc channel (closure-based dispatch). Clone-able, Send+Sync. `with_db` releases the mutex before calling `send()` to avoid deadlocks.

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -149,11 +149,12 @@ All SQLite timestamp columns use ISO 8601 TEXT format (`%Y-%m-%dT%H:%M:%SZ`). Th
 
 ## Schema Version
 
-**Current: v21.** Tables: sessions, messages, team_workspace, audit_events, skill_overrides, tasks (with manual/callback/a2a trigger types), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
+**Current: v22.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides, tasks (with manual/callback/a2a trigger types), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
 
 Recent migrations:
 - v18->v19: `sessions.task_id` column for reverse session->task lookups. `get_sessions_for_task_tree()`.
 - v19->v20: `skill_overrides.llm_provider` and `skill_overrides.llm_model` for per-skill LLM override.
 - v20->v21: `llm_calls.prompt_variant` for skill prompt variant recording.
+- v21->v22: `messages.internal` column (`INTEGER NOT NULL DEFAULT 0`) for agent-to-agent message visibility. TUI inbox mode filters internal messages at the DB level.
 
 Full migration history: see `docs/runtime-structure.md`.

--- a/crates/mika-agent/docs/runtime-structure.md
+++ b/crates/mika-agent/docs/runtime-structure.md
@@ -75,7 +75,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **PRAGMAs:** `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`, `busy_timeout=5000`, `auto_vacuum=INCREMENTAL`
 
-**Current schema version:** 19
+**Current schema version:** 22
 
 **Timestamp format:** All timestamp columns use ISO 8601 TEXT (`%Y-%m-%dT%H:%M:%SZ`) — not Unix epoch integers. SQL defaults use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`. Fixed-width UTC format ensures correct lexicographic ordering.
 
@@ -87,7 +87,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`
 
-**messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`
+**messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`, `internal INTEGER NOT NULL DEFAULT 0` (agent-to-agent messages hidden from TUI inbox mode)
 
 ### Memory Tables
 

--- a/crates/mika-agent/docs/slash-commands.md
+++ b/crates/mika-agent/docs/slash-commands.md
@@ -487,6 +487,23 @@ Only available in team mode (`mika --team <name>`).
 
 ---
 
+### /inbox
+
+Toggle between inbox mode (hide internal agent-to-agent messages) and audit mode (show all messages). Inbox mode is the default.
+
+**Aliases:** None | **Arguments:** None
+
+When toggled, message history is reloaded from the database with the new filter setting. In inbox mode, a `[N hidden]` footer badge shows the count of suppressed internal messages.
+
+**Example:**
+```
+/inbox
+```
+
+Output: `Switched to audit mode (all messages visible).` or `Switched to inbox mode (internal messages hidden).`
+
+---
+
 ### /undo
 
 Undo the last exchange (user message + assistant response) and reverse any memory changes made during that exchange. Equivalent to `/rewind 1`.
@@ -556,7 +573,7 @@ to a safe subset. Agent-specific commands are disabled:
 |-----------|----------|
 | `/help`, `/clear`, `/exit`, `/quit` | `/model`, `/think`, `/agent`, `/switch` |
 | `/export`, `/teams`, `/agents` | `/memory`, `/reminders`, `/compact`, `/soul` |
-| `/status`, `/team`, `/verbose` | `/config`, `/skills`, `/skill`, `/attach`, `/tasks` |
+| `/status`, `/team`, `/verbose`, `/inbox` | `/config`, `/skills`, `/skill`, `/attach`, `/tasks` |
 |  | `/undo`, `/rewind` |
 
 In team mode, `/status` and `/team` both show team info (name, orchestrator,

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -894,6 +894,7 @@ async fn run_loop(
                             &text,
                             metadata.as_deref(),
                             Some(tool_ctx.trace_id),
+                            false,
                         )
                         .await?;
                     }
@@ -1491,6 +1492,7 @@ async fn run_agent_inner(params: &AgentParams<'_>, trace_id: &str) -> Result<Age
             &cont.text,
             metadata.as_deref(),
             Some(trace_id),
+            false,
         )
         .await?;
         return Ok(AgentOutput {
@@ -3749,6 +3751,7 @@ mod tests {
             "I searched your memory.",
             Some(metadata),
             None,
+            false,
         )
         .await
         .unwrap();
@@ -3775,9 +3778,16 @@ mod tests {
     #[tokio::test]
     async fn test_save_message_with_null_metadata() {
         let db = test_async_db();
-        db.save_message_with_metadata("test-session", "assistant", "No tools used.", None, None)
-            .await
-            .unwrap();
+        db.save_message_with_metadata(
+            "test-session",
+            "assistant",
+            "No tools used.",
+            None,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
 
         let messages = db.load_recent_messages(10).await.unwrap();
         assert_eq!(messages.len(), 1);

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -587,6 +587,25 @@ impl AsyncDatabase {
             .await
     }
 
+    /// Save a message marked as internal (hidden from TUI inbox mode).
+    pub async fn save_internal_message(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        let (a, sid, r, c, t) = (
+            self.agent_id.clone(),
+            session_id.to_owned(),
+            role.to_owned(),
+            content.to_owned(),
+            trace_id.map(|s| s.to_owned()),
+        );
+        self.with_db(move |db| db.save_internal_message(&a, &sid, &r, &c, t.as_deref()))
+            .await
+    }
+
     pub async fn save_message_with_metadata(
         &self,
         session_id: &str,
@@ -603,6 +622,29 @@ impl AsyncDatabase {
             metadata,
             trace_id,
         )
+        .await
+    }
+
+    /// Save a message with metadata, marked as internal (hidden from TUI inbox mode).
+    pub async fn save_internal_message_with_metadata(
+        &self,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        metadata: Option<&str>,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        let (a, sid, r, c, m, t) = (
+            self.agent_id.clone(),
+            session_id.to_owned(),
+            role.to_owned(),
+            content.to_owned(),
+            metadata.map(|s| s.to_owned()),
+            trace_id.map(|s| s.to_owned()),
+        );
+        self.with_db(move |db| {
+            db.save_internal_message_with_metadata(&a, &sid, &r, &c, m.as_deref(), t.as_deref())
+        })
         .await
     }
 
@@ -636,6 +678,17 @@ impl AsyncDatabase {
     pub async fn load_recent_messages(&self, limit: usize) -> Result<Vec<SessionMessage>> {
         let a = self.agent_id.clone();
         self.with_db(move |db| db.load_recent_messages(&a, limit))
+            .await
+    }
+
+    /// Load recent messages with optional internal-message filtering.
+    pub async fn load_recent_messages_filtered(
+        &self,
+        limit: usize,
+        exclude_internal: bool,
+    ) -> Result<Vec<SessionMessage>> {
+        let a = self.agent_id.clone();
+        self.with_db(move |db| db.load_recent_messages_filtered(&a, limit, exclude_internal))
             .await
     }
 
@@ -904,6 +957,13 @@ impl AsyncDatabase {
     pub async fn compact_old_audit_events(&self, days: u32) -> Result<usize> {
         let a = self.agent_id.clone();
         self.with_db(move |db| db.compact_old_audit_events(&a, days))
+            .await
+    }
+
+    /// Count internal messages after a given message ID (for TUI hidden-count badge).
+    pub async fn count_internal_messages_after(&self, after_id: i64) -> Result<i64> {
+        let a = self.agent_id.clone();
+        self.with_db(move |db| db.count_internal_messages_after(&a, after_id))
             .await
     }
 

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -587,25 +587,6 @@ impl AsyncDatabase {
             .await
     }
 
-    /// Save a message marked as internal (hidden from TUI inbox mode).
-    pub async fn save_internal_message(
-        &self,
-        session_id: &str,
-        role: &str,
-        content: &str,
-        trace_id: Option<&str>,
-    ) -> Result<i64> {
-        let (a, sid, r, c, t) = (
-            self.agent_id.clone(),
-            session_id.to_owned(),
-            role.to_owned(),
-            content.to_owned(),
-            trace_id.map(|s| s.to_owned()),
-        );
-        self.with_db(move |db| db.save_internal_message(&a, &sid, &r, &c, t.as_deref()))
-            .await
-    }
-
     pub async fn save_message_with_metadata(
         &self,
         session_id: &str,
@@ -613,26 +594,7 @@ impl AsyncDatabase {
         content: &str,
         metadata: Option<&str>,
         trace_id: Option<&str>,
-    ) -> Result<i64> {
-        self.save_message_as(
-            &self.agent_id.clone(),
-            session_id,
-            role,
-            content,
-            metadata,
-            trace_id,
-        )
-        .await
-    }
-
-    /// Save a message with metadata, marked as internal (hidden from TUI inbox mode).
-    pub async fn save_internal_message_with_metadata(
-        &self,
-        session_id: &str,
-        role: &str,
-        content: &str,
-        metadata: Option<&str>,
-        trace_id: Option<&str>,
+        internal: bool,
     ) -> Result<i64> {
         let (a, sid, r, c, m, t) = (
             self.agent_id.clone(),
@@ -643,7 +605,7 @@ impl AsyncDatabase {
             trace_id.map(|s| s.to_owned()),
         );
         self.with_db(move |db| {
-            db.save_internal_message_with_metadata(&a, &sid, &r, &c, m.as_deref(), t.as_deref())
+            db.save_message_with_metadata(&a, &sid, &r, &c, m.as_deref(), t.as_deref(), internal)
         })
         .await
     }
@@ -670,7 +632,7 @@ impl AsyncDatabase {
             trace_id.map(|s| s.to_owned()),
         );
         self.with_db(move |db| {
-            db.save_message_with_metadata(&a, &sid, &r, &c, m.as_deref(), t.as_deref())
+            db.save_message_with_metadata(&a, &sid, &r, &c, m.as_deref(), t.as_deref(), false)
         })
         .await
     }
@@ -957,13 +919,6 @@ impl AsyncDatabase {
     pub async fn compact_old_audit_events(&self, days: u32) -> Result<usize> {
         let a = self.agent_id.clone();
         self.with_db(move |db| db.compact_old_audit_events(&a, days))
-            .await
-    }
-
-    /// Count internal messages after a given message ID (for TUI hidden-count badge).
-    pub async fn count_internal_messages_after(&self, after_id: i64) -> Result<i64> {
-        let a = self.agent_id.clone();
-        self.with_db(move |db| db.count_internal_messages_after(&a, after_id))
             .await
     }
 
@@ -2177,7 +2132,7 @@ mod tests {
         db.create_session(team_sid, "mika", "team").await.unwrap();
 
         // save_message_with_metadata uses self.agent_id (default "mika")
-        db.save_message_with_metadata(team_sid, "assistant", "from default", None, None)
+        db.save_message_with_metadata(team_sid, "assistant", "from default", None, None, false)
             .await
             .unwrap();
 

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -22,7 +22,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 21;
+pub const CURRENT_SCHEMA_VERSION: i64 = 22;
 
 /// SQL for the unified_timeline VIEW — cross-subsystem event correlation.
 /// Used in both clean-slate schema creation and incremental migration.
@@ -199,6 +199,8 @@ pub struct SessionMessage {
     pub metadata: Option<String>,
     pub trace_id: Option<String>,
     pub created_at: String,
+    /// Whether this message is internal (agent-to-agent) and should be hidden from inbox mode.
+    pub internal: bool,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -741,6 +743,10 @@ impl Database {
             self.migrate_v20_to_v21()?;
             info!(version = 21, "database migrated to v21");
         }
+        if (3..=21).contains(&version) {
+            self.migrate_v21_to_v22()?;
+            info!(version = 22, "database migrated to v22");
+        }
         Ok(())
     }
 
@@ -797,7 +803,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (21);
+            INSERT INTO schema_version (version) VALUES (22);
 
             CREATE TABLE agents (
                 id TEXT PRIMARY KEY,
@@ -916,7 +922,8 @@ impl Database {
                 metadata TEXT,
                 trace_id TEXT,
                 compacted_through_id INTEGER,
-                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                internal INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX idx_msg_session ON messages(session_id, created_at ASC);
             CREATE INDEX idx_msg_agent_created ON messages(agent_id, created_at DESC);
@@ -2489,6 +2496,21 @@ impl Database {
             sql.push_str("ALTER TABLE llm_calls ADD COLUMN prompt_variant TEXT;\n");
         }
         sql.push_str("INSERT INTO schema_version (version) VALUES (21);\nCOMMIT;");
+
+        self.conn.execute_batch(&sql)?;
+        Ok(())
+    }
+
+    fn migrate_v21_to_v22(&self) -> Result<()> {
+        info!("migrating database schema v21 → v22 (messages: internal flag)");
+
+        let has_col = self.column_exists("messages", "internal")?;
+
+        let mut sql = String::from("BEGIN IMMEDIATE;\n");
+        if !has_col {
+            sql.push_str("ALTER TABLE messages ADD COLUMN internal INTEGER NOT NULL DEFAULT 0;\n");
+        }
+        sql.push_str("INSERT INTO schema_version (version) VALUES (22);\nCOMMIT;");
 
         self.conn.execute_batch(&sql)?;
         Ok(())
@@ -4288,6 +4310,23 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
+    /// Save a message marked as internal (hidden from TUI inbox mode).
+    pub fn save_internal_message(
+        &self,
+        agent_id: &str,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO messages (session_id, agent_id, role, content, trace_id, internal)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+            params![session_id, agent_id, role, content, trace_id],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
     pub fn save_message_with_metadata(
         &self,
         agent_id: &str,
@@ -4305,7 +4344,25 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
-    const SESSION_MESSAGE_COLUMNS: &'static str = "m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at";
+    /// Save a message with metadata, marked as internal (hidden from TUI inbox mode).
+    pub fn save_internal_message_with_metadata(
+        &self,
+        agent_id: &str,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        metadata: Option<&str>,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO messages (session_id, agent_id, role, content, metadata, trace_id, internal)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
+            params![session_id, agent_id, role, content, metadata, trace_id],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    const SESSION_MESSAGE_COLUMNS: &'static str = "m.id, m.session_id, m.agent_id, m.role, m.content, s.channel_type, m.metadata, m.trace_id, m.created_at, m.internal";
 
     fn row_to_session_message(r: &rusqlite::Row<'_>) -> rusqlite::Result<SessionMessage> {
         Ok(SessionMessage {
@@ -4318,6 +4375,7 @@ impl Database {
             metadata: r.get(6)?,
             trace_id: r.get(7)?,
             created_at: r.get(8)?,
+            internal: r.get::<_, i64>(9).unwrap_or(0) != 0,
         })
     }
 
@@ -4326,11 +4384,28 @@ impl Database {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<SessionMessage>> {
+        self.load_recent_messages_filtered(agent_id, limit, false)
+    }
+
+    /// Load recent messages with optional internal-message filtering.
+    /// When `exclude_internal` is true, messages with `internal = 1` are excluded.
+    pub fn load_recent_messages_filtered(
+        &self,
+        agent_id: &str,
+        limit: usize,
+        exclude_internal: bool,
+    ) -> Result<Vec<SessionMessage>> {
+        let internal_filter = if exclude_internal {
+            " AND m.internal = 0"
+        } else {
+            ""
+        };
         let sql = format!(
             "SELECT {} FROM messages m JOIN sessions s ON m.session_id = s.id
-              WHERE m.agent_id = ?1 AND m.role != 'summary' AND s.channel_type != 'team'
+              WHERE m.agent_id = ?1 AND m.role != 'summary' AND s.channel_type != 'team'{}
               ORDER BY m.created_at DESC, m.id DESC LIMIT ?2",
-            Self::SESSION_MESSAGE_COLUMNS
+            Self::SESSION_MESSAGE_COLUMNS,
+            internal_filter,
         );
         let mut stmt = self.conn.prepare(&sql)?;
         let mut messages = stmt
@@ -4445,6 +4520,17 @@ impl Database {
             .query_map(params![agent_id, after_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
         Ok(rows)
+    }
+
+    /// Count internal messages after a given message ID (for TUI hidden-count badge).
+    pub fn count_internal_messages_after(&self, agent_id: &str, after_id: i64) -> Result<i64> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM messages
+              WHERE agent_id = ?1 AND id > ?2 AND internal = 1",
+            params![agent_id, after_id],
+            |r| r.get(0),
+        )?;
+        Ok(n)
     }
 
     pub fn max_message_id(&self, agent_id: &str) -> Result<i64> {
@@ -9671,5 +9757,92 @@ mod tests {
     fn test_format_age_invalid_timestamp() {
         let now = Utc::now();
         assert_eq!(format_age("not-a-timestamp", now), "unknown");
+    }
+
+    // ===== Internal message tests (#494) =====
+
+    #[test]
+    fn test_internal_column_exists() {
+        let db = db();
+        assert!(db.column_exists("messages", "internal").unwrap());
+    }
+
+    #[test]
+    fn test_save_internal_message() {
+        let (db, sid) = db_with_session();
+        db.save_internal_message("mika", &sid, "assistant", "internal msg", None)
+            .unwrap();
+        let msgs = db.load_recent_messages("mika", 10).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].internal);
+        assert_eq!(msgs[0].content, "internal msg");
+    }
+
+    #[test]
+    fn test_save_internal_message_with_metadata() {
+        let (db, sid) = db_with_session();
+        db.save_internal_message_with_metadata(
+            "mika",
+            &sid,
+            "assistant",
+            "internal with meta",
+            Some(r#"{"tool_calls":[]}"#),
+            None,
+        )
+        .unwrap();
+        let msgs = db.load_recent_messages("mika", 10).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].internal);
+        assert!(msgs[0].metadata.is_some());
+    }
+
+    #[test]
+    fn test_save_message_defaults_not_internal() {
+        let (db, sid) = db_with_session();
+        db.save_message("mika", &sid, "user", "hello", None)
+            .unwrap();
+        let msgs = db.load_recent_messages("mika", 10).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(!msgs[0].internal);
+    }
+
+    #[test]
+    fn test_load_recent_messages_filtered_excludes_internal() {
+        let (db, sid) = db_with_session();
+        db.save_message("mika", &sid, "user", "visible 1", None)
+            .unwrap();
+        db.save_internal_message("mika", &sid, "assistant", "hidden", None)
+            .unwrap();
+        db.save_message("mika", &sid, "assistant", "visible 2", None)
+            .unwrap();
+
+        // Without filter: all 3
+        let all = db.load_recent_messages_filtered("mika", 10, false).unwrap();
+        assert_eq!(all.len(), 3);
+
+        // With filter: only 2 visible
+        let visible = db.load_recent_messages_filtered("mika", 10, true).unwrap();
+        assert_eq!(visible.len(), 2);
+        assert!(visible.iter().all(|m| !m.internal));
+    }
+
+    #[test]
+    fn test_count_internal_messages_after() {
+        let (db, sid) = db_with_session();
+        let id1 = db
+            .save_message("mika", &sid, "user", "msg 1", None)
+            .unwrap();
+        db.save_internal_message("mika", &sid, "assistant", "internal 1", None)
+            .unwrap();
+        db.save_internal_message("mika", &sid, "assistant", "internal 2", None)
+            .unwrap();
+        db.save_message("mika", &sid, "assistant", "visible", None)
+            .unwrap();
+
+        let count = db.count_internal_messages_after("mika", id1).unwrap();
+        assert_eq!(count, 2);
+
+        let count_all = db.count_internal_messages_after("mika", 0).unwrap();
+        assert_eq!(count_all, 2);
     }
 }

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -4310,23 +4310,7 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
-    /// Save a message marked as internal (hidden from TUI inbox mode).
-    pub fn save_internal_message(
-        &self,
-        agent_id: &str,
-        session_id: &str,
-        role: &str,
-        content: &str,
-        trace_id: Option<&str>,
-    ) -> Result<i64> {
-        self.conn.execute(
-            "INSERT INTO messages (session_id, agent_id, role, content, trace_id, internal)
-             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
-            params![session_id, agent_id, role, content, trace_id],
-        )?;
-        Ok(self.conn.last_insert_rowid())
-    }
-
+    #[allow(clippy::too_many_arguments)]
     pub fn save_message_with_metadata(
         &self,
         agent_id: &str,
@@ -4335,29 +4319,12 @@ impl Database {
         content: &str,
         metadata: Option<&str>,
         trace_id: Option<&str>,
-    ) -> Result<i64> {
-        self.conn.execute(
-            "INSERT INTO messages (session_id, agent_id, role, content, metadata, trace_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![session_id, agent_id, role, content, metadata, trace_id],
-        )?;
-        Ok(self.conn.last_insert_rowid())
-    }
-
-    /// Save a message with metadata, marked as internal (hidden from TUI inbox mode).
-    pub fn save_internal_message_with_metadata(
-        &self,
-        agent_id: &str,
-        session_id: &str,
-        role: &str,
-        content: &str,
-        metadata: Option<&str>,
-        trace_id: Option<&str>,
+        internal: bool,
     ) -> Result<i64> {
         self.conn.execute(
             "INSERT INTO messages (session_id, agent_id, role, content, metadata, trace_id, internal)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
-            params![session_id, agent_id, role, content, metadata, trace_id],
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![session_id, agent_id, role, content, metadata, trace_id, internal as i64],
         )?;
         Ok(self.conn.last_insert_rowid())
     }
@@ -4520,17 +4487,6 @@ impl Database {
             .query_map(params![agent_id, after_id], Self::row_to_session_message)?
             .collect::<rusqlite::Result<_>>()?;
         Ok(rows)
-    }
-
-    /// Count internal messages after a given message ID (for TUI hidden-count badge).
-    pub fn count_internal_messages_after(&self, agent_id: &str, after_id: i64) -> Result<i64> {
-        let n: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM messages
-              WHERE agent_id = ?1 AND id > ?2 AND internal = 1",
-            params![agent_id, after_id],
-            |r| r.get(0),
-        )?;
-        Ok(n)
     }
 
     pub fn max_message_id(&self, agent_id: &str) -> Result<i64> {
@@ -7348,7 +7304,7 @@ mod tests {
     fn test_get_messages_by_trace_id() {
         let (db, sid) = db_with_session();
         let trace = "aaaa0000bbbb1111cccc2222dddd3333";
-        db.save_message_with_metadata("mika", &sid, "user", "traced msg", None, Some(trace))
+        db.save_message_with_metadata("mika", &sid, "user", "traced msg", None, Some(trace), false)
             .unwrap();
         db.save_message("mika", &sid, "assistant", "no trace", None)
             .unwrap();
@@ -9770,7 +9726,7 @@ mod tests {
     #[test]
     fn test_save_internal_message() {
         let (db, sid) = db_with_session();
-        db.save_internal_message("mika", &sid, "assistant", "internal msg", None)
+        db.save_message_with_metadata("mika", &sid, "assistant", "internal msg", None, None, true)
             .unwrap();
         let msgs = db.load_recent_messages("mika", 10).unwrap();
         assert_eq!(msgs.len(), 1);
@@ -9781,13 +9737,14 @@ mod tests {
     #[test]
     fn test_save_internal_message_with_metadata() {
         let (db, sid) = db_with_session();
-        db.save_internal_message_with_metadata(
+        db.save_message_with_metadata(
             "mika",
             &sid,
             "assistant",
             "internal with meta",
             Some(r#"{"tool_calls":[]}"#),
             None,
+            true,
         )
         .unwrap();
         let msgs = db.load_recent_messages("mika", 10).unwrap();
@@ -9811,7 +9768,7 @@ mod tests {
         let (db, sid) = db_with_session();
         db.save_message("mika", &sid, "user", "visible 1", None)
             .unwrap();
-        db.save_internal_message("mika", &sid, "assistant", "hidden", None)
+        db.save_message_with_metadata("mika", &sid, "assistant", "hidden", None, None, true)
             .unwrap();
         db.save_message("mika", &sid, "assistant", "visible 2", None)
             .unwrap();
@@ -9824,25 +9781,5 @@ mod tests {
         let visible = db.load_recent_messages_filtered("mika", 10, true).unwrap();
         assert_eq!(visible.len(), 2);
         assert!(visible.iter().all(|m| !m.internal));
-    }
-
-    #[test]
-    fn test_count_internal_messages_after() {
-        let (db, sid) = db_with_session();
-        let id1 = db
-            .save_message("mika", &sid, "user", "msg 1", None)
-            .unwrap();
-        db.save_internal_message("mika", &sid, "assistant", "internal 1", None)
-            .unwrap();
-        db.save_internal_message("mika", &sid, "assistant", "internal 2", None)
-            .unwrap();
-        db.save_message("mika", &sid, "assistant", "visible", None)
-            .unwrap();
-
-        let count = db.count_internal_messages_after("mika", id1).unwrap();
-        assert_eq!(count, 2);
-
-        let count_all = db.count_internal_messages_after("mika", 0).unwrap();
-        assert_eq!(count_all, 2);
     }
 }

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -1890,6 +1890,7 @@ mod tests {
             "traced message",
             None,
             Some(trace_id),
+            false,
         )
         .await
         .unwrap();

--- a/crates/mika-agent/src/tools/delegate_task.rs
+++ b/crates/mika-agent/src/tools/delegate_task.rs
@@ -259,9 +259,9 @@ impl Tool for DelegateTaskTool {
             tracing::warn!(session = %session_id, error = %e, "failed to create delegate session");
         }
 
-        // Persist the delegated task as a user message
+        // Persist the delegated task as a user message (internal — agent-to-agent)
         if let Err(e) = async_db
-            .save_message(&session_id, "user", task, Some(ctx.trace_id))
+            .save_internal_message(&session_id, "user", task, Some(ctx.trace_id))
             .await
         {
             tracing::warn!(session = %session_id, error = %e, "failed to persist delegate task message");
@@ -292,11 +292,11 @@ impl Tool for DelegateTaskTool {
 
         let result = crate::agent::run_team_agent(&params).await;
 
-        // Persist result message for observability (#253)
+        // Persist result message for observability (#253) — internal (agent-to-agent)
         match &result {
             Ok(Some(text)) => {
                 if let Err(e) = async_db
-                    .save_message(&session_id, "assistant", text, Some(ctx.trace_id))
+                    .save_internal_message(&session_id, "assistant", text, Some(ctx.trace_id))
                     .await
                 {
                     tracing::warn!(session = %session_id, error = %e, "failed to persist delegate response");
@@ -306,7 +306,7 @@ impl Tool for DelegateTaskTool {
             Err(e) => {
                 let error_msg = format!("Delegation failed: {e}");
                 if let Err(pe) = async_db
-                    .save_message(&session_id, "system", &error_msg, Some(ctx.trace_id))
+                    .save_internal_message(&session_id, "system", &error_msg, Some(ctx.trace_id))
                     .await
                 {
                     tracing::warn!(session = %session_id, error = %pe, "failed to persist delegate error");

--- a/crates/mika-agent/src/tools/delegate_task.rs
+++ b/crates/mika-agent/src/tools/delegate_task.rs
@@ -261,7 +261,7 @@ impl Tool for DelegateTaskTool {
 
         // Persist the delegated task as a user message (internal — agent-to-agent)
         if let Err(e) = async_db
-            .save_internal_message(&session_id, "user", task, Some(ctx.trace_id))
+            .save_message_with_metadata(&session_id, "user", task, None, Some(ctx.trace_id), true)
             .await
         {
             tracing::warn!(session = %session_id, error = %e, "failed to persist delegate task message");
@@ -296,7 +296,14 @@ impl Tool for DelegateTaskTool {
         match &result {
             Ok(Some(text)) => {
                 if let Err(e) = async_db
-                    .save_internal_message(&session_id, "assistant", text, Some(ctx.trace_id))
+                    .save_message_with_metadata(
+                        &session_id,
+                        "assistant",
+                        text,
+                        None,
+                        Some(ctx.trace_id),
+                        true,
+                    )
                     .await
                 {
                     tracing::warn!(session = %session_id, error = %e, "failed to persist delegate response");
@@ -306,7 +313,14 @@ impl Tool for DelegateTaskTool {
             Err(e) => {
                 let error_msg = format!("Delegation failed: {e}");
                 if let Err(pe) = async_db
-                    .save_internal_message(&session_id, "system", &error_msg, Some(ctx.trace_id))
+                    .save_message_with_metadata(
+                        &session_id,
+                        "system",
+                        &error_msg,
+                        None,
+                        Some(ctx.trace_id),
+                        true,
+                    )
                     .await
                 {
                     tracing::warn!(session = %session_id, error = %pe, "failed to persist delegate error");

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -29,10 +29,6 @@ impl Tool for SendMessageTool {
                     "text": {
                         "type": "string",
                         "description": "The message to send to the user"
-                    },
-                    "internal": {
-                        "type": "boolean",
-                        "description": "If true, marks this message as internal (agent-to-agent). Internal messages are hidden from the TUI inbox view but visible in audit mode. Use when communicating with other agents rather than the human user."
                     }
                 },
                 "required": ["text"]
@@ -52,8 +48,6 @@ impl Tool for SendMessageTool {
             )));
         }
 
-        let internal = input["internal"].as_bool().unwrap_or(false);
-
         // Strip any internal metadata tags the LLM may have echoed
         let cleaned = mika_common::llm::strip_internal_tags(text);
         if cleaned.is_empty() {
@@ -61,15 +55,9 @@ impl Tool for SendMessageTool {
         }
 
         // Persist the outbound message for conversation history
-        if internal {
-            ctx.db
-                .save_internal_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
-                .await?;
-        } else {
-            ctx.db
-                .save_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
-                .await?;
-        }
+        ctx.db
+            .save_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
+            .await?;
 
         match &ctx.message_sender {
             Some(sender) => {

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -29,6 +29,10 @@ impl Tool for SendMessageTool {
                     "text": {
                         "type": "string",
                         "description": "The message to send to the user"
+                    },
+                    "internal": {
+                        "type": "boolean",
+                        "description": "If true, marks this message as internal (agent-to-agent). Internal messages are hidden from the TUI inbox view but visible in audit mode. Use when communicating with other agents rather than the human user."
                     }
                 },
                 "required": ["text"]
@@ -48,6 +52,8 @@ impl Tool for SendMessageTool {
             )));
         }
 
+        let internal = input["internal"].as_bool().unwrap_or(false);
+
         // Strip any internal metadata tags the LLM may have echoed
         let cleaned = mika_common::llm::strip_internal_tags(text);
         if cleaned.is_empty() {
@@ -55,9 +61,15 @@ impl Tool for SendMessageTool {
         }
 
         // Persist the outbound message for conversation history
-        ctx.db
-            .save_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
-            .await?;
+        if internal {
+            ctx.db
+                .save_internal_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
+                .await?;
+        } else {
+            ctx.db
+                .save_message(ctx.session_id, "assistant", &cleaned, Some(ctx.trace_id))
+                .await?;
+        }
 
         match &ctx.message_sender {
             Some(sender) => {

--- a/crates/mika-cli/CLAUDE.md
+++ b/crates/mika-cli/CLAUDE.md
@@ -29,10 +29,11 @@ Scoped flags: `--agent <name>` (override active agent, most subcommands), `--tea
 
 ## TUI Features
 
-- **Slash commands:** `/clear`, `/model`, `/provider`, `/think`, `/agent`, `/undo`, `/rewind`
+- **Slash commands:** `/clear`, `/model`, `/provider`, `/think`, `/agent`, `/undo`, `/rewind`, `/inbox`
 - `/clear` ends the current session, creates a new one, notifies the agent worker, drains stale responses from `agent_rx`, and resets all transient state; user preferences (`thinking_level`, model, provider) are preserved; `active_background_task_count` is intentionally NOT reset (agent-scoped, not session-scoped)
 - `/provider` and `/model` pre-validate via `Settings::make_llm_provider()` before updating the UI. `/provider` switch persists default `{provider}_model` when none exists, warns about stale fields and max_tokens limits, and spawns a background `get_models()` to pre-warm the model list cache. `/model` lists available models from cache/API, supports aliases and direct `provider/model` format with cross-provider switching
-- **Footer badges:** `[N tasks]` (Cyan) for pending reminders, `[N running]` (Yellow) for active background callback tasks (polled every ~5s), and dashboard status indicator with clickable `[start]`/`[stop]` and `[open]` buttons
+- **Footer badges:** `[N tasks]` (Cyan) for pending reminders, `[N running]` (Yellow) for active background callback tasks (polled every ~5s), `[N hidden]` (DarkGray) for suppressed internal messages in inbox mode, and dashboard status indicator with clickable `[start]`/`[stop]` and `[open]` buttons
+- **Inbox mode:** Default on — hides internal (agent-to-agent) messages from the chat view. `/inbox` toggles between inbox mode (filtered) and audit mode (all messages visible). Reloads message history from DB on toggle. `hidden_internal_count` tracks new internal messages arriving during the session
 - **Input:** Shell-like Tab completion with context-aware argument completers. Multi-line input via Alt+Enter (primary) or Shift+Enter. Image paste (Ctrl+V), persistent per-agent input history, mouse scroll, click-drag text selection with clipboard copy, bracketed paste (100KB limit)
 - **Team mode:** Streams `TeamEvent` callbacks, split-pane dashboard, `/verbose` toggles agent responses; team runs persisted to shared DB. Run-scoped workspace directories: each run creates `workspace/{run-uuid}/` with `.meta/` subdirectory for engine metadata
 - **Run context:** When `--run-id` or `--last-run` is used, the TUI displays a styled context block at the top of the chat area showing the referenced run's metadata

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 use crate::init::{self, AppContext};
 use crate::tui::app::{
     AgentRequest, AgentResponse, App, ChatMessage, ChatRole, TeamRequest,
-    callback_label_from_metadata,
+    session_message_to_chat_message,
 };
 use crate::tui::event::{AppEvent, EventReader};
 use crate::tui::input;
@@ -488,39 +488,18 @@ pub async fn run(
         worker._ctx.settings.llm_provider,
     );
 
-    // Load recent conversation history so the user sees prior messages on restart
-    if let Ok(history) = worker._ctx.async_db.load_recent_messages(20).await {
+    // Load recent conversation history so the user sees prior messages on restart.
+    // In inbox mode (default), internal messages are filtered at the DB level.
+    if let Ok(history) = worker
+        ._ctx
+        .async_db
+        .load_recent_messages_filtered(20, app.inbox_mode)
+        .await
+    {
         for msg in history {
-            let role = match msg.role.as_str() {
-                "user" => {
-                    // Skip stale framing messages saved before the callback save fix
-                    if msg.content.starts_with("A background task has completed.") {
-                        continue;
-                    }
-                    ChatRole::User
-                }
-                "assistant" => ChatRole::Assistant,
-                "tool_result" => ChatRole::System,
-                _ => continue,
-            };
-            let channel = if msg.channel_type == "cli" {
-                None
-            } else {
-                Some(msg.channel_type.clone())
-            };
-            // For tool_result, show a brief summary with label from metadata
-            let content = if msg.role == "tool_result" {
-                let label = callback_label_from_metadata(&msg.metadata);
-                format!("[Task: {}] Result received", label)
-            } else {
-                msg.content
-            };
-            app.messages.push(ChatMessage {
-                role,
-                content,
-                rendered: None,
-                channel,
-            });
+            if let Some(chat_msg) = session_message_to_chat_message(&msg) {
+                app.messages.push(chat_msg);
+            }
         }
     }
 
@@ -549,6 +528,7 @@ pub async fn run(
             content: warning.trim_end().to_string(),
             rendered: None,
             channel: None,
+            internal: false,
         });
     }
 
@@ -664,6 +644,7 @@ pub async fn run(
                                 ),
                                 rendered: None,
                                 channel: None,
+                                internal: false,
                             });
                         }
                         Err(e) => {
@@ -672,6 +653,7 @@ pub async fn run(
                                 content: format!("Failed to switch agent: {e}"),
                                 rendered: None,
                                 channel: None,
+                                internal: false,
                             });
                         }
                     }
@@ -682,6 +664,7 @@ pub async fn run(
                         content: format!("Failed to switch agent: {e}"),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                 }
             }
@@ -846,6 +829,7 @@ pub async fn run_team(team_name: &str, global_home: &Path, run_id: Option<&str>)
             content: warning,
             rendered: None,
             channel: None,
+            internal: false,
         });
     }
 

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -325,6 +325,7 @@ async fn spawn_agent_worker(
                             &result,
                             Some(&metadata),
                             trace_id.as_deref(),
+                            false,
                         )
                         .await;
 
@@ -528,7 +529,6 @@ pub async fn run(
             content: warning.trim_end().to_string(),
             rendered: None,
             channel: None,
-            internal: false,
         });
     }
 
@@ -644,7 +644,6 @@ pub async fn run(
                                 ),
                                 rendered: None,
                                 channel: None,
-                                internal: false,
                             });
                         }
                         Err(e) => {
@@ -653,7 +652,6 @@ pub async fn run(
                                 content: format!("Failed to switch agent: {e}"),
                                 rendered: None,
                                 channel: None,
-                                internal: false,
                             });
                         }
                     }
@@ -664,7 +662,6 @@ pub async fn run(
                         content: format!("Failed to switch agent: {e}"),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                 }
             }
@@ -829,7 +826,6 @@ pub async fn run_team(team_name: &str, global_home: &Path, run_id: Option<&str>)
             content: warning,
             rendered: None,
             channel: None,
-            internal: false,
         });
     }
 

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -48,10 +48,6 @@ pub struct ChatMessage {
     pub rendered: Option<Vec<Line<'static>>>,
     /// Source channel: None = CLI (local), Some("telegram") = Telegram, etc.
     pub channel: Option<String>,
-    /// Whether this message is internal (agent-to-agent). Hidden in inbox mode.
-    /// Read by audit-mode rendering (future: dimmed styling for internal messages).
-    #[allow(dead_code)]
-    pub internal: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -218,7 +214,6 @@ pub fn session_message_to_chat_message(
         content,
         rendered: None,
         channel,
-        internal: msg.internal,
     })
 }
 
@@ -723,7 +718,6 @@ impl<'a> App<'a> {
                 content: format_previous_run_context(&summary),
                 rendered: None,
                 channel: None,
-                internal: false,
             }]
         } else {
             Vec::new()
@@ -835,7 +829,6 @@ impl<'a> App<'a> {
                 content: text.clone(),
                 rendered: None,
                 channel: None,
-                internal: false,
             });
             let _ = team_tx.send(TeamRequest::Goal(text.clone()));
             // Persist user message to DB (fire-and-forget)
@@ -874,7 +867,6 @@ impl<'a> App<'a> {
             content: display,
             rendered: None,
             channel: None,
-            internal: false,
         });
 
         // Drain pending images
@@ -909,7 +901,6 @@ impl<'a> App<'a> {
                     content: output,
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
             }
@@ -962,7 +953,6 @@ impl<'a> App<'a> {
                 content: msg,
                 rendered: None,
                 channel: None,
-                internal: false,
             });
             self.auto_scroll_to_bottom();
             self.needs_redraw = true;
@@ -1004,7 +994,6 @@ impl<'a> App<'a> {
                     content: full,
                     rendered: Some(rendered),
                     channel: None,
-                    internal: false,
                 });
                 self.reveal_index = 0;
                 self.status = AgentStatus::Idle;
@@ -1077,7 +1066,6 @@ impl<'a> App<'a> {
                     content: msg,
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1094,7 +1082,6 @@ impl<'a> App<'a> {
                     content: format!("Phase: {phase} (iteration {iteration})"),
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1122,7 +1109,6 @@ impl<'a> App<'a> {
                         content: format!("[{agent}] {response}"),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.auto_scroll_to_bottom();
                 }
@@ -1141,7 +1127,6 @@ impl<'a> App<'a> {
                         content: format!("[{agent}] [failed] {error}"),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.auto_scroll_to_bottom();
                 }
@@ -1156,7 +1141,6 @@ impl<'a> App<'a> {
                             content: format!("[{}] [assigned] {}", task.agent, task.task),
                             rendered: None,
                             channel: None,
-                            internal: false,
                         });
                     }
                 }
@@ -1169,7 +1153,6 @@ impl<'a> App<'a> {
                     ),
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1185,7 +1168,6 @@ impl<'a> App<'a> {
                     content: format!("Critic (iteration {iteration}): {verdict}. {feedback}"),
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1198,7 +1180,6 @@ impl<'a> App<'a> {
                         content: "Team completed with no deliverable.".to_string(),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                 } else {
@@ -1219,7 +1200,6 @@ impl<'a> App<'a> {
                     content: format!("Team error: {msg}"),
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 self.status = AgentStatus::Idle;
                 self.needs_redraw = true;
@@ -1231,7 +1211,6 @@ impl<'a> App<'a> {
                         content: "Team worker stopped unexpectedly.".to_string(),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                     self.needs_redraw = true;
@@ -1261,7 +1240,6 @@ impl<'a> App<'a> {
                         content: format!("Error: {}", response.content),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                 } else {
@@ -1273,7 +1251,6 @@ impl<'a> App<'a> {
                             content: thinking,
                             rendered: Some(rendered),
                             channel: None,
-                            internal: false,
                         });
                     }
 
@@ -1284,7 +1261,6 @@ impl<'a> App<'a> {
                             content: mika_agent::agent::EMPTY_RESPONSE_FALLBACK.to_string(),
                             rendered: None,
                             channel: None,
-                            internal: false,
                         });
                         self.status = AgentStatus::Idle;
                     } else {
@@ -1303,7 +1279,6 @@ impl<'a> App<'a> {
                         content: "Agent worker stopped unexpectedly.".to_string(),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                     self.needs_redraw = true;
@@ -1545,7 +1520,6 @@ impl<'a> App<'a> {
                 content: format!("[{}] {}", task.label, status_label),
                 rendered: None,
                 channel: None,
-                internal: false,
             });
 
             let original_status = task.status.clone();
@@ -1579,7 +1553,6 @@ impl<'a> App<'a> {
                 ),
                 rendered: None,
                 channel: None,
-                internal: false,
             });
             self.needs_redraw = true;
         }

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -48,6 +48,10 @@ pub struct ChatMessage {
     pub rendered: Option<Vec<Line<'static>>>,
     /// Source channel: None = CLI (local), Some("telegram") = Telegram, etc.
     pub channel: Option<String>,
+    /// Whether this message is internal (agent-to-agent). Hidden in inbox mode.
+    /// Read by audit-mode rendering (future: dimmed styling for internal messages).
+    #[allow(dead_code)]
+    pub internal: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -176,6 +180,46 @@ pub fn callback_label_from_metadata(metadata: &Option<String>) -> String {
         .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
         .and_then(|v| v.get("label")?.as_str().map(|s| s.to_string()))
         .unwrap_or_else(|| "background task".to_string())
+}
+
+/// Convert a `SessionMessage` to a `ChatMessage` for TUI display.
+///
+/// Returns `None` if the message should be skipped (unsupported role, stale framing, etc.).
+/// This is the single conversion point used by startup history load, cross-channel poll,
+/// and rewind reload to ensure consistent filtering and formatting.
+pub fn session_message_to_chat_message(
+    msg: &mika_agent::db::SessionMessage,
+) -> Option<ChatMessage> {
+    let role = match msg.role.as_str() {
+        "user" => {
+            // Skip stale framing messages saved before the callback save fix
+            if msg.content.starts_with("A background task has completed.") {
+                return None;
+            }
+            ChatRole::User
+        }
+        "assistant" => ChatRole::Assistant,
+        "tool_result" => ChatRole::System,
+        _ => return None,
+    };
+    let channel = if msg.channel_type == "cli" {
+        None
+    } else {
+        Some(msg.channel_type.clone())
+    };
+    let content = if msg.role == "tool_result" {
+        let label = callback_label_from_metadata(&msg.metadata);
+        format!("[Task: {}] Result received", label)
+    } else {
+        msg.content.clone()
+    };
+    Some(ChatMessage {
+        role,
+        content,
+        rendered: None,
+        channel,
+        internal: msg.internal,
+    })
 }
 
 /// Format a previous team run summary as a human-readable context block.
@@ -552,6 +596,10 @@ pub struct App<'a> {
     pub team_dir: Option<PathBuf>,
     /// Verbose mode: show individual agent responses in team mode.
     pub verbose_mode: bool,
+    /// Inbox mode: hide internal (agent-to-agent) messages. Default: true.
+    pub inbox_mode: bool,
+    /// Count of hidden internal messages (for footer badge).
+    pub hidden_internal_count: usize,
     /// Live dashboard state during team runs (created on first PhaseChanged event).
     pub team_dashboard: Option<TeamDashboardState>,
 
@@ -641,6 +689,8 @@ impl<'a> App<'a> {
             team_name: None,
             team_dir: None,
             verbose_mode: false,
+            inbox_mode: true,
+            hidden_internal_count: 0,
             team_dashboard: None,
             dashboard_running: false,
             footer_open_rect: None,
@@ -673,6 +723,7 @@ impl<'a> App<'a> {
                 content: format_previous_run_context(&summary),
                 rendered: None,
                 channel: None,
+                internal: false,
             }]
         } else {
             Vec::new()
@@ -725,6 +776,8 @@ impl<'a> App<'a> {
             team_name: Some(team_name.to_string()),
             team_dir: Some(team_dir),
             verbose_mode: false,
+            inbox_mode: true,
+            hidden_internal_count: 0,
             team_dashboard: None,
             dashboard_running: false,
             footer_open_rect: None,
@@ -782,6 +835,7 @@ impl<'a> App<'a> {
                 content: text.clone(),
                 rendered: None,
                 channel: None,
+                internal: false,
             });
             let _ = team_tx.send(TeamRequest::Goal(text.clone()));
             // Persist user message to DB (fire-and-forget)
@@ -820,6 +874,7 @@ impl<'a> App<'a> {
             content: display,
             rendered: None,
             channel: None,
+            internal: false,
         });
 
         // Drain pending images
@@ -854,6 +909,7 @@ impl<'a> App<'a> {
                     content: output,
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
             }
@@ -906,6 +962,7 @@ impl<'a> App<'a> {
                 content: msg,
                 rendered: None,
                 channel: None,
+                internal: false,
             });
             self.auto_scroll_to_bottom();
             self.needs_redraw = true;
@@ -947,6 +1004,7 @@ impl<'a> App<'a> {
                     content: full,
                     rendered: Some(rendered),
                     channel: None,
+                    internal: false,
                 });
                 self.reveal_index = 0;
                 self.status = AgentStatus::Idle;
@@ -1019,6 +1077,7 @@ impl<'a> App<'a> {
                     content: msg,
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1035,6 +1094,7 @@ impl<'a> App<'a> {
                     content: format!("Phase: {phase} (iteration {iteration})"),
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1062,6 +1122,7 @@ impl<'a> App<'a> {
                         content: format!("[{agent}] {response}"),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.auto_scroll_to_bottom();
                 }
@@ -1080,6 +1141,7 @@ impl<'a> App<'a> {
                         content: format!("[{agent}] [failed] {error}"),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.auto_scroll_to_bottom();
                 }
@@ -1094,6 +1156,7 @@ impl<'a> App<'a> {
                             content: format!("[{}] [assigned] {}", task.agent, task.task),
                             rendered: None,
                             channel: None,
+                            internal: false,
                         });
                     }
                 }
@@ -1106,6 +1169,7 @@ impl<'a> App<'a> {
                     ),
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1121,6 +1185,7 @@ impl<'a> App<'a> {
                     content: format!("Critic (iteration {iteration}): {verdict}. {feedback}"),
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.auto_scroll_to_bottom();
                 self.needs_redraw = true;
@@ -1133,6 +1198,7 @@ impl<'a> App<'a> {
                         content: "Team completed with no deliverable.".to_string(),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                 } else {
@@ -1153,6 +1219,7 @@ impl<'a> App<'a> {
                     content: format!("Team error: {msg}"),
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 self.status = AgentStatus::Idle;
                 self.needs_redraw = true;
@@ -1164,6 +1231,7 @@ impl<'a> App<'a> {
                         content: "Team worker stopped unexpectedly.".to_string(),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                     self.needs_redraw = true;
@@ -1193,6 +1261,7 @@ impl<'a> App<'a> {
                         content: format!("Error: {}", response.content),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                 } else {
@@ -1204,6 +1273,7 @@ impl<'a> App<'a> {
                             content: thinking,
                             rendered: Some(rendered),
                             channel: None,
+                            internal: false,
                         });
                     }
 
@@ -1214,6 +1284,7 @@ impl<'a> App<'a> {
                             content: mika_agent::agent::EMPTY_RESPONSE_FALLBACK.to_string(),
                             rendered: None,
                             channel: None,
+                            internal: false,
                         });
                         self.status = AgentStatus::Idle;
                     } else {
@@ -1232,6 +1303,7 @@ impl<'a> App<'a> {
                         content: "Agent worker stopped unexpectedly.".to_string(),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                     self.status = AgentStatus::Idle;
                     self.needs_redraw = true;
@@ -1382,41 +1454,17 @@ impl<'a> App<'a> {
         }
 
         for msg in &new_msgs {
-            let role = match msg.role.as_str() {
-                "user" => {
-                    // Skip stale framing messages saved before the callback save fix
-                    if msg.content.starts_with("A background task has completed.") {
-                        continue;
-                    }
-                    ChatRole::User
-                }
-                "assistant" => ChatRole::Assistant,
-                "tool_result" => ChatRole::System,
-                _ => continue,
-            };
-            // CLI messages from other processes don't need a channel badge
-            // (same channel as the TUI), matching the history loader behavior.
-            let channel = if msg.channel_type == "cli" {
-                None
-            } else {
-                Some(msg.channel_type.clone())
-            };
-            // For tool_result, show a brief summary with label from metadata
-            let content = if msg.role == "tool_result" {
-                let label = callback_label_from_metadata(&msg.metadata);
-                format!("[Task: {}] Result received", label)
-            } else {
-                msg.content.clone()
-            };
-            self.messages.push(ChatMessage {
-                role,
-                content,
-                rendered: None,
-                channel,
-            });
+            // In inbox mode, skip internal messages but count them
+            if self.inbox_mode && msg.internal {
+                self.hidden_internal_count += 1;
+                continue;
+            }
+            if let Some(chat_msg) = session_message_to_chat_message(msg) {
+                self.messages.push(chat_msg);
+            }
         }
 
-        // Update watermark
+        // Update watermark (always advance, even for filtered messages)
         if let Some(last) = new_msgs.last() {
             self.last_seen_msg_id = last.id;
         }
@@ -1497,6 +1545,7 @@ impl<'a> App<'a> {
                 content: format!("[{}] {}", task.label, status_label),
                 rendered: None,
                 channel: None,
+                internal: false,
             });
 
             let original_status = task.status.clone();
@@ -1530,6 +1579,7 @@ impl<'a> App<'a> {
                 ),
                 rendered: None,
                 channel: None,
+                internal: false,
             });
             self.needs_redraw = true;
         }

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -1103,7 +1103,6 @@ async fn handle_think(app: &mut App<'_>, args: &str) -> Option<String> {
         content: format!("[think:{level}] {prompt}"),
         rendered: None,
         channel: None,
-        internal: false,
     });
 
     let images = std::mem::take(&mut app.pending_images);
@@ -1437,7 +1436,6 @@ mod tests {
             content: "hello".to_string(),
             rendered: None,
             channel: None,
-            internal: false,
         });
 
         let output = handle_clear(&mut app, "").await;

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -7,7 +7,7 @@ use mika_common::team;
 
 use crate::tui::app::{
     AgentRequest, AgentStatus, App, ChatMessage, ChatRole, MessagesLayout, SelectionState,
-    callback_label_from_metadata,
+    session_message_to_chat_message,
 };
 use crate::tui::commands::{COMMANDS, parse_command, resolve_thinking_level};
 use crate::tui::input;
@@ -67,6 +67,7 @@ pub async fn dispatch(app: &mut App<'_>, input: &str) -> Option<String> {
             }
         }
         "verbose" | "v" => Some(handle_verbose(app)),
+        "inbox" => Some(handle_inbox(app).await),
         "think" | "t" => handle_think(app, args).await,
         "attach" | "img" => Some(handle_attach(app, args)),
         "undo" => Some(handle_undo(app).await),
@@ -145,6 +146,7 @@ async fn handle_clear(app: &mut App<'_>, _args: &str) -> String {
     app.has_new_message = false;
     app.selection_state = SelectionState::None;
     app.pending_task_count = 0;
+    app.hidden_internal_count = 0;
 
     app.needs_redraw = true;
 
@@ -976,6 +978,36 @@ fn handle_verbose(app: &mut App<'_>) -> String {
     format!("Verbose mode: {state}")
 }
 
+/// Toggle between inbox mode (hide internal messages) and audit mode (show all).
+async fn handle_inbox(app: &mut App<'_>) -> String {
+    app.inbox_mode = !app.inbox_mode;
+
+    // Reload messages from DB with the new filter setting
+    app.messages.clear();
+    if let Ok(recent) = app
+        .db
+        .load_recent_messages_filtered(20, app.inbox_mode)
+        .await
+    {
+        for msg in &recent {
+            if let Some(chat_msg) = session_message_to_chat_message(msg) {
+                app.messages.push(chat_msg);
+            }
+        }
+    }
+
+    // Reset hidden count — will be refreshed on next poll tick
+    app.hidden_internal_count = 0;
+    app.scroll_offset = 0;
+    app.messages_layout = MessagesLayout::default();
+
+    if app.inbox_mode {
+        "Switched to inbox mode (internal messages hidden).".to_string()
+    } else {
+        "Switched to audit mode (all messages visible).".to_string()
+    }
+}
+
 fn handle_team_info(app: &App<'_>) -> String {
     let team_name = app.team_name.as_deref().unwrap_or("unknown");
     let mut out = String::new();
@@ -1071,6 +1103,7 @@ async fn handle_think(app: &mut App<'_>, args: &str) -> Option<String> {
         content: format!("[think:{level}] {prompt}"),
         rendered: None,
         channel: None,
+        internal: false,
     });
 
     let images = std::mem::take(&mut app.pending_images);
@@ -1194,36 +1227,15 @@ async fn handle_rewind_impl(
             // that are never in app.messages, so counting-based truncation is unreliable.
             // This mirrors the startup loader in chat.rs.
             app.messages.clear();
-            if let Ok(recent) = app.db.load_recent_messages(20).await {
+            if let Ok(recent) = app
+                .db
+                .load_recent_messages_filtered(20, app.inbox_mode)
+                .await
+            {
                 for msg in &recent {
-                    let role = match msg.role.as_str() {
-                        "user" => {
-                            if msg.content.starts_with("A background task has completed.") {
-                                continue;
-                            }
-                            ChatRole::User
-                        }
-                        "assistant" => ChatRole::Assistant,
-                        "tool_result" => ChatRole::System,
-                        _ => continue,
-                    };
-                    let channel = if msg.channel_type == "cli" {
-                        None
-                    } else {
-                        Some(msg.channel_type.clone())
-                    };
-                    let content = if msg.role == "tool_result" {
-                        let label = callback_label_from_metadata(&msg.metadata);
-                        format!("[Task: {}] Result received", label)
-                    } else {
-                        msg.content.clone()
-                    };
-                    app.messages.push(ChatMessage {
-                        role,
-                        content,
-                        rendered: None,
-                        channel,
-                    });
+                    if let Some(chat_msg) = session_message_to_chat_message(msg) {
+                        app.messages.push(chat_msg);
+                    }
                 }
             }
             app.scroll_offset = 0;
@@ -1425,6 +1437,7 @@ mod tests {
             content: "hello".to_string(),
             rendered: None,
             channel: None,
+            internal: false,
         });
 
         let output = handle_clear(&mut app, "").await;

--- a/crates/mika-cli/src/tui/commands/mod.rs
+++ b/crates/mika-cli/src/tui/commands/mod.rs
@@ -174,6 +174,13 @@ pub const COMMANDS: &[SlashCommand] = &[
         completer: None,
     },
     SlashCommand {
+        name: "inbox",
+        aliases: &[],
+        description: "Toggle inbox/audit mode (hide/show internal messages)",
+        args_hint: None,
+        completer: None,
+    },
+    SlashCommand {
         name: "undo",
         aliases: &[],
         description: "Undo last exchange and reverse memory changes",

--- a/crates/mika-cli/src/tui/input.rs
+++ b/crates/mika-cli/src/tui/input.rs
@@ -591,6 +591,7 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                         content: "Image attachments are not supported in team mode.".to_string(),
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                 } else if let Some(err) = app.attach_image(attachment) {
                     app.messages.push(crate::tui::app::ChatMessage {
@@ -598,6 +599,7 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                         content: err,
                         rendered: None,
                         channel: None,
+                        internal: false,
                     });
                 }
                 return;
@@ -614,6 +616,7 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                             .to_string(),
                     rendered: None,
                     channel: None,
+                    internal: false,
                 });
                 return;
             }
@@ -799,6 +802,7 @@ pub fn handle_paste(app: &mut App<'_>, text: &str) {
             ),
             rendered: None,
             channel: None,
+            internal: false,
         });
         &text[..text.floor_char_boundary(MAX_PASTE_BYTES)]
     } else {

--- a/crates/mika-cli/src/tui/input.rs
+++ b/crates/mika-cli/src/tui/input.rs
@@ -591,7 +591,6 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                         content: "Image attachments are not supported in team mode.".to_string(),
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                 } else if let Some(err) = app.attach_image(attachment) {
                     app.messages.push(crate::tui::app::ChatMessage {
@@ -599,7 +598,6 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                         content: err,
                         rendered: None,
                         channel: None,
-                        internal: false,
                     });
                 }
                 return;
@@ -616,7 +614,6 @@ fn handle_key_normal(app: &mut App<'_>, key: KeyEvent) {
                             .to_string(),
                     rendered: None,
                     channel: None,
-                    internal: false,
                 });
                 return;
             }
@@ -802,7 +799,6 @@ pub fn handle_paste(app: &mut App<'_>, text: &str) {
             ),
             rendered: None,
             channel: None,
-            internal: false,
         });
         &text[..text.floor_char_boundary(MAX_PASTE_BYTES)]
     } else {

--- a/crates/mika-cli/src/tui/ui.rs
+++ b/crates/mika-cli/src/tui/ui.rs
@@ -1052,6 +1052,14 @@ fn draw_footer(f: &mut Frame<'_>, app: &mut App<'_>, area: Rect, terminal_width:
                 Style::default().fg(Color::Cyan),
             ));
         }
+        // Hidden internal messages badge (inbox mode)
+        if app.inbox_mode && app.hidden_internal_count > 0 {
+            s.push(Span::styled(" | ", Style::default().fg(Color::DarkGray)));
+            s.push(Span::styled(
+                format!("[{} hidden]", app.hidden_internal_count),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
         // Active background task badge
         if app.active_background_task_count > 0 {
             s.push(Span::styled(" | ", Style::default().fg(Color::DarkGray)));

--- a/docs/plans/2026-04-12-002-feat-silence-internal-dev-questions-tui-plan.md
+++ b/docs/plans/2026-04-12-002-feat-silence-internal-dev-questions-tui-plan.md
@@ -1,0 +1,179 @@
+---
+title: "feat: Silence internal dev questions in the TUI"
+type: feat
+status: completed
+date: 2026-04-12
+issue: "#494"
+---
+
+# Silence Internal Dev Questions in the TUI
+
+## Overview
+
+Keep agent-to-agent "dev" questions out of the TUI's main view while preserving full threading in the audit log. The TUI becomes an **escalation-only inbox** — quiet until a question is actually addressed to the human.
+
+## Problem Statement
+
+The TUI currently shows every question regardless of intended audience. When mika-dev asks mika-qa something, the human sees it and has to mentally filter. This breaks the "Mika as coworker" perspective and turns the TUI into a debug console.
+
+## Proposed Solution
+
+Two complementary changes:
+
+1. **Tag at source:** Add `internal: bool` field to the `messages` table. Messages in delegate sessions (`delegate-*`) are implicitly internal. The `send_message` tool gains an optional `internal` parameter for explicit opt-in from other contexts (callbacks, heartbeats).
+
+2. **Filter at view:** TUI defaults to **inbox mode** (hides `internal: true` messages). A `/inbox` toggle switches to **audit mode** (shows all). A footer badge shows the count of hidden internal messages.
+
+## Technical Approach
+
+### Phase 1: Data Model — `internal` Column on `messages`
+
+**Schema migration v21→v22** in `crates/mika-agent/src/db.rs`:
+
+```sql
+ALTER TABLE messages ADD COLUMN internal INTEGER NOT NULL DEFAULT 0;
+```
+
+A dedicated column (not JSON metadata) because:
+- SQL-level filtering with correct `LIMIT` semantics (no limit starvation)
+- Indexable for performance
+- Clean query predicates without `json_extract()`
+
+**Struct changes:**
+- `SessionMessage` (`db.rs:192`): add `pub internal: bool`
+- All `SELECT` queries that read from `messages` must include the new column
+
+**Write paths — set `internal = true` for:**
+- `save_message()` and `save_message_with_metadata()`: add `internal: bool` parameter
+- All delegate sessions (`delegate-*`): the `delegate_task` tool (`tools/delegate_task.rs`) saves messages with `internal: true`
+- `send_message` tool: new optional `internal` bool parameter (default `false`)
+- Callback result messages saved by the TUI (`chat.rs:322`): `internal: false` (callback results are user-relevant)
+- Agent loop response saves (`agent.rs`): pass `internal: false` for conversation mode, `internal: true` for silent mode delegate contexts
+
+### Phase 2: DB Query Filtering
+
+**`load_recent_messages(agent_id, limit)`** → **`load_recent_messages(agent_id, limit, exclude_internal: bool)`**
+
+```sql
+SELECT ... FROM messages m JOIN sessions s ON m.session_id = s.id
+WHERE m.agent_id = ?1 AND m.role != 'summary' AND s.channel_type != 'team'
+  AND (?3 = 0 OR m.internal = 0)   -- filter when exclude_internal = true
+ORDER BY m.id DESC LIMIT ?2
+```
+
+**`load_messages_after(agent_id, after_id)`** → **`load_messages_after(agent_id, after_id, exclude_internal: bool)`**
+
+Same pattern — add `AND (?3 = 0 OR m.internal = 0)`.
+
+**`count_internal_messages_after(agent_id, after_id) -> i64`** — new query for the footer badge count.
+
+**`AsyncDatabase` wrappers:** Update to pass through the new parameter.
+
+### Phase 3: TUI Inbox Mode
+
+**`App` struct** (`crates/mika-cli/src/tui/app.rs:554`):
+- Add `pub inbox_mode: bool` (default `true`) alongside `verbose_mode`
+- Add `pub hidden_internal_count: usize` (for footer badge)
+
+**`ChatMessage` struct** (`app.rs:44`):
+- Add `pub internal: bool` field
+
+**Four display paths must respect `inbox_mode`:**
+
+1. **Startup history load** (`chat.rs:491-525`): Pass `exclude_internal: self.inbox_mode` to `load_recent_messages`. When constructing `ChatMessage`, carry `internal` from `SessionMessage`.
+
+2. **Cross-channel poll** (`app.rs:1370-1425`, `poll_cross_channel_messages`): Pass `exclude_internal: self.inbox_mode` to `load_messages_after`. When `inbox_mode` is true, skip internal messages. Increment `hidden_internal_count` for skipped messages.
+
+3. **Callback poll** (`app.rs:1427-1530`, `poll_callback_tasks`): Pass through — callback task results are user-facing (`internal: false`).
+
+4. **Rewind history reload** (`handlers.rs:1196-1228`): Same as startup — pass `exclude_internal: self.inbox_mode`.
+
+**Shared conversion helper:**
+Extract a `session_message_to_chat_message(msg: &SessionMessage, inbox_mode: bool) -> Option<ChatMessage>` function to unify the four paths and eliminate copy-pasted conversion logic.
+
+### Phase 4: Toggle Command and Footer Badge
+
+**`/inbox` slash command** (`crates/mika-cli/src/tui/commands/`):
+- Register in `handlers.rs:21` command list and `handlers.rs:69` dispatch
+- Add to `completers.rs` for tab completion
+- Toggles `app.inbox_mode` between `true` (inbox/escalation-only) and `false` (audit/show all)
+- On toggle to audit mode: reload messages from DB without the internal filter (call existing rewind-reload logic with `exclude_internal: false`)
+- On toggle to inbox mode: reload with filter active
+- Print system message: `"Switched to inbox mode (internal messages hidden)"` or `"Switched to audit mode (all messages visible)"`
+
+**Footer badge** (`crates/mika-cli/src/tui/ui.rs:936`, badge pattern at lines 1047-1062):
+- When `inbox_mode == true && hidden_internal_count > 0`: render `[N hidden]` badge in DarkGray
+- Follows existing badge pattern (`[N tasks]` in Cyan, `[N running]` in Yellow)
+
+**Hidden count maintenance:**
+- Increment `hidden_internal_count` in `poll_cross_channel_messages` when skipping internal messages
+- Reset on `/clear` (new session)
+- Reset on mode toggle (reloaded from DB)
+- Periodically refresh via `count_internal_messages_after` query (piggyback on existing 5s poll tick)
+
+### Phase 5: `/undo` and `/rewind` Awareness
+
+**`/undo`** in inbox mode should skip internal messages — undo the last **visible** exchange:
+- In `handlers.rs` rewind logic: when `inbox_mode == true`, filter out internal messages from the candidate list before selecting the undo target
+
+**`/rewind N`** in inbox mode: count only visible messages when determining how far back to go.
+
+## Acceptance Criteria
+
+- [x] Schema v22: `messages.internal` column (INTEGER NOT NULL DEFAULT 0)
+- [x] `SessionMessage` struct carries `internal: bool`
+- [x] `save_internal_message` / `save_internal_message_with_metadata` persist internal flag
+- [x] Delegate task messages saved with `internal: true`
+- [x] `send_message` tool accepts optional `internal` parameter
+- [x] `load_recent_messages_filtered` supports `exclude_internal` filter
+- [x] `ChatMessage` carries `internal: bool`
+- [x] TUI defaults to inbox mode (`inbox_mode: true`)
+- [x] Startup history load respects inbox mode
+- [x] Cross-channel poll respects inbox mode
+- [x] Rewind reload respects inbox mode
+- [x] `/inbox` command toggles between inbox and audit mode with message reload
+- [x] Footer shows `[N hidden]` badge when internal messages are suppressed
+- [x] `/undo` in inbox mode works correctly (exchange-level boundaries naturally skip internal)
+- [x] All existing tests pass (`cargo test`)
+- [x] New tests for internal message filtering (6 DB-level tests)
+
+## Design Decisions
+
+### Column vs. JSON metadata
+**Chosen: dedicated column.** JSON metadata (`json_extract`) cannot be indexed efficiently, causes limit starvation when filtering with `LIMIT`, and adds parsing overhead. A column enables clean SQL predicates and correct pagination.
+
+### Session-level vs. message-level tagging
+**Chosen: message-level with session-level defaults.** Delegate sessions are implicitly internal (all messages `internal: true`). Other contexts use explicit opt-in via the `send_message` tool parameter. This gives both convenience (delegate sessions auto-tagged) and flexibility (any message can be tagged).
+
+### `internal: false` as global default
+**Chosen: false globally.** The issue's open question #1 asked about per-agent defaults. Global false is simpler — the primary use case (delegate sessions) is handled by implicit tagging, not per-agent config. Agent-level defaults can be added later without schema changes.
+
+### Deferred to follow-up issues
+- Auto-promote internal questions on timeout (issue open question #2)
+- Retroactive tagging of in-flight questions (issue open question #4)
+- Dashboard API filtering for internal messages
+- Compaction handling of internal messages (summary inherits internal flag)
+
+## System-Wide Impact
+
+### Interaction graph
+`save_message_with_metadata()` is called from: agent loop EndTurn, agent loop tool_result, `send_message` tool, delegate task save, callback result save. All callers need the `internal` parameter.
+
+### Error propagation
+No new error paths. The `internal` column has a `DEFAULT 0` — callers that don't pass it get `false`.
+
+### State lifecycle risks
+None. The column is additive with a safe default. Existing messages get `internal = 0` (visible).
+
+### API surface parity
+Dashboard API (`/api/v1/messages`, `/api/v1/sessions/*/messages`): `SessionMessage` will carry `internal` in the JSON response. No server-side filtering — dashboard decides client-side.
+
+`mika ask` stdout output: unaffected (shows all messages, no inbox concept).
+
+## Sources
+
+- Issue: [#494](https://github.com/senara-solutions/mika/issues/494)
+- Precedent: `verbose_mode` toggle (`app.rs:554`, `handlers.rs:970`)
+- Precedent: `strip_internal_tags()` pattern (`docs/solutions/ui-bugs/strip-internal-metadata-tags-from-display.md`)
+- Learning: dual-path consistency (`docs/solutions/logic-errors/tui-callback-skips-mika-qa-delegation.md`)
+- Learning: inclusive filter patterns (`docs/solutions/dashboard-issues/dev-runs-source-filter-too-restrictive.md`)

--- a/docs/plans/2026-04-12-002-feat-silence-internal-dev-questions-tui-plan.md
+++ b/docs/plans/2026-04-12-002-feat-silence-internal-dev-questions-tui-plan.md
@@ -122,20 +122,19 @@ Extract a `session_message_to_chat_message(msg: &SessionMessage, inbox_mode: boo
 
 - [x] Schema v22: `messages.internal` column (INTEGER NOT NULL DEFAULT 0)
 - [x] `SessionMessage` struct carries `internal: bool`
-- [x] `save_internal_message` / `save_internal_message_with_metadata` persist internal flag
+- [x] `save_message_with_metadata` gains `internal: bool` parameter (consolidated — no separate methods)
 - [x] Delegate task messages saved with `internal: true`
-- [x] `send_message` tool accepts optional `internal` parameter
 - [x] `load_recent_messages_filtered` supports `exclude_internal` filter
-- [x] `ChatMessage` carries `internal: bool`
 - [x] TUI defaults to inbox mode (`inbox_mode: true`)
-- [x] Startup history load respects inbox mode
-- [x] Cross-channel poll respects inbox mode
+- [x] Startup history load respects inbox mode (DB-level filtering)
+- [x] Cross-channel poll respects inbox mode (app-level filtering + hidden count)
 - [x] Rewind reload respects inbox mode
 - [x] `/inbox` command toggles between inbox and audit mode with message reload
 - [x] Footer shows `[N hidden]` badge when internal messages are suppressed
 - [x] `/undo` in inbox mode works correctly (exchange-level boundaries naturally skip internal)
+- [x] `session_message_to_chat_message()` shared helper deduplicates 3 conversion sites
 - [x] All existing tests pass (`cargo test`)
-- [x] New tests for internal message filtering (6 DB-level tests)
+- [x] New tests for internal message filtering (5 DB-level tests)
 
 ## Design Decisions
 

--- a/docs/runtime-structure.md
+++ b/docs/runtime-structure.md
@@ -75,7 +75,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **PRAGMAs:** `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`, `busy_timeout=5000`, `auto_vacuum=INCREMENTAL`
 
-**Current schema version:** 19
+**Current schema version:** 22
 
 **Timestamp format:** All timestamp columns use ISO 8601 TEXT (`%Y-%m-%dT%H:%M:%SZ`) — not Unix epoch integers. SQL defaults use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`. Fixed-width UTC format ensures correct lexicographic ordering.
 
@@ -87,7 +87,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`
 
-**messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`
+**messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`, `internal INTEGER NOT NULL DEFAULT 0` (agent-to-agent messages hidden from TUI inbox mode)
 
 ### Memory Tables
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -487,6 +487,23 @@ Only available in team mode (`mika --team <name>`).
 
 ---
 
+### /inbox
+
+Toggle between inbox mode (hide internal agent-to-agent messages) and audit mode (show all messages). Inbox mode is the default.
+
+**Aliases:** None | **Arguments:** None
+
+When toggled, message history is reloaded from the database with the new filter setting. In inbox mode, a `[N hidden]` footer badge shows the count of suppressed internal messages.
+
+**Example:**
+```
+/inbox
+```
+
+Output: `Switched to audit mode (all messages visible).` or `Switched to inbox mode (internal messages hidden).`
+
+---
+
 ### /undo
 
 Undo the last exchange (user message + assistant response) and reverse any memory changes made during that exchange. Equivalent to `/rewind 1`.
@@ -556,7 +573,7 @@ to a safe subset. Agent-specific commands are disabled:
 |-----------|----------|
 | `/help`, `/clear`, `/exit`, `/quit` | `/model`, `/think`, `/agent`, `/switch` |
 | `/export`, `/teams`, `/agents` | `/memory`, `/reminders`, `/compact`, `/soul` |
-| `/status`, `/team`, `/verbose` | `/config`, `/skills`, `/skill`, `/attach`, `/tasks` |
+| `/status`, `/team`, `/verbose`, `/inbox` | `/config`, `/skills`, `/skill`, `/attach`, `/tasks` |
 |  | `/undo`, `/rewind` |
 
 In team mode, `/status` and `/team` both show team info (name, orchestrator,

--- a/docs/solutions/architecture-patterns/internal-message-tagging-tui-inbox-mode.md
+++ b/docs/solutions/architecture-patterns/internal-message-tagging-tui-inbox-mode.md
@@ -1,0 +1,68 @@
+---
+title: "Internal message tagging with TUI inbox/audit mode"
+category: architecture-patterns
+date: 2026-04-12
+tags: [tui, messages, filtering, schema, inbox, delegate-task, internal]
+issue: "#494"
+---
+
+# Internal Message Tagging with TUI Inbox/Audit Mode
+
+## Problem
+
+The TUI showed every message regardless of intended audience. When mika-dev delegated tasks to mika-qa, the human saw agent-to-agent questions and had to mentally filter them. This turned the TUI into a debug console rather than an escalation-only inbox.
+
+## Root Cause
+
+No concept of message visibility existed in the data model. All messages — whether user-facing or agent-to-agent — were treated identically in queries and display.
+
+## Solution
+
+### 1. Data model: dedicated `internal` column (schema v22)
+
+Added `internal INTEGER NOT NULL DEFAULT 0` to the `messages` table via `ALTER TABLE ADD COLUMN`. A dedicated column (not JSON metadata) because:
+
+- SQL-level filtering with correct `LIMIT` semantics (no limit starvation)
+- Indexable for performance if needed
+- Clean query predicates without `json_extract()`
+
+The `DEFAULT 0` means all existing messages remain visible — safe, additive migration.
+
+### 2. Write path: tag at source
+
+- `save_message_with_metadata()` gained an `internal: bool` parameter (consolidated from initially-proposed separate `save_internal_message` methods — fewer methods, same capability)
+- `delegate_task` tool hardcodes `internal: true` for all delegate session messages — agent-to-agent traffic is automatically tagged without LLM involvement
+- `save_message()` (no metadata) omits the column, falling back to `DEFAULT 0`
+
+**Key design decision:** The `internal` flag is NOT exposed in any tool's `input_schema`. The LLM cannot mark its own messages as internal. Only server-side code paths (`delegate_task`) set it. This prevents the agent from accidentally hiding user-facing messages.
+
+### 3. Read path: filter at view
+
+- `load_recent_messages_filtered(agent_id, limit, exclude_internal)` applies `AND m.internal = 0` in the WHERE clause before LIMIT
+- Startup history load and rewind reload use DB-level filtering
+- Cross-channel poll uses app-level filtering (needed to advance the watermark past internal messages while counting them for the badge)
+
+### 4. TUI inbox mode
+
+- `App.inbox_mode: bool` (default `true`) — hides internal messages
+- `/inbox` slash command toggles between inbox (filtered) and audit (all visible) mode
+- On toggle: reloads message history from DB with new filter setting
+- `[N hidden]` footer badge in DarkGray shows suppressed internal message count
+
+### 5. Shared conversion helper
+
+Extracted `session_message_to_chat_message()` to deduplicate 3 copy-pasted `SessionMessage`-to-`ChatMessage` conversion blocks (startup history, cross-channel poll, rewind reload).
+
+## Prevention
+
+- **SESSION_MESSAGE_COLUMNS pattern:** When adding columns to `messages`, always update the `SESSION_MESSAGE_COLUMNS` constant and `row_to_session_message()`. Positional column indexing means a missing column causes cascading silent data corruption. (Documented in `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md`)
+- **Dual-path consistency:** The startup loader, cross-channel poll, and rewind reload all display messages. Use a single shared conversion function (`session_message_to_chat_message`) rather than copy-pasting conversion logic.
+- **Watermark advancement:** When filtering messages in the poll loop, always advance the watermark (`last_seen_msg_id`) for ALL messages (including filtered ones) to prevent infinite re-fetch loops.
+
+## Related
+
+- [Delegate session persistence](delegate-task-session-message-persistence.md) — the delegate_task persistence pattern this builds on
+- [Delegate channel type taxonomy](delegate-channel-type-taxonomy.md) — `channel_type` filtering context
+- [SQL column mismatch](../database-issues/sql-column-mismatch-trace-detail-view.md) — the `SESSION_MESSAGE_COLUMNS` pattern
+- [Callback TUI delivery polling](callback-tui-delivery-polling.md) — the poll architecture this integrates with
+- [Strip internal tags](../ui-bugs/strip-internal-metadata-tags-from-display.md) — related internal content hiding (tag-level vs message-level)

--- a/todos/759-pending-p3-dashboard-api-internal-field.md
+++ b/todos/759-pending-p3-dashboard-api-internal-field.md
@@ -1,0 +1,35 @@
+---
+status: pending
+priority: p3
+issue_id: 759
+tags: [code-review, dashboard, agent-native]
+dependencies: []
+---
+
+# Dashboard API `MessageResponse` missing `internal` field
+
+## Problem Statement
+
+The `MessageResponse` struct in `crates/mika-agent/src/server/dashboard.rs` does not include the `internal: bool` field from `SessionMessage`. When messages are returned via the dashboard API (`/api/v1/sessions/:id/messages`), the internal flag is silently dropped.
+
+## Findings
+
+- `SessionMessage` gained `internal: bool` in schema v22 (#494)
+- The `From<SessionMessage>` impl for `MessageResponse` does not map the field
+- Dashboard and API consumers cannot distinguish internal from user-facing messages
+- The plan for #494 explicitly defers dashboard API filtering to a follow-up issue
+
+## Proposed Solutions
+
+### Option A: Add field to MessageResponse (recommended)
+Add `pub internal: bool` to `MessageResponse` and map it in the `From` impl. Optional: add `?exclude_internal=true` query parameter to message endpoints.
+
+- **Pros:** Simple, preserves information, backward-compatible (new JSON field)
+- **Cons:** None significant
+- **Effort:** Small
+- **Risk:** Low
+
+## Acceptance Criteria
+
+- [ ] `MessageResponse` includes `internal: bool`
+- [ ] API responses include the `internal` field in JSON

--- a/todos/760-pending-p3-save-message-params-struct.md
+++ b/todos/760-pending-p3-save-message-params-struct.md
@@ -1,0 +1,42 @@
+---
+status: pending
+priority: p3
+issue_id: 760
+tags: [code-review, architecture, tech-debt]
+dependencies: []
+---
+
+# `save_message_with_metadata` has too many positional parameters
+
+## Problem Statement
+
+`Database::save_message_with_metadata()` now has 8 positional parameters (self, agent_id, session_id, role, content, metadata, trace_id, internal) after #494 added the `internal: bool` flag. A `#[allow(clippy::too_many_arguments)]` suppression was added.
+
+## Findings
+
+- Several `Option<&str>` params make callsites hard to read
+- The clippy suppression is pragmatic but signals the API is at its limit
+- Any future parameter additions will worsen readability
+
+## Proposed Solutions
+
+### Option A: SaveMessageParams struct
+Replace positional params with a builder or params struct.
+
+- **Pros:** Cleaner callsites, self-documenting field names, extensible
+- **Cons:** More code, all callers need updating
+- **Effort:** Medium
+- **Risk:** Low
+
+### Option B: Leave as-is
+The function is an internal DB helper, not a public API. The suppression is fine.
+
+- **Pros:** No churn
+- **Cons:** Readability won't improve
+- **Effort:** None
+- **Risk:** None
+
+## Acceptance Criteria
+
+- [ ] Decide on approach
+- [ ] If Option A: refactor and remove clippy suppression


### PR DESCRIPTION
## Summary

- Add `internal` column to `messages` table (schema v22) for agent-to-agent message visibility
- `delegate_task` tool automatically marks all delegate session messages as `internal: true`
- TUI defaults to **inbox mode** — hides internal messages, shows `[N hidden]` footer badge
- `/inbox` slash command toggles between inbox (filtered) and audit (all visible) mode
- Extract `session_message_to_chat_message()` shared helper, deduplicating 3 copy-pasted conversion blocks
- Consolidate `save_internal_message` / `save_internal_message_with_metadata` into single `save_message_with_metadata(internal: bool)` parameter

## Key design decisions

- **Dedicated column over JSON metadata** — enables SQL-level filtering with correct LIMIT semantics
- **Internal flag NOT exposed in tool input_schema** — LLM cannot mark its own messages as internal; only server-side code (`delegate_task`) sets it
- **DB-level filtering for startup/reload, app-level for poll** — poll needs to advance watermark past internal messages while counting them for the badge

Closes #494

## Test plan

- [x] All 2,199 existing tests pass (`cargo test`)
- [x] 5 new DB-level tests for internal message filtering
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass (fmt, clippy, secrets scan)
- [ ] Manual: run `mika` TUI, verify internal messages hidden by default
- [ ] Manual: `/inbox` toggles audit mode, shows all messages
- [ ] Manual: delegate a task, verify delegate messages tagged internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)