### PR TITLE
feat(agent): structural pull_request_review verdict handler

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -59,6 +59,10 @@ Tool trait uses `#[async_trait]` (Send futures). Per-tool timeout override via `
 
 `pr_merge_with_gate` builtin tool — structural backstop against merging PRs with failing required CI checks. Registered in `default_tools()` (all agents, including delegates). Decision matrix: fail/cancel -> blocked; pending -> auto-merge; all pass -> immediate merge; already merged -> no-op. 60s timeout. Requires `ctx.github_token`. See #490.
 
+### Structural Verdict Handler
+
+`server::verdict_handler` — intercepts `pull_request_review.submitted` webhook events **before** the LLM turn in `handle_message`. Parses `VERDICT:` line from the review body. For `pass` verdicts with matching `in_progress` work items: initiates merge via `run_gh_checks` + `run_gh_merge` (reused from `pr_merge_with_gate`), updates work item metadata, logs `verdict_handled` audit event, sends notification. For `block[*]`/`hold[*]` verdicts: passes through to LLM. For missing `VERDICT:` line: passes through with `verdict_missing=true` enrichment. Parser in `server::verdict` depends on gateway's `format_event_text()` output format. 60s timeout on subprocess calls. See #524.
+
 ### Introspection Tools
 
 4 read-only tools: `query_timeline`, `get_session_messages`, `list_audit_events`, `search_tool_history` (30-day retention, 500-char field truncation, 10KB output cap). Non-orchestrator agents scoped to their own agent_id/sessions.

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -346,6 +346,13 @@ impl AsyncDatabase {
             .await
     }
 
+    pub async fn find_active_work_item_by_pr_url(&self, pr_url: &str) -> Result<Option<Task>> {
+        let a = self.agent_id.clone();
+        let url = pr_url.to_owned();
+        self.with_db(move |db| db.find_active_work_item_by_pr_url(&a, &url))
+            .await
+    }
+
     pub async fn find_active_work_item_by_label(&self, label: &str) -> Result<Option<Task>> {
         let a = self.agent_id.clone();
         let l = label.to_owned();

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -3178,6 +3178,29 @@ impl Database {
             .map_err(Into::into)
     }
 
+    /// Find an active manual work item by agent_id and PR URL stored in metadata.
+    /// Looks up `json_extract(metadata, '$.claude_pilot.pr_url')` for matching.
+    /// Used to locate the parent work item when a PR review verdict arrives.
+    pub fn find_active_work_item_by_pr_url(
+        &self,
+        agent_id: &str,
+        pr_url: &str,
+    ) -> Result<Option<Task>> {
+        let sql = format!(
+            "SELECT {} FROM tasks
+             WHERE agent_id = ?1
+               AND json_extract(metadata, '$.claude_pilot.pr_url') = ?2
+               AND trigger_type = 'manual'
+               AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
+             LIMIT 1",
+            Self::TASK_COLUMNS
+        );
+        self.conn
+            .query_row(&sql, params![agent_id, pr_url], Self::row_to_task)
+            .optional()
+            .map_err(Into::into)
+    }
+
     /// Find an active manual work item by agent_id and label (case-insensitive).
     /// Used as a fallback dedup path when `create_work_item` is called without a reference_url.
     pub fn find_active_work_item_by_label(
@@ -9781,5 +9804,82 @@ mod tests {
         let visible = db.load_recent_messages_filtered("mika", 10, true).unwrap();
         assert_eq!(visible.len(), 2);
         assert!(visible.iter().all(|m| !m.internal));
+    }
+
+    // -- find_active_work_item_by_pr_url tests --
+
+    #[test]
+    fn test_find_active_work_item_by_pr_url_found() {
+        let db = db();
+        let pr_url = "https://github.com/senara-solutions/mika/pull/42";
+        let task = new_task("mika", "Implement feature", "manual", "none");
+        let id = db.create_task(&task).unwrap();
+        let meta =
+            r#"{"claude_pilot":{"pr_url":"https://github.com/senara-solutions/mika/pull/42"}}"#;
+        db.update_work_item_metadata(&id, meta).unwrap();
+
+        let found = db.find_active_work_item_by_pr_url("mika", pr_url).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, id);
+    }
+
+    #[test]
+    fn test_find_active_work_item_by_pr_url_not_found() {
+        let db = db();
+        let task = new_task("mika", "Implement feature", "manual", "none");
+        let id = db.create_task(&task).unwrap();
+        let meta =
+            r#"{"claude_pilot":{"pr_url":"https://github.com/senara-solutions/mika/pull/42"}}"#;
+        db.update_work_item_metadata(&id, meta).unwrap();
+
+        let found = db
+            .find_active_work_item_by_pr_url(
+                "mika",
+                "https://github.com/senara-solutions/mika/pull/99",
+            )
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_find_active_work_item_by_pr_url_completed_not_returned() {
+        let db = db();
+        let task = new_task("mika", "Done feature", "manual", "none");
+        let id = db.create_task(&task).unwrap();
+        let meta =
+            r#"{"claude_pilot":{"pr_url":"https://github.com/senara-solutions/mika/pull/42"}}"#;
+        db.update_work_item_metadata(&id, meta).unwrap();
+        db.conn
+            .execute(
+                "UPDATE tasks SET status = 'completed' WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+
+        let found = db
+            .find_active_work_item_by_pr_url(
+                "mika",
+                "https://github.com/senara-solutions/mika/pull/42",
+            )
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_find_active_work_item_by_pr_url_wrong_metadata_path() {
+        let db = db();
+        let task = new_task("mika", "Wrong path", "manual", "none");
+        let id = db.create_task(&task).unwrap();
+        // pr_url in a different metadata path (not under claude_pilot)
+        let meta = r#"{"other":{"pr_url":"https://github.com/senara-solutions/mika/pull/42"}}"#;
+        db.update_work_item_metadata(&id, meta).unwrap();
+
+        let found = db
+            .find_active_work_item_by_pr_url(
+                "mika",
+                "https://github.com/senara-solutions/mika/pull/42",
+            )
+            .unwrap();
+        assert!(found.is_none());
     }
 }

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -22,6 +22,7 @@ use super::types::{
     AcceptedResponse, HealthResponse, MessageRequest, TaskCancelRequest, TaskCancelResponse,
     TaskCompleteRequest, TaskCompleteResponse,
 };
+use super::verdict_handler::{VerdictAction, try_handle_pr_review_verdict};
 
 /// Media types accepted by the Claude API for image content blocks.
 const ALLOWED_IMAGE_MEDIA_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
@@ -220,6 +221,33 @@ pub async fn handle_message(
                 None,
             );
             let sender_arc: Arc<dyn MessageSender> = Arc::new(sender);
+
+            // Structural verdict handler: intercept PR review webhooks before
+            // the LLM turn and act on VERDICT: pass deterministically (#524).
+            // NOTE: This depends on the gateway's format_event_text() output
+            // format for pull_request_review events.
+            if req.channel == "github" {
+                let action = try_handle_pr_review_verdict(
+                    &req.text,
+                    &a.db,
+                    s.github_token.as_deref(),
+                    Some(&sender_arc),
+                    &session_id,
+                    &req.request_id,
+                )
+                .await;
+                match action {
+                    VerdictAction::Handled { pre_digest } => {
+                        req.text = pre_digest;
+                    }
+                    VerdictAction::Passthrough {
+                        enrichment: Some(e),
+                    } => {
+                        req.text = format!("{e}{}", req.text);
+                    }
+                    VerdictAction::Passthrough { enrichment: None } => {}
+                }
+            }
 
             let params = AgentParams {
                 db: &a.db,

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -10,6 +10,8 @@ pub mod openapi;
 pub mod rewind;
 pub mod state;
 pub mod types;
+pub(crate) mod verdict;
+pub mod verdict_handler;
 
 use anyhow::{Result, anyhow};
 use axum::{

--- a/crates/mika-agent/src/server/verdict.rs
+++ b/crates/mika-agent/src/server/verdict.rs
@@ -1,0 +1,248 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Parsed PR review event from gateway-formatted text.
+#[derive(Debug, Clone)]
+pub(crate) struct PrReviewEvent {
+    pub state: String,
+    pub repo: String,
+    pub pr_number: u64,
+    #[allow(dead_code)] // Parsed for completeness; used in Debug output and tests
+    pub title: String,
+    pub reviewer: String,
+    pub review_url: String,
+    pub body: String,
+}
+
+impl PrReviewEvent {
+    /// Construct the PR HTML URL from repo and number.
+    pub fn pr_url(&self) -> String {
+        format!("https://github.com/{}/pull/{}", self.repo, self.pr_number)
+    }
+}
+
+/// Parsed verdict from a review body.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Verdict {
+    Pass,
+    Block(String),
+    Hold(String),
+    Missing { truncated: bool },
+}
+
+static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\[GitHub\] PR review \(([^)]+)\) on ([^#]+)#(\d+) \((.+)\) by @(\S+)$")
+        .expect("header regex")
+});
+
+static VERDICT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?mi)^VERDICT:\s*(.+)$").expect("verdict regex"));
+
+static BLOCK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^block\[([^\]]+)\]$").expect("block regex"));
+
+static HOLD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^hold\[([^\]]+)\]$").expect("hold regex"));
+
+/// Parse a gateway-formatted PR review event into structured data.
+///
+/// Returns `None` if the text does not match the expected format.
+pub(crate) fn parse_pr_review_event(text: &str) -> Option<PrReviewEvent> {
+    let mut lines = text.lines();
+
+    let first_line = lines.next()?;
+    let caps = HEADER_RE.captures(first_line)?;
+
+    let state = caps[1].to_string();
+    let repo = caps[2].to_string();
+    let pr_number: u64 = caps[3].parse().ok()?;
+    let title = caps[4].to_string();
+    let reviewer = caps[5].to_string();
+
+    let review_url = lines
+        .next()
+        .map(|l| l.trim().to_string())
+        .unwrap_or_default();
+
+    // Body is everything after the first blank line
+    let body = {
+        // Skip until we find a blank line
+        let mut found_blank = false;
+        let mut body_lines = Vec::new();
+        for line in lines {
+            if !found_blank {
+                if line.trim().is_empty() {
+                    found_blank = true;
+                }
+            } else {
+                body_lines.push(line);
+            }
+        }
+        body_lines.join("\n")
+    };
+
+    Some(PrReviewEvent {
+        state,
+        repo,
+        pr_number,
+        title,
+        reviewer,
+        review_url,
+        body,
+    })
+}
+
+/// Parse a verdict from a review body.
+pub(crate) fn parse_verdict(body: &str) -> Verdict {
+    if let Some(caps) = VERDICT_RE.captures(body) {
+        let value = caps[1].trim();
+
+        if value.eq_ignore_ascii_case("pass") {
+            return Verdict::Pass;
+        }
+
+        if let Some(bcaps) = BLOCK_RE.captures(value) {
+            return Verdict::Block(bcaps[1].to_string());
+        }
+
+        if let Some(hcaps) = HOLD_RE.captures(value) {
+            return Verdict::Hold(hcaps[1].to_string());
+        }
+
+        // Unrecognized verdict value
+        return Verdict::Missing {
+            truncated: body.contains("[truncated]"),
+        };
+    }
+
+    Verdict::Missing {
+        truncated: body.contains("[truncated]"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_APPROVED: &str = "\
+[GitHub] PR review (approved) on senara-solutions/mika#522 (fix: something) by @mika-qa
+https://github.com/senara-solutions/mika/pull/522#pullrequestreview-12345
+
+VERDICT: pass
+
+Some review body text here...";
+
+    #[test]
+    fn parse_pr_review_approved_with_verdict_pass() {
+        let event = parse_pr_review_event(SAMPLE_APPROVED).unwrap();
+        assert_eq!(event.state, "approved");
+        assert_eq!(event.repo, "senara-solutions/mika");
+        assert_eq!(event.pr_number, 522);
+        assert_eq!(event.title, "fix: something");
+        assert_eq!(event.reviewer, "mika-qa");
+        assert_eq!(
+            event.review_url,
+            "https://github.com/senara-solutions/mika/pull/522#pullrequestreview-12345"
+        );
+        assert_eq!(
+            event.pr_url(),
+            "https://github.com/senara-solutions/mika/pull/522"
+        );
+        assert!(event.body.contains("VERDICT: pass"));
+        assert!(event.body.contains("Some review body text here..."));
+
+        let verdict = parse_verdict(&event.body);
+        assert_eq!(verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn parse_pr_review_block_ci() {
+        let body = "VERDICT: block[ci]\n\nCI checks are failing.";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Block("ci".to_string()));
+    }
+
+    #[test]
+    fn parse_pr_review_hold_review() {
+        let body = "VERDICT: hold[review]\n\nNeeds another look.";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Hold("review".to_string()));
+    }
+
+    #[test]
+    fn parse_verdict_missing() {
+        let body = "No verdict line here, just comments.";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Missing { truncated: false });
+    }
+
+    #[test]
+    fn parse_verdict_case_insensitive() {
+        let body = "verdict: PASS";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Pass);
+
+        let body2 = "VERDICT: Block[Security]";
+        let verdict2 = parse_verdict(body2);
+        assert_eq!(verdict2, Verdict::Block("Security".to_string()));
+
+        let body3 = "VERDICT: HOLD[Review]";
+        let verdict3 = parse_verdict(body3);
+        assert_eq!(verdict3, Verdict::Hold("Review".to_string()));
+    }
+
+    #[test]
+    fn parse_verdict_no_space_after_colon() {
+        let body = "VERDICT:pass";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn parse_verdict_multiple_lines_first_wins() {
+        let body = "VERDICT: pass\nVERDICT: block[ci]";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn parse_non_review_event_returns_none() {
+        let text = "This is just a regular message, not a PR review event.";
+        assert!(parse_pr_review_event(text).is_none());
+    }
+
+    #[test]
+    fn parse_review_changes_requested() {
+        let text = "\
+[GitHub] PR review (changes_requested) on senara-solutions/mika#100 (feat: add feature) by @reviewer
+https://github.com/senara-solutions/mika/pull/100#pullrequestreview-99999
+
+VERDICT: block[pipeline]
+
+Please fix the pipeline issues.";
+
+        let event = parse_pr_review_event(text).unwrap();
+        assert_eq!(event.state, "changes_requested");
+        assert_eq!(event.pr_number, 100);
+        assert_eq!(event.reviewer, "reviewer");
+
+        let verdict = parse_verdict(&event.body);
+        assert_eq!(verdict, Verdict::Block("pipeline".to_string()));
+    }
+
+    #[test]
+    fn parse_verdict_truncated_body_missing() {
+        let body = "Some text...\n[truncated]";
+        let verdict = parse_verdict(body);
+        assert_eq!(verdict, Verdict::Missing { truncated: true });
+    }
+
+    #[test]
+    fn parse_malformed_first_line() {
+        let text = "[GitHub] PR review on something broken";
+        assert!(parse_pr_review_event(text).is_none());
+
+        let text2 = "[GitHub] PR review (approved) on repo#notanumber (title) by @user";
+        assert!(parse_pr_review_event(text2).is_none());
+    }
+}

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -1,0 +1,531 @@
+//! Structural handler for `pull_request_review.submitted` webhook events.
+//!
+//! Intercepts PR review events **before** the LLM turn and acts on
+//! `VERDICT: pass` deterministically (look up work item, initiate merge,
+//! update metadata, audit, notify). This removes the merge decision from
+//! LLM improvisation — it's a state-machine transition, not a judgement call.
+//!
+//! See issue #524 and the compound doc at
+//! `docs/solutions/agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md`.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::async_db::AsyncDatabase;
+use crate::messaging::MessageSender;
+use crate::tools::pr_merge_with_gate::{
+    CheckClassification, classify_checks, run_gh_checks, run_gh_merge,
+};
+use crate::work_item_metadata::merge_metadata;
+
+use super::verdict::{Verdict, parse_pr_review_event, parse_verdict};
+
+/// Result of the structural verdict handler.
+#[derive(Debug)]
+pub enum VerdictAction {
+    /// The handler acted on the verdict (merge initiated or error).
+    /// The pre-digest text should replace the original message.
+    Handled { pre_digest: String },
+    /// The handler did not act — pass through to the LLM.
+    /// Optional enrichment text to prepend to the original message.
+    Passthrough { enrichment: Option<String> },
+}
+
+/// Attempt to handle a PR review verdict structurally before the LLM turn.
+///
+/// Returns `VerdictAction::Handled` when the handler initiated a merge (or
+/// encountered a merge error), with a pre-digest message for the LLM.
+/// Returns `VerdictAction::Passthrough` for all other cases (non-review events,
+/// non-approved reviews, block/hold verdicts, missing verdicts, missing work items).
+#[allow(clippy::too_many_arguments)]
+pub async fn try_handle_pr_review_verdict(
+    text: &str,
+    db: &AsyncDatabase,
+    github_token: Option<&str>,
+    message_sender: Option<&Arc<dyn MessageSender>>,
+    session_id: &str,
+    trace_id: &str,
+) -> VerdictAction {
+    // 1. Parse the PR review event from formatted text
+    let event = match parse_pr_review_event(text) {
+        Some(e) => e,
+        None => return VerdictAction::Passthrough { enrichment: None },
+    };
+
+    // 2. Only act on approved reviews
+    if event.state != "approved" {
+        return VerdictAction::Passthrough { enrichment: None };
+    }
+
+    // 3. Parse the verdict
+    let verdict = parse_verdict(&event.body);
+
+    match verdict {
+        Verdict::Block(_) | Verdict::Hold(_) => {
+            // Let the LLM handle block/hold verdicts
+            VerdictAction::Passthrough { enrichment: None }
+        }
+        Verdict::Missing { truncated } => {
+            if truncated {
+                warn!(
+                    pr_number = event.pr_number,
+                    repo = %event.repo,
+                    "PR review body was truncated and no VERDICT: line found — possible data loss"
+                );
+            } else {
+                warn!(
+                    pr_number = event.pr_number,
+                    repo = %event.repo,
+                    reviewer = %event.reviewer,
+                    "PR review approved but no VERDICT: line found (contract violation)"
+                );
+            }
+            VerdictAction::Passthrough {
+                enrichment: Some(
+                    "[verdict_missing=true] No VERDICT: line found in approved review.\n\n"
+                        .to_string(),
+                ),
+            }
+        }
+        Verdict::Pass => {
+            handle_pass_verdict(
+                &event,
+                db,
+                github_token,
+                message_sender,
+                session_id,
+                trace_id,
+            )
+            .await
+        }
+    }
+}
+
+/// Handle a VERDICT: pass — look up work item, initiate merge, update metadata.
+async fn handle_pass_verdict(
+    event: &super::verdict::PrReviewEvent,
+    db: &AsyncDatabase,
+    github_token: Option<&str>,
+    message_sender: Option<&Arc<dyn MessageSender>>,
+    session_id: &str,
+    trace_id: &str,
+) -> VerdictAction {
+    let pr_url = event.pr_url();
+
+    // Require GitHub token for merge operations
+    let token = match github_token {
+        Some(t) => t,
+        None => {
+            warn!(
+                pr_number = event.pr_number,
+                repo = %event.repo,
+                "VERDICT: pass but no GitHub token available — cannot initiate merge"
+            );
+            return VerdictAction::Passthrough {
+                enrichment: Some(
+                    "[verdict_handler] VERDICT: pass received but no GitHub token configured. \
+                     Manual merge required.\n\n"
+                        .to_string(),
+                ),
+            };
+        }
+    };
+
+    // Look up the work item by PR URL
+    let work_item = match db.find_active_work_item_by_pr_url(&pr_url).await {
+        Ok(Some(task)) => task,
+        Ok(None) => {
+            info!(
+                pr_number = event.pr_number,
+                repo = %event.repo,
+                pr_url = %pr_url,
+                "VERDICT: pass but no active work item found for PR — passing through to LLM"
+            );
+            return VerdictAction::Passthrough { enrichment: None };
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                pr_url = %pr_url,
+                "Failed to look up work item by PR URL — passing through to LLM"
+            );
+            return VerdictAction::Passthrough { enrichment: None };
+        }
+    };
+
+    // Only act when work item is in_progress
+    if work_item.status != "in_progress" {
+        info!(
+            task_id = %work_item.id,
+            status = %work_item.status,
+            pr_url = %pr_url,
+            "VERDICT: pass but work item not in_progress (status: {}) — skipping structural merge",
+            work_item.status
+        );
+        return VerdictAction::Passthrough { enrichment: None };
+    }
+
+    let task_id = work_item.id.clone();
+
+    // Run CI check classification (reuse pr_merge_with_gate logic).
+    // Wrap in a 60-second timeout matching PrMergeWithGateTool::timeout_secs()
+    // to prevent a hanging gh subprocess from blocking the agent lock.
+    let checks_future = run_gh_checks(event.pr_number, &event.repo, token);
+    let checks = match tokio::time::timeout(std::time::Duration::from_secs(60), checks_future).await
+    {
+        Ok(Ok(c)) => c,
+        Ok(Err(e)) => {
+            warn!(
+                error = %e,
+                pr_number = event.pr_number,
+                "Failed to fetch CI checks for structural merge"
+            );
+            return VerdictAction::Handled {
+                pre_digest: format_error_pre_digest(event, &e),
+            };
+        }
+        Err(_) => {
+            warn!(
+                pr_number = event.pr_number,
+                "CI check fetch timed out after 60s for structural merge"
+            );
+            return VerdictAction::Handled {
+                pre_digest: format_error_pre_digest(event, "CI check fetch timed out after 60s"),
+            };
+        }
+    };
+
+    let classification = classify_checks(&checks);
+
+    match classification {
+        CheckClassification::HasFailures => {
+            let failing: Vec<String> = checks
+                .iter()
+                .filter(|c| matches!(c.bucket.as_str(), "fail" | "cancel"))
+                .map(|c| format!("  - {} ({})", c.name, c.state))
+                .collect();
+
+            info!(
+                pr_number = event.pr_number,
+                "VERDICT: pass but CI checks failing — passing through to LLM"
+            );
+
+            VerdictAction::Passthrough {
+                enrichment: Some(format!(
+                    "[verdict_handler] VERDICT: pass received but CI checks are failing:\n{}\n\
+                     The structural merge handler did not act. Handle the CI failures.\n\n",
+                    failing.join("\n")
+                )),
+            }
+        }
+        CheckClassification::HasPending | CheckClassification::AllPassed => {
+            let is_auto = classification == CheckClassification::HasPending;
+
+            let merge_future = run_gh_merge(
+                event.pr_number,
+                &event.repo,
+                "squash",
+                true, // delete_branch
+                is_auto,
+                token,
+            );
+            let merge_result =
+                tokio::time::timeout(std::time::Duration::from_secs(60), merge_future).await;
+
+            // Flatten timeout + Result<String, String> into a single Result
+            let merge_result = match merge_result {
+                Ok(inner) => inner,
+                Err(_) => {
+                    warn!(
+                        pr_number = event.pr_number,
+                        "gh pr merge timed out after 60s"
+                    );
+                    Err("gh pr merge timed out after 60s".to_string())
+                }
+            };
+
+            match merge_result {
+                Ok(_output) => {
+                    let action_desc = if is_auto {
+                        "auto_merge_enabled"
+                    } else {
+                        "merge_initiated"
+                    };
+
+                    // Update work item metadata
+                    if let Err(e) = update_verdict_metadata(
+                        db,
+                        &task_id,
+                        &work_item.metadata,
+                        action_desc,
+                        event.pr_number,
+                        &pr_url,
+                    )
+                    .await
+                    {
+                        warn!(error = %e, task_id = %task_id, "Failed to update work item metadata after merge");
+                    }
+
+                    // Log audit event
+                    if let Err(e) = db
+                        .log_audit_event(
+                            session_id,
+                            "verdict_handled",
+                            &format!("task:{task_id}"),
+                            Some("in_progress"),
+                            Some(action_desc),
+                            Some(&format!(
+                                "verdict=pass action={action_desc} pr_url={pr_url} work_item_id={task_id}"
+                            )),
+                            Some(trace_id),
+                        )
+                        .await
+                    {
+                        warn!(error = %e, "Failed to log verdict_handled audit event");
+                    }
+
+                    // Send notification
+                    if let Some(sender) = message_sender {
+                        let notification = if is_auto {
+                            format!(
+                                "PR #{} on {} — VERDICT: pass from @{}. \
+                                 Auto-merge enabled (CI checks still pending). \
+                                 GitHub will finalize when all checks pass.",
+                                event.pr_number, event.repo, event.reviewer
+                            )
+                        } else {
+                            format!(
+                                "PR #{} on {} — VERDICT: pass from @{}. \
+                                 Merge initiated (squash, delete branch).",
+                                event.pr_number, event.repo, event.reviewer
+                            )
+                        };
+                        if let Err(e) = sender.send(&notification).await {
+                            warn!(error = %e, "Failed to send merge notification");
+                        }
+                    }
+
+                    info!(
+                        pr_number = event.pr_number,
+                        repo = %event.repo,
+                        action = action_desc,
+                        task_id = %task_id,
+                        "Structural verdict handler: {action_desc} for PR #{}",
+                        event.pr_number
+                    );
+
+                    VerdictAction::Handled {
+                        pre_digest: format_success_pre_digest(event, action_desc, &task_id),
+                    }
+                }
+                Err(e) => {
+                    // Check for "already merged" in the error
+                    let lower = e.to_lowercase();
+                    if lower.contains("already merged") {
+                        info!(
+                            pr_number = event.pr_number,
+                            "PR already merged — structural handler acknowledging"
+                        );
+                        return VerdictAction::Handled {
+                            pre_digest: format_already_merged_pre_digest(event, &task_id),
+                        };
+                    }
+
+                    warn!(
+                        error = %e,
+                        pr_number = event.pr_number,
+                        "Structural merge failed"
+                    );
+                    VerdictAction::Handled {
+                        pre_digest: format_error_pre_digest(event, &e),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Update work item metadata with verdict merge state.
+async fn update_verdict_metadata(
+    db: &AsyncDatabase,
+    task_id: &str,
+    existing_metadata: &Option<String>,
+    action: &str,
+    pr_number: u64,
+    pr_url: &str,
+) -> Result<()> {
+    let mut base = existing_metadata
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .unwrap_or_else(|| json!({}));
+
+    let incoming = json!({
+        "verdict_merge": {
+            "state": action,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "handled_at": crate::timestamp::now(),
+        }
+    });
+
+    merge_metadata(&mut base, &incoming);
+    let merged_str = serde_json::to_string(&base)?;
+    db.update_work_item_metadata(task_id, &merged_str).await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Pre-digest message formatting
+// ---------------------------------------------------------------------------
+
+/// Format the pre-digest message for a successful merge action.
+///
+/// IMPORTANT: Avoids completion-claim guard trigger words (merged, deployed,
+/// completed, complete, shipped). Uses "initiated" / "enabled" phrasing.
+fn format_success_pre_digest(
+    event: &super::verdict::PrReviewEvent,
+    action: &str,
+    task_id: &str,
+) -> String {
+    let action_text = match action {
+        "auto_merge_enabled" => format!(
+            "Auto-merge has been enabled for PR #{} on {}. \
+             GitHub will finalize the squash-merge once all CI checks pass.",
+            event.pr_number, event.repo
+        ),
+        "merge_initiated" => format!(
+            "Squash-merge has been initiated for PR #{} on {} (branch deletion requested).",
+            event.pr_number, event.repo
+        ),
+        _ => format!(
+            "Structural merge action '{}' taken on PR #{} on {}.",
+            action, event.pr_number, event.repo
+        ),
+    };
+
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review (approved) on {}#{} by @{}\n\
+         VERDICT: pass — structural handler acted.\n\n\
+         {action_text}\n\n\
+         Work item: {task_id}\n\
+         Review: {}\n\n\
+         Do NOT call pr_merge_with_gate — the merge action is already in progress.\n\
+         Update the work item status to reflect the outcome, then notify the user.\n\
+         </verdict_handler>",
+        event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
+/// Format the pre-digest for a PR that was already merged.
+fn format_already_merged_pre_digest(
+    event: &super::verdict::PrReviewEvent,
+    task_id: &str,
+) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review (approved) on {}#{} by @{}\n\
+         VERDICT: pass — PR was already finalized before the handler ran.\n\n\
+         Work item: {task_id}\n\
+         Review: {}\n\n\
+         Do NOT call pr_merge_with_gate — no action needed.\n\
+         Update the work item status if not already done, then notify the user.\n\
+         </verdict_handler>",
+        event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
+/// Format the pre-digest for a merge error.
+fn format_error_pre_digest(event: &super::verdict::PrReviewEvent, error: &str) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review (approved) on {}#{} by @{}\n\
+         VERDICT: pass — structural handler attempted merge but encountered an error.\n\n\
+         Error: {error}\n\n\
+         The structural merge handler could not finalize the merge. \
+         Investigate the error and decide the next action.\n\
+         </verdict_handler>",
+        event.repo, event.pr_number, event.reviewer
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verify pre-digest messages don't trigger the completion-claim guard.
+    // The guard regex: (?i)\b(merged|deployed|completed?|shipped)\b
+    static COMPLETION_CLAIM_RE: std::sync::LazyLock<regex::Regex> =
+        std::sync::LazyLock::new(|| {
+            regex::Regex::new(r"(?i)\b(merged|deployed|completed?|shipped)\b")
+                .expect("completion claim regex")
+        });
+
+    fn sample_event() -> super::super::verdict::PrReviewEvent {
+        super::super::verdict::PrReviewEvent {
+            state: "approved".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 522,
+            title: "fix: something".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/522#pullrequestreview-12345"
+                .to_string(),
+            body: "VERDICT: pass\n\nLooks good.".to_string(),
+        }
+    }
+
+    #[test]
+    fn success_pre_digest_avoids_completion_claim_words() {
+        let event = sample_event();
+        let text = format_success_pre_digest(&event, "merge_initiated", "task-123");
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "Pre-digest contains completion-claim trigger word: {text}"
+        );
+    }
+
+    #[test]
+    fn success_pre_digest_auto_merge_avoids_completion_claim_words() {
+        let event = sample_event();
+        let text = format_success_pre_digest(&event, "auto_merge_enabled", "task-123");
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "Pre-digest contains completion-claim trigger word: {text}"
+        );
+    }
+
+    #[test]
+    fn already_merged_pre_digest_avoids_completion_claim_words() {
+        let event = sample_event();
+        let text = format_already_merged_pre_digest(&event, "task-123");
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "Pre-digest contains completion-claim trigger word: {text}"
+        );
+    }
+
+    #[test]
+    fn error_pre_digest_contains_error_message() {
+        let event = sample_event();
+        let text = format_error_pre_digest(&event, "Merge conflicts");
+        assert!(text.contains("Merge conflicts"));
+        assert!(text.contains("verdict_handler"));
+    }
+
+    #[test]
+    fn success_pre_digest_contains_do_not_call_instruction() {
+        let event = sample_event();
+        let text = format_success_pre_digest(&event, "merge_initiated", "task-123");
+        assert!(text.contains("Do NOT call pr_merge_with_gate"));
+    }
+
+    #[test]
+    fn success_pre_digest_contains_work_item_id() {
+        let event = sample_event();
+        let text = format_success_pre_digest(&event, "merge_initiated", "task-123");
+        assert!(text.contains("task-123"));
+    }
+}

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -26,7 +26,7 @@ mod list_tasks;
 mod list_teams;
 mod list_work_items;
 mod list_workspace;
-mod pr_merge_with_gate;
+pub(crate) mod pr_merge_with_gate;
 mod query_timeline;
 mod read_agent_file;
 mod read_workspace;

--- a/crates/mika-agent/src/tools/pr_merge_with_gate.rs
+++ b/crates/mika-agent/src/tools/pr_merge_with_gate.rs
@@ -238,26 +238,26 @@ enum MergeGateResult {
 
 /// Check info included in the structured result.
 #[derive(Debug, Clone, Serialize, PartialEq)]
-struct CheckInfo {
-    name: String,
-    state: String,
+pub(crate) struct CheckInfo {
+    pub(crate) name: String,
+    pub(crate) state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    link: Option<String>,
+    pub(crate) link: Option<String>,
 }
 
 /// A single check from `gh pr checks --json` output.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-struct GhCheck {
-    name: String,
-    state: String,
-    bucket: String,
+pub(crate) struct GhCheck {
+    pub(crate) name: String,
+    pub(crate) state: String,
+    pub(crate) bucket: String,
     #[serde(default)]
-    link: Option<String>,
+    pub(crate) link: Option<String>,
 }
 
 /// Classification of the overall check status.
 #[derive(Debug, Clone, PartialEq)]
-enum CheckClassification {
+pub(crate) enum CheckClassification {
     /// All checks passed (or no required checks exist).
     AllPassed,
     /// Some checks are pending, but none have failed.
@@ -300,7 +300,7 @@ fn validate_merge_method(method: &str) -> Result<(), String> {
 // Check classification (pure function — easily testable)
 // ---------------------------------------------------------------------------
 
-fn classify_checks(checks: &[GhCheck]) -> CheckClassification {
+pub(crate) fn classify_checks(checks: &[GhCheck]) -> CheckClassification {
     let has_failures = checks
         .iter()
         .any(|c| matches!(c.bucket.as_str(), "fail" | "cancel"));
@@ -321,7 +321,11 @@ fn classify_checks(checks: &[GhCheck]) -> CheckClassification {
 
 /// Run `gh pr checks <number> --repo <repo> --required --json name,state,bucket,link`
 /// and return the parsed check list.
-async fn run_gh_checks(pr_number: u64, repo: &str, token: &str) -> Result<Vec<GhCheck>, String> {
+pub(crate) async fn run_gh_checks(
+    pr_number: u64,
+    repo: &str,
+    token: &str,
+) -> Result<Vec<GhCheck>, String> {
     let pr_str = pr_number.to_string();
     let args = vec![
         "pr",
@@ -348,7 +352,7 @@ async fn run_gh_checks(pr_number: u64, repo: &str, token: &str) -> Result<Vec<Gh
 
 /// Run `gh pr merge <number> --repo <repo> --<method> [--delete-branch] [--auto]`
 /// and return stdout on success or stderr on failure.
-async fn run_gh_merge(
+pub(crate) async fn run_gh_merge(
     pr_number: u64,
     repo: &str,
     merge_method: &str,
@@ -374,7 +378,7 @@ async fn run_gh_merge(
 ///
 /// Returns stdout on success. On failure, returns an error string combining
 /// exit code and stderr.
-async fn run_gh_subprocess(args: &[&str], token: &str) -> Result<String, String> {
+pub(crate) async fn run_gh_subprocess(args: &[&str], token: &str) -> Result<String, String> {
     let mut cmd = tokio::process::Command::new("gh");
     cmd.args(args);
     cmd.env("GH_PROMPT_DISABLED", "1");

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -13,4 +13,5 @@ mod eval {
     mod test_error_handling;
     mod test_multi_step;
     mod test_tool_calling;
+    mod test_verdict_handler;
 }

--- a/crates/mika-agent/tests/eval/test_verdict_handler.rs
+++ b/crates/mika-agent/tests/eval/test_verdict_handler.rs
@@ -1,0 +1,414 @@
+//! Integration tests for the structural PR review verdict handler (#524).
+//!
+//! These tests exercise `try_handle_pr_review_verdict` with a real AsyncDatabase
+//! to verify work item lookups, metadata updates, and audit event logging.
+//! The `gh` subprocess calls (run_gh_checks, run_gh_merge) are NOT called because
+//! these tests use scenarios that short-circuit before reaching the merge path
+//! (no matching work item, wrong status, block verdict, etc.).
+
+use anyhow::Result;
+use serde_json::json;
+
+use mika_agent::async_db::AsyncDatabase;
+use mika_agent::db::{Database, NewTask};
+use mika_agent::server::verdict_handler::{VerdictAction, try_handle_pr_review_verdict};
+use mika_agent::task_engine::types::{action_type, trigger_type};
+
+/// Default agent ID used by `AsyncDatabase::new()`.
+const AGENT_ID: &str = "mika";
+const SESSION_ID: &str = "verdict-test-session";
+
+/// Helper to create an in-memory async database for tests.
+async fn test_db() -> AsyncDatabase {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    // create_session is a sync method on Database — must be called before wrapping
+    db.create_session(SESSION_ID, AGENT_ID, "github")
+        .expect("create session");
+    AsyncDatabase::new(db)
+}
+
+/// Helper to create a work item with PR URL in metadata.
+async fn create_work_item_with_pr_url(db: &AsyncDatabase, pr_url: &str) -> String {
+    let metadata = json!({
+        "claude_pilot": {
+            "pr_url": pr_url,
+            "branch": "feat/test"
+        }
+    });
+
+    let task_id = db
+        .create_task(NewTask {
+            agent_id: AGENT_ID.to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: format!("Test work item for {pr_url}"),
+            trigger_type: trigger_type::MANUAL.to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: action_type::NONE.to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some(SESSION_ID.to_string()),
+            created_trace_id: None,
+            reference_url: Some(pr_url.to_string()),
+            source: Some("github_issue".to_string()),
+            metadata: Some(serde_json::to_string(&metadata).unwrap()),
+        })
+        .await
+        .expect("create task");
+
+    // Transition to in_progress
+    db.update_manual_task_status(&task_id, "in_progress")
+        .await
+        .expect("update to in_progress");
+
+    task_id
+}
+
+/// Build a gateway-formatted PR review event text.
+fn pr_review_text(state: &str, repo: &str, number: u64, reviewer: &str, body: &str) -> String {
+    format!(
+        "[GitHub] PR review ({state}) on {repo}#{number} (feat: test feature) by @{reviewer}\n\
+         https://github.com/{repo}/pull/{number}#pullrequestreview-12345\n\
+         \n\
+         {body}"
+    )
+}
+
+// -------------------------------------------------------------------------
+// Test: block verdict -> Passthrough (R7)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_block_ci_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "VERDICT: block[ci]\n\nCI checks are failing.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(enrichment.is_none(), "block verdict should not enrich");
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("block verdict should not be handled structurally");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: hold verdict -> Passthrough
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_hold_review_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "VERDICT: hold[review]\n\nNeeds another look.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(enrichment.is_none(), "hold verdict should not enrich");
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("hold verdict should not be handled structurally");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: missing verdict -> Passthrough with enrichment (R4)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_missing_passes_through_with_enrichment() -> Result<()> {
+    let db = test_db().await;
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "Looks good, approved!",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            let e = enrichment.expect("missing verdict should enrich");
+            assert!(e.contains("verdict_missing=true"));
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("missing verdict should not be handled structurally");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: non-PR-review event -> Passthrough (no verdict handling)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_pr_review_event_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let text = "[GitHub] Issue assigned: senara-solutions/mika#100 — fix: bug\n\
+                https://github.com/senara-solutions/mika/issues/100\n\n\
+                Assigned to: @mika-dev";
+
+    let action =
+        try_handle_pr_review_verdict(text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(
+                enrichment.is_none(),
+                "non-review event should pass through cleanly"
+            );
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("non-review event should not be handled");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: pass verdict but no matching work item -> Passthrough
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_pass_no_work_item_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        999,
+        "mika-qa",
+        "VERDICT: pass\n\nAll good.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(
+                enrichment.is_none(),
+                "pass with no work item should pass through cleanly"
+            );
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("pass with no work item should not be handled");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: pass verdict with work item in completed status -> Passthrough (R5)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_pass_completed_work_item_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let pr_url = "https://github.com/senara-solutions/mika/pull/42";
+    let task_id = create_work_item_with_pr_url(&db, pr_url).await;
+
+    // Transition to completed (terminal)
+    db.update_manual_task_status(&task_id, "completed")
+        .await
+        .expect("update to completed");
+
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "VERDICT: pass\n\nAll good.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(
+                enrichment.is_none(),
+                "pass with completed work item should pass through cleanly"
+            );
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("pass with completed work item should not be handled");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: pass verdict with work item in pending status -> Passthrough (R5)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_pass_pending_work_item_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let pr_url = "https://github.com/senara-solutions/mika/pull/50";
+
+    let metadata = json!({
+        "claude_pilot": {
+            "pr_url": pr_url,
+        }
+    });
+
+    let task_id = db
+        .create_task(NewTask {
+            agent_id: AGENT_ID.to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "Pending work item".to_string(),
+            trigger_type: trigger_type::MANUAL.to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: action_type::NONE.to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some(SESSION_ID.to_string()),
+            created_trace_id: None,
+            reference_url: Some(pr_url.to_string()),
+            source: Some("github_issue".to_string()),
+            metadata: Some(serde_json::to_string(&metadata).unwrap()),
+        })
+        .await
+        .expect("create task");
+
+    // Leave in pending status (don't transition to in_progress)
+    let _ = task_id;
+
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        50,
+        "mika-qa",
+        "VERDICT: pass\n\nAll good.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(
+                enrichment.is_none(),
+                "pass with pending work item should pass through cleanly"
+            );
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("pass with pending work item should not be handled");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: pass verdict but no github token -> Passthrough with enrichment
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn verdict_pass_no_github_token_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let pr_url = "https://github.com/senara-solutions/mika/pull/42";
+    let _task_id = create_work_item_with_pr_url(&db, pr_url).await;
+
+    let text = pr_review_text(
+        "approved",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "VERDICT: pass\n\nAll good.",
+    );
+
+    let action = try_handle_pr_review_verdict(
+        &text, &db, None, // no github token
+        None, SESSION_ID, "trace-1",
+    )
+    .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            let e = enrichment.expect("no-token should enrich");
+            assert!(e.contains("no GitHub token"));
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("no-token case should pass through, not handle");
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Test: non-approved review state -> Passthrough
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_approved_review_passes_through() -> Result<()> {
+    let db = test_db().await;
+    let text = pr_review_text(
+        "commented",
+        "senara-solutions/mika",
+        42,
+        "mika-qa",
+        "VERDICT: pass\n\nLooks good.",
+    );
+
+    let action =
+        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
+            .await;
+
+    match action {
+        VerdictAction::Passthrough { enrichment } => {
+            assert!(
+                enrichment.is_none(),
+                "non-approved review should pass through cleanly"
+            );
+        }
+        VerdictAction::Handled { .. } => {
+            panic!("non-approved review should not be handled");
+        }
+    }
+    Ok(())
+}

--- a/docs/plans/2026-04-13-001-feat-structural-pr-review-verdict-handler-plan.md
+++ b/docs/plans/2026-04-13-001-feat-structural-pr-review-verdict-handler-plan.md
@@ -1,0 +1,380 @@
+---
+title: "feat: Structural pull_request_review.submitted verdict handler"
+type: feat
+status: active
+date: 2026-04-13
+issue: 524
+---
+
+# feat: Structural pull_request_review.submitted verdict handler
+
+## Overview
+
+Add a structural webhook handler in `mika-agent` that intercepts `pull_request_review.submitted` events **before** the LLM turn, parses the `VERDICT:` line from the review body, and for `pass` verdicts automatically initiates a PR merge via `gh pr merge`. This removes the merge decision from LLM improvisation and makes it a deterministic state-machine transition.
+
+## Problem Frame
+
+On 2026-04-11, mika-dev (qwen3-coder) received a `pull_request_review.submitted(approved)` webhook for PR #522 with `VERDICT: pass` in the review body. Instead of merging, mika-dev misclassified the event as `pull_request.opened`, fabricated a task_id, and re-dispatched `run_claude_pilot` for an unrelated issue. PR #522 sat unmerged for ~7 hours until manually merged.
+
+Root cause: the verdict-to-merge decision was left to LLM interpretation of raw webhook text. The LLM never parsed `VERDICT: pass`, never checked PR state, and improvised a completely wrong action. This is a state-machine transition, not a judgement call.
+
+## Requirements Trace
+
+- R1. On `pull_request_review.submitted` with `state=approved` AND review body containing `VERDICT: pass`: look up work item, initiate merge, update status, notify user, pre-digest for LLM
+- R2. Handler runs before the LLM turn — no dependency on LLM tool calls for the merge action
+- R3. `block[*]` or `hold[*]` verdicts pass through to LLM as today
+- R4. Missing `VERDICT:` line: log warning, pass through to LLM with verdict_missing flag
+- R5. Non-`in_progress` work item status: log and skip, no double-merge
+- R6. Integration test: `pass` verdict triggers merge, `run_claude_pilot` not called
+- R7. Integration test: `block[ci]` verdict does NOT trigger auto-merge
+- R8. Telemetry: `verdict_handled` audit event with `(verdict, action, work_item_id, pr_url)`
+
+## Scope Boundaries
+
+- Gateway routing is unchanged — `pull_request_review.submitted` still routes to mika-dev
+- The `pr_merge_with_gate` LLM tool continues to exist for manual merge scenarios
+- No new work item statuses are added to the schema (avoids v23 migration) — uses existing `in_progress` + metadata tracking instead
+- No reviewer identity filtering — the handler keys off the `VERDICT:` line presence, which implicitly filters for mika-qa (the only agent emitting `VERDICT:` lines). Human reviews without `VERDICT:` lines pass through to the LLM.
+- No gateway-side changes — the structural handling happens entirely in mika-agent
+
+### Deferred to Separate Tasks
+
+- Tool-level refusal for `run_claude_pilot` when work item is in terminal/merge states: mika#525
+- QA review skill enforcement of `VERDICT:` format: companion ticket on mika-skills
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/server/handlers.rs` — `handle_message()` is the interception point. The spawned async task (line 185) acquires the agent lock, then passes `req.text` directly to `run_agent()`. The verdict handler inserts between lock acquisition and `run_agent()`.
+- `crates/mika-agent/src/tools/pr_merge_with_gate.rs` — Contains `run_gh_checks()`, `classify_checks()`, and `run_gh_merge()` as private helpers. These need to be made `pub(crate)` for reuse by the verdict handler.
+- `crates/mika-agent/src/db.rs:3123` — `find_active_work_item_by_ref_url(agent_id, reference_url)` queries the `tasks` table by `reference_url` column (indexed). Work items have `reference_url` set to the GitHub issue URL, while PR URLs are in `metadata.claude_pilot.pr_url`.
+- `crates/mika-gateway/src/github.rs:241-261` — `format_event_text()` for `pull_request_review` produces structured text: `[GitHub] PR review ({state}) on {repo}#{number} ({title}) by @{reviewer}\n{review_url}\n\n{body}`. The `state` and `body` are extractable from this formatted text.
+- `crates/mika-agent/src/server/types.rs:13` — `MessageRequest` has `text`, `chat_id`, `channel`, `request_id`, `agent`, `images`. No structured metadata field exists.
+- `crates/mika-agent/src/async_db.rs:339` — Async wrapper for `find_active_work_item_by_ref_url`.
+- `crates/mika-agent/src/tools/update_work_item_status.rs` — Status state machine: `pending` -> any; `in_progress` -> blocked/completed/cancelled; `blocked` -> in_progress/completed/cancelled. Terminal states: completed, cancelled.
+- `crates/mika-agent/src/work_item_metadata.rs` — Two-level shallow merge for work item metadata JSON.
+
+### Institutional Learnings
+
+- **Verdict misclassification compound doc** (`docs/solutions/agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md`): "Verdict-to-action mapping is a state machine, not a prompt." Pre-digest the event as a fait accompli.
+- **CI gate tool backstop** (`docs/solutions/architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md`): `pr_merge_with_gate` is an existing atomic check+merge tool. Reuse its internal logic.
+- **Merge two-step contracts** (`docs/solutions/architecture-patterns/merge-two-step-llm-tool-contracts.md`): The verdict handler must be atomic — not split into "parse verdict" then "act on verdict" as two LLM-chained steps.
+- **Completion-claim guard** (`docs/solutions/architecture-patterns/completion-claim-guard-work-item-state-enforcement.md`): The pre-digested message must avoid trigger words like "merged"/"completed" since the engine action happens outside the LLM's tool calls. Use "merge initiated" phrasing.
+- **Engine-level callback metadata extraction** (`docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md`): Establishes the pattern of deterministic extraction before `run_silent_agent()`.
+- **Silent callback max_steps exhaustion** (`docs/solutions/runtime-errors/silent-callback-max-steps-exhaustion.md`): Pre-digesting the verdict eliminates most LLM steps needed to handle it.
+
+## Key Technical Decisions
+
+- **Intercept in `handle_message` spawned task, not in a new endpoint:** The gateway already sends formatted text to `/message`. Adding a new endpoint would require gateway changes. Instead, parse the formatted text for verdict patterns inside the existing `handle_message` async task, after lock acquisition but before `run_agent()`. This is the minimal-change approach.
+- **Parse from formatted text, not raw webhook payload:** The agent only receives formatted text from the gateway. Parsing `[GitHub] PR review (approved)` and extracting `VERDICT:` from the body is reliable because `format_event_text()` has a stable format. No gateway changes needed.
+- **Reuse `run_gh_checks`/`classify_checks`/`run_gh_merge` from `pr_merge_with_gate`:** These are already battle-tested. Make them `pub(crate)` instead of duplicating logic. The verdict handler uses the same CI gate classification.
+- **Work item lookup by metadata `pr_url`, not `reference_url`:** The `reference_url` column stores the GitHub issue URL (e.g., `https://github.com/senara-solutions/mika/issues/42`), not the PR URL. The PR URL is in `metadata.claude_pilot.pr_url`. Add a new `find_active_work_item_by_pr_url()` DB method that queries via `json_extract(metadata, '$.claude_pilot.pr_url')`.
+- **No new work item statuses:** Adding `in_pr` and `merging` would require a schema migration (v23) with a full `tasks` table rebuild. Instead: gate on `in_progress` status + presence of `metadata.claude_pilot.pr_url`, and track merge-in-progress via `metadata.verdict_merge.state` field.
+- **Pre-digest replaces, not augments, the user message:** When the verdict handler acts, the original webhook text is replaced with a pre-digest message that describes what the engine did. The LLM receives this as a fait accompli and cannot countermand it. For block/hold/missing verdicts, the original text passes through unmodified.
+- **Merge failure falls through to LLM:** If `gh pr merge` fails, log the error, do NOT update work item metadata, and enrich the pre-digest with the failure reason so the LLM can decide the next action.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Should the handler filter by reviewer identity?** No. The `VERDICT:` line is the implicit filter — only mika-qa emits it. Human reviews without `VERDICT:` pass through normally.
+- **Q: What if `gh pr merge --auto` succeeds but the PR never actually merges?** The handler uses `classify_checks()` from `pr_merge_with_gate` — if all checks pass, it merges immediately; if pending, it enables auto-merge. The pre-digest message distinguishes these cases ("merged" vs "auto-merge enabled") so the LLM and user know the actual state.
+- **Q: Could the LLM duplicate the merge in its tool loop?** The pre-digest explicitly tells the LLM not to call `pr_merge_with_gate`. The existing `AlreadyMerged` detection in the tool provides defense-in-depth.
+- **Q: What about multiple VERDICT lines?** First match wins. The QA review skill emits exactly one `VERDICT:` line per review.
+- **Q: How to extract PR number and repo from the formatted text?** Parse from the `[GitHub] PR review ({state}) on {repo}#{number}` pattern using regex.
+
+### Deferred to Implementation
+
+- Exact regex patterns for parsing the formatted webhook text — will be refined against real gateway output
+- Whether `json_extract` on the `metadata` column needs a partial index for performance — likely not needed given low work item volume per agent
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+handle_message() spawned task:
+  ├─ acquire agent lock
+  ├─ [NEW] try_handle_pr_review_verdict(&req, &agent_state, &app_state)
+  │   ├─ parse_pr_review_event(text) -> Option<PrReviewEvent>
+  │   │   └─ regex: "[GitHub] PR review ({state}) on {repo}#{number}" + VERDICT: line
+  │   ├─ if no match -> return None (passthrough)
+  │   ├─ parse_verdict(body) -> Verdict { Pass, Block(sub), Hold(sub), Missing }
+  │   ├─ if Block/Hold/Missing -> return VerdictAction::Passthrough { enrichment }
+  │   ├─ if Pass:
+  │   │   ├─ find_work_item_by_pr_url(pr_url)
+  │   │   ├─ if not found or status != in_progress -> return Passthrough
+  │   │   ├─ run_gh_checks + classify_checks + run_gh_merge (reused from pr_merge_with_gate)
+  │   │   ├─ on success: update work item metadata, log audit event, send notification
+  │   │   └─ return VerdictAction::Handled { pre_digest_text }
+  │   └─ on merge failure: return VerdictAction::Handled { pre_digest_with_error }
+  ├─ match verdict_action:
+  │   ├─ Handled -> replace req.text with pre_digest_text
+  │   └─ Passthrough -> optionally enrich req.text with verdict_missing flag
+  └─ run_agent(params) as today
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Extract merge helpers from `pr_merge_with_gate` to `pub(crate)`**
+
+**Goal:** Make `run_gh_checks`, `classify_checks`, `run_gh_merge`, `run_gh_subprocess`, and the supporting types (`GhCheck`, `CheckClassification`, `CheckInfo`, `MergeGateResult`) reusable by the verdict handler.
+
+**Requirements:** R1 (merge reuse)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/pr_merge_with_gate.rs`
+- Test: existing tests in same file should continue passing
+
+**Approach:**
+- Change visibility of `run_gh_checks`, `classify_checks`, `run_gh_merge`, `run_gh_subprocess` from private to `pub(crate)`
+- Change visibility of `GhCheck`, `CheckClassification`, `CheckInfo` types to `pub(crate)`
+- No behavioral changes — purely a visibility refactor
+
+**Patterns to follow:**
+- Existing `pub(crate)` patterns in the codebase (e.g., `crate::skills::executor::scrub_mika_env_vars`)
+
+**Test scenarios:**
+- Happy path: All existing `pr_merge_with_gate` tests pass unchanged (no regressions from visibility change)
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- `cargo clippy -p mika-agent` passes
+
+- [x] **Unit 2: Add `find_work_items_by_pr_url` DB method**
+
+**Goal:** Enable lookup of active work items by the PR URL stored in `metadata.claude_pilot.pr_url`.
+
+**Requirements:** R1 (work item lookup)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs`
+- Modify: `crates/mika-agent/src/async_db.rs`
+- Test: `crates/mika-agent/src/db.rs` (inline tests)
+
+**Approach:**
+- Add `find_active_work_item_by_pr_url(agent_id, pr_url)` to `Database` that queries `WHERE json_extract(metadata, '$.claude_pilot.pr_url') = ?2 AND trigger_type = 'manual' AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')`
+- Add corresponding async wrapper in `AsyncDatabase`
+- Return `Option<Task>` matching the same pattern as `find_active_work_item_by_ref_url`
+
+**Patterns to follow:**
+- `find_active_work_item_by_ref_url` in `db.rs:3123` — same query structure with column-based WHERE
+- Async wrapper pattern in `async_db.rs`
+
+**Test scenarios:**
+- Happy path: Create work item with `metadata.claude_pilot.pr_url` set, look up by that URL, find it
+- Edge case: No matching work item returns `None`
+- Edge case: Work item exists but is in terminal status (`completed`) — not returned
+- Edge case: Work item exists but `pr_url` is in a different metadata path — not returned
+- Edge case: Multiple work items with same `pr_url` — returns one (LIMIT 1)
+
+**Verification:**
+- New unit tests pass
+- `cargo test -p mika-agent` passes
+
+- [x] **Unit 3: Implement verdict parser module**
+
+**Goal:** Parse `pull_request_review.submitted` formatted text into structured verdict data, extracting review state, repo, PR number, reviewer, PR URL, and the verdict classification.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `crates/mika-agent/src/server/verdict.rs`
+- Modify: `crates/mika-agent/src/server/mod.rs`
+- Test: `crates/mika-agent/src/server/verdict.rs` (inline tests)
+
+**Approach:**
+- Define `PrReviewEvent` struct: `{ state, repo, pr_number, reviewer, review_url, body }`
+- Define `Verdict` enum: `Pass`, `Block(String)`, `Hold(String)`, `Missing`
+- `parse_pr_review_event(text: &str) -> Option<PrReviewEvent>` — regex match on `[GitHub] PR review ({state}) on {owner/repo}#{number} ({title}) by @{reviewer}` first line, extract review URL from second line, body from remainder
+- `parse_verdict(body: &str) -> Verdict` — case-insensitive scan for `VERDICT:` at start of line. First match wins. Parse value: `pass`, `block[...]`, `hold[...]`. If no match, return `Missing`.
+- Construct PR URL from repo + number: `https://github.com/{repo}/pull/{number}`
+
+**Patterns to follow:**
+- `parse_github_ref` in `crates/mika-agent/src/tools/check_work_item.rs` for URL parsing patterns
+- `LazyLock<Regex>` pattern from `pr_merge_with_gate.rs`
+
+**Test scenarios:**
+- Happy path: Parse well-formed `[GitHub] PR review (approved)` text with `VERDICT: pass` -> `PrReviewEvent` + `Verdict::Pass`
+- Happy path: Parse `VERDICT: block[ci]` -> `Verdict::Block("ci")`
+- Happy path: Parse `VERDICT: hold[review]` -> `Verdict::Hold("review")`
+- Edge case: Review text with no `VERDICT:` line -> `Verdict::Missing`
+- Edge case: `VERDICT: PASS` (uppercase) -> `Verdict::Pass` (case-insensitive)
+- Edge case: `verdict: pass` (lowercase prefix) -> `Verdict::Pass`
+- Edge case: Multiple `VERDICT:` lines -> first match wins
+- Edge case: `VERDICT:pass` (no space after colon) -> `Verdict::Pass`
+- Edge case: Non-review GitHub event text (issue, PR opened) -> `parse_pr_review_event` returns `None`
+- Edge case: Review with state `changes_requested` -> parsed but state is not `approved`
+- Edge case: Truncated body (`[truncated]` suffix) with no `VERDICT:` line -> `Verdict::Missing` with truncation noted
+- Error path: Malformed first line (missing repo/number) -> returns `None`
+
+**Verification:**
+- All unit tests pass covering the verdict parsing matrix
+- `cargo clippy` clean
+
+- [x] **Unit 4: Implement verdict handler logic**
+
+**Goal:** The core handler that coordinates verdict parsing, work item lookup, merge execution, metadata update, audit event, and notification. Returns either a pre-digest message (for pass verdicts) or a passthrough signal (for other cases).
+
+**Requirements:** R1, R2, R3, R4, R5, R8
+
+**Dependencies:** Unit 1, Unit 2, Unit 3
+
+**Files:**
+- Create: `crates/mika-agent/src/server/verdict_handler.rs`
+- Modify: `crates/mika-agent/src/server/mod.rs`
+- Test: `crates/mika-agent/src/server/verdict_handler.rs` (inline tests)
+
+**Approach:**
+- Define `VerdictAction` enum: `Handled { pre_digest: String }`, `Passthrough { enrichment: Option<String> }`
+- `try_handle_pr_review_verdict(text, db, github_token, message_sender, agent_id, session_id, trace_id) -> VerdictAction`:
+  1. Parse `PrReviewEvent` from text — return `Passthrough` if not a PR review
+  2. Check `state == "approved"` — return `Passthrough` if not approved
+  3. Parse `Verdict` from body
+  4. For `Block`/`Hold`: return `Passthrough` (LLM handles)
+  5. For `Missing`: log warning, return `Passthrough` with `verdict_missing=true` enrichment
+  6. For `Pass`:
+     a. Construct PR URL, find work item by `pr_url`
+     b. If no work item or status != `in_progress`: log, return `Passthrough`
+     c. Call `run_gh_checks` + `classify_checks`
+     d. Based on classification: `AllPassed` -> `run_gh_merge` (immediate), `HasPending` -> `run_gh_merge` with `--auto`, `HasFailures` -> return `Passthrough` with enrichment
+     e. On merge success: update work item metadata (set `verdict_merge.state`, `verdict_merge.merged_at`, `verdict_merge.pr_number`), log `verdict_handled` audit event, send notification
+     f. On merge failure: log error, return `Handled` with error pre-digest
+  7. Build pre-digest message with clear "do not call pr_merge_with_gate" instruction
+
+- Audit event follows existing pattern: `log_audit_event(agent_id, session_id, "verdict_handled", target_key, before_value, after_value, reasoning, trace_id)`
+- Notification uses `message_sender.send()` directly
+
+**Patterns to follow:**
+- `try_extract_callback_metadata()` in `task_engine/dispatcher.rs` — engine-level extraction before LLM turn
+- `format_callback_framing()` in `agent.rs` — pre-digest XML wrapping pattern
+- Audit event pattern in `update_work_item_status.rs`
+
+**Test scenarios:**
+- Happy path: Approved review with `VERDICT: pass`, work item in `in_progress`, all CI checks pass -> `Handled` with merge pre-digest, audit event logged
+- Happy path: `VERDICT: pass` with pending CI checks -> `Handled` with auto-merge pre-digest
+- Happy path: `VERDICT: block[ci]` -> `Passthrough` (no merge action)
+- Happy path: `VERDICT: hold[review]` -> `Passthrough`
+- Edge case: Missing `VERDICT:` line -> `Passthrough` with warning logged
+- Edge case: Approved review but no matching work item -> `Passthrough` with log
+- Edge case: Work item found but status is `completed` (terminal) -> `Passthrough` with log
+- Edge case: Work item found but status is `pending` (not `in_progress`) -> `Passthrough` with log
+- Edge case: CI checks have failures -> `Passthrough` with enrichment about failing checks
+- Error path: `gh pr merge` subprocess fails -> `Handled` with error pre-digest, work item metadata NOT updated
+- Error path: `gh pr checks` fails -> `Handled` with error pre-digest
+- Edge case: Review state is `commented` (not `approved`) -> `Passthrough`
+- Edge case: `github_token` is None -> `Passthrough` with warning (cannot merge without token)
+- Integration: Audit event contains correct `(verdict, action, work_item_id, pr_url)` fields
+
+**Verification:**
+- All unit tests pass (mock DB, mock subprocess where needed)
+- Pre-digest message avoids completion-claim guard trigger words
+- `cargo clippy` clean
+
+- [x] **Unit 5: Wire verdict handler into `handle_message`**
+
+**Goal:** Insert the verdict handler call into the `handle_message` async task, between agent lock acquisition and `run_agent()`, so verdicts are handled structurally before the LLM sees the message.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/handlers.rs`
+- Test: `crates/mika-agent/tests/eval/` (integration tests in Unit 6)
+
+**Approach:**
+- After lock acquisition and before `run_agent()` call (around line 187-224 in `handlers.rs`), add:
+  1. Check if `req.channel == "github"` (skip for non-GitHub messages)
+  2. Call `try_handle_pr_review_verdict()` with the request text and agent state
+  3. Match on `VerdictAction`:
+     - `Handled { pre_digest }` -> replace `req.text` with `pre_digest`
+     - `Passthrough { enrichment: Some(e) }` -> prepend enrichment to `req.text`
+     - `Passthrough { enrichment: None }` -> no change
+  4. Continue to `run_agent()` with the (potentially modified) text
+
+- The handler needs: `&a.db`, `s.github_token`, `sender_arc`, `a.db.agent_id()`, `&session_id`, `req.request_id` (as trace_id)
+
+**Patterns to follow:**
+- The existing skill hot-reload block (lines 189-202) as an example of pre-agent-loop logic inside the spawned task
+- `is_callback_turn` flag pattern for signaling special turn context to `AgentParams`
+
+**Test scenarios:**
+- Test expectation: none — integration coverage provided by Unit 6. This unit is wiring only.
+
+**Verification:**
+- `cargo build -p mika-agent` compiles
+- `cargo clippy -p mika-agent` clean
+- Existing handler tests still pass
+
+- [x] **Unit 6: Integration tests**
+
+**Goal:** End-to-end tests that verify the structural verdict handler works correctly for both pass and block scenarios, matching the acceptance criteria.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Create: `crates/mika-agent/tests/eval/verdict_handler.rs`
+- Modify: `crates/mika-agent/tests/eval/mod.rs` (if module registration needed)
+- Test: `crates/mika-agent/tests/eval/verdict_handler.rs`
+
+**Approach:**
+- Use `EvalHarness` with `MockLlmProvider` to exercise the full `run_agent()` path
+- Create test work items with `metadata.claude_pilot.pr_url` set to match test PR URLs
+- Simulate the exact formatted webhook text that the gateway produces for `pull_request_review.submitted`
+- For the merge subprocess: the tests should verify the handler's decision logic (verdict parsing, work item lookup, action selection) rather than actually calling `gh`. Mock or stub `run_gh_merge`/`run_gh_checks` at the function level.
+
+**Execution note:** Study existing eval tests in `crates/mika-agent/tests/eval/` for harness patterns before implementing.
+
+**Patterns to follow:**
+- Existing eval tests in `crates/mika-agent/tests/eval/` — `EvalHarness` builder, `MockLlmProvider` sequence
+- Test data setup for work items in `update_work_item_status.rs` tests
+
+**Test scenarios:**
+- Integration: VERDICT: pass with matching `in_progress` work item -> handler produces pre-digest text, `run_agent()` receives modified message, LLM does NOT invoke `pr_merge_with_gate` or `run_claude_pilot`
+- Integration: VERDICT: block[ci] -> handler does NOT merge, `run_agent()` receives original text, LLM sees the review for decision-making
+- Integration: VERDICT: pass but no matching work item -> passthrough to LLM
+- Integration: Non-PR-review GitHub event (e.g., issue assigned) -> passthrough, no verdict handling attempted
+- Integration: VERDICT: pass with work item in `completed` status -> passthrough, no merge
+
+**Verification:**
+- `cargo test -p mika-agent --test eval` passes with new verdict handler tests
+- Tests are deterministic (no network calls, mock subprocess)
+
+## System-Wide Impact
+
+- **Interaction graph:** The verdict handler runs in `handle_message` before `run_agent()`. It calls into `pr_merge_with_gate`'s extracted helpers (subprocess), `AsyncDatabase` (work item lookup + metadata update + audit), and `MessageSender` (notification). The LLM's `run_agent()` receives either the original text or a pre-digest.
+- **Error propagation:** Merge subprocess failures produce a pre-digest error message for the LLM rather than bubbling up as HTTP errors. DB failures in work item lookup are logged and treated as passthrough (graceful degradation).
+- **State lifecycle risks:** The handler updates `metadata.verdict_merge` but does NOT transition work item status — that's left to the LLM after confirming the merge. This avoids the completion-claim guard false-positive. If the handler crashes mid-execution (after `gh pr merge` but before metadata update), the PR may be merged without metadata tracking — acceptable since `AlreadyMerged` detection handles the idempotency concern.
+- **API surface parity:** The `POST /message` endpoint behavior changes — it now has a side-effect path for GitHub PR review messages. No external API contract changes (same request/response shapes).
+- **Integration coverage:** Unit 6 covers the full handler-to-agent-loop path. The `pr_merge_with_gate` tool's existing tests cover the merge subprocess logic.
+- **Unchanged invariants:** The gateway's `format_event_text()` format is the contract the verdict parser relies on. Any change to the `pull_request_review` text format would break parsing. The `MessageRequest` schema is unchanged. The work item status state machine is unchanged.
+- **Post-condition guard interaction:** The pre-digest message for successful merges must avoid the completion-claim guard trigger words ("merged", "completed"). Use phrasing like "merge initiated" or "auto-merge enabled". The fabricated-action-claim guard should not fire because the engine action is not a tool call visible to the guard.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Gateway changes `format_event_text()` format, breaking verdict parser | Add a comment in `format_event_text()` noting the agent-side parser dependency. Parser tests catch regressions. |
+| `json_extract` on metadata column is slow for agents with many work items | Low risk — work item volume per agent is small (tens, not thousands). Can add index later if needed. |
+| Agent lock held during `gh pr merge` subprocess (up to 60s) blocks other messages | Existing behavior for all messages — the agent already holds the lock during `run_agent()` which can run for minutes. The merge subprocess is faster. |
+| Pre-digest wording triggers completion-claim guard | Carefully avoid trigger words. Test the exact pre-digest text against `detect_completion_claim()`. |
+| `gh` CLI not installed in agent container | Existing risk for `pr_merge_with_gate` — the verdict handler uses the same subprocess path and fails gracefully. |
+
+## Sources & References
+
+- Related issue: #524
+- Related issue: #525 (companion: tool-level refusal)
+- Compound doc: `docs/solutions/agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md`
+- Stuck PR: senara-solutions/mika#522
+- Existing merge tool: `crates/mika-agent/src/tools/pr_merge_with_gate.rs`
+- CI gate backstop learning: `docs/solutions/architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md`

--- a/docs/solutions/architecture-patterns/structural-verdict-handler-pr-review-auto-merge.md
+++ b/docs/solutions/architecture-patterns/structural-verdict-handler-pr-review-auto-merge.md
@@ -1,0 +1,89 @@
+---
+module: mika-agent
+date: 2026-04-13
+problem_type: best_practice
+component: tooling
+severity: high
+tags:
+  - webhook-handler
+  - verdict-handler
+  - pr-merge
+  - structural-handler
+  - pre-digest
+  - llm-bypass
+  - state-machine
+related_issues:
+  - 524
+  - 522
+  - 525
+applies_when:
+  - An external event should trigger a deterministic state transition
+  - The LLM could misinterpret or improvise on a raw webhook payload
+  - A time-sensitive action (like PR merge) cannot wait for LLM processing
+---
+
+# Structural PR Review Verdict Handler — Engine-Level Auto-Merge
+
+## Context
+
+On 2026-04-11, mika-dev (qwen3-coder) received a `pull_request_review.submitted(approved)` webhook for PR #522 with `VERDICT: pass` in the review body. Instead of calling `gh pr merge`, mika-dev misclassified the event as `pull_request.opened`, fabricated a task_id, and re-dispatched `run_claude_pilot` for an unrelated issue. PR #522 sat unmerged for ~7 hours until manually merged.
+
+Root cause: the verdict-to-merge decision was left to LLM interpretation of raw webhook text. The LLM never parsed `VERDICT: pass`, never checked PR state, and improvised a completely wrong action. This is a state-machine transition, not a judgement call.
+
+See also: `docs/solutions/agent-quality/2026-04-11-mika-dev-verdict-misclassification-pr-522.md` for the incident post-mortem.
+
+## Guidance
+
+**When an external event should trigger a deterministic action, handle it structurally in the engine layer before the LLM turn — not via prompt instructions.**
+
+The verdict handler (`server::verdict_handler`) intercepts `pull_request_review.submitted` webhook events in `handle_message()`, after the agent lock is acquired but before `run_agent()` is called:
+
+1. **Parse** the gateway-formatted text using `parse_pr_review_event()` (regex match on `[GitHub] PR review ({state}) on {repo}#{number}`)
+2. **Extract verdict** from the review body using `parse_verdict()` — case-insensitive match on `VERDICT:` at start of line
+3. **Act on verdict:**
+   - `pass` → look up work item by `metadata.claude_pilot.pr_url`, check status is `in_progress`, then call `run_gh_checks` + `classify_checks` + `run_gh_merge` (reused from `pr_merge_with_gate`)
+   - `block[*]` / `hold[*]` → pass through to LLM (LLM still drives retry logic)
+   - Missing → log warning, pass through with `verdict_missing=true` enrichment
+4. **Pre-digest** the result for the LLM as a fait accompli — the LLM receives "merge initiated" rather than the raw review text
+
+Key design decisions:
+- **Reuse `pr_merge_with_gate` internals** (`run_gh_checks`, `classify_checks`, `run_gh_merge`) — made `pub(crate)` for shared access. Same CI gate classification logic applies.
+- **No new work item statuses** — gates on existing `in_progress` + `metadata.claude_pilot.pr_url` presence. Tracks merge state in `metadata.verdict_merge` to avoid schema migration.
+- **Pre-digest avoids completion-claim guard trigger words** — uses "merge initiated" / "auto-merge enabled" instead of "merged" / "completed" since the engine action happens outside the LLM's tool calls.
+- **60-second timeout** on subprocess calls to prevent agent lock starvation.
+
+## Why This Matters
+
+- **LLMs improvise on state-machine transitions.** When the correct action is deterministic (approved + VERDICT: pass → merge), leaving it to the LLM introduces unnecessary failure modes: misclassification, hallucinated task IDs, re-dispatch of unrelated work.
+- **Pre-digestion eliminates LLM step waste.** Without the handler, the LLM burns 10+ tool steps discovering the PR state, parsing the verdict, and deciding to merge. The handler does it in one structural pass.
+- **Prompt-only enforcement is unreliable after compaction.** The system prompt can instruct "parse VERDICT: and merge" but the LLM ignores instructions after context compaction. Code-level handlers survive compaction.
+
+## When to Apply
+
+Use this pattern when:
+- An external event (webhook, callback, timer) should trigger a deterministic action
+- The action has a clear state-machine transition (status X + event Y → action Z)
+- The LLM interpretation of the raw event has historically been unreliable
+- The action is time-sensitive (PR merges should happen immediately, not after LLM deliberation)
+
+Do NOT use this pattern when:
+- The action requires judgement (which retry strategy? what error message to send?)
+- The event is ambiguous and benefits from LLM reasoning
+- The action needs access to conversation history or memory context
+
+## Examples
+
+**Before (LLM-driven, unreliable):**
+The LLM receives raw webhook text `[GitHub] PR review (approved) on repo#522 by @mika-qa` and must independently: (1) recognize this is an approval, (2) find `VERDICT: pass` in the body, (3) look up the work item, (4) call `pr_merge_with_gate`. Any step can fail or be improvised incorrectly.
+
+**After (structural handler):**
+The engine intercepts the event, parses the verdict, looks up the work item, and calls merge before the LLM sees the message. The LLM receives a pre-digested `<verdict_handler>` block describing what the engine did.
+
+## Related
+
+- `docs/solutions/architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md` — the PR merge gate tool that the verdict handler reuses
+- `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md` — same pattern of engine-level extraction before LLM turn
+- `docs/solutions/architecture-patterns/merge-two-step-llm-tool-contracts.md` — anti-pattern the handler avoids (atomic, not two-step)
+- `docs/solutions/architecture-patterns/deterministic-skill-context-injection.md` — related pattern of engine-owned pre-fetch
+- mika#524 — implementation issue
+- mika#525 — companion: tool-level refusal for `run_claude_pilot` on invalid work item states


