### PR TITLE
docs: plan and compound for webhook QA pass entry point (#553)

### DIFF
--- a/docs/plans/2026-04-12-002-feat-tighten-webhook-entry-point-qa-pass-plan.md
+++ b/docs/plans/2026-04-12-002-feat-tighten-webhook-entry-point-qa-pass-plan.md
@@ -1,0 +1,69 @@
+---
+title: "feat: tighten webhook entry point — QA pass + open PR = immediate merge"
+type: feat
+status: active
+date: 2026-04-12
+---
+
+# feat: tighten webhook entry point — QA pass + open PR = immediate merge
+
+## Overview
+
+When a `pull_request_review.submitted` webhook arrives with verdict `pass` and the PR is open, the agent should immediately call `pr_merge_with_gate` without narrating, questioning, or waiting for confirmation. The PR #522 incident (2026-04-11) showed that despite having the correct decision tree in the prompt, the LLM misclassified the event and narrated instead of acting, leaving the PR stuck for 7 hours.
+
+This issue tightens the prompt-level directives as an intermediate fix. The structural runtime handler (mika#524) is a separate, deeper fix.
+
+## Problem Statement
+
+Three gaps in the current `self-dev-webhook-qa/system_prompt.md` allowed the PR #522 failure:
+
+1. **No explicit "zero narration" directive.** The prompt says "DO NOT end your turn without acting" and "MUST call pr_merge_with_gate" — but never says "DO NOT narrate, explain, or ask questions before acting." The LLM fills silence with narration.
+2. **Work item correlation is a prerequisite for merge.** Step 1 requires correlating to a work item before parsing the verdict. If correlation fails or confuses the LLM, the merge never happens. The PR URL is in the webhook — merge should not depend on work item lookup.
+3. **Event type identity is implicit.** The prompt assumes the LLM correctly identifies `pull_request_review.submitted` from the message text. PR #522 showed the LLM misread it as `pull_request.opened`. The prompt needs an explicit event-type fingerprint check.
+
+## Proposed Solution
+
+### Change 1: Tighten `self-dev-webhook-qa/system_prompt.md`
+
+**File:** `mika-skills/self-dev-webhook-qa/system_prompt.md`
+
+Add hard directives at the top of the pass verdict section:
+
+1. **Zero-narration rule:** Add explicit directive: "On a `pass` verdict, your FIRST output MUST be a tool call. No text, no explanation, no questions before the tool call. Narration before action is a workflow failure."
+2. **Decouple merge from work item correlation:** Restructure the pass flow to:
+   - Step 1: Parse `VERDICT:` line from review body
+   - Step 2: If `pass` → extract PR number and repo from PR URL → call `pr_merge_with_gate` immediately
+   - Step 3: AFTER merge result, correlate to work item and update status
+   - This ensures merge happens even if work item lookup fails or confuses the model
+3. **Event-type fingerprint:** Add an explicit check at the top: "This event contains a review body with a `VERDICT:` line. This is a QA verdict event — NOT a new PR, NOT a CI event, NOT a comment. Your only job is to parse the verdict and act on it."
+4. **Simplify the pass case preamble:** Remove multi-step extraction instructions that add cognitive load. The PR URL is right there in the message — make the instruction direct: "Extract pr_number and repo from the PR URL in the message, then call pr_merge_with_gate."
+
+### Change 2: Reinforce `soul.md` (minor)
+
+**File:** `~/.mika/agents/mika-dev/soul.md`
+
+The "Evidence → Action" principle at lines 54-62 is already well-stated. Minor reinforcement:
+- Add: "On webhook events with clear verdicts, act first — correlate and update state after."
+- This aligns soul.md with the reordered flow (merge first, correlate second).
+
+## Acceptance Criteria
+
+- [x] `self-dev-webhook-qa/system_prompt.md` — pass verdict section has zero-narration directive
+- [x] `self-dev-webhook-qa/system_prompt.md` — pass flow reordered: parse verdict → merge → correlate work item (not: correlate → parse → merge)
+- [x] `self-dev-webhook-qa/system_prompt.md` — event-type fingerprint check at top prevents misclassification
+- [x] `soul.md` — "Evidence → Action" section reinforced with "act first, correlate after" on webhook events
+- [x] No narration or clarifying questions on QA pass events
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `mika-skills/self-dev-webhook-qa/system_prompt.md` | Tighten pass verdict flow: zero-narration, decouple merge from work item, event fingerprint |
+| `~/.mika/agents/mika-dev/soul.md` | Minor reinforcement of Evidence → Action for webhook events |
+
+## Sources
+
+- **Incident:** [mika-dev verdict misclassification on PR #522](../solutions/agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md) — LLM misclassified `pull_request_review.submitted` as `pull_request.opened`, narrated instead of merging
+- **Structural fix (separate):** mika#524 — hard-wired verdict→merge handler in agent runtime
+- **Related patterns:** [CI gate tool as structural backstop](../solutions/architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md), [grounding rule](../solutions/prompt-engineering/grounding-rule-downstream-state-hallucination.md)
+- Issue: #553

--- a/docs/plans/2026-04-12-002-feat-tighten-webhook-entry-point-qa-pass-plan.md
+++ b/docs/plans/2026-04-12-002-feat-tighten-webhook-entry-point-qa-pass-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: tighten webhook entry point — QA pass + open PR = immediate merge"
 type: feat
-status: active
+status: completed
 date: 2026-04-12
 ---
 

--- a/docs/solutions/prompt-engineering/2026-04-12-tighten-webhook-qa-pass-entry-point.md
+++ b/docs/solutions/prompt-engineering/2026-04-12-tighten-webhook-qa-pass-entry-point.md
@@ -1,0 +1,62 @@
+---
+title: "Tighten webhook QA pass entry point — merge before correlate"
+category: prompt-engineering
+date: 2026-04-12
+tags: [webhook, qa-verdict, pr-merge, self-dev-webhook-qa, evidence-action, zero-narration, mika-dev]
+repos: [mika-skills]
+---
+
+# Tighten webhook QA pass entry point — merge before correlate
+
+## Problem
+
+mika-dev received a `pull_request_review.submitted` webhook with `VERDICT: pass` visible in context but misclassified it as `pull_request.opened`, re-dispatched claude-pilot instead of merging, and left the PR stuck for 7 hours (incident: PR #522, 2026-04-11).
+
+Three gaps in the `self-dev-webhook-qa/system_prompt.md` allowed this:
+
+1. **No event-type fingerprint.** The prompt assumed the LLM would correctly identify `pull_request_review.submitted` from message text. The LLM misread it as `pull_request.opened`.
+2. **Work item correlation before action.** Step 1 was "correlate to work item" — if that step confused the LLM, merge never happened. The PR URL was already in the webhook; merge should not depend on work item lookup.
+3. **No zero-narration directive.** The prompt said "DO NOT end your turn without acting" but never prohibited narration *before* acting. The LLM filled silence with text instead of making a tool call.
+
+## Solution
+
+Three changes to `mika-skills/self-dev-webhook-qa/system_prompt.md`:
+
+### 1. Event identity check at the top
+
+Added explicit fingerprint block that names what the event IS and what it is NOT:
+
+> **EVENT IDENTITY CHECK:** This message contains a PR review body with a `VERDICT:` line posted by mika-qa. This is a **QA verdict event** — NOT a new PR (`pull_request.opened`), NOT a CI event (`check_suite`), NOT an informational comment.
+
+### 2. Reordered flow: parse → merge → correlate
+
+Old order: correlate work item (Step 1) → parse verdict (Step 2) → act (Step 3)
+
+New order: parse verdict (Step 1) → extract PR coords (Step 2) → act/merge (Step 3) → correlate work item (Step 4) → update status (Step 5)
+
+The `pass` case now calls `pr_merge_with_gate` before any work item lookup. If correlation fails later, the merge already succeeded. Step 4 says: "If no work item found, skip work item updates — the merge/action in Step 3 already succeeded."
+
+### 3. Zero-narration rule on pass verdict
+
+> **ZERO-NARRATION RULE: On a `pass` verdict, your FIRST output MUST be a `pr_merge_with_gate` tool call. No text, no explanation, no questions, no status checks before the tool call. Narration before action is a workflow failure. Evidence → Action.**
+
+### 4. soul.md reinforcement (minor)
+
+Added to the "Evidence → Action" section:
+- "On webhook events with clear verdicts: act first, correlate and update state after."
+- "On a QA pass verdict, your first output is a tool call — not text."
+
+## Prevention
+
+- **When an external event should trigger a deterministic action, put the action first.** Correlation, state updates, and notifications are follow-up work that should not gate the primary action.
+- **Event identity checks prevent misclassification.** Explicitly naming what an event IS and IS NOT reduces the chance of the LLM pattern-matching to the wrong event type.
+- **Zero-narration directives close the "narrate instead of act" failure mode.** "DO NOT end without acting" is weaker than "your FIRST output MUST be a tool call."
+- **This is a prompt-level fix.** The structural runtime handler (mika#524) is the deeper solution — it moves verdict→merge out of the LLM entirely. This prompt fix reduces failure probability; the structural fix eliminates it.
+
+## Related
+
+- [mika-dev verdict misclassification on PR #522](../agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md) — the incident that motivated this fix
+- [CI gate tool as structural backstop](../architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md) — the `pr_merge_with_gate` tool
+- [Grounding rule](grounding-rule-downstream-state-hallucination.md) — related principle about evidence-based claims
+- mika#524 — structural verdict→merge handler (separate, deeper fix)
+- mika#553 — this issue


### PR DESCRIPTION
## Summary

Tightens the `self-dev-webhook-qa` skill prompt to ensure mika-dev immediately merges PRs when receiving a QA pass verdict, without narration or questions. Motivated by the PR #522 incident where the LLM misclassified a `pull_request_review.submitted` event and left the PR stuck for 7 hours.

Three prompt-level changes applied to `mika-skills/self-dev-webhook-qa/system_prompt.md`:

1. **Event identity check** — explicit fingerprint naming what the event IS and IS NOT, preventing misclassification
2. **Reordered flow** — parse verdict → merge → correlate (not: correlate → parse → merge), decoupling merge from work item lookup
3. **Zero-narration rule** — "your FIRST output MUST be a `pr_merge_with_gate` tool call" on pass verdicts

This is the prompt-level fix. The structural runtime handler (mika#524) is a separate, deeper fix.

Closes #553

## Test plan

- [ ] Verify plan doc and compound doc are well-structured
- [ ] Verify `self-dev-webhook-qa/system_prompt.md` in mika-skills repo has the tightened directives
- [ ] Validate mika-dev handles a QA pass webhook by immediately calling `pr_merge_with_gate`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: docs-only change in the mika repo. The behavioral change is in the mika-skills prompt, validated by observing mika-dev's response to the next QA pass webhook.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)