### PR TITLE
fix(skills): canonicalize both paths in handler symlink containment check

### DIFF
--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -769,9 +769,12 @@ pub fn validate_skill(skill_dir: &Path) -> Vec<SkillDiagnostic> {
                                                     cmd_path.display()
                                                 )));
                                             } else {
-                                                // Symlink containment check
-                                                if let Ok(canonical) = cmd_path.canonicalize()
-                                                    && !canonical.starts_with(skill_dir)
+                                                // Symlink containment check — canonicalize both
+                                                // paths so symlinked skills don't false-positive (#526)
+                                                if let (Ok(canonical_cmd), Ok(canonical_dir)) = (
+                                                    cmd_path.canonicalize(),
+                                                    skill_dir.canonicalize(),
+                                                ) && !canonical_cmd.starts_with(&canonical_dir)
                                                 {
                                                     diags.push(SkillDiagnostic::warn(format!(
                                                         "tool '{}': handler command '{}' resolves outside skill directory",
@@ -4728,5 +4731,179 @@ mod tests {
         let resolved = entry.resolve_prompt("anthropic", "claude-sonnet-4-6");
         assert_eq!(resolved.text, "Hand.");
         assert_eq!(resolved.source, PromptVariantSource::HandAuthoredModel);
+    }
+
+    // -- symlink containment check tests (#526) --
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_skill_symlinked_handler_no_false_positive() {
+        use std::os::unix::fs as unix_fs;
+
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Source skill directory with handler
+        let source_dir = tmp.path().join("source-skill");
+        let handlers_dir = source_dir.join("handlers");
+        fs::create_dir_all(&handlers_dir).unwrap();
+        fs::write(
+            source_dir.join("skill.toml"),
+            r#"
+            [skill]
+            name = "my-skill"
+            description = "Test skill"
+            "#,
+        )
+        .unwrap();
+        fs::write(source_dir.join("system_prompt.md"), "Do stuff").unwrap();
+        let handler_path = handlers_dir.join("do_stuff.sh");
+        fs::write(&handler_path, "#!/bin/sh\necho ok").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&handler_path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        // tools.json referencing the handler
+        fs::write(
+            source_dir.join("tools.json"),
+            r#"[{
+                "name": "do_stuff",
+                "description": "does stuff",
+                "input_schema": {"type": "object", "properties": {}},
+                "handler": {"type": "exec", "command": "handlers/do_stuff.sh"}
+            }]"#,
+        )
+        .unwrap();
+
+        // Agent home with symlink to source skill
+        let agent_skills = tmp.path().join("agent-home/skills");
+        fs::create_dir_all(&agent_skills).unwrap();
+        let linked_skill = agent_skills.join("my-skill");
+        unix_fs::symlink(&source_dir, &linked_skill).unwrap();
+
+        // Validate via the symlink path
+        let diags = validate_skill(&linked_skill);
+        let outside_warn = diags.iter().find(|d| {
+            d.level == DiagnosticLevel::Warn
+                && d.message.contains("resolves outside skill directory")
+        });
+        assert!(
+            outside_warn.is_none(),
+            "Symlinked skill should NOT produce 'resolves outside' warning. Got: {diags:?}"
+        );
+        // Should still have the OK diagnostic for the handler
+        let ok_handler = diags
+            .iter()
+            .find(|d| d.level == DiagnosticLevel::Ok && d.message.contains("handler command OK"));
+        assert!(
+            ok_handler.is_some(),
+            "Expected OK handler diagnostic. Got: {diags:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_skill_handler_escape_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("escape-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+
+        // Create the escape target OUTSIDE the skill dir
+        let escape_script = tmp.path().join("escapeme.sh");
+        fs::write(&escape_script, "#!/bin/sh\necho pwned").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&escape_script, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        fs::write(
+            skill_dir.join("skill.toml"),
+            r#"
+            [skill]
+            name = "escape-skill"
+            description = "Tries to escape"
+            "#,
+        )
+        .unwrap();
+        fs::write(skill_dir.join("system_prompt.md"), "Escape").unwrap();
+        fs::write(
+            skill_dir.join("tools.json"),
+            r#"[{
+                "name": "bad_tool",
+                "description": "escapes",
+                "input_schema": {"type": "object", "properties": {}},
+                "handler": {"type": "exec", "command": "../escapeme.sh"}
+            }]"#,
+        )
+        .unwrap();
+
+        let diags = validate_skill(&skill_dir);
+        let outside_warn = diags.iter().find(|d| {
+            d.level == DiagnosticLevel::Warn
+                && d.message.contains("resolves outside skill directory")
+        });
+        assert!(
+            outside_warn.is_some(),
+            "Handler escaping via ../ should produce 'resolves outside' warning. Got: {diags:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_skill_symlinked_handler_pointing_outside_warns() {
+        use std::os::unix::fs as unix_fs;
+
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Source skill directory
+        let source_dir = tmp.path().join("source-skill");
+        let handlers_dir = source_dir.join("handlers");
+        fs::create_dir_all(&handlers_dir).unwrap();
+        fs::write(
+            source_dir.join("skill.toml"),
+            r#"
+            [skill]
+            name = "my-skill"
+            description = "Test skill"
+            "#,
+        )
+        .unwrap();
+        fs::write(source_dir.join("system_prompt.md"), "Do stuff").unwrap();
+
+        // External script outside the skill directory
+        let external_script = tmp.path().join("external.sh");
+        fs::write(&external_script, "#!/bin/sh\necho external").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&external_script, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        // Handler is a symlink pointing outside the skill dir
+        unix_fs::symlink(&external_script, handlers_dir.join("sneaky.sh")).unwrap();
+
+        fs::write(
+            source_dir.join("tools.json"),
+            r#"[{
+                "name": "sneaky",
+                "description": "sneaky handler",
+                "input_schema": {"type": "object", "properties": {}},
+                "handler": {"type": "exec", "command": "handlers/sneaky.sh"}
+            }]"#,
+        )
+        .unwrap();
+
+        // Validate the source directory directly (no skill-level symlink)
+        let diags = validate_skill(&source_dir);
+        let outside_warn = diags.iter().find(|d| {
+            d.level == DiagnosticLevel::Warn
+                && d.message.contains("resolves outside skill directory")
+        });
+        assert!(
+            outside_warn.is_some(),
+            "Handler symlink pointing outside skill dir should warn. Got: {diags:?}"
+        );
     }
 }

