### PR TITLE
fix(investigate): handle empty LLM response and fix lock race

### DIFF
--- a/crates/mika-agent/src/server/investigate.rs
+++ b/crates/mika-agent/src/server/investigate.rs
@@ -765,6 +765,8 @@ async fn run_investigation(
         model_name: llm.model_name(),
     };
 
+    let mut text_sent = false;
+
     for _step in 0..MAX_INVESTIGATION_STEPS {
         let request = LlmRequest {
             model: llm.model_name().to_string(),
@@ -802,6 +804,15 @@ async fn run_investigation(
                 }
             };
 
+        // Warn on empty LLM response (0 output tokens)
+        if response.content.is_empty() {
+            tracing::warn!(
+                provider = llm.provider_name(),
+                model = llm.model_name(),
+                "investigation LLM returned empty response (0 output tokens)"
+            );
+        }
+
         // Collect text and tool_use blocks
         let mut text_parts = Vec::new();
         let mut tool_uses = Vec::new();
@@ -824,16 +835,28 @@ async fn run_investigation(
         // Send any text as a delta
         if !text_parts.is_empty() {
             let full_text = text_parts.join("");
-            if send_event(&tx, InvestigateEvent::TextDelta { text: full_text })
-                .await
-                .is_err()
-            {
-                return; // Client disconnected
+            if !full_text.is_empty() {
+                text_sent = true;
+                if send_event(&tx, InvestigateEvent::TextDelta { text: full_text })
+                    .await
+                    .is_err()
+                {
+                    return; // Client disconnected
+                }
             }
         }
 
         // If stop_reason is end_turn (no tool calls), we're done
         if response.stop_reason == LlmStopReason::EndTurn || tool_uses.is_empty() {
+            if !text_sent {
+                let _ = send_event(
+                    &tx,
+                    InvestigateEvent::TextDelta {
+                        text: "[The model did not generate a response after using tools. This can happen with some LLM providers. Try asking again or check the agent's LLM configuration.]".to_string(),
+                    },
+                )
+                .await;
+            }
             let _ = send_event(&tx, InvestigateEvent::Done {}).await;
             return;
         }
@@ -997,13 +1020,20 @@ pub async fn handle_investigate(
     }
 
     // --- Acquire investigation lock (non-blocking) ---
-    if state.investigation_lock.try_lock().is_err() {
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(serde_json::json!({"error": "another investigation is already running"})),
-        )
-            .into_response());
-    }
+    // Use try_lock_owned() so the OwnedMutexGuard can move into the spawned
+    // task without a gap — prevents the race where try_lock() would drop the
+    // guard immediately and another request slips through before the spawned
+    // task re-acquires.
+    let investigation_guard = match state.investigation_lock.clone().try_lock_owned() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return Err((
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(serde_json::json!({"error": "another investigation is already running"})),
+            )
+                .into_response());
+        }
+    };
 
     // --- Check GitHub tool availability ---
     let has_github =