### PR DESCRIPTION
## Summary

- Add engine-level `verdict_handler` that intercepts `pull_request_review.submitted` webhooks **before** the LLM turn in `handle_message()`
- Parse `VERDICT: pass/block[*]/hold[*]` from review body and act deterministically — look up work item, initiate merge via CI-gated `run_gh_checks` + `run_gh_merge`, update metadata, log audit event, notify user
- For `block[*]`/`hold[*]` verdicts: pass through to LLM as today
- For missing `VERDICT:` line: log warning, pass through with `verdict_missing=true` enrichment
- Reuse `pr_merge_with_gate` internals (`pub(crate)` visibility) — same CI gate classification logic
- 60-second timeout on subprocess calls to prevent agent lock starvation
- Pre-digest messages avoid completion-claim guard trigger words

**Motivation:** On 2026-04-11, mika-dev received a `VERDICT: pass` on PR #522 but misclassified the event, fabricated a task_id, and left the PR unmerged for 7 hours. This was a state-machine transition masquerading as an LLM judgement call.

Closes #524

## Test plan

- [x] 11 verdict parser unit tests (parse_pr_review_event, parse_verdict)
- [x] 6 verdict handler unit tests (pre-digest formatting, completion-claim guard word avoidance)
- [x] 4 DB unit tests (find_active_work_item_by_pr_url)
- [x] 9 integration tests (block/hold/missing/passthrough/no-work-item/completed/pending/no-token/non-approved)
- [x] All 1535 existing tests pass
- [x] clippy clean, fmt clean, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)