### PR TITLE
feat(gateway): route pull_request.closed webhook to mika-dev

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -17,7 +17,7 @@ Telegram and GitHub webhook router with Postgres customer registry. Handles text
 ## GitHub Webhook Integration
 
 HMAC-SHA256 signature validation via `X-Hub-Signature-256`. Event routing:
-- `issues.assigned` and `issue_comment.created` and `pull_request_review.submitted` and `check_suite.completed(failure)` -> mika-dev
+- `issues.assigned` and `issue_comment.created` and `pull_request_review.submitted` and `pull_request.closed` and `check_suite.completed(failure)` -> mika-dev
 - `pull_request.opened/synchronize` -> mika-qa
 - Delivery UUID dedup via 10k-entry LRU cache
 - 256KB body limit

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -103,6 +103,7 @@ pub struct GitHubPullRequest {
     pub html_url: Option<String>,
     pub body: Option<String>,
     pub head: Option<GitHubRef>,
+    pub merged: Option<bool>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -147,6 +148,7 @@ pub fn route_event(
         ("issues", Some("assigned")) => Some("mika-dev"),
         ("issue_comment", Some("created")) => Some("mika-dev"),
         ("pull_request", Some("opened" | "synchronize")) => Some("mika-qa"),
+        ("pull_request", Some("closed")) => Some("mika-dev"),
         ("pull_request_review", Some("submitted")) => Some("mika-dev"),
         ("check_suite", Some("completed")) => match check_conclusion {
             Some("failure" | "timed_out") => Some("mika-dev"),
@@ -233,6 +235,10 @@ pub fn format_event_text(event_type: &str, event: &GitHubWebhookEvent) -> String
             let mut text = format!(
                 "[GitHub] PR {action}: {repo_name}#{number} — {title} (branch: {branch})\n{url}"
             );
+            if action == "closed" {
+                let merged = pr.and_then(|p| p.merged).unwrap_or(false);
+                text.push_str(&format!("\nMerged: {merged}"));
+            }
             if !body.is_empty() {
                 text.push_str(&format!("\n\n{body}"));
             }
@@ -740,7 +746,10 @@ mod tests {
 
     #[test]
     fn test_route_event_pr_closed() {
-        assert_eq!(route_event("pull_request", Some("closed"), None), None);
+        assert_eq!(
+            route_event("pull_request", Some("closed"), None),
+            Some("mika-dev")
+        );
     }
 
     #[test]
@@ -838,6 +847,7 @@ mod tests {
                 head: Some(GitHubRef {
                     ref_name: Some("fix/bug".to_string()),
                 }),
+                merged: None,
             }),
             comment: None,
             review: None,

--- a/docs/plans/2026-04-13-008-feat-route-pr-closed-to-mika-dev-plan.md
+++ b/docs/plans/2026-04-13-008-feat-route-pr-closed-to-mika-dev-plan.md
@@ -1,0 +1,85 @@
+---
+title: "feat: Route pull_request.closed webhook to mika-dev"
+type: feat
+status: active
+date: 2026-04-13
+---
+
+# Route pull_request.closed webhook to mika-dev
+
+## Overview
+
+When mika-qa passes a PR and `pr_merge_with_gate` enables auto-merge, the PR eventually closes via GitHub's auto-merge. Currently `pull_request.closed` events are silently dropped by the gateway — mika-dev never learns the PR merged, so the work item stays `in_progress` forever.
+
+## Acceptance Criteria
+
+- [x] `route_event("pull_request", Some("closed"), None)` returns `Some("mika-dev")`
+- [x] `GitHubPullRequest` struct has `merged: Option<bool>` field
+- [x] `format_event_text` for `pull_request` closed action includes merged status
+- [x] Existing `test_route_event_pr_closed` updated to assert `Some("mika-dev")`
+- [x] All existing gateway tests pass (`cargo test -p mika-gateway`)
+
+## MVP
+
+### `crates/mika-gateway/src/github.rs` — route_event()
+
+Add `("pull_request", Some("closed"))` arm routing to `"mika-dev"`:
+
+```rust
+("pull_request", Some("opened" | "synchronize")) => Some("mika-qa"),
+("pull_request", Some("closed")) => Some("mika-dev"),  // NEW
+```
+
+### `crates/mika-gateway/src/github.rs` — GitHubPullRequest struct
+
+Add `merged` field:
+
+```rust
+pub struct GitHubPullRequest {
+    pub number: Option<u64>,
+    pub title: Option<String>,
+    pub html_url: Option<String>,
+    pub body: Option<String>,
+    pub head: Option<GitHubRef>,
+    pub merged: Option<bool>,  // NEW — true when PR was merged (vs closed without merge)
+}
+```
+
+### `crates/mika-gateway/src/github.rs` — format_event_text()
+
+In the `"pull_request"` match arm, append merged status when action is "closed":
+
+```rust
+"pull_request" => {
+    // ... existing code ...
+    let mut text = format!(
+        "[GitHub] PR {action}: {repo_name}#{number} — {title} (branch: {branch})\n{url}"
+    );
+    // NEW: include merged status for closed PRs
+    if action == "closed" {
+        let merged = pr.and_then(|p| p.merged).unwrap_or(false);
+        text.push_str(&format!("\nMerged: {merged}"));
+    }
+    // ... existing body append ...
+}
+```
+
+### `crates/mika-gateway/src/github.rs` — test
+
+Update existing test:
+
+```rust
+#[test]
+fn test_route_event_pr_closed() {
+    assert_eq!(
+        route_event("pull_request", Some("closed"), None),
+        Some("mika-dev")
+    );
+}
+```
+
+## Sources
+
+- Gateway webhook routing: `crates/mika-gateway/src/github.rs:141-157`
+- Format function: `crates/mika-gateway/src/github.rs:174-277`
+- Existing test: `crates/mika-gateway/src/github.rs:742-744`

--- a/docs/plans/2026-04-13-008-feat-route-pr-closed-to-mika-dev-plan.md
+++ b/docs/plans/2026-04-13-008-feat-route-pr-closed-to-mika-dev-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Route pull_request.closed webhook to mika-dev"
 type: feat
-status: active
+status: completed
 date: 2026-04-13
 ---
 

--- a/docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md
+++ b/docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md
@@ -1,0 +1,26 @@
+---
+title: Route pull_request.closed webhook to mika-dev
+category: integration-issues
+date: 2026-04-13
+tags: [gateway, webhook, github, auto-merge, work-item-lifecycle]
+---
+
+# Gateway drops pull_request.closed — work items stuck in_progress
+
+## Problem
+
+When mika-qa passes a PR and `pr_merge_with_gate` enables auto-merge, GitHub eventually closes the PR (merged: true) after CI passes. The gateway's `route_event()` had no arm for `pull_request.closed`, so the event was silently dropped. mika-dev never learned the PR merged and the work item stayed `in_progress` indefinitely.
+
+## Root Cause
+
+`route_event()` in `crates/mika-gateway/src/github.rs` only matched `opened | synchronize` for `pull_request` events — the `closed` action fell through to the `_ => None` catch-all.
+
+## Solution
+
+1. Added `("pull_request", Some("closed")) => Some("mika-dev")` to `route_event()`
+2. Added `merged: Option<bool>` to `GitHubPullRequest` struct (matches GitHub's payload)
+3. In `format_event_text()`, appended `Merged: true/false` line when action is `"closed"` so the downstream skill can distinguish merged vs. closed-without-merge
+
+## Prevention
+
+When adding new webhook event handling in the autonomous loop, trace the full lifecycle: event source (GitHub) -> gateway routing -> skill activation -> work item state transition. Any gap in this chain means state gets stuck.


### PR DESCRIPTION
## Summary

- Route `pull_request.closed` events to mika-dev so the autonomous loop can detect when GitHub auto-merge fires
- Add `merged: Option<bool>` to `GitHubPullRequest` struct and include merged status in formatted event text
- Enables mika-dev to complete work items after auto-merge instead of leaving them stuck in `in_progress`

## Changes

- `crates/mika-gateway/src/github.rs`: new routing arm, struct field, format_event_text enhancement, test update
- `crates/mika-gateway/CLAUDE.md`: updated routing docs

## Test plan

- [x] `test_route_event_pr_closed` asserts `Some("mika-dev")`
- [x] All 122 gateway tests pass (`cargo test -p mika-gateway`)
- [x] Pre-commit hooks pass (fmt, clippy, secrets, file size)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: routing change only adds a new event type to an existing path. mika-dev's webhook handler will log receipt of `pull_request.closed` events.

## Companion PR

senara-solutions/mika-skills#147 — adds skill prompt handling for the new event

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)