--- a/docs/plans/2026-04-13-005-fix-skills-validator-handler-path-canonicalization-plan.md
+++ b/docs/plans/2026-04-13-005-fix-skills-validator-handler-path-canonicalization-plan.md
@@ -1,0 +1,95 @@
+---
+title: "fix: Canonicalize both paths in handler symlink containment check"
+type: fix
+status: active
+date: 2026-04-13
+---
+
+# fix: Canonicalize both paths in handler symlink containment check
+
+## Overview
+
+The skills validator's symlink containment check produces false-positive "resolves outside skill directory" warnings for every exec handler in symlinked skills. The fix is to canonicalize both the handler path and the skill directory before comparing them.
+
+## Problem Frame
+
+When a skill is installed via `--link` (symlink), the skill directory inside the agent home (e.g., `~/.mika/agents/mika-qa/skills/qa-review`) is a symlink pointing to the source directory (e.g., `mika-skills/qa-review`). The validator canonicalizes the handler command path (which resolves the symlink), but compares against the non-canonical skill directory. Since the canonical handler path is under the symlink target while the skill directory is the symlink source, `starts_with()` always fails — producing a warning for every handler in every linked skill.
+
+This erodes operator trust in validator output and discourages use of `--link` mode for active skill development.
+
+## Requirements Trace
+
+- R1. Symlinked skills with handlers inside the skill directory must not produce false-positive "resolves outside" warnings
+- R2. Handlers that genuinely escape the skill directory (e.g., `../escapeme.sh`) must still produce warnings
+- R3. Unit tests cover both the symlink false-positive case and the genuine-escape case
+
+## Scope Boundaries
+
+- Only the symlink containment check in `validate_skill()` is affected
+- No changes to skill installation, loading, or execution logic
+- No changes to `validate_and_resolve_path()` in `tools/mod.rs` (different purpose)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/skills/index.rs:773-774` — the bug: `cmd_path.canonicalize()` compared against non-canonical `skill_dir`
+- `crates/mika-agent/src/skills/index.rs:637` — `validate_skill(skill_dir: &Path)` function signature
+- Existing test pattern: `tempfile::tempdir()` + filesystem setup + call `validate_skill()` + assert on diagnostics
+
+## Key Technical Decisions
+
+- **Canonicalize `skill_dir` alongside `cmd_path`:** Both paths go through `canonicalize()` so symlinks on either side are resolved consistently. If either canonicalization fails, the check is silently skipped (existing behavior for `cmd_path`; extending to `skill_dir` is consistent).
+
+## Implementation Units
+
+- [x] **Unit 1: Fix canonicalization comparison**
+
+**Goal:** Canonicalize both `cmd_path` and `skill_dir` before the `starts_with()` comparison.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/index.rs`
+- Test: `crates/mika-agent/src/skills/index.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Change the `if let` at line 773 from canonicalizing only `cmd_path` to canonicalizing both paths:
+  ```
+  if let (Ok(canonical_cmd), Ok(canonical_dir)) = (cmd_path.canonicalize(), skill_dir.canonicalize())
+      && !canonical_cmd.starts_with(&canonical_dir)
+  ```
+- No other code changes needed — the warning message and diagnostic level remain the same.
+
+**Patterns to follow:**
+- Existing `if let Ok(canonical) = ...` pattern at the same site
+- Existing test patterns using `tempfile::tempdir()` and `validate_skill()`
+
+**Test scenarios:**
+- Happy path: symlinked skill with handler inside — `tmpdir/source/handlers/h.sh` + symlink `tmpdir/agent/skills/my-skill -> tmpdir/source` — call `validate_skill()` on the symlink path, assert zero "resolves outside" warnings
+- Happy path: non-symlinked skill with handler inside — no warnings
+- Error path: handler escaping via `../escapeme.sh` — assert warning is produced
+- Edge case: symlinked skill where handler itself is a symlink pointing outside the skill — assert warning is produced
+
+**Verification:**
+- `cargo test -p mika-agent -- test_validate_skill_symlinked_handler` passes
+- `cargo test -p mika-agent -- test_validate_skill_handler_escape` passes
+- `cargo clippy -p mika-agent` clean
+
+## System-Wide Impact
+
+- **Interaction graph:** None — `validate_skill()` is a pure diagnostic function with no side effects
+- **Error propagation:** Warnings are collected in `Vec<SkillDiagnostic>` and displayed; no change to propagation
+- **Unchanged invariants:** Startup validation (`SkillRegistry::validate_loaded()`) and `is_skip_worthy_failure()` classification are unaffected — they only act on `Fail` diagnostics, not `Warn`
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `canonicalize()` on `skill_dir` could fail for non-existent paths | Both canonicalizations are in a single `if let` tuple — if either fails, the entire check is skipped (safe default) |
+
+## Sources & References
+
+- Related issue: #526

--- a/docs/solutions/logic-errors/skills-validator-symlink-handler-path-false-positive.md
+++ b/docs/solutions/logic-errors/skills-validator-symlink-handler-path-false-positive.md
@@ -1,0 +1,74 @@
+---
+title: Skills validator handler-path canonicalization false positive on symlinked skills
+date: 2026-04-13
+category: logic-errors
+module: mika-agent/skills
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "validate_skill() emits 'handler command resolves outside skill directory' warning for every exec handler in symlinked skills"
+  - "mika skills validate produces spurious warnings when skill is installed via --link"
+root_cause: logic_error
+resolution_type: code_fix
+severity: low
+tags:
+  - skills-validator
+  - symlink
+  - canonicalize
+  - false-positive
+  - handler-path
+  - link-mode
+---
+
+# Skills validator handler-path canonicalization false positive on symlinked skills
+
+## Problem
+
+`mika --agent <name> skills validate <skill>` produced false-positive "resolves outside skill directory" warnings for every exec handler when the skill was installed via symlink (`mika skills install <path> --link`). The warnings eroded operator trust in validator output and discouraged use of `--link` mode for active skill development.
+
+## Symptoms
+
+- Every exec handler in a `--link`-installed skill triggered: `[WARN] tool '<name>': handler command '<path>' resolves outside skill directory`
+- The handler files were actually inside the skill directory — no real escape
+- Non-symlinked skills validated cleanly
+
+## What Didn't Work
+
+The original containment check canonicalized only the handler command path (`cmd_path.canonicalize()`) but compared against the raw (non-canonical) skill directory. For symlinked skills, the canonical handler path landed in the symlink target (e.g., `mika-skills/qa-review/handlers/...`) while the skill directory was the symlink source (`~/.mika/agents/mika-qa/skills/qa-review`). The two paths could never share a prefix.
+
+## Solution
+
+Canonicalize **both** the handler path and the skill directory before comparison:
+
+```rust
+// Before — only cmd_path canonicalized:
+if let Ok(canonical) = cmd_path.canonicalize()
+    && !canonical.starts_with(skill_dir)
+
+// After — both paths canonicalized (#526):
+if let (Ok(canonical_cmd), Ok(canonical_dir)) = (
+    cmd_path.canonicalize(),
+    skill_dir.canonicalize(),
+) && !canonical_cmd.starts_with(&canonical_dir)
+```
+
+File: `crates/mika-agent/src/skills/index.rs`, inside the exec handler validation loop in `validate_skill()`.
+
+## Why This Works
+
+`Path::canonicalize()` resolves all symlinks, `.`, and `..` components, returning the absolute real path. When both sides are canonicalized, `starts_with()` compares real filesystem locations — the symlink indirection is transparent. Handlers genuinely inside the skill directory (even through symlinks) produce matching prefixes, while handlers that escape via `../` or external symlinks still fail the check.
+
+If either `canonicalize()` call fails (e.g., path deleted between existence check and canonicalization), the `if let` tuple match silently skips the check — consistent with the pre-existing fail-open behavior for `cmd_path.canonicalize()`.
+
+## Prevention
+
+- When comparing filesystem paths for containment, always canonicalize both sides. Raw path comparison breaks when either side involves symlinks.
+- The `--link` install mode is the recommended workflow for active skill development (per CLAUDE.md). Validator checks must work correctly for linked skills, not just copied ones.
+- Three unit tests now cover the containment check: symlinked skill (no false positive), handler escape via `../` (still warns), and handler symlink pointing outside (still warns).
+
+## Related Issues
+
+- Issue: #526
+- Related doc: `docs/solutions/integration-issues/is-legacy-format-false-positive-on-valid-skills.md` — prior false-positive in skill validator (different check)
+- Related doc: `docs/solutions/architecture-patterns/local-source-skills-install-link-mode.md` — `--link` mode implementation and canonicalization rules
+- Related doc: `docs/solutions/architecture-patterns/startup-skill-validation-structural-enforcement.md` — startup validation (#530) that surfaces these diagnostics


### PR DESCRIPTION
## Summary

- Fix false-positive "resolves outside skill directory" warnings in `validate_skill()` for symlinked skills (`--link` installs)
- Canonicalize both the handler command path **and** the skill directory before the `starts_with()` containment comparison
- Add 3 unit tests: symlinked skill (no false positive), handler escape via `../` (still warns), handler symlink pointing outside (still warns)

## Root Cause

The symlink containment check canonicalized only `cmd_path` but compared against the raw (non-canonical) `skill_dir`. For `--link` installed skills, the canonical handler path resolved to the symlink target while the skill directory remained the symlink source — the two paths could never share a prefix, so every handler triggered a false warning.

## Test Plan

- [x] `cargo test -p mika-agent -- test_validate_skill_symlinked_handler` — all 3 new tests pass
- [x] `cargo clippy -p mika-agent` — clean
- [x] `cargo fmt` — clean
- [ ] Manual: `mika skills install <path> --link` then `mika --agent <name> skills validate <skill>` produces clean output

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>