### PR TITLE
feat(skills): prevent reviewed skill from being triggered during its own review

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -87,6 +87,8 @@ Git-based and local skill distribution via `mika skills install/uninstall/update
 
 **Match-reason conditioning (#265):** `match_skills()` returns `MatchedSkill` wrappers with `MatchReason` (`Keyword`, `AlwaysOn`, `Dependency`). `always_on` skills do not enforce constraints unless the user's message also triggered a keyword.
 
+**Review-target exclusion (#513):** `review_filter::apply_review_filter()` runs after `match_message()` and before `resolve_contexts()` in both conversation and team mode. When `skill-review` is keyword-matched, any other keyword-matched skill whose name appears in the user message (case-insensitive) is excluded from the matched set. This prevents the reviewed skill's prompt from contaminating the review context. `AlwaysOn` and `Dependency` skills are never excluded. Silent mode is unaffected (no keyword matching).
+
 ## Exec Handlers
 
 **Image protocol (`__mika_v1`):** Scripts return images via JSON envelope `{"__mika_v1": {"text": "...", "images": ["/path/to/img"]}}`. Executor validates files (5MB limit, magic-byte check for JPEG/PNG/GIF/WebP), base64-encodes, max 5 images per result.

--- a/crates/mika-agent/docs/skills.md
+++ b/crates/mika-agent/docs/skills.md
@@ -326,6 +326,8 @@ On each user turn, the `SkillRegistry` determines which skills are active:
 
 4. **Unmatched skills** are excluded from the turn entirely. Their tools are not sent to Claude and their prompt snippets are not injected.
 
+5. **Review-target exclusion (#513):** When `skill-review` is keyword-matched (i.e., the user is reviewing a skill), any other keyword-matched skill whose name appears in the user message is excluded from the matched set before prompt injection. This prevents the reviewed skill's prompt from contaminating the review context. `AlwaysOn` and `Dependency` skills are never excluded by this mechanism. Applied in both conversation and team mode via `review_filter::apply_review_filter()`.
+
 The matching algorithm is intentionally simple and cheap. Claude still makes the final decision about which tools to actually call from the matched set. The keyword system acts as a coarse filter to avoid sending irrelevant tools on every turn.
 
 **Fallback behavior:** If no skills directory exists or the `SkillRegistry` has zero loaded skills, all builtin tools are sent to Claude on every turn (pre-skill legacy behavior). This ensures Mika works out of the box even if the skills directory is missing.

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -23,6 +23,7 @@ use crate::skills::executor;
 use crate::skills::index::{ResolvedSkillTool, SkillEntry};
 use crate::skills::manifest::ToolHandler;
 use crate::skills::matcher::{MatchReason, MatchedSkill};
+use crate::skills::review_filter;
 use crate::tools::{ToolContext, ToolOutput, ToolRegistry};
 use mika_common::config::Settings;
 use mika_common::embedding::EmbeddingClient;
@@ -1267,6 +1268,12 @@ async fn run_agent_inner(params: &AgentParams<'_>, trace_id: &str) -> Result<Age
 
     // Match skills and resolve tool definitions
     let mut matched = params.skills.match_message(params.user_message);
+
+    // Exclude skills that are the target of a skill-review turn (#513).
+    // Must run before context resolution so excluded skills don't participate
+    // in context fetching, LLM override, or prompt injection.
+    review_filter::apply_review_filter(&mut matched, params.user_message);
+
     let matched_entries: Vec<&SkillEntry> = matched.iter().map(|m| m.entry).collect();
 
     // Resolve context requirements before LLM override
@@ -2399,6 +2406,10 @@ async fn run_team_agent_inner_impl(params: &TeamAgentParams<'_>) -> Result<Optio
 
     // Match skills and resolve tool definitions
     let mut matched = params.skills.match_message(params.task_message);
+
+    // Exclude skills that are the target of a skill-review turn (#513).
+    review_filter::apply_review_filter(&mut matched, params.task_message);
+
     let matched_entries: Vec<&SkillEntry> = matched.iter().map(|m| m.entry).collect();
 
     // Resolve context requirements before LLM override

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -7,6 +7,7 @@ pub mod install;
 pub mod manifest;
 pub mod marketplace;
 pub mod matcher;
+pub mod review_filter;
 
 use std::path::Path;
 

--- a/crates/mika-agent/src/skills/review_filter.rs
+++ b/crates/mika-agent/src/skills/review_filter.rs
@@ -1,0 +1,262 @@
+use super::matcher::{MatchReason, MatchedSkill};
+
+/// Name of the skill-review skill. Used to detect when a review turn is active.
+const SKILL_REVIEW_NAME: &str = "skill-review";
+
+/// Identify matched skills that should be excluded because they are the target
+/// of a `skill-review` turn.
+///
+/// When `skill-review` is keyword-matched, any *other* keyword-matched skill
+/// whose name appears in the user message (case-insensitive) is treated as the
+/// review target and excluded from the matched set. This prevents the reviewed
+/// skill's prompt from contaminating the review context.
+///
+/// Returns indices in **descending** order so the caller can safely remove them
+/// via `matched.remove(idx)` without invalidating earlier indices.
+///
+/// Only `Keyword`-matched skills are candidates for exclusion — `AlwaysOn` and
+/// `Dependency` skills are never excluded by this mechanism.
+/// Exclude review-target skills from the matched set in place.
+///
+/// Convenience wrapper around [`exclude_review_targets`] that removes the
+/// identified skills from `matched` and emits a debug log for each removal.
+/// Call this once at the call site instead of duplicating the removal loop.
+pub fn apply_review_filter(matched: &mut Vec<MatchedSkill<'_>>, user_message: &str) {
+    let exclude = exclude_review_targets(matched, user_message);
+    for &idx in &exclude {
+        tracing::debug!(
+            skill = matched[idx].entry.manifest.skill.name,
+            "excluding skill from review turn"
+        );
+        matched.remove(idx);
+    }
+}
+
+/// Identify matched skills that should be excluded because they are the target
+/// of a `skill-review` turn (internal — prefer [`apply_review_filter`]).
+fn exclude_review_targets(matched: &[MatchedSkill<'_>], user_message: &str) -> Vec<usize> {
+    // Check if skill-review is keyword-matched in this turn.
+    let has_skill_review_keyword = matched.iter().any(|m| {
+        m.reason == MatchReason::Keyword
+            && m.entry
+                .manifest
+                .skill
+                .name
+                .eq_ignore_ascii_case(SKILL_REVIEW_NAME)
+    });
+
+    if !has_skill_review_keyword {
+        return Vec::new();
+    }
+
+    let message_lower = user_message.to_lowercase();
+
+    let mut exclude_indices: Vec<usize> = matched
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| {
+            // Only exclude Keyword-matched skills (not AlwaysOn or Dependency).
+            m.reason == MatchReason::Keyword
+                // Never exclude skill-review itself.
+                && !m
+                    .entry
+                    .manifest
+                    .skill
+                    .name
+                    .eq_ignore_ascii_case(SKILL_REVIEW_NAME)
+                // The skill's name must appear in the user message (case-insensitive).
+                && message_lower.contains(&m.entry.manifest.skill.name.to_lowercase())
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    // Sort descending for safe removal via matched.remove(idx).
+    exclude_indices.sort_unstable_by(|a, b| b.cmp(a));
+    exclude_indices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::index::SkillEntry;
+    use crate::skills::manifest::{SkillInfo, SkillManifest, Triggers};
+    use std::path::PathBuf;
+
+    fn make_entry(name: &str, keywords: &[&str], always_on: bool) -> SkillEntry {
+        SkillEntry {
+            manifest: SkillManifest {
+                skill: SkillInfo {
+                    name: name.to_string(),
+                    description: format!("{name} skill"),
+                    version: String::new(),
+                    always_on,
+                    timeout_secs: 30,
+                    dependencies: vec![],
+                    max_prompt_size: None,
+                },
+                triggers: Triggers {
+                    keywords: keywords.iter().map(|s| s.to_string()).collect(),
+                },
+                llm: Default::default(),
+                constraints: Default::default(),
+                context: std::collections::HashMap::new(),
+            },
+            dir: PathBuf::from(format!("/skills/{name}")),
+            keywords_lower: keywords.iter().map(|s| s.to_lowercase()).collect(),
+            prompt_snippet: String::new(),
+            skill_tools: vec![],
+            enabled: true,
+            has_override: false,
+            provider_overrides: std::collections::HashMap::new(),
+            model_prompts: std::collections::HashMap::new(),
+            model_overrides: std::collections::HashMap::new(),
+            generated_model_prompts: std::collections::HashMap::new(),
+        }
+    }
+
+    fn matched_keyword(entry: &SkillEntry) -> MatchedSkill<'_> {
+        MatchedSkill {
+            entry,
+            reason: MatchReason::Keyword,
+        }
+    }
+
+    fn matched_always_on(entry: &SkillEntry) -> MatchedSkill<'_> {
+        MatchedSkill {
+            entry,
+            reason: MatchReason::AlwaysOn,
+        }
+    }
+
+    fn matched_dependency(entry: &SkillEntry) -> MatchedSkill<'_> {
+        MatchedSkill {
+            entry,
+            reason: MatchReason::Dependency,
+        }
+    }
+
+    #[test]
+    fn test_excludes_review_target() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("self-dev", &["self-dev", "dev"], false);
+        let matched = vec![matched_keyword(&review), matched_keyword(&self_dev)];
+
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert_eq!(excluded, vec![1]);
+    }
+
+    #[test]
+    fn test_excludes_web_search_target() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let web_search = make_entry("web-search", &["web search", "search"], false);
+        let matched = vec![matched_keyword(&review), matched_keyword(&web_search)];
+
+        let excluded = exclude_review_targets(&matched, "review skill web-search");
+        assert_eq!(excluded, vec![1]);
+    }
+
+    #[test]
+    fn test_no_other_keyword_matched_skills() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let matched = vec![matched_keyword(&review)];
+
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_skill_review_matched_via_always_on_no_exclusion() {
+        let review = make_entry("skill-review", &["review skill"], true);
+        let self_dev = make_entry("self-dev", &["self-dev"], false);
+        let matched = vec![matched_always_on(&review), matched_keyword(&self_dev)];
+
+        // skill-review is AlwaysOn, not Keyword — no exclusion triggered.
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_target_matched_via_always_on_not_excluded() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("self-dev", &["self-dev"], true);
+        let matched = vec![matched_keyword(&review), matched_always_on(&self_dev)];
+
+        // self-dev is AlwaysOn — should not be excluded.
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_target_matched_via_dependency_not_excluded() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("self-dev", &["self-dev"], false);
+        let matched = vec![matched_keyword(&review), matched_dependency(&self_dev)];
+
+        // self-dev is a Dependency — should not be excluded.
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_keyword_only_matching_name_excluded() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("self-dev", &["self-dev"], false);
+        let reminders = make_entry("reminders", &["review"], false);
+        let matched = vec![
+            matched_keyword(&review),
+            matched_keyword(&self_dev),
+            matched_keyword(&reminders),
+        ];
+
+        // "reminders" does not appear in the message, only "self-dev" does.
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert_eq!(excluded, vec![1]);
+    }
+
+    #[test]
+    fn test_skill_review_not_in_matched_set() {
+        let self_dev = make_entry("self-dev", &["self-dev"], false);
+        let matched = vec![matched_keyword(&self_dev)];
+
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_batch_mode_no_exclusion() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("self-dev", &["self-dev"], false);
+        let matched = vec![matched_keyword(&review), matched_keyword(&self_dev)];
+
+        // Batch mode: "review skill *" — asterisk is not a skill name.
+        let excluded = exclude_review_targets(&matched, "review skill *");
+        assert!(excluded.is_empty());
+    }
+
+    #[test]
+    fn test_case_insensitive_skill_name_match() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let self_dev = make_entry("Self-Dev", &["self-dev"], false);
+        let matched = vec![matched_keyword(&review), matched_keyword(&self_dev)];
+
+        let excluded = exclude_review_targets(&matched, "review skill self-dev");
+        assert_eq!(excluded, vec![1]);
+    }
+
+    #[test]
+    fn test_descending_index_order_for_safe_removal() {
+        let review = make_entry("skill-review", &["review skill"], false);
+        let skill_a = make_entry("skill-a", &["skill-a"], false);
+        let skill_b = make_entry("skill-b", &["skill-b"], false);
+        let matched = vec![
+            matched_keyword(&review),
+            matched_keyword(&skill_a),
+            matched_keyword(&skill_b),
+        ];
+
+        // Both skill names appear in the message.
+        let excluded =
+            exclude_review_targets(&matched, "review skill skill-a and skill-b together");
+        assert_eq!(excluded, vec![2, 1]); // Descending order.
+    }
+}

--- a/docs/plans/2026-04-15-002-feat-prevent-reviewed-skill-trigger-plan.md
+++ b/docs/plans/2026-04-15-002-feat-prevent-reviewed-skill-trigger-plan.md
@@ -1,0 +1,193 @@
+---
+title: "feat: Prevent reviewed skill from being triggered during its own review"
+type: feat
+status: active
+date: 2026-04-15
+---
+
+# feat: Prevent reviewed skill from being triggered during its own review
+
+## Overview
+
+When the `skill-review` skill is keyword-triggered (e.g., "review skill self-dev"), the skill being reviewed (e.g., `self-dev`) must be excluded from the matched skill set before prompt injection. This prevents circular activation where the reviewed skill's prompt contaminates the review context.
+
+## Problem Frame
+
+During a `review_skill` turn, the user message (e.g., "review skill self-dev") may contain keywords that match the target skill. If `self-dev` has keywords like "dev" or "self-dev" that appear in the message, it gets keyword-matched alongside `skill-review`. Both prompts are then injected into the system prompt, meaning the reviewer is contaminated by the reviewed skill's instructions — the reviewer becomes the reviewed.
+
+This is a structural safety issue. The fix must be code-level enforcement, not prompt-level guards (per institutional learning: prompt enforcement fails when the LLM controls the critical path).
+
+## Requirements Trace
+
+- R1. When `skill-review` is keyword-matched, exclude the target skill from `match_skills()` results before prompt injection
+- R2. Applies to all skills — not just trust-critical ones
+- R3. Exclusion is turn-scoped (lasts for the single agent turn, not the entire session)
+- R4. The exclusion must work in both conversation mode and team mode paths
+
+## Scope Boundaries
+
+- Only excludes skills that are identified as the review target — other keyword-matched skills remain
+- Does not modify `match_skills()` internals — uses post-match filtering (existing pattern)
+- Does not change `ToolContext` — the exclusion is applied before the LLM turn, not during tool execution
+- `always_on` skills are never excluded by this mechanism (they don't inject via keyword match anyway, and removing them would break unrelated functionality)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/agent.rs:1269-1283` — Conversation mode: `match_message()` → context exclusion pattern
+- `crates/mika-agent/src/agent.rs:2401-2414` — Team mode: identical pipeline
+- `crates/mika-agent/src/skills/matcher.rs:37-88` — `match_skills()` function with `MatchReason` enum
+- `crates/mika-agent/src/skills/mod.rs:180-182` — `SkillRegistry::match_message()`
+- `crates/mika-agent/src/skills/builtin_handlers.rs:934-1032` — `review_skill` handler
+- `crates/mika-agent/templates/skills/skill-review/skill.toml` — Keywords: `["review skill", "adapt skill", "generate variant", "tune prompt", "skill variant"]`
+
+### Institutional Learnings
+
+- **Deterministic skill context injection** (`docs/solutions/architecture-patterns/deterministic-skill-context-injection.md`): Pre-LLM pipeline ordering is `match_skills() → resolve_contexts() → exclude failed → resolve_skill_llm_override() → collect_required_tools() → inject_skills_and_resolve_tools()`. New filtering must slot in correctly.
+- **Conditional required_tools enforcement** (`docs/solutions/architecture-patterns/conditional-required-tools-enforcement-via-match-reason.md`): Established pattern of filtering `MatchedSkill` by `MatchReason` at call sites.
+- **Trust-critical skill tier** (`docs/solutions/architecture-patterns/trust-critical-skill-tier-and-template-sync.md`): `skill-review` is trust-critical; other skills are reviewable.
+- **Prompt enforcement fails** (`docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md`): Code-level guards required for reliable prevention.
+
+## Key Technical Decisions
+
+- **Post-match filtering (not matcher modification):** Follow the existing `context_exclude` pattern at lines 1280-1283. This keeps `match_skills()` pure (input → output, no side effects) and localizes the concern to the agent loop call site. The alternative of adding an `exclude` parameter to `match_skills()` would require threading review state through `SkillRegistry::match_message()`, which couples matching to review awareness unnecessarily.
+
+- **Skill-name-in-message heuristic for target detection:** When `skill-review` is keyword-matched, scan the user message for names of other keyword-matched skills. Any skill whose name (case-insensitive) appears as a word in the user message is the review target and gets excluded. This is reliable because: (a) the user must name the skill to review it, (b) we only exclude from the *already keyword-matched* set (not all skills), and (c) we only check skills matched via `Keyword` reason (not `AlwaysOn` or `Dependency`).
+
+- **Dedicated helper function:** Extract the filtering logic into a standalone `fn exclude_review_targets(matched, user_message) -> Vec<usize>` in `agent.rs` (or a new `skills/review_filter.rs`). This keeps the agent loop clean and makes the logic independently testable.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to place the exclusion in the pipeline?** Right after `match_message()` and before `resolve_contexts()`. The excluded skill should not participate in context resolution, LLM override, or prompt injection. This is the earliest safe point.
+
+- **Should `AlwaysOn` skills be excludable?** No. `AlwaysOn` skills don't inject via keyword context — they provide baseline capabilities. Excluding them would break unrelated functionality. Only `Keyword`-matched skills are candidates for exclusion.
+
+- **What if the skill name is a substring of a common word?** The heuristic matches skill names against the user message. Skill names are typically multi-word or hyphenated (e.g., `self-dev`, `web-search`), making false positives unlikely. The `name-in-keywords` rejection (#510) already prevents skills from having names that are too generic. Additionally, we only exclude from skills that already keyword-matched — the intersection of "keyword-matched AND name-in-message" is a strong signal.
+
+### Deferred to Implementation
+
+- **Exact word-boundary matching strategy:** Whether to use simple `contains()` or a word-boundary-aware check. Implementation should test both and pick the simplest that passes all test scenarios.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+User message: "review skill self-dev"
+                    │
+                    ▼
+        match_skills(skills, message)
+                    │
+                    ▼
+    matched = [skill-review (Keyword), self-dev (Keyword)]
+                    │
+                    ▼
+    detect skill-review in matched (Keyword reason)
+         ├── YES → extract review targets from message
+         │         exclude targets from matched
+         │         matched = [skill-review (Keyword)]
+         └── NO  → no filtering
+                    │
+                    ▼
+    resolve_contexts() → ... → inject_skills_and_resolve_tools()
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `exclude_review_targets` helper function**
+
+**Goal:** Create a function that, given the matched skill set and user message, returns indices of skills that should be excluded because they are review targets.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `crates/mika-agent/src/skills/review_filter.rs`
+- Modify: `crates/mika-agent/src/skills/mod.rs` (add `pub mod review_filter;`)
+- Test: `crates/mika-agent/src/skills/review_filter.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- The function accepts `&[MatchedSkill]` and `&str` (user message)
+- First, check if any matched skill named `"skill-review"` has `MatchReason::Keyword`. If not, return empty vec (no exclusion needed)
+- If skill-review is keyword-matched, iterate remaining keyword-matched skills. For each, check if the skill's name appears in the lowercased user message (case-insensitive substring match). Collect indices of matches.
+- Return the indices in reverse order (for safe removal via `matched.remove(idx)`)
+
+**Patterns to follow:**
+- `context::resolve_contexts()` returning `context_exclude: Vec<usize>` indices
+- `matcher.rs` test helper `make_entry()` for constructing test skill entries
+
+**Test scenarios:**
+- Happy path: message "review skill self-dev" with skill-review (Keyword) and self-dev (Keyword) matched → self-dev excluded
+- Happy path: message "review skill web-search" with skill-review (Keyword) and web-search (Keyword) → web-search excluded
+- Edge case: skill-review matched but no other keyword-matched skills → empty exclusion
+- Edge case: skill-review matched via AlwaysOn (hypothetical) → no exclusion (only triggers on Keyword match)
+- Edge case: target skill matched via AlwaysOn → not excluded (only Keyword-matched targets are candidates)
+- Edge case: target skill matched via Dependency → not excluded
+- Edge case: multiple skills keyword-matched alongside skill-review, only one name appears in message → only that one excluded
+- Edge case: skill-review not in matched set → no exclusion
+- Edge case: batch mode message "review skill *" → no skill name matches (asterisk is not a skill name)
+
+**Verification:**
+- All test scenarios pass
+- `cargo clippy` clean
+
+- [ ] **Unit 2: Integrate exclusion into conversation and team mode pipelines**
+
+**Goal:** Wire `exclude_review_targets` into both agent loop paths (conversation mode and team mode), inserting the filtering step right after `match_message()` and before `resolve_contexts()`.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/agent.rs`
+- Test: `crates/mika-agent/src/agent.rs` (inline tests) and `crates/mika-agent/tests/eval/` (integration test)
+
+**Approach:**
+- In conversation mode (after line 1269): call `exclude_review_targets(&matched, params.user_message)` and remove returned indices from `matched` before the context resolution step
+- In team mode (after line 2401): identical pattern with `params.task_message`
+- Add a `tracing::debug!` log when skills are excluded, naming the excluded skills
+- The pattern mirrors the existing `context_exclude` removal loop at lines 1280-1283
+
+**Patterns to follow:**
+- Lines 1280-1283: `for &idx in context_exclude.iter().rev() { matched.remove(idx); }` — exact same pattern
+- Lines 2411-2413: Team mode equivalent
+
+**Test scenarios:**
+- Integration: agent turn with "review skill self-dev" message where self-dev has a keyword matching → self-dev prompt NOT in system prompt, skill-review prompt IS in system prompt
+- Integration: agent turn with normal message (no skill-review trigger) → all matching skills injected as usual (no regression)
+- Happy path: conversation mode excludes review target
+- Happy path: team mode excludes review target
+- Edge case: review target has context requirements → context resolution not called for excluded skill
+
+**Verification:**
+- `cargo test` passes (no regressions)
+- `cargo clippy` clean
+- Manual or eval test confirms reviewed skill prompt is absent from system prompt during review turns
+
+## System-Wide Impact
+
+- **Interaction graph:** The filtering step runs between `match_message()` and `resolve_contexts()`. It does not affect silent mode (which uses `safe_always_on_skills()` / `callback_safe_skills()` — no keyword matching). It does not affect the `review_skill` tool handler itself.
+- **Error propagation:** No new error paths. The function returns indices; if empty, nothing changes.
+- **State lifecycle risks:** None. The exclusion is computed per-turn from immutable inputs (matched set + user message). No persistent state involved.
+- **API surface parity:** Silent mode does not keyword-match, so no changes needed there.
+- **Integration coverage:** The eval harness (`EvalHarness` + `MockLlmProvider`) can verify that the system prompt does not contain the excluded skill's prompt snippet.
+- **Unchanged invariants:** `match_skills()` signature and behavior unchanged. `ToolContext` unchanged. `review_skill` handler unchanged. `SkillRegistry` API unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Skill name substring false positives (e.g., skill "dev" matching in "review skill self-dev") | Unlikely in practice due to name-in-keywords rejection (#510) preventing generic names. Word-boundary matching can further reduce risk. |
+| Batch mode "review skill *" accidentally excluding skills | Asterisk is not a valid skill name, so no skill name will match "*" in the message |
+| Future paths that call `match_message()` without the filter | The filter is applied at the call site, not inside `match_message()`. New call sites must add it explicitly. A code comment at the filter call site documents this coupling. |
+
+## Sources & References
+
+- Related issues: #513, #512 (parent), #510 (name-in-keywords), #265 (match reason conditioning)
+- Related code: `crates/mika-agent/src/skills/matcher.rs`, `crates/mika-agent/src/agent.rs`
+- Institutional learnings: `docs/solutions/architecture-patterns/deterministic-skill-context-injection.md`, `docs/solutions/architecture-patterns/conditional-required-tools-enforcement-via-match-reason.md`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -326,6 +326,8 @@ On each user turn, the `SkillRegistry` determines which skills are active:
 
 4. **Unmatched skills** are excluded from the turn entirely. Their tools are not sent to Claude and their prompt snippets are not injected.
 
+5. **Review-target exclusion (#513):** When `skill-review` is keyword-matched (i.e., the user is reviewing a skill), any other keyword-matched skill whose name appears in the user message is excluded from the matched set before prompt injection. This prevents the reviewed skill's prompt from contaminating the review context. `AlwaysOn` and `Dependency` skills are never excluded by this mechanism. Applied in both conversation and team mode via `review_filter::apply_review_filter()`.
+
 The matching algorithm is intentionally simple and cheap. Claude still makes the final decision about which tools to actually call from the matched set. The keyword system acts as a coarse filter to avoid sending irrelevant tools on every turn.
 
 **Fallback behavior:** If no skills directory exists or the `SkillRegistry` has zero loaded skills, all builtin tools are sent to Claude on every turn (pre-skill legacy behavior). This ensures Mika works out of the box even if the skills directory is missing.

--- a/docs/solutions/architecture-patterns/review-target-exclusion-filter.md
+++ b/docs/solutions/architecture-patterns/review-target-exclusion-filter.md
@@ -1,0 +1,82 @@
+---
+title: Post-match review-target exclusion prevents circular skill activation
+date: 2026-04-15
+category: architecture-patterns
+module: skills/review_filter, agent
+problem_type: best_practice
+component: assistant
+severity: high
+applies_when:
+  - Adding new post-match filtering steps to the skill pipeline
+  - Modifying skill-review activation or skill matching behavior
+  - Adding new agent loop paths that call match_message()
+tags:
+  - skill-matching
+  - review-skill
+  - circular-activation
+  - post-match-filter
+  - prompt-injection-prevention
+  - match-reason
+---
+
+# Post-match review-target exclusion prevents circular skill activation
+
+## Context
+
+When the `skill-review` skill is keyword-triggered (e.g., "review skill self-dev"), the user message may contain keywords that also match the skill being reviewed. If both skills activate, the reviewed skill's prompt is injected into the system prompt alongside the review instructions — the reviewer becomes contaminated by the reviewed skill's behavioral directives.
+
+This is a structural safety concern. Prompt-level guards were already in place (3-call cap per skill in the skill-review system prompt), but institutional learning from the deterministic-context-injection work proved that prompt enforcement fails when the LLM controls the critical path. Code-level structural enforcement was required.
+
+## Guidance
+
+The solution uses **post-match filtering** — the established pattern in the agent loop for removing skills from the matched set before prompt injection. The filter lives in `skills/review_filter.rs` and exposes a single public function: `apply_review_filter(&mut matched, user_message)`.
+
+**Pipeline position:** The filter runs after `match_message()` and before `resolve_contexts()`. This is the earliest safe point — excluded skills do not participate in context resolution, LLM override selection, required_tools collection, or prompt injection.
+
+**Activation conditions:**
+1. `skill-review` must be keyword-matched (not AlwaysOn or Dependency) in the current turn
+2. Only other keyword-matched skills are candidates for exclusion (AlwaysOn and Dependency skills are never excluded)
+3. The candidate skill's name must appear in the user message (case-insensitive substring match)
+
+**Applied in both paths:** The filter is wired into conversation mode (`run_agent_inner`) and team mode (`run_team_agent_inner_impl`). Silent mode is correctly exempt — it uses `safe_always_on_skills()` / `callback_safe_skills()` which never keyword-match, making the filter a no-op.
+
+## Why This Matters
+
+Without this filter, reviewing a skill that has keywords matching the user message (e.g., "review skill self-dev" where `self-dev` has keyword "self-dev") causes both `skill-review` and `self-dev` to activate. The `self-dev` prompt is then injected into the system prompt alongside review instructions, which can:
+
+1. Contaminate the review with the reviewed skill's behavioral directives
+2. Cause the agent to execute the reviewed skill's workflow instead of objectively reviewing its prompt
+3. Create circular activation where the reviewer is influenced by the very content it should be evaluating
+
+## When to Apply
+
+- **New agent loop paths:** Any new code path that calls `match_message()` must also call `apply_review_filter()` before the matched set is used for context resolution or prompt injection
+- **New post-match filters:** Follow the same pattern — accept `&[MatchedSkill]`, return indices in descending order, remove at the call site or provide a convenience `apply_*` wrapper
+- **Skill matching changes:** If the matching algorithm changes (e.g., new MatchReason variants), verify the review filter still correctly identifies keyword-matched skills
+
+## Examples
+
+The filter follows the existing `context_exclude` pattern in `agent.rs`:
+
+```rust
+// Before (context exclusion — existing pattern):
+let (resolved_context, context_exclude) = context::resolve_contexts(...).await;
+for &idx in context_exclude.iter().rev() {
+    matched.remove(idx);
+}
+
+// After (review-target exclusion — same pattern, new step):
+review_filter::apply_review_filter(&mut matched, params.user_message);
+// Then context resolution, LLM override, prompt injection...
+```
+
+The `apply_review_filter` function encapsulates the detection, index collection, logging, and removal in one call — no need for callers to manage descending-index removal.
+
+## Related
+
+- Issue #513 (this feature), parent #512
+- `docs/solutions/architecture-patterns/deterministic-skill-context-injection.md` — pipeline ordering
+- `docs/solutions/architecture-patterns/conditional-required-tools-enforcement-via-match-reason.md` — MatchReason filtering precedent
+- `docs/solutions/architecture-patterns/callback-task-loop-prevention.md` — same class of structural-over-prompt defense
+- `docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md` — complementary prompt-level cap
+- `docs/solutions/security-issues/review-skill-builtin-trust-boundary.md` — trust-critical skill guards


### PR DESCRIPTION
## Summary

- Adds `review_filter` module that excludes a skill from keyword matching when it is the target of a `review_skill` call, preventing circular prompt injection during skill review
- Filter runs after `match_message()` and before `resolve_contexts()` in both conversation and team agent paths
- Only keyword-matched skills are candidates for exclusion; AlwaysOn and Dependency skills are never excluded

Closes #513

## How it works

When `skill-review` is keyword-matched in a turn, `apply_review_filter()` checks all other keyword-matched skills. If a skill's name appears (case-insensitive) in the user message, it is removed from the matched set before prompt injection. This is a structural code-level guard — no prompt-level enforcement needed.

## Test plan

- [x] 11 unit tests covering: basic exclusion, case-insensitive matching, AlwaysOn/Dependency immunity, batch mode no-op, multi-skill filtering, descending index ordering for safe removal
- [ ] Manual: `review skill self-dev` should NOT trigger `self-dev`'s prompt injection
- [ ] Manual: `review skill *` (batch mode) should not exclude any skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)