@@ -1081,15 +1111,15 @@ pub async fn handle_investigate(
         .clone();
     let db = state.dashboard_db.clone();
     let agents = state.agents.clone();
-    let lock = state.investigation_lock.clone();
     let investigation_session_id = message.session_id.clone();
     let investigation_trace_id = message.trace_id.clone().unwrap_or_default();
 
     info!(message_id = req.message_id, "starting investigation");
 
     tokio::spawn(async move {
-        // Hold the lock for the entire investigation duration
-        let _guard = lock.lock().await;
+        // Guard was acquired in the handler via try_lock_owned() and moved here
+        // — no gap between the check and the hold.
+        let _guard = investigation_guard;
         let _agents = agents; // keep alive for the duration
         run_investigation(
             llm.as_ref(),

--- a/dashboard/src/components/InvestigationPanel.tsx
+++ b/dashboard/src/components/InvestigationPanel.tsx
@@ -99,10 +99,12 @@ export default function InvestigationPanel({
 
       // Add user message using functional update to avoid stale closure
       const userMsg: ChatMessage = { role: 'user', content: question }
-      // Capture history from ref before state update
+      // Capture history from ref before state update.
+      // Filter out the '...' placeholder that gets set when tools run but no
+      // text response arrives — sending it as history confuses follow-up LLM calls.
       const history = messagesRef.current.map((m) => ({
         role: m.role,
-        content: m.content,
+        content: m.content === '...' ? '' : m.content,
       }))
       setMessages((prev) => [...prev, userMsg])
       setInput('')

--- a/docs/plans/2026-04-13-001-fix-investigation-panel-empty-response-and-lock-race-plan.md
+++ b/docs/plans/2026-04-13-001-fix-investigation-panel-empty-response-and-lock-race-plan.md
@@ -1,0 +1,106 @@
+---
+title: "fix: investigation panel — empty response handling and lock race"
+type: fix
+status: active
+date: 2026-04-13
+---
+
+# fix: investigation panel — empty response handling and lock race
+
+## Problem Statement
+
+The investigation panel is broken: tools execute successfully (green checkmarks) but no text response appears. Follow-up questions also produce no response. Server logs confirm the root cause: `qwen/qwen3-coder-next` via OpenRouter returns **0 output tokens** with `stop_reason: EndTurn` after processing tool results. The backend sends `Done` without ever sending a `TextDelta`, leaving the user with no feedback.
+
+Two additional bugs compound the issue:
+1. The investigation lock race allows concurrent investigations through a `try_lock()`/`lock()` gap
+2. The frontend sends `'...'` placeholder text as history content for follow-up questions
+
+## Evidence
+
+Server logs from 2026-04-12T15:23:
+
+```
+15:23:14 → LLM call #1: 80 tokens, stop_reason=ToolUse   (tools dispatched)
+15:23:24 → LLM call #2: 37 tokens, stop_reason=ToolUse   (more tools)
+15:23:33 → LLM call #3: 0 tokens, stop_reason=EndTurn    ← EMPTY
+15:24:15 → "allo ?" follow-up: 0 tokens, stop_reason=EndTurn ← EMPTY again
+```
+
+## Proposed Solution
+
+### Bug 1: Empty LLM response (backend)
+
+**File:** `crates/mika-agent/src/server/investigate.rs`
+
+Track whether any `TextDelta` was sent during the investigation. After the loop ends (either by EndTurn, empty tool_uses, or max steps), if no text was emitted, send a fallback `TextDelta`:
+
+```rust
+let mut text_sent = false;
+
+// In the text sending block (~line 825):
+if !text_parts.is_empty() {
+    text_sent = true;
+    // ... send TextDelta
+}
+
+// After the loop, before the max-steps fallback (~line 910):
+if !text_sent {
+    let _ = send_event(&tx, InvestigateEvent::TextDelta {
+        text: "\n\n[The model did not generate a response after using tools. This can happen with some providers. Try asking again or check the agent's LLM configuration.]".to_string(),
+    }).await;
+}
+```
+
+Also add a `warn!` log when the LLM returns 0 output tokens.
+
+### Bug 2: Investigation lock race (backend)
+
+**File:** `crates/mika-agent/src/server/investigate.rs`
+
+Replace the broken `try_lock()` + spawned `lock()` pattern with `try_lock_owned()` that moves the `OwnedMutexGuard` into the spawned task:
+
+```rust
+// Before (broken):
+if state.investigation_lock.try_lock().is_err() { return 429; }
+// ...
+tokio::spawn(async move {
+    let _guard = lock.lock().await;  // race window!
+    run_investigation(...).await;
+});
+
+// After (correct):
+let guard = match state.investigation_lock.clone().try_lock_owned() {
+    Ok(g) => g,
+    Err(_) => return 429,
+};
+// ...
+tokio::spawn(async move {
+    let _guard = guard;  // no gap — guard moves directly
+    run_investigation(...).await;
+});
+```
+
+Remove the separate `lock` variable and the `lock.lock().await` in the spawned task.
+
+### Bug 3: History placeholder leak (frontend)
+
+**File:** `dashboard/src/components/InvestigationPanel.tsx`
+
+When sending history for follow-up questions, filter out the `'...'` placeholder:
+
+```typescript
+const history = messagesRef.current.map((m) => ({
+    role: m.role,
+    content: m.content === '...' ? '' : m.content,
+}))
+```
+
+## Acceptance Criteria
+
+- [ ] When the LLM returns 0 tokens after tool use, the user sees a fallback message explaining the model didn't respond
+- [ ] A `warn!` log is emitted when the LLM returns 0 output tokens during investigation
+- [ ] Concurrent investigation requests are properly rejected with 429 (no race window)
+- [ ] Follow-up questions don't send `'...'` as assistant content in history
+- [ ] Existing investigation functionality (text responses, tool badges, error handling) continues to work
+- [ ] `cargo test` passes
+- [ ] `cargo clippy` passes

--- a/docs/solutions/dashboard-issues/investigation-panel-empty-response-and-lock-race.md
+++ b/docs/solutions/dashboard-issues/investigation-panel-empty-response-and-lock-race.md
@@ -1,0 +1,88 @@
+---
+title: "Investigation panel — empty LLM response and lock race"
+category: dashboard-issues
+date: 2026-04-13
+tags: [investigation-panel, sse, llm-provider, concurrency, openrouter, qwen]
+---
+
+# Investigation Panel — Empty LLM Response and Lock Race
+
+## Problem
+
+The investigation panel showed tool badges (query_messages ✓, query_audit_events ✓) but no text response. Follow-up questions also produced no response. The panel appeared completely broken.
+
+## Root Cause
+
+**Three independent bugs:**
+
+1. **Empty LLM response (primary):** The default agent's LLM (`qwen/qwen3-coder-next` via OpenRouter) returned **0 output tokens** with `stop_reason: EndTurn` after processing tool results. Server logs confirmed:
+   ```
+   llm_call completed  input_tokens=7887  output_tokens=0  stop_reason=EndTurn
+   ```
+   The backend sent `Done` without ever sending a `TextDelta`, leaving the frontend with tool badges but no answer. This is a provider-specific behavior — some models return empty content after tool results.
+
+2. **Investigation lock race:** The handler used `try_lock()` (which acquires and immediately drops the guard) then the spawned task used `lock().await` to re-acquire. Between these two, concurrent requests could slip through. Server logs showed duplicate "starting investigation" entries at the same timestamp confirming the race (though these turned out to be duplicate logging from stdout + log file both going to the same path).
+
+3. **History placeholder leak:** When tools ran but no text arrived, the frontend set assistant content to `'...'` as a placeholder. Follow-up questions sent this `'...'` as the assistant's response in the conversation history, confusing the LLM.
+
+## Solution
+
+### Empty response fallback (investigate.rs)
+
+Track whether any `TextDelta` was sent during the investigation loop. When the loop exits without sending text (EndTurn with 0 tokens), send a user-visible fallback message:
+
+```rust
+let mut text_sent = false;
+
+// In text sending block:
+if !full_text.is_empty() {
+    text_sent = true;
+    send_event(&tx, InvestigateEvent::TextDelta { text: full_text }).await;
+}
+
+// At EndTurn exit:
+if !text_sent {
+    send_event(&tx, InvestigateEvent::TextDelta {
+        text: "[The model did not generate a response...]".to_string(),
+    }).await;
+}
+```
+
+Also added `warn!` log when `response.content.is_empty()` for diagnostics.
+
+### Lock race fix (investigate.rs)
+
+Replaced `try_lock()` + spawned `lock()` with `try_lock_owned()` that moves the `OwnedMutexGuard` into the spawned task with no gap:
+
+```rust
+// Before (broken — guard drops immediately):
+if state.investigation_lock.try_lock().is_err() { return 429; }
+tokio::spawn(async move { let _guard = lock.lock().await; ... });
+
+// After (correct — guard transfers directly):
+let guard = state.investigation_lock.clone().try_lock_owned()?;
+tokio::spawn(async move { let _guard = guard; ... });
+```
+
+### History placeholder (InvestigationPanel.tsx)
+
+Filter `'...'` from history content before sending follow-up requests:
+
+```typescript
+content: m.content === '...' ? '' : m.content,
+```
+
+## Prevention
+
+- **Empty response handling:** Any agent loop that calls an LLM after tool execution should check for 0-token responses. The main agent loop already has `EMPTY_RESPONSE_FALLBACK` — the investigation loop was missing this pattern.
+- **Lock transfer pattern:** When a handler spawns an async task that needs exclusive access, always use `try_lock_owned()` to move the guard — never `try_lock()` followed by `lock()` in the spawn.
+- **Provider testing:** The investigation panel uses the default agent's LLM, which may be a non-Anthropic model. Test investigation with the actual configured provider, not just Claude.
+
+## Diagnostic checklist
+
+When the investigation panel shows no response:
+
+1. Check server logs for `output_tokens: 0` on investigation LLM calls
+2. Check which model/provider the default agent uses
+3. Look for the new `warn!` log: "investigation LLM returned empty response"
+4. Check for duplicate "starting investigation" logs (lock race symptom)


### PR DESCRIPTION
## Summary

Fixes the investigation panel showing tool badges but no text response:

- **Empty response fallback**: When the LLM returns 0 output tokens after tool execution (observed with `qwen/qwen3-coder-next` via OpenRouter), a user-visible fallback message is now displayed instead of silently ending. A `warn!` log is emitted for diagnostics.
- **Lock race fix**: Replaced `try_lock()` + spawned `lock()` pattern with `try_lock_owned()` that moves the `OwnedMutexGuard` directly into the spawned task — eliminates the window where concurrent requests could bypass the 429 guard.
- **History placeholder fix**: Filters out `'...'` placeholder content from follow-up question history so the LLM doesn't receive nonsensical assistant turns.

## Root cause

Server logs showed the investigation model returning **0 output tokens** with `EndTurn` after processing tool results. The backend sent `Done` without ever sending a `TextDelta`, leaving the user with tool badges but no answer. Follow-up questions also got 0-token responses.

## Test plan

- [ ] Verify investigation with a model that supports tool use shows normal text responses
- [ ] Verify investigation with a model that returns empty responses shows the fallback message
- [ ] Verify concurrent investigation requests are properly rejected with 429
- [ ] Verify follow-up questions don't send '...' as history content
- [ ] `cargo clippy` and `cargo test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)