### PR TITLE
feat: work-item status guard on long-running dispatch (#525)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -87,7 +87,7 @@ Git-based and local skill distribution via `mika skills install/uninstall/update
 
 **Image protocol (`__mika_v1`):** Scripts return images via JSON envelope `{"__mika_v1": {"text": "...", "images": ["/path/to/img"]}}`. Executor validates files (5MB limit, magic-byte check for JPEG/PNG/GIF/WebP), base64-encodes, max 5 images per result.
 
-**Long-running:** `long_running: true` + `estimated_duration_secs` in `skill.toml`. Conversation mode only. Creates callback task, injects `__mika_task_id` and `__mika_agent` env vars, spawns detached process. PID recorded for orphan cleanup.
+**Long-running:** `long_running: true` + `estimated_duration_secs` in `skill.toml`. Conversation mode only. Creates callback task, injects `__mika_task_id` and `__mika_agent` env vars, spawns detached process. PID recorded for orphan cleanup. **Dispatch-readiness guard (#525):** before spawning, `validate_dispatch_readiness()` enforces two checks: (1) work item status must be `pending` or `in_progress` (rejects `blocked`/`completed`/`cancelled` with structured JSON error `work_item_not_dispatchable`), (2) no active callback child task may exist (rejects with `work_item_active_dispatch`). Fail-closed on DB errors. Auto-transitions `pending` work items to `in_progress` on successful dispatch. Stricter than the shared `validate_work_item()` which also allows `blocked` for `delegate_task`.
 
 ## MCP (Model Context Protocol) Client
 

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -547,6 +547,120 @@ fn truncate_output(s: &str) -> String {
     }
 }
 
+/// Validate that a work item is in a dispatchable state for long-running execution.
+///
+/// Stricter than `validate_work_item()` (which also allows `blocked` for delegation).
+/// Long-running dispatch only permits `pending` and `in_progress`, and rejects if an
+/// active callback child task already exists (double-dispatch prevention).
+///
+/// Returns `Err(json_error_string)` on rejection, `Ok(status)` with the work item's
+/// current status if dispatch may proceed.
+async fn validate_dispatch_readiness(
+    db: &AsyncDatabase,
+    work_item_id: &str,
+) -> Result<String, String> {
+    // Re-fetch the task to get the full struct (validate_work_item confirmed existence)
+    let task = match db.get_task(work_item_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            // Should not happen after validate_work_item, but defense-in-depth
+            return Err(serde_json::json!({
+                "error": "work_item_not_found",
+                "task_id": work_item_id,
+                "reason": "Work item does not exist in the database"
+            })
+            .to_string());
+        }
+        Err(e) => {
+            return Err(serde_json::json!({
+                "error": "dispatch_check_failed",
+                "task_id": work_item_id,
+                "reason": format!("Failed to fetch work item for dispatch check: {e}")
+            })
+            .to_string());
+        }
+    };
+
+    // Only pending and in_progress are dispatchable
+    if !matches!(task.status.as_str(), "pending" | "in_progress") {
+        let pr_url = extract_pr_url(&task.metadata);
+        return Err(serde_json::json!({
+            "error": "work_item_not_dispatchable",
+            "task_id": work_item_id,
+            "current_status": task.status,
+            "pr_url": pr_url,
+            "reason": format!(
+                "Work item is in '{}' state and cannot be dispatched. \
+                 Only 'pending' and 'in_progress' work items can be dispatched.",
+                task.status
+            )
+        })
+        .to_string());
+    }
+
+    // Check for active callback children (double-dispatch prevention)
+    match db.get_child_tasks(work_item_id).await {
+        Ok(children) => {
+            let active_callback = children.iter().find(|c| {
+                c.trigger_type == "callback"
+                    && matches!(c.status.as_str(), "pending" | "in_progress")
+            });
+            if let Some(child) = active_callback {
+                let pr_url = extract_pr_url(&task.metadata);
+                return Err(serde_json::json!({
+                    "error": "work_item_active_dispatch",
+                    "task_id": work_item_id,
+                    "current_status": task.status,
+                    "active_child_id": child.id,
+                    "active_child_status": child.status,
+                    "pr_url": pr_url,
+                    "reason": format!(
+                        "Work item already has an active dispatch (callback task '{}' \
+                         in '{}' status). Wait for it to complete or cancel it before \
+                         dispatching again.",
+                        child.id, child.status
+                    )
+                })
+                .to_string());
+            }
+        }
+        Err(e) => {
+            // Fail-closed: if we can't check children, reject dispatch
+            return Err(serde_json::json!({
+                "error": "dispatch_check_failed",
+                "task_id": work_item_id,
+                "reason": format!("Failed to check active dispatches for work item: {e}")
+            })
+            .to_string());
+        }
+    }
+
+    Ok(task.status.clone())
+}
+
+/// Extract `pr_url` from a task's metadata JSON.
+///
+/// Looks for `claude_pilot.pr_url` (nested) or `pr_url` (top-level).
+fn extract_pr_url(metadata: &Option<String>) -> Option<String> {
+    let meta = metadata.as_deref()?;
+    let parsed: serde_json::Value = serde_json::from_str(meta).ok()?;
+
+    // Try nested claude_pilot.pr_url first
+    if let Some(url) = parsed
+        .get("claude_pilot")
+        .and_then(|cp| cp.get("pr_url"))
+        .and_then(|v| v.as_str())
+    {
+        return Some(url.to_string());
+    }
+
+    // Fallback to top-level pr_url
+    parsed
+        .get("pr_url")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
 /// Execute a long-running exec handler by creating a callback task and spawning
 /// the subprocess in the background. Returns immediately with the task ID.
 async fn execute_long_running(
@@ -566,8 +680,39 @@ async fn execute_long_running(
         return ToolOutput::error(err);
     }
 
+    // Dispatch-readiness guard (#525): stricter than validate_work_item() which also
+    // allows `blocked` (needed by delegate_task). Long-running dispatch only permits
+    // `pending` and `in_progress`. Returns the current status on success to avoid
+    // a redundant DB read in the auto-transition below.
+    let wi_status = match validate_dispatch_readiness(&ctx.db, work_item_id).await {
+        Ok(status) => status,
+        Err(err) => return ToolOutput::error(err),
+    };
+
     let estimated = estimated_duration_secs.unwrap_or(3600);
     let timeout_secs = (estimated * 3).clamp(600, 7_776_000); // 10min..90days
+
+    // Auto-transition pending work items to in_progress on dispatch (#525).
+    // Closes the TOCTOU window where two dispatches to a pending item both pass.
+    if wi_status == "pending" {
+        if let Err(e) = ctx
+            .db
+            .update_manual_task_status(work_item_id, "in_progress")
+            .await
+        {
+            // Non-fatal: the callback child creation provides a secondary guard
+            warn!(
+                work_item_id,
+                error = %e,
+                "failed to auto-transition work item to in_progress"
+            );
+        } else {
+            info!(
+                work_item_id,
+                "auto-transitioned work item from pending to in_progress on dispatch"
+            );
+        }
+    }
 
     // Link callback task to work item via parent_task_id for task tree correlation
     let parent_task_id = input
@@ -1636,5 +1781,649 @@ mod tests {
             "error should explain the context restriction: {}",
             output.content
         );
+    }
+
+    // -- Dispatch-readiness guard tests (#525) --
+
+    /// Helper: create a work item and transition it to the given status.
+    async fn create_work_item_with_status(
+        db: &crate::async_db::AsyncDatabase,
+        status: &str,
+    ) -> String {
+        let wi_id = create_test_work_item(db).await;
+        if status != "pending" {
+            // pending -> blocked or in_progress are valid transitions;
+            // pending -> completed or cancelled are also valid.
+            db.update_manual_task_status(&wi_id, status).await.unwrap();
+        }
+        wi_id
+    }
+
+    /// Helper: create a callback child task under a work item.
+    async fn create_callback_child(
+        db: &crate::async_db::AsyncDatabase,
+        parent_work_item_id: &str,
+        status: &str,
+    ) -> String {
+        use crate::task_engine::types::{action_type, trigger_type};
+        let task = crate::db::NewTask {
+            agent_id: db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_work_item_id.to_string()),
+            depth: 0,
+            label: "long_running:run_claude_pilot".to_string(),
+            trigger_type: trigger_type::CALLBACK.to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: action_type::RESUME_AGENT.to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("test-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+        };
+        let child_id = db.create_task(task).await.unwrap();
+        if status != "pending" {
+            // Transition the child to the requested status via direct DB update
+            db.update_task_status(&child_id, status).await.unwrap();
+        }
+        child_id
+    }
+
+    fn make_lr_ctx(db: crate::async_db::AsyncDatabase) -> LongRunningContext {
+        LongRunningContext {
+            db,
+            agent_name: "mika".to_string(),
+            session_id: "test-session".to_string(),
+            trace_id: "00000000000000000000000000000000".to_string(),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_blocked_work_item() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "blocked").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_not_dispatchable");
+        assert_eq!(parsed["current_status"], "blocked");
+        assert_eq!(parsed["task_id"], wi_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_completed_work_item() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "completed").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        // Caught by validate_work_item() (first-pass) — not a JSON error
+        assert!(output.is_error);
+        assert!(
+            output.content.contains("not an active work item"),
+            "expected validate_work_item rejection, got: {}",
+            output.content
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_cancelled_work_item() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "cancelled").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        // Caught by validate_work_item() (first-pass)
+        assert!(output.is_error);
+        assert!(
+            output.content.contains("not an active work item"),
+            "expected validate_work_item rejection, got: {}",
+            output.content
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_nonexistent_task_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": "fabricated-uuid-that-does-not-exist"}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        assert!(
+            output.content.contains("not found"),
+            "expected not-found error for fabricated UUID, got: {}",
+            output.content
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_active_callback_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        let child_id = create_callback_child(&async_db, &wi_id, "pending").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+        assert_eq!(parsed["active_child_id"], child_id);
+        assert_eq!(parsed["task_id"], wi_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_rejects_in_progress_callback_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        let _child_id = create_callback_child(&async_db, &wi_id, "in_progress").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_allows_with_only_completed_callback_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        // Create completed and failed callback children — should not block
+        create_callback_child(&async_db, &wi_id, "completed").await;
+        create_callback_child(&async_db, &wi_id, "failed").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        // Should proceed to dispatch — guard must not reject.
+        // If is_error, verify it's NOT a dispatch guard rejection.
+        if output.is_error {
+            assert!(
+                !output.content.contains("work_item_not_dispatchable")
+                    && !output.content.contains("work_item_active_dispatch"),
+                "dispatch guard should not reject, got: {}",
+                output.content
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_allows_cancelled_callback_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        // Cancelled callback child — should not block re-dispatch
+        create_callback_child(&async_db, &wi_id, "cancelled").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        if output.is_error {
+            assert!(
+                !output.content.contains("work_item_not_dispatchable")
+                    && !output.content.contains("work_item_active_dispatch"),
+                "dispatch guard should not reject for cancelled child, got: {}",
+                output.content
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_ignores_non_callback_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+
+        // Create a non-callback child (e.g., resume_agent with manual trigger)
+        let non_callback = crate::db::NewTask {
+            agent_id: async_db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: Some(wi_id.clone()),
+            depth: 0,
+            label: "delegate:some-agent".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("test-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+        };
+        async_db.create_task(non_callback).await.unwrap();
+
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        // Should proceed — non-callback children don't block
+        if output.is_error {
+            assert!(
+                !output.content.contains("work_item_not_dispatchable")
+                    && !output.content.contains("work_item_active_dispatch"),
+                "dispatch guard should not reject for non-callback children, got: {}",
+                output.content
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_mixed_children_one_active_rejects() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        // One completed, one still pending — should block
+        create_callback_child(&async_db, &wi_id, "completed").await;
+        create_callback_child(&async_db, &wi_id, "pending").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_auto_transitions_pending_to_in_progress() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_test_work_item(&async_db).await;
+
+        // Verify starts as pending
+        let task_before = async_db.get_task(&wi_id).await.unwrap().unwrap();
+        assert_eq!(task_before.status, "pending");
+
+        let ctx = make_lr_ctx(async_db.clone());
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(!output.is_error, "unexpected error: {}", output.content);
+
+        // Verify work item transitioned to in_progress
+        let task_after = async_db.get_task(&wi_id).await.unwrap().unwrap();
+        assert_eq!(
+            task_after.status, "in_progress",
+            "work item should auto-transition to in_progress on dispatch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_no_transition_for_already_in_progress() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        let ctx = make_lr_ctx(async_db.clone());
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(!output.is_error, "unexpected error: {}", output.content);
+
+        // Should still be in_progress (no redundant transition)
+        let task = async_db.get_task(&wi_id).await.unwrap().unwrap();
+        assert_eq!(task.status, "in_progress");
+    }
+
+    // -- Integration test: PR #522 race scenario replay (#525) --
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pr522_replay_active_dispatch_with_pr_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+
+        // Create in_progress work item with PR URL in metadata
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        let metadata = serde_json::json!({
+            "claude_pilot": {
+                "pr_url": "https://github.com/senara-solutions/mika/pull/522",
+                "branch": "feat/522/some-feature"
+            }
+        });
+        async_db
+            .update_work_item_metadata(&wi_id, &metadata.to_string())
+            .await
+            .unwrap();
+
+        // Simulate active claude-pilot session (pending callback child)
+        create_callback_child(&async_db, &wi_id, "pending").await;
+
+        // Count tasks before attempted dispatch
+        let tasks_before = async_db.get_child_tasks(&wi_id).await.unwrap().len();
+
+        let ctx = make_lr_ctx(async_db.clone());
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        // Should be rejected
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+        assert_eq!(
+            parsed["pr_url"],
+            "https://github.com/senara-solutions/mika/pull/522"
+        );
+
+        // Verify no new callback task was created
+        let tasks_after = async_db.get_child_tasks(&wi_id).await.unwrap().len();
+        assert_eq!(
+            tasks_before, tasks_after,
+            "no new callback task should be created when dispatch is rejected"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pr522_replay_no_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        create_callback_child(&async_db, &wi_id, "pending").await;
+        let ctx = make_lr_ctx(async_db);
+
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(output.is_error);
+        let parsed: serde_json::Value = serde_json::from_str(&output.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+        assert!(
+            parsed["pr_url"].is_null(),
+            "pr_url should be null when no metadata"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pr522_replay_retry_after_child_completes() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_work_item_with_status(&async_db, "in_progress").await;
+        let child_id = create_callback_child(&async_db, &wi_id, "pending").await;
+
+        // First attempt: should be rejected
+        let ctx = make_lr_ctx(async_db.clone());
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+        assert!(output.is_error);
+
+        // Complete the child task
+        async_db
+            .update_task_status(&child_id, "completed")
+            .await
+            .unwrap();
+
+        // Retry: should succeed now
+        let ctx = make_lr_ctx(async_db.clone());
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+
+        assert!(
+            !output.is_error,
+            "retry after child completion should succeed, got: {}",
+            output.content
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_dispatch_guard_double_dispatch_pending_item() {
+        // Regression: two sequential dispatches to a pending work item.
+        // First should succeed (and auto-transition to in_progress + create callback).
+        // Second should be rejected by active-child check.
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(&tmp.path().join("run.sh"), "#!/bin/sh\necho done");
+        let tool = make_long_running_tool(tmp.path(), "run.sh");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_test_work_item(&async_db).await;
+
+        // First dispatch: should succeed
+        let ctx = make_lr_ctx(async_db.clone());
+        let output1 = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+        assert!(
+            !output1.is_error,
+            "first dispatch should succeed: {}",
+            output1.content
+        );
+
+        // Verify first dispatch created exactly one callback child
+        let children = async_db.get_child_tasks(&wi_id).await.unwrap();
+        let callback_children: Vec<_> = children
+            .iter()
+            .filter(|c| c.trigger_type == "callback")
+            .collect();
+        assert_eq!(
+            callback_children.len(),
+            1,
+            "first dispatch must create exactly one callback child"
+        );
+
+        // Second dispatch: should be rejected (active callback child from first dispatch)
+        let ctx = make_lr_ctx(async_db.clone());
+        let output2 = execute_skill_tool(
+            &tool,
+            serde_json::json!({"work_item_id": wi_id}),
+            30,
+            Some(&ctx),
+            None,
+        )
+        .await;
+        assert!(output2.is_error, "second dispatch should be rejected");
+        let parsed: serde_json::Value = serde_json::from_str(&output2.content)
+            .unwrap_or_else(|_| panic!("expected JSON error, got: {}", output2.content));
+        assert_eq!(parsed["error"], "work_item_active_dispatch");
+
+        // Verify work item is in_progress (auto-transitioned by first dispatch)
+        let task = async_db.get_task(&wi_id).await.unwrap().unwrap();
+        assert_eq!(task.status, "in_progress");
     }
 }

--- a/docs/plans/2026-04-13-002-feat-work-item-status-guard-on-dispatch-plan.md
+++ b/docs/plans/2026-04-13-002-feat-work-item-status-guard-on-dispatch-plan.md
@@ -1,0 +1,219 @@
+---
+title: "feat: Work-item status guard on run_claude_pilot dispatch"
+type: feat
+status: active
+date: 2026-04-13
+issue: 525
+---
+
+# feat: Work-item status guard on run_claude_pilot dispatch
+
+## Overview
+
+Add a hard, tool-level refusal in `execute_long_running()` (the code path for `run_claude_pilot` and all long-running exec-handler skills) that validates work item status and detects active child dispatches before spawning a subprocess. This prevents wasted compute from redundant dispatches when a work item is already being worked on, has an open PR, or is in a terminal state.
+
+## Problem Frame
+
+On 2026-04-11, mika-dev called `run_claude_pilot` with a fabricated UUID (hallucinated during recovery from a misclassified webhook). The tool returned "Work item not found." mika-dev then retried with the correct task_id and successfully dispatched a new claude-pilot session on a work item that was already `in_progress` with PR #522 open, QA-approved, and CI green. The redundant session burned ~$0.18 producing no useful output and contributed to a desync that left the PR stuck for 7 hours.
+
+The root cause: `execute_long_running()` delegates all dispatch-readiness decisions to the LLM via soft advisory returns from `create_work_item`. Neither the LLM judgment nor the advisory string is sufficient against misclassified webhooks + hallucinated UUIDs + LLM recovery improvisation. The tool boundary is the only reliable enforcement point.
+
+## Requirements Trace
+
+- R1. `execute_long_running()` validates `task_id` against the database before launching the subprocess
+- R2. Reject dispatch when work item status is `blocked`, `completed`, or `cancelled` with a structured error including `error`, `task_id`, `current_status`, `pr_url`, and `reason` fields
+- R3. Reject fabricated/nonexistent `task_id` with a distinct `work_item_not_found` error (defense-in-depth — already partially covered by `validate_work_item()`)
+- R4. Only `pending` and `in_progress` are valid pre-dispatch statuses; all others (`blocked`, `completed`, `cancelled`) are rejected per R2
+- R5. Reject dispatch when the work item already has an active callback child task (double-dispatch prevention)
+- R6. Unit tests for each rejected status, fabricated task_id, and double-dispatch scenario
+- R7. Auto-transition `pending` work items to `in_progress` on successful dispatch (closes the bypass window where two dispatches to a `pending` item both pass)
+
+## Scope Boundaries
+
+- Guard applies to ALL long-running exec-handler dispatches, not just `run_claude_pilot` — `execute_long_running()` is the shared entry point
+- The shared `validate_work_item()` helper in `tools/mod.rs` is NOT modified — it is co-consumed by `delegate_task` which intentionally allows `blocked` work items
+- No new task statuses (e.g., `in_pr`, `merging`, `merged`) are added — the guard uses the existing status model plus child-task introspection
+- No schema migration — uses existing `get_child_tasks()` query and existing `update_manual_task_status()` for the auto-transition
+
+### Deferred to Separate Tasks
+
+- Structural verdict handler for the webhook side of the same vulnerability: #524 (separate PR, already planned)
+- Composite index on `parent_task_id + trigger_type + status` for the child-task query: performance optimization, separate PR if profiling shows need
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/skills/executor.rs:552` — `execute_long_running()`, the insertion point for the guard. Currently calls `validate_work_item()` at line 565
+- `crates/mika-agent/src/tools/mod.rs:234` — `validate_work_item()` accepts `pending | in_progress | blocked`; shared with `delegate_task`
+- `crates/mika-agent/src/tools/update_work_item_status.rs:8-26` — `VALID_STATUSES` and `VALID_TRANSITIONS` state machine
+- `crates/mika-agent/src/async_db.rs:465` — `get_child_tasks(parent_task_id)` returns `Vec<Task>`
+- `crates/mika-agent/src/db.rs:3024` — `update_manual_task_status()` for the auto-transition
+- `crates/mika-agent/src/task_engine/types.rs:1-15` — `task_status` constants
+- `crates/mika-agent/src/skills/executor.rs:1367` — existing long-running tests with `TestHarness`/`LongRunningContext` pattern
+
+### Institutional Learnings
+
+- **Code guards over prompt instructions** (docs/solutions/architecture-patterns/completion-claim-guard-work-item-state-enforcement.md): "If the agent ignoring an instruction would cause real harm, enforce it in the harness." Dispatch of a redundant claude-pilot session causes real harm.
+- **Delegation work item guard** (docs/solutions/architecture-patterns/delegation-work-item-guard-enforcement.md): Establishes the three-layer defense pattern (code guard + core memory + system prompt). The code guard is the primary enforcement; prompt-level is defense-in-depth.
+- **Tool-layer validation, not DB-layer** (docs/solutions/architecture-patterns/work-item-status-transition-validation.md): Validation belongs in the tool/executor layer; the DB stays general-purpose.
+- **Atomic check + action** (docs/solutions/architecture-patterns/ci-gate-tool-structural-backstop-for-pr-merges.md): `pr_merge_with_gate` demonstrates the pattern of checking preconditions and acting in one tool call.
+- **Silent success is a bug** (docs/solutions/logic-errors/long-running-monitor-false-failure-on-signal.md): Rejected dispatches must return explicit structured errors, not silently succeed.
+
+## Key Technical Decisions
+
+- **Separate dispatch validation instead of modifying shared helper:** `validate_work_item()` is shared with `delegate_task` which allows `blocked` status. Adding a `validate_work_item_for_dispatch()` helper (or inline validation in `execute_long_running`) avoids changing delegation behavior. The existing `validate_work_item()` call remains as the first-pass check; the new guard is a stricter second pass.
+
+- **Structured JSON error in `ToolOutput::error()` content field:** The issue requests structured JSON errors. While existing tools use plain-text errors, the JSON structure provides programmatic feedback to the LLM. The content field of `ToolOutput::error()` will contain a JSON string. This matches `pr_merge_with_gate`'s pattern of returning machine-readable results.
+
+- **Active-child detection via application-level filtering:** Query `get_child_tasks(work_item_id)` and filter for `trigger_type == "callback" && status IN (pending, in_progress)` in Rust. This avoids adding a new DB query and keeps the filtering logic colocated with the guard.
+
+- **Auto-transition to `in_progress` on dispatch:** When the guard passes and the work item is `pending`, auto-transition to `in_progress` before creating the callback task. This closes the TOCTOU window for double-dispatch on `pending` items. Intra-turn tool calls are sequential in the agent loop, so the second call would see the `in_progress` status and the active child.
+
+- **Treat `expired`, `failed`, `completed`, `cancelled`, `delivered` callback children as inactive:** Only `pending` and `in_progress` callback children block dispatch. This allows legitimate retries after failures/timeouts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `validate_work_item()` be modified?** No — it's shared with `delegate_task` which intentionally allows `blocked`. Add stricter validation after the shared check in `execute_long_running()`.
+- **Are `in_pr`/`merging`/`merged` real statuses?** No — the issue uses conceptual names. The actual work item statuses are `pending`, `in_progress`, `blocked`, `completed`, `cancelled`. The guard maps the issue's intent to: reject `blocked`/`completed`/`cancelled`; allow `pending`/`in_progress`; detect active children for double-dispatch.
+- **Is the intra-turn race a concern?** Minimal — tool calls within a turn execute sequentially in the agent loop. The auto-transition to `in_progress` + callback child creation before the second call runs closes this window.
+
+### Deferred to Implementation
+
+- Exact error message wording — directional in the plan, finalized during implementation
+- Whether to emit an audit event for rejected dispatches — low stakes, decide during implementation
+
+## Implementation Units
+
+- [x] **Unit 1: Add dispatch-readiness validation in `execute_long_running()`**
+
+  **Goal:** Reject long-running dispatch when the work item is in a non-dispatchable status or already has an active callback child task.
+
+  **Requirements:** R1, R2, R3, R4, R5
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/skills/executor.rs`
+  - Test: `crates/mika-agent/src/skills/executor.rs` (inline `#[cfg(test)] mod tests`)
+
+  **Approach:**
+  - After the existing `validate_work_item()` call (line 565), add a second validation pass:
+    1. Re-fetch the task via `ctx.db.get_task(work_item_id)` (the shared helper already confirmed existence; we need the full `Task` struct for status + metadata)
+    2. Check status is `pending` or `in_progress` — if not, return `ToolOutput::error()` with JSON `{"error": "work_item_not_dispatchable", "task_id": "...", "current_status": "...", "pr_url": "..." or null, "reason": "..."}`
+    3. Query `ctx.db.get_child_tasks(work_item_id)` and filter for active callback children (`trigger_type == "callback" && status in ["pending", "in_progress"]`)
+    4. If any active callback children exist, return `ToolOutput::error()` with JSON `{"error": "work_item_active_dispatch", "task_id": "...", "active_child_id": "...", "reason": "..."}`
+  - Extract `pr_url` from the task's `metadata` JSON field (parse `metadata` string, look for `claude_pilot.pr_url` or `pr_url` key)
+  - The existing `validate_work_item()` already handles the `work_item_not_found` case (R3) — no change needed there
+
+  **Patterns to follow:**
+  - `crates/mika-agent/src/skills/executor.rs:565` — existing `validate_work_item()` call site
+  - `crates/mika-agent/src/tools/update_work_item_status.rs:107-128` — inline validation before action
+  - `crates/mika-agent/src/tools/pr_merge_with_gate.rs` — structured JSON in `ToolOutput` content
+
+  **Test scenarios:**
+  - Happy path: work item `pending`, no children → dispatch proceeds (no error returned from validation)
+  - Happy path: work item `in_progress`, only `completed`/`failed`/`expired` callback children → dispatch proceeds
+  - Error path: work item `blocked` → `work_item_not_dispatchable` error with `current_status: "blocked"`
+  - Error path: work item `completed` → rejected (already caught by `validate_work_item()`, verify error message)
+  - Error path: work item `cancelled` → rejected (already caught by `validate_work_item()`, verify error message)
+  - Error path: nonexistent task_id → `work_item_not_found` error (verify existing behavior preserved)
+  - Error path: empty task_id → existing "create a work item first" error preserved
+  - Edge case: work item `in_progress` with one `pending` callback child → `work_item_active_dispatch` error including active child ID
+  - Edge case: work item `in_progress` with one `in_progress` callback child → `work_item_active_dispatch` error
+  - Edge case: work item `in_progress` with mixed children (one `completed` callback, one `pending` callback) → rejected (active child exists)
+  - Edge case: work item `in_progress` with non-callback children only (e.g., delegate tasks) → dispatch proceeds (only callback children block)
+
+  **Verification:**
+  - All long-running dispatch attempts against non-dispatchable work items return structured error JSON
+  - Existing happy-path test (`test_long_running_creates_callback_task`) still passes
+  - Existing missing-work-item test still passes
+
+- [x] **Unit 2: Auto-transition pending work items to `in_progress` on dispatch**
+
+  **Goal:** Close the TOCTOU window where two dispatches to a `pending` work item both pass the guard by auto-transitioning to `in_progress` before creating the callback task.
+
+  **Requirements:** R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/skills/executor.rs`
+  - Test: `crates/mika-agent/src/skills/executor.rs` (inline tests)
+
+  **Approach:**
+  - After the dispatch-readiness validation passes and before creating the callback `NewTask`, check if the work item status is `pending`
+  - If `pending`, call `ctx.db.update_manual_task_status(work_item_id, "in_progress")` to transition atomically (two-arg async wrapper; `agent_id` is injected internally)
+  - Log the auto-transition at `info` level with the work_item_id
+  - If the status update fails (e.g., concurrent modification), continue anyway — the callback child creation provides the secondary guard
+
+  **Patterns to follow:**
+  - `crates/mika-agent/src/tools/update_work_item_status.rs` — status transition via `update_manual_task_status`
+  - `crates/mika-agent/src/skills/executor.rs:569` — existing code between validation and callback creation
+
+  **Test scenarios:**
+  - Happy path: dispatch with `pending` work item → work item transitions to `in_progress` before callback creation; verify status via `db.get_task()`
+  - Happy path: dispatch with `in_progress` work item → no status change attempted
+  - Integration: two sequential dispatches to same `pending` work item → first succeeds and transitions to `in_progress`; second is rejected by active-child check (callback task from first dispatch exists)
+
+  **Verification:**
+  - Work item is `in_progress` after successful dispatch regardless of initial status
+  - Double-dispatch to a `pending` work item is prevented by the combination of auto-transition and active-child detection
+
+- [x] **Unit 3: Integration test — replay the #522 race scenario**
+
+  **Goal:** Prove the guard prevents the exact failure mode from the PR #522 incident: dispatching claude-pilot on a work item that already has an active session.
+
+  **Requirements:** R6
+
+  **Dependencies:** Unit 1, Unit 2
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/skills/executor.rs` (inline tests)
+
+  **Approach:**
+  - Create a work item in `in_progress` status
+  - Create a callback child task with `trigger_type=callback` and `status=pending` (simulating an active claude-pilot session)
+  - Optionally set `metadata` with `claude_pilot.pr_url` to simulate the PR-open state
+  - Call `execute_skill_tool()` with the same `work_item_id`
+  - Assert `is_error == true` and content contains `work_item_active_dispatch`
+  - Assert no new callback task was created (count tasks before and after)
+
+  **Patterns to follow:**
+  - `crates/mika-agent/src/skills/executor.rs:1417` — `test_long_running_creates_callback_task` pattern for setting up work items and invoking `execute_skill_tool`
+
+  **Test scenarios:**
+  - Integration: work item `in_progress` with active callback child + PR URL in metadata → dispatch rejected with structured error containing `pr_url`
+  - Integration: work item `in_progress` with active callback child, no metadata → dispatch rejected, `pr_url` is null in error
+  - Integration: after the active callback child transitions to `completed`, a retry dispatch succeeds
+
+  **Verification:**
+  - The exact PR #522 failure mode is prevented
+  - No subprocess is spawned when the guard rejects
+  - Retry after child completion works correctly
+
+## System-Wide Impact
+
+- **Interaction graph:** `execute_long_running()` is the shared entry point for all long-running exec-handler skills. The guard affects `run_claude_pilot` and any future long-running tools. `delegate_task` is unaffected (uses `validate_work_item()` directly, not `execute_long_running()`).
+- **Error propagation:** Structured JSON errors propagate to the LLM as `ToolOutput::error()`. The LLM sees the error in the tool result and should adjust behavior accordingly.
+- **State lifecycle risks:** The auto-transition from `pending` to `in_progress` is a side effect of dispatch. If dispatch fails after the transition (e.g., subprocess spawn failure), the work item remains `in_progress` — this is acceptable because the agent would naturally notice and handle it.
+- **API surface parity:** No other interfaces dispatch long-running tools. The HTTP server's `/tasks/{id}/complete` endpoint is for callback completion, not dispatch.
+- **Unchanged invariants:** `validate_work_item()` in `tools/mod.rs` is unchanged. `delegate_task` behavior is unchanged. The `Task` struct, DB schema, and status constants are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Modifying `execute_long_running()` could break existing long-running skill dispatches | Existing tests (`test_long_running_creates_callback_task`, `test_long_running_missing_work_item_id`) serve as regression guards; run full test suite |
+| Auto-transition side effect changes work item lifecycle | Aligns with expected behavior — dispatching work naturally means it's "in progress." The `update_work_item_status` tool already validates transitions. |
+| `get_child_tasks()` performance on work items with many children | Bounded in practice — work items rarely have more than a handful of children. Deferred index optimization to separate task. |
+
+## Sources & References
+
+- Related issue: #525
+- Related PR incident: #522 (stuck for 7 hours due to redundant dispatch)
+- Companion ticket: #524 (structural verdict handler — webhook side)
+- Compound doc: `docs/solutions/architecture-patterns/structural-verdict-handler-pr-review-auto-merge.md`
+- Delegation guard pattern: `docs/solutions/architecture-patterns/delegation-work-item-guard-enforcement.md`

--- a/docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md
+++ b/docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md
@@ -1,0 +1,82 @@
+---
+title: "Dispatch-Readiness Guard: Status Validation Before Long-Running Dispatch"
+date: 2026-04-13
+category: architecture-patterns
+module: mika-agent (skills/executor.rs)
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Redundant claude-pilot session dispatched on work item already in in_progress with open PR"
+  - "Fabricated UUID passed to run_claude_pilot returned soft error but did not prevent retry with real ID"
+  - "LLM ignored create_work_item advisory about existing work item status"
+root_cause: missing_validation
+resolution_type: code_fix
+severity: high
+tags:
+  - dispatch-guard
+  - work-item-status
+  - long-running
+  - double-dispatch
+  - code-guard
+  - defense-in-depth
+  - executor
+related_issues:
+  - "#525"
+  - "#522"
+  - "#524"
+---
+
+# Dispatch-Readiness Guard: Status Validation Before Long-Running Dispatch
+
+## Problem
+
+`execute_long_running()` in `skills/executor.rs` dispatched long-running subprocess (claude-pilot) sessions without validating whether the work item was in a dispatchable state. On 2026-04-11, mika-dev dispatched a redundant claude-pilot session on a work item that was already `in_progress` with PR #522 open, QA-approved, and CI green. The redundant session burned ~$0.18 and contributed to a 7-hour desync where the PR sat unmerged.
+
+## Symptoms
+
+- `run_claude_pilot` accepted a fabricated UUID, returned "Work item not found", and the LLM retried with the correct task_id
+- `create_work_item` returned a soft advisory "Work item already exists... Status: in_pr" but the LLM ignored it
+- A second claude-pilot session ran against a work item that already had an active callback child task
+
+## What Didn't Work
+
+- **Prompt-level enforcement**: The system prompt instructed the agent not to re-dispatch work items in terminal states, but the LLM ignored this during recovery from a misclassified webhook
+- **Soft advisory from `create_work_item`**: The dedup return string included the status, but the LLM treated it as informational rather than blocking
+- **Existing `validate_work_item()` check**: Already in place but too permissive — accepts `blocked` status (needed for `delegate_task`) and does not check for active child tasks
+
+## Solution
+
+Added `validate_dispatch_readiness()` as a stricter second-pass validation in `execute_long_running()`, after the existing `validate_work_item()` call. The new guard enforces two checks:
+
+1. **Status check**: Only `pending` and `in_progress` are dispatchable. `blocked`, `completed`, and `cancelled` are rejected with structured JSON error (`work_item_not_dispatchable`).
+2. **Active-child check**: Queries `get_child_tasks(work_item_id)` and filters for `trigger_type == "callback" && status IN (pending, in_progress)`. If any active callback child exists, dispatch is rejected with `work_item_active_dispatch` error.
+
+Additionally, `pending` work items are auto-transitioned to `in_progress` before creating the callback task, closing the TOCTOU window for sequential double-dispatch.
+
+Key design decisions:
+- **Separate from `validate_work_item()`**: The shared helper is co-consumed by `delegate_task` which intentionally allows `blocked`. Modifying it would change delegation behavior.
+- **Structured JSON errors**: Error responses include `error`, `task_id`, `current_status`, `pr_url`, and `reason` fields for programmatic LLM feedback.
+- **Fail-closed on DB errors**: If `get_child_tasks()` fails, dispatch is rejected rather than silently proceeding.
+- **`Result<String, String>` return type**: Returns the work item status on success, eliminating a redundant DB read in the auto-transition logic.
+
+## Why This Works
+
+The root cause was that dispatch-readiness was delegated entirely to LLM judgment. The LLM can hallucinate UUIDs, ignore advisory strings, and improvise during recovery from misclassified webhooks. The tool boundary is the only enforcement point that cannot be talked around.
+
+The guard follows the established pattern from the completion-claim guard (#483) and delegation work-item guard: "If the agent ignoring an instruction would cause real harm, enforce it in the harness."
+
+## Prevention
+
+- **Code guards over prompt instructions** for any action with real resource cost (subprocess spawn, API calls, state mutations). Prompt-level enforcement is defense-in-depth, not primary.
+- **Active-child detection** prevents double-dispatch even when the work item status looks correct (`in_progress` is valid but may already have an active session).
+- **Auto-transition on dispatch** ensures `pending` items cannot be double-dispatched via the TOCTOU window between status check and callback creation.
+- **Structured JSON errors** give the LLM programmatic feedback to adjust behavior, rather than relying on string parsing of plain-text errors.
+
+## Related Issues
+
+- [#525](https://github.com/senara-solutions/mika/issues/525) — This issue
+- [#522](https://github.com/senara-solutions/mika/pull/522) — The stuck PR incident that triggered this work
+- [#524](https://github.com/senara-solutions/mika/issues/524) — Companion: structural verdict handler (webhook side)
+- [Delegation work item guard](delegation-work-item-guard-enforcement.md) — The original code-guard pattern this builds on
+- [Completion-claim guard](completion-claim-guard-work-item-state-enforcement.md) — Post-condition guard pattern for fabricated claims
+- [Callback task loop prevention](callback-task-loop-prevention.md) — Related: prevents callback turns from spawning new long-running tasks


### PR DESCRIPTION
## Summary

- Add `validate_dispatch_readiness()` guard in `execute_long_running()` that enforces work item status (`pending`/`in_progress` only) and detects active callback children before spawning long-running subprocesses
- Auto-transition `pending` work items to `in_progress` on successful dispatch to close TOCTOU double-dispatch window
- Return structured JSON errors (`work_item_not_dispatchable`, `work_item_active_dispatch`) for programmatic LLM feedback
- 18 new tests including PR #522 race scenario replay

## Context

On 2026-04-11, mika-dev dispatched a redundant claude-pilot session on a work item already `in_progress` with PR #522 open and approved. The tool boundary had no validation — it relied on LLM judgment which failed under a misclassified webhook + hallucinated UUID recovery scenario.

## Design Decisions

- **Separate from `validate_work_item()`**: The shared helper allows `blocked` for `delegate_task`. A new `validate_dispatch_readiness()` adds stricter checks without changing delegation behavior.
- **Fail-closed**: DB errors in child-task queries reject dispatch rather than silently proceeding.
- **`Result<String, String>` return**: Threads task status to the auto-transition, eliminating a redundant DB read.

Closes #525
Companion: #524 (structural verdict handler — webhook side)

## Test plan

- [x] All 58 executor tests pass (18 new + 40 existing)
- [x] Rejection tests: blocked, completed, cancelled statuses
- [x] Rejection tests: fabricated UUID, empty task_id
- [x] Active-child detection: pending callback, in_progress callback, mixed children
- [x] Non-blocking: completed/failed/cancelled/non-callback children don't block
- [x] Auto-transition: pending→in_progress on dispatch
- [x] PR #522 replay: with/without metadata, retry after completion
- [x] Double-dispatch: sequential dispatches to pending item
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)