### PR TITLE
feat(tools): report skipped skill count in list_skills output

### DIFF
--- a/crates/mika-agent/docs/skills.md
+++ b/crates/mika-agent/docs/skills.md
@@ -1133,6 +1133,8 @@ Both exec and http handlers enforce the `timeout_secs` value from the manifest (
 
 The skill scanner (`scan_skills_dir`) catches all errors -- missing files, invalid TOML, bad JSON -- and logs them as warnings. A broken skill is simply skipped. This ensures that a single bad skill file cannot prevent Mika from starting.
 
+The `list_skills` agent tool runs `validate_loaded()` and reports the skipped count in its output. When skills were skipped, a warning footer is appended: `Warning: N skill(s) skipped due to errors. Run 'mika skills validate' for details.` This enables agents to self-diagnose a degraded skill registry. When no skills are skipped, the output is unchanged.
+
 ## QA Verdict Contract
 
 mika-qa-bot posts PR verdicts as GitHub reviews with:

--- a/crates/mika-agent/src/tools/list_skills.rs
+++ b/crates/mika-agent/src/tools/list_skills.rs
@@ -10,6 +10,18 @@ use crate::skills::marketplace::get_marketplace_entry;
 
 pub struct ListSkillsTool;
 
+const SKIPPED_WARNING: &str =
+    "Warning: {} skill(s) skipped due to errors. Run 'mika skills validate' for details.";
+
+/// Format the skipped-skills warning line, or empty string if none skipped.
+fn skipped_warning(count: usize) -> String {
+    if count > 0 {
+        SKIPPED_WARNING.replace("{}", &count.to_string())
+    } else {
+        String::new()
+    }
+}
+
 #[async_trait]
 impl Tool for ListSkillsTool {
     fn name(&self) -> &str {
@@ -38,10 +50,21 @@ impl Tool for ListSkillsTool {
             registry.apply_overrides(&overrides);
         }
 
+        // Run semantic validation to promote broken-handler/tools.json skills to skipped,
+        // matching the startup paths (chat.rs, ask.rs, server/mod.rs).
+        registry.validate_loaded();
+
         let entries = registry.skills();
 
         if entries.is_empty() {
-            return Ok(ToolOutput::success("No skills installed."));
+            let warning = skipped_warning(registry.skipped_count());
+            if warning.is_empty() {
+                return Ok(ToolOutput::success("No skills installed."));
+            }
+            return Ok(ToolOutput::success(format!(
+                "No skills installed.\n\n{}\n",
+                warning
+            )));
         }
 
         let mut output = format!("Installed skills ({}):\n", entries.len());
@@ -87,6 +110,11 @@ impl Tool for ListSkillsTool {
                 keywords,
                 tools_count,
             ));
+        }
+
+        let warning = skipped_warning(registry.skipped_count());
+        if !warning.is_empty() {
+            output.push_str(&format!("\n{}\n", warning));
         }
 
         Ok(ToolOutput::success(output))
@@ -201,6 +229,118 @@ mod tests {
         assert!(
             result.content.contains("[custom]"),
             "expected [custom] tag in: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_skills_no_warning_when_no_skipped() {
+        let (tmp, harness) = setup();
+        let ctx = harness.ctx_with_home(tmp.path());
+
+        // Create a valid skill — no skipped entries
+        let skill_dir = tmp.path().join("skills/valid-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("skill.toml"),
+            r#"
+            [skill]
+            name = "valid-skill"
+            description = "A valid skill"
+            [triggers]
+            keywords = ["valid"]
+            "#,
+        )
+        .unwrap();
+
+        let tool = ListSkillsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.content.contains("valid-skill"));
+        assert!(
+            !result.content.contains("Warning"),
+            "should not contain warning when no skills skipped: {}",
+            result.content
+        );
+        assert!(
+            !result.content.contains("skipped"),
+            "should not mention skipped when none skipped: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_skills_shows_skipped_warning() {
+        let (tmp, harness) = setup();
+        let ctx = harness.ctx_with_home(tmp.path());
+
+        // Create a valid skill
+        let valid_dir = tmp.path().join("skills/valid-skill");
+        std::fs::create_dir_all(&valid_dir).unwrap();
+        std::fs::write(
+            valid_dir.join("skill.toml"),
+            r#"
+            [skill]
+            name = "valid-skill"
+            description = "A valid skill"
+            [triggers]
+            keywords = ["valid"]
+            "#,
+        )
+        .unwrap();
+
+        // Create an invalid skill (malformed TOML triggers skip)
+        let invalid_dir = tmp.path().join("skills/broken-skill");
+        std::fs::create_dir_all(&invalid_dir).unwrap();
+        std::fs::write(
+            invalid_dir.join("skill.toml"),
+            "this is not valid toml {{{{",
+        )
+        .unwrap();
+
+        let tool = ListSkillsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        // Valid skill still listed
+        assert!(result.content.contains("valid-skill"));
+        // Warning footer present
+        assert!(
+            result
+                .content
+                .contains("Warning: 1 skill(s) skipped due to errors"),
+            "expected skipped warning in: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("mika skills validate"),
+            "expected validate hint in: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_skills_all_skipped_shows_warning() {
+        let (tmp, harness) = setup();
+        let ctx = harness.ctx_with_home(tmp.path());
+
+        // Only invalid skills — no valid ones
+        let invalid_dir = tmp.path().join("skills/broken-skill");
+        std::fs::create_dir_all(&invalid_dir).unwrap();
+        std::fs::write(invalid_dir.join("skill.toml"), "not valid toml {{{{").unwrap();
+
+        let tool = ListSkillsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(
+            result.content.contains("No skills installed."),
+            "expected 'No skills installed.' in: {}",
+            result.content
+        );
+        assert!(
+            result
+                .content
+                .contains("Warning: 1 skill(s) skipped due to errors"),
+            "expected skipped warning in: {}",
             result.content
         );
     }

--- a/docs/plans/2026-04-15-003-feat-list-skills-report-skipped-count-plan.md
+++ b/docs/plans/2026-04-15-003-feat-list-skills-report-skipped-count-plan.md
@@ -1,0 +1,101 @@
+---
+title: "feat: Report skipped skill count in list_skills tool output"
+type: feat
+status: active
+date: 2026-04-15
+---
+
+# feat: Report skipped skill count in list_skills tool output
+
+## Overview
+
+Add a warning footer to the `list_skills` agent tool output when skills were skipped during registry loading. This enables agents to self-diagnose a degraded skill registry without changing output for the normal (zero-skipped) case.
+
+## Problem Frame
+
+The `list_skills` tool calls `SkillRegistry::from_dir()` which tracks skipped skills (via `skipped_count()` / `skipped()`), but the tool only reports loaded entries. An agent cannot detect that skills were silently skipped due to errors (oversized prompts, missing handlers, broken manifests). The TUI `/skills` command already surfaces skipped skills — the agent tool should too.
+
+Related: #334, #331, #333.
+
+## Requirements Trace
+
+- R1. When `skipped_count > 0`, append a warning footer to `list_skills` output
+- R2. No output change when `skipped_count == 0`
+- R3. Test coverage for both cases
+
+## Scope Boundaries
+
+- Only the `list_skills` agent tool output is changed
+- The TUI `/skills` command already handles this — no changes needed there
+- No new tools, no schema changes, no new dependencies
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/tools/list_skills.rs` — tool implementation, line 92 is the return point
+- `crates/mika-agent/src/skills/mod.rs` — `SkillRegistry::skipped_count()` (line 75), `with_skipped()` (line 66)
+- `crates/mika-agent/src/skills/index.rs` — `SkippedSkill { name, reason }` struct (line 281)
+- `crates/mika-cli/src/tui/commands/handlers.rs` — TUI precedent: shows `"Loaded skills ({}, {} skipped):\n"` header + `SKIPPED` section
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/custom-skill-silent-loading-failure.md` — documents the silent-skip problem; `scan_skills_dir()` emits `warn!` but users/agents never see it
+- `docs/solutions/integration-issues/always-on-skill-oversized-prompt-loud-failure.md` — introduced `skipped_count` tracking; data already exists, just not exposed via tool
+- `docs/solutions/architecture-patterns/startup-skill-validation-structural-enforcement.md` — `validate_loaded()` pattern classifies failures; the tool is a natural channel to surface skipped skills
+
+## Key Technical Decisions
+
+- **Footer, not header:** Append a warning footer after the skills list rather than modifying the header. This preserves backward compatibility for agents that parse the header line, and matches the issue's proposed solution.
+- **Use `skipped_count` only, not individual reasons:** The footer directs to `mika skills validate` for details, keeping tool output concise. Individual `SkippedSkill` reasons are available but would clutter the output.
+- **Test via invalid skill directory:** Create a skill directory with a malformed `skill.toml` to trigger a skip, rather than refactoring to inject a registry. This keeps the test realistic and matches existing test patterns.
+
+## Implementation Units
+
+- [x] **Unit 1: Add skipped count warning footer to list_skills output**
+
+**Goal:** When `registry.skipped_count() > 0`, append a warning line after the skills listing.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/list_skills.rs`
+- Test: `crates/mika-agent/src/tools/list_skills.rs` (inline `#[cfg(test)]` module)
+
+**Approach:**
+- After line 90 (end of the entries loop), before line 92 (return), check `registry.skipped_count()`
+- If > 0, push `"\nWarning: N skill(s) skipped due to errors. Run 'mika skills validate' for details.\n"` to `output`
+- The `registry` variable is already in scope (line 34)
+
+**Patterns to follow:**
+- TUI handler at `crates/mika-cli/src/tui/commands/handlers.rs` — already surfaces skipped count
+- Existing test pattern: `setup()` creates `TempDir` + `TestHarness`, writes `skill.toml` files
+
+**Test scenarios:**
+- Happy path: list skills with no skipped entries — output does NOT contain "Warning" or "skipped"
+- Happy path: list skills with skipped entries — output contains `"Warning: 1 skill(s) skipped due to errors"` and `"mika skills validate"`
+- Edge case: all skills skipped (only invalid skill dirs) — output is "No skills installed." with the warning appended
+- Edge case: mix of valid and invalid skills — output shows valid skills AND the warning footer
+
+**Verification:**
+- `cargo test -p mika-agent -- list_skills` passes with both existing and new tests
+- `cargo clippy -p mika-agent` clean
+
+## System-Wide Impact
+
+- **API surface parity:** The TUI `/skills` command already reports skipped count — this brings the agent tool to parity
+- **Unchanged invariants:** `list_skills` JSON schema, tool name, and input format are unchanged. Output is text, not structured — the footer is additive
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Agents parsing the output string may break | Footer is appended after existing content; header format unchanged. Low risk — output is free-text, not structured |
+
+## Sources & References
+
+- Related issue: #334
+- Related PRs: #333, #331
+- Code: `crates/mika-agent/src/tools/list_skills.rs`, `crates/mika-agent/src/skills/mod.rs`

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1133,6 +1133,8 @@ Both exec and http handlers enforce the `timeout_secs` value from the manifest (
 
 The skill scanner (`scan_skills_dir`) catches all errors -- missing files, invalid TOML, bad JSON -- and logs them as warnings. A broken skill is simply skipped. This ensures that a single bad skill file cannot prevent Mika from starting.
 
+The `list_skills` agent tool runs `validate_loaded()` and reports the skipped count in its output. When skills were skipped, a warning footer is appended: `Warning: N skill(s) skipped due to errors. Run 'mika skills validate' for details.` This enables agents to self-diagnose a degraded skill registry. When no skills are skipped, the output is unchanged.
+
 ## QA Verdict Contract
 
 mika-qa-bot posts PR verdicts as GitHub reviews with:

--- a/docs/solutions/best-practices/agent-tool-must-call-validate-loaded-on-skill-registry.md
+++ b/docs/solutions/best-practices/agent-tool-must-call-validate-loaded-on-skill-registry.md
@@ -1,0 +1,73 @@
+---
+title: Agent tools must call validate_loaded() on SkillRegistry
+date: 2026-04-15
+category: best-practices
+module: skills
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Building agent tools that construct a SkillRegistry via from_dir()
+  - Reporting skill status or counts to the agent
+tags:
+  - skills
+  - list-skills
+  - validate-loaded
+  - agent-tools
+  - skipped-count
+---
+
+# Agent tools must call validate_loaded() on SkillRegistry
+
+## Context
+
+The `list_skills` agent tool constructs a fresh `SkillRegistry` via `from_dir()` and `apply_overrides()` but was not calling `validate_loaded()`. This caused `skipped_count()` to under-report because only parse-time failures (invalid TOML, missing manifest) were counted. Skills with valid manifests but broken runtime structure (missing handler, non-executable handler, broken tools.json) were reported as loaded when the startup paths had actually skipped them.
+
+The three startup sites (`chat.rs`, `ask.rs`, `server/mod.rs`) all follow the pattern `from_dir -> apply_overrides -> validate_loaded`. Any agent tool constructing its own registry must follow the same sequence.
+
+## Guidance
+
+When building a `SkillRegistry` in an agent tool, always call the full initialization sequence:
+
+```rust
+let mut registry = SkillRegistry::from_dir(&skills_dir);
+registry.apply_overrides(&overrides);
+registry.validate_loaded();  // promotes broken-handler skills to skipped
+```
+
+The `validate_loaded()` step runs semantic validation (missing handler, broken tools.json, oversized prompts) and moves skip-worthy skills from the loaded list to the skipped list. Without it, `skipped_count()` and `skills()` reflect only parse-time state, not the full validation the agent runtime applies.
+
+## Why This Matters
+
+If an agent tool reports skill status without `validate_loaded()`, the agent sees a different picture than what the runtime actually uses. A skill may appear as "loaded" in the tool output when the startup paths actually skipped it. This prevents agents from self-diagnosing degraded skill registries -- the exact gap the `list_skills` skipped-count feature (#334) was designed to close.
+
+## When to Apply
+
+- Any agent tool or CLI command that constructs `SkillRegistry::from_dir()` and reports skill state
+- When adding new skill-listing or skill-status endpoints
+- When the reported count or status must match what the running agent actually loaded
+
+## Examples
+
+Before (under-reports skipped count):
+```rust
+let mut registry = SkillRegistry::from_dir(&skills_dir);
+registry.apply_overrides(&overrides);
+// Missing validate_loaded() -- skipped_count() only shows parse errors
+let count = registry.skipped_count(); // May be 0 when runtime skipped 3
+```
+
+After (matches startup behavior):
+```rust
+let mut registry = SkillRegistry::from_dir(&skills_dir);
+registry.apply_overrides(&overrides);
+registry.validate_loaded(); // Promotes broken-handler skills to skipped
+let count = registry.skipped_count(); // Matches what the running agent skipped
+```
+
+## Related
+
+- Issue: #334
+- `crates/mika-agent/src/tools/list_skills.rs` -- the tool where this was fixed
+- `crates/mika-agent/src/skills/mod.rs` -- `SkillRegistry::validate_loaded()` implementation
+- `docs/solutions/architecture-patterns/startup-skill-validation-structural-enforcement.md` -- the validation decision matrix

--- a/todos/738-pending-p2-list-skills-report-skipped-count.md
+++ b/todos/738-pending-p2-list-skills-report-skipped-count.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p2
 issue_id: 738
 tags: [code-review, skills, agent-native]
@@ -43,5 +43,5 @@ Expose `validate_skill()` as an agent tool for server-mode agents.
 
 ## Acceptance Criteria
 
-- [ ] `list_skills` output includes skipped_count when > 0
-- [ ] Agent can detect degraded skill loading at runtime
+- [x] `list_skills` output includes skipped_count when > 0
+- [x] Agent can detect degraded skill loading at runtime


### PR DESCRIPTION
## Summary

- Surface `skipped_count` in the `list_skills` agent tool output so agents can self-diagnose degraded skill registries
- Add `validate_loaded()` call to match startup behavior (catches missing handlers, broken tools.json — not just parse errors)
- Extract duplicated warning format string to a `const SKIPPED_WARNING`
- Append warning footer when skills were skipped: `Warning: N skill(s) skipped due to errors. Run 'mika skills validate' for details.`
- No output change when `skipped_count == 0`

Closes #334

## Test plan

- [x] `test_list_skills_no_warning_when_no_skipped` — valid skills only, no warning in output
- [x] `test_list_skills_shows_skipped_warning` — mix of valid and invalid skills, warning footer present
- [x] `test_list_skills_all_skipped_shows_warning` — only invalid skills, "No skills installed." + warning
- [x] All 8 `list_skills` tests pass (`cargo test -p mika-agent -- list_skills`)
- [x] `cargo clippy -p mika-agent` clean
- [x] Pre-commit hooks (fmt, clippy, secrets scan) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)