### PR TITLE
feat(tools): list_work_items returns status-count summary + filter guidance

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -51,6 +51,8 @@ Tool trait uses `#[async_trait]` (Send futures). Per-tool timeout override via `
 
 4 tools: **Write** (orchestrator-only): `create_work_item`, `update_work_item_status`. **Read** (all agents): `list_work_items`, `check_work_item` (with optional GitHub PR/issue status enrichment). Work items reuse `tasks` table with `trigger_type='manual'` + `action_type='none'`.
 
+**`list_work_items` output enrichment:** Response includes a `Summary:` line with status-count breakdown (e.g., `"50 items total — 2 blocked, 48 completed"`) computed in-memory from the result set. Fully unfiltered calls also include a `Note:` with filter guidance discouraging redundant re-filtering. Filtered calls (by status or source) get a scoped summary but no guidance note. See #572.
+
 **Status transition state machine:** `pending` -> any; `in_progress` -> blocked/completed/cancelled; `blocked` -> in_progress/completed/cancelled. Terminal states cannot transition.
 
 **Idempotent creation:** Deduplicates on `reference_url` (DB partial unique index `idx_tasks_manual_active_ref_url`) and on label (case-insensitive pre-check). Five loop-prevention guards. Max 5 agent-created items per session (user_request exempt).

--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -226,7 +226,7 @@ All 22 builtin tools, registered in `crates/mika-agent/src/tools/mod.rs` via
 | `list_audit_events` | List recent memory mutation audit events (fact stores, updates, core memory edits). Useful for self-introspection. Non-orchestrator agents scoped to own events. | Introspection |
 | `search_tool_history` | Search past tool call history across sessions by tool name, keyword, time range, and success status. Returns truncated input/output (500 chars), 10KB output cap, 30-day retention. Non-orchestrator agents scoped to own tool calls. | Introspection |
 | `a2a_call` | Call a remote A2A agent via the A2A protocol's `message/send` method. Sends a message to an external agent endpoint and returns the response. Optional Bearer token auth. 120s timeout. | A2A |
-| `list_work_items` | List work items with optional status and source filters. Returns up to 50, ordered by creation date. | Work Items |
+| `list_work_items` | List work items with optional status and source filters. Returns up to 50, ordered by creation date. Includes status-count summary and filter guidance note (unfiltered calls only). | Work Items |
 | `check_work_item` | Read work item details and check linked GitHub PR/issue status. Parses `reference_url` for GitHub URLs, calls GitHub REST API with `github_token`. Graceful degradation when no token. 15s timeout. | Work Items |
 | `pr_merge_with_gate` | Merge a GitHub PR with a CI gate. Checks required CI checks via `gh pr checks --required`, classifies by decision matrix (blocked/auto_merge_enabled/merged/already_merged). Spawns `gh` subprocess with `scrub_mika_env_vars` + `GH_TOKEN` re-injection. Requires `github_token`. 60s timeout. See #490. | PR Merge |
 

--- a/crates/mika-agent/src/tools/list_work_items.rs
+++ b/crates/mika-agent/src/tools/list_work_items.rs
@@ -8,6 +8,40 @@ use crate::db::format_ts;
 
 pub struct ListWorkItemsTool;
 
+/// Status display order: active statuses first, then terminal.
+const STATUS_ORDER: &[&str] = &[
+    "pending",
+    "in_progress",
+    "blocked",
+    "completed",
+    "cancelled",
+];
+
+const FILTER_GUIDANCE_NOTE: &str = "All items are returned in this response. \
+    Filter by status= only when you need a strict subset for a subsequent action \
+    — not to verify counts already shown in summary.";
+
+/// Build a status-count summary line from the result set.
+/// Returns e.g. "50 items total — 2 blocked, 48 completed" (omits zero-count statuses).
+fn status_summary(items: &[(crate::db::Task, Option<i64>)]) -> String {
+    let total = items.len();
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (task, _) in items {
+        *counts.entry(task.status.as_str()).or_insert(0) += 1;
+    }
+
+    let parts: Vec<String> = STATUS_ORDER
+        .iter()
+        .filter_map(|s| counts.get(s).map(|c| format!("{c} {s}")))
+        .collect();
+
+    if parts.is_empty() {
+        format!("{total} items total")
+    } else {
+        format!("{total} items total \u{2014} {}", parts.join(", "))
+    }
+}
+
 #[async_trait]
 impl Tool for ListWorkItemsTool {
     fn name(&self) -> &str {
@@ -124,6 +158,15 @@ impl Tool for ListWorkItemsTool {
                 id = task.id,
                 label = task.label,
             ));
+        }
+
+        // Append status-count summary
+        lines.push(String::new()); // blank line separator
+        lines.push(format!("Summary: {}", status_summary(&items)));
+
+        // Append filter guidance note for unfiltered calls only
+        if status.is_none() {
+            lines.push(format!("Note: {FILTER_GUIDANCE_NOTE}"));
         }
 
         Ok(ToolOutput::success(lines.join("\n")))
@@ -289,6 +332,161 @@ mod tests {
         assert!(
             result.content.contains("children:1"),
             "should show child count: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_work_items_summary_mixed_statuses() {
+        let harness = TestHarness::new();
+        // Create items in different statuses
+        create_work_item(&harness, "Item 1", Some("user_request"), None).await;
+        create_work_item(&harness, "Item 2", Some("user_request"), None).await;
+        let id3 = create_work_item(&harness, "Item 3", Some("user_request"), None).await;
+        let id4 = create_work_item(&harness, "Item 4", Some("user_request"), None).await;
+
+        harness
+            .db
+            .update_manual_task_status(&id3, "in_progress")
+            .await
+            .unwrap();
+        harness
+            .db
+            .update_manual_task_status(&id4, "blocked")
+            .await
+            .unwrap();
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        // Summary should show counts in order: pending, in_progress, blocked
+        assert!(
+            result
+                .content
+                .contains("Summary: 4 items total \u{2014} 2 pending, 1 in_progress, 1 blocked"),
+            "unexpected summary in: {}",
+            result.content
+        );
+        // Note should be present (unfiltered call)
+        assert!(
+            result
+                .content
+                .contains("Note: All items are returned in this response."),
+            "missing note in: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_work_items_summary_single_status() {
+        let harness = TestHarness::new();
+        create_work_item(&harness, "Item A", Some("user_request"), None).await;
+        create_work_item(&harness, "Item B", Some("user_request"), None).await;
+        create_work_item(&harness, "Item C", Some("user_request"), None).await;
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(
+            result
+                .content
+                .contains("Summary: 3 items total \u{2014} 3 pending"),
+            "unexpected summary in: {}",
+            result.content
+        );
+        // Note present for unfiltered
+        assert!(result.content.contains("Note: All items are returned"));
+    }
+
+    #[tokio::test]
+    async fn test_list_work_items_filtered_summary_no_note() {
+        let harness = TestHarness::new();
+        let id1 = create_work_item(&harness, "Blocked 1", Some("user_request"), None).await;
+        let id2 = create_work_item(&harness, "Blocked 2", Some("user_request"), None).await;
+        create_work_item(&harness, "Pending 1", Some("user_request"), None).await;
+
+        harness
+            .db
+            .update_manual_task_status(&id1, "blocked")
+            .await
+            .unwrap();
+        harness
+            .db
+            .update_manual_task_status(&id2, "blocked")
+            .await
+            .unwrap();
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+
+        let result = tool
+            .execute(serde_json::json!({"status": "blocked"}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        // Scoped summary for filtered subset
+        assert!(
+            result
+                .content
+                .contains("Summary: 2 items total \u{2014} 2 blocked"),
+            "unexpected summary in: {}",
+            result.content
+        );
+        // No note on filtered calls
+        assert!(
+            !result.content.contains("Note:"),
+            "note should not appear on filtered calls: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_work_items_summary_all_statuses() {
+        let harness = TestHarness::new();
+        let id1 = create_work_item(&harness, "Pending", Some("user_request"), None).await;
+        let id2 = create_work_item(&harness, "In Progress", Some("user_request"), None).await;
+        let id3 = create_work_item(&harness, "Blocked", Some("user_request"), None).await;
+        let id4 = create_work_item(&harness, "Completed", Some("user_request"), None).await;
+        let id5 = create_work_item(&harness, "Cancelled", Some("user_request"), None).await;
+
+        // Leave id1 as pending
+        let _ = id1;
+        harness
+            .db
+            .update_manual_task_status(&id2, "in_progress")
+            .await
+            .unwrap();
+        harness
+            .db
+            .update_manual_task_status(&id3, "blocked")
+            .await
+            .unwrap();
+        harness
+            .db
+            .update_manual_task_status(&id4, "completed")
+            .await
+            .unwrap();
+        harness
+            .db
+            .update_manual_task_status(&id5, "cancelled")
+            .await
+            .unwrap();
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        // All 5 statuses in declaration order
+        assert!(
+            result.content.contains(
+                "Summary: 5 items total \u{2014} 1 pending, 1 in_progress, 1 blocked, 1 completed, 1 cancelled"
+            ),
+            "unexpected summary in: {}",
             result.content
         );
     }

--- a/crates/mika-agent/src/tools/list_work_items.rs
+++ b/crates/mika-agent/src/tools/list_work_items.rs
@@ -88,22 +88,15 @@ impl Tool for ListWorkItemsTool {
             .filter(|s| !s.is_empty());
         let include_children = input["include_children"].as_bool().unwrap_or(false);
 
-        const VALID_STATUSES: &[&str] = &[
-            "pending",
-            "in_progress",
-            "blocked",
-            "completed",
-            "cancelled",
-        ];
         const VALID_SOURCES: &[&str] = &["user_request", "github_issue", "team_run", "self_dev"];
 
         if let Some(s) = status
-            && !VALID_STATUSES.contains(&s)
+            && !STATUS_ORDER.contains(&s)
         {
             return Ok(ToolOutput::error(format!(
                 "Invalid status '{}'. Must be one of: {}",
                 s,
-                VALID_STATUSES.join(", ")
+                STATUS_ORDER.join(", ")
             )));
         }
         if let Some(s) = source
@@ -164,8 +157,8 @@ impl Tool for ListWorkItemsTool {
         lines.push(String::new()); // blank line separator
         lines.push(format!("Summary: {}", status_summary(&items)));
 
-        // Append filter guidance note for unfiltered calls only
-        if status.is_none() {
+        // Append filter guidance note for fully unfiltered calls only
+        if status.is_none() && source.is_none() {
             lines.push(format!("Note: {FILTER_GUIDANCE_NOTE}"));
         }
 
@@ -286,6 +279,12 @@ mod tests {
         assert!(!result.is_error);
         assert!(result.content.contains("GH item"));
         assert!(!result.content.contains("User item"));
+        // Source-only filter should NOT show the guidance note (not fully unfiltered)
+        assert!(
+            !result.content.contains("Note:"),
+            "note should not appear on source-filtered calls: {}",
+            result.content
+        );
     }
 
     #[tokio::test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,7 +226,7 @@ All 22 builtin tools, registered in `crates/mika-agent/src/tools/mod.rs` via
 | `list_audit_events` | List recent memory mutation audit events (fact stores, updates, core memory edits). Useful for self-introspection. Non-orchestrator agents scoped to own events. | Introspection |
 | `search_tool_history` | Search past tool call history across sessions by tool name, keyword, time range, and success status. Returns truncated input/output (500 chars), 10KB output cap, 30-day retention. Non-orchestrator agents scoped to own tool calls. | Introspection |
 | `a2a_call` | Call a remote A2A agent via the A2A protocol's `message/send` method. Sends a message to an external agent endpoint and returns the response. Optional Bearer token auth. 120s timeout. | A2A |
-| `list_work_items` | List work items with optional status and source filters. Returns up to 50, ordered by creation date. | Work Items |
+| `list_work_items` | List work items with optional status and source filters. Returns up to 50, ordered by creation date. Includes status-count summary and filter guidance note (unfiltered calls only). | Work Items |
 | `check_work_item` | Read work item details and check linked GitHub PR/issue status. Parses `reference_url` for GitHub URLs, calls GitHub REST API with `github_token`. Graceful degradation when no token. 15s timeout. | Work Items |
 | `pr_merge_with_gate` | Merge a GitHub PR with a CI gate. Checks required CI checks via `gh pr checks --required`, classifies by decision matrix (blocked/auto_merge_enabled/merged/already_merged). Spawns `gh` subprocess with `scrub_mika_env_vars` + `GH_TOKEN` re-injection. Requires `github_token`. 60s timeout. See #490. | PR Merge |
 

--- a/docs/plans/2026-04-15-004-feat-list-work-items-status-summary-plan.md
+++ b/docs/plans/2026-04-15-004-feat-list-work-items-status-summary-plan.md
@@ -1,0 +1,108 @@
+---
+title: "feat: list_work_items returns status-count summary + filter guidance"
+type: feat
+status: active
+date: 2026-04-15
+issue: 572
+---
+
+# feat: list_work_items returns status-count summary + filter guidance
+
+## Overview
+
+Add a status-count summary line and a filter guidance note to `list_work_items` tool output, so the agent sees aggregate status distribution in one call and never needs to re-query with status filters to verify counts.
+
+## Problem Frame
+
+Models (kimi-k2.5, qwen, others) routinely follow an unfiltered `list_work_items({})` with 3+ redundant filtered calls (`status:"in_progress"`, `status:"blocked"`, `status:"completed"`) to reconstruct counts the first response already contained. This is ritual thoroughness — the unfiltered output shows each item's status but doesn't make the aggregate obvious. The fix is structural: compute the summary server-side and include just-in-time guidance discouraging defensive re-filtering.
+
+## Requirements Trace
+
+- R1. Unfiltered calls include a `summary` line: `"N items total — X blocked, Y in_progress, Z pending"` (omit zero-count statuses)
+- R2. Filtered calls include a scoped summary for the filtered subset
+- R3. Unfiltered calls include a `note` field with filter guidance
+- R4. No new DB queries — counts computed in-memory from the already-fetched result set
+- R5. No new fields on `ToolContext`, no new external crates
+- R6. All existing tests pass, new tests cover summary and note
+
+## Scope Boundaries
+
+- This change applies only to `list_work_items`. Do not generalize to `list_tasks`, `list_agents`, etc. (YAGNI — measure impact first)
+- No changes to the DB layer, `Task` struct, or `list_manual_tasks` query
+- No JSON serialization change — output remains plain text via `ToolOutput::success(String)`
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/tools/list_work_items.rs` — target file, currently builds plain-text output with `"Work items (N):\n"` header + item lines
+- `crates/mika-agent/src/tools/list_skills.rs` — direct precedent: `skipped_warning()` helper appends a conditional footer line after the item listing
+- `crates/mika-agent/src/tools/update_work_item_status.rs` — `VALID_STATUSES` and `VALID_TRANSITIONS` constants define the 5 statuses
+- `crates/mika-agent/src/db.rs` — `list_manual_tasks()` returns `Vec<(Task, Option<i64>)>`, capped at 50, already has status on each `Task`
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/merge-two-step-llm-tool-contracts.md` — "Splitting one logical operation across two tools introduced three independent failure modes." Embedding summary data in list responses is the correct agent-native pattern.
+- `docs/solutions/logic-errors/create-work-item-duplicate-on-retry.md` — structural signals in tool output are more reliable than prompt instructions alone for preventing over-action.
+
+## Key Technical Decisions
+
+- **Plain-text format, not JSON:** All list tools return formatted text. The summary and note are appended as text lines, following the `list_skills` footer pattern.
+- **Summary format:** `"N items total — X status_a, Y status_b"` with em-dash separator, omitting zero-count statuses. Status order: `pending`, `in_progress`, `blocked`, `completed`, `cancelled` (matches `VALID_STATUSES` declaration order, groups active before terminal).
+- **Note only on unfiltered calls:** The guidance note ("All items are returned...") only makes sense when no status filter is applied. Filtered calls already demonstrate intent.
+- **Summary on both filtered and unfiltered:** Filtered calls get a scoped summary (e.g., "2 items total — 2 blocked") so the output is self-describing regardless of filter.
+
+## Implementation Units
+
+- [x] **Unit 1: Add status-count summary and filter guidance note**
+
+**Goal:** Compute status counts from the in-memory result set and append summary + note lines to the tool output.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/list_work_items.rs`
+
+**Approach:**
+- After fetching `items` and before building the output string, iterate `items` to build a `HashMap<&str, usize>` (or a fixed-order counting approach) of status → count
+- Build a summary string: total count, then each non-zero status in declaration order (`pending`, `in_progress`, `blocked`, `completed`, `cancelled`), separated by commas, with em-dash after total
+- Build the note string (constant) for unfiltered calls only
+- Append summary after the item listing, then note (if applicable), separated by blank lines
+- Follow the `list_skills` pattern: helper function(s) that return empty string when not applicable
+
+**Patterns to follow:**
+- `list_skills.rs` `skipped_warning()` — conditional footer helper returning `String`
+- Existing `VALID_STATUSES` constant in `list_work_items.rs` for status order
+
+**Test scenarios:**
+- Happy path: unfiltered call with mixed statuses (2 pending, 1 in_progress, 1 blocked) → summary includes all three non-zero statuses in correct order, note field present
+- Happy path: unfiltered call with single status (3 pending) → summary shows "3 items total — 3 pending", note present
+- Happy path: filtered call (`status: "blocked"`) with 2 blocked items → summary shows "2 items total — 2 blocked", no note
+- Edge case: empty result → no summary or note (existing "No work items found" message unchanged)
+- Edge case: all 5 statuses represented → summary lists all 5 in declaration order
+- Integration: existing tests (`test_list_work_items_basic`, `test_list_work_items_filter_by_status`) still pass with updated output format
+
+**Verification:**
+- `cargo test -p mika-agent` passes (all existing + new tests)
+- `cargo clippy -p mika-agent` clean
+- Output format matches acceptance criteria from issue #572
+
+## System-Wide Impact
+
+- **API surface parity:** No other consumers of `list_manual_tasks` are affected — the change is purely in the tool's output formatting layer
+- **Unchanged invariants:** `ToolOutput` struct, `list_manual_tasks` DB method, `Task` struct, and all other list tools remain unchanged
+- **Delegate visibility:** Delegates and silent agents also call `list_work_items` (read-only tool in `default_tools()`). The summary is lightweight context, not a call-to-action — appropriate for all agent types
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Existing test assertions break due to output format change | Review all 6 existing tests; update assertions that check exact header format if needed |
+
+## Sources & References
+
+- Related issue: #572
+- Related code: `crates/mika-agent/src/tools/list_work_items.rs`, `crates/mika-agent/src/tools/list_skills.rs`
+- Related learnings: `docs/solutions/architecture-patterns/merge-two-step-llm-tool-contracts.md`

--- a/docs/solutions/best-practices/list-tool-status-summary-reduces-redundant-calls.md
+++ b/docs/solutions/best-practices/list-tool-status-summary-reduces-redundant-calls.md
@@ -1,0 +1,119 @@
+---
+title: List tool status-count summary reduces redundant agent calls
+date: 2026-04-15
+category: best-practices
+module: mika-agent/tools/list_work_items
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding or modifying a list tool that returns items with a categorical field (e.g., status, type, priority)
+  - Agent models issue redundant filtered calls to reconstruct counts from an unfiltered result set
+  - Tool output format does not surface aggregate information at a glance
+tags:
+  - list-tools
+  - tool-output
+  - agent-efficiency
+  - status-summary
+  - redundant-tool-calls
+  - work-items
+---
+
+# List tool status-count summary reduces redundant agent calls
+
+## Context
+
+Models (kimi-k2.5, qwen, and others) routinely followed an unfiltered `list_work_items({})` with 3+ redundant filtered calls (`status:"in_progress"`, `status:"blocked"`, `status:"completed"`) to reconstruct counts the first response already contained. The unfiltered response listed each item with its status, but didn't make the aggregate distribution obvious — so models fell into "ritual thoroughness": re-querying to verify counts already in hand.
+
+This is a structural problem, not model-specific. The tool output didn't make the right next action obvious, forcing callers into defensive re-querying.
+
+## Guidance
+
+When a list tool returns items with a categorical field, compute the aggregate distribution server-side and include it in the tool output. This eliminates the need for the caller to re-query with filters solely to verify counts.
+
+The pattern has three parts:
+
+1. **Status-count summary line** — Computed in-memory from the already-fetched result set (no extra DB queries). Format: `"Summary: N items total — X status_a, Y status_b"`. Omit zero-count categories. Preserve a consistent display order (e.g., active before terminal statuses).
+
+2. **Filter guidance note** — A just-in-time instruction co-located with the decision point: `"Note: All items are returned in this response. Filter by status= only when you need a strict subset for a subsequent action — not to verify counts already shown in summary."` Only shown for fully unfiltered calls (no status or source filter applied). The note is UX-only — it discourages redundant re-filtering but is not an enforcement mechanism.
+
+3. **Scoped summary on filtered calls** — Filtered results still get a summary line scoped to the returned subset, so the output is self-describing regardless of filter state.
+
+Key implementation details:
+
+- Use a module-level constant for status display order (e.g., `STATUS_ORDER`) and reuse it for both validation and summary formatting to avoid duplicate maintenance.
+- The summary counts from `items.len()` and in-memory iteration — no new DB queries.
+- The guidance note guard must check ALL filter parameters, not just the primary one. A source-only filter produces a partial result set, so "all items returned" would be false.
+
+## Why This Matters
+
+**Tool outputs should make the right next action obvious, not force the caller into defensive re-querying.** The server has the data; the server should do the work.
+
+Each redundant tool call costs:
+- An LLM turn (input + output tokens)
+- A DB query (even if fast)
+- Context window space consumed by redundant results
+- Latency in the agent loop
+
+For a status check that triggers 4 calls instead of 1, that's 3x wasted work per query. Across autonomous sessions that check status frequently (heartbeats, callbacks, orchestrator flows), this compounds.
+
+The broader principle: when the intent is "know the counts," the right action is "compute the counts server-side and return them" — not "let the caller re-query per status to reconstruct what the server already knows."
+
+## When to Apply
+
+- Adding a new list tool that returns items with a status, type, category, or other discrete-valued field
+- Observing agents making redundant filtered calls after an unfiltered query
+- Any list tool where aggregate counts are a common follow-up question
+- Do NOT generalize prematurely — prove the pattern with one tool, measure the change in call counts, then apply to others if evidence holds (YAGNI)
+
+## Examples
+
+Before (4 tool calls for a status question):
+```
+list_work_items({})                          → 50 items (all fields)
+list_work_items({"status":"in_progress"})   → 0 items (redundant)
+list_work_items({"status":"blocked"})        → 2 items (redundant)
+list_work_items({"status":"completed"})      → 48 items (redundant)
+```
+
+After (1 tool call):
+```
+list_work_items({})
+→ Work items (50):
+  - [blocked] uuid-1 Fix auth flow (created:...)
+  - [blocked] uuid-2 Update schema (created:...)
+  - [completed] uuid-3 Add health endpoint (created:...)
+  ...
+
+  Summary: 50 items total — 2 blocked, 48 completed
+  Note: All items are returned in this response. Filter by status= only when you need a strict subset for a subsequent action — not to verify counts already shown in summary.
+```
+
+Implementation pattern (Rust):
+```rust
+// Module-level constant — reused for both validation and summary
+const STATUS_ORDER: &[&str] = &["pending", "in_progress", "blocked", "completed", "cancelled"];
+
+fn status_summary(items: &[(Task, Option<i64>)]) -> String {
+    let total = items.len();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for (task, _) in items {
+        *counts.entry(task.status.as_str()).or_insert(0) += 1;
+    }
+    let parts: Vec<String> = STATUS_ORDER.iter()
+        .filter_map(|s| counts.get(s).map(|c| format!("{c} {s}")))
+        .collect();
+    if parts.is_empty() {
+        format!("{total} items total")
+    } else {
+        format!("{total} items total — {}", parts.join(", "))
+    }
+}
+```
+
+## Related
+
+- `docs/solutions/architecture-patterns/merge-two-step-llm-tool-contracts.md` — the foundational pattern: embedding summary data eliminates fragile two-step tool contracts
+- `docs/solutions/logic-errors/create-work-item-duplicate-on-retry.md` — structural signals in tool output are more reliable than prompt instructions alone
+- `docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md` — motivates why status awareness at the read step prevents downstream dispatch failures
+- GitHub issue: #572


### PR DESCRIPTION
## Summary

- Add status-count summary line to `list_work_items` tool output (`"Summary: N items total — X blocked, Y in_progress, Z pending"`)
- Add filter guidance note for fully unfiltered calls discouraging redundant re-filtering
- Filtered calls get scoped summary but no guidance note
- Consolidate `STATUS_ORDER` and `VALID_STATUSES` into a single module-level constant

## Problem

Models (kimi-k2.5, qwen, others) routinely follow an unfiltered `list_work_items({})` with 3+ redundant filtered calls to reconstruct counts already present in the first response. This is "ritual thoroughness" — the fix is structural: compute the summary server-side and return it in the tool output.

## Changes

- **`crates/mika-agent/src/tools/list_work_items.rs`**: Add `STATUS_ORDER` constant, `status_summary()` helper, `FILTER_GUIDANCE_NOTE` constant. Append summary + note to tool output. Guard note on both `status.is_none()` and `source.is_none()`.
- **5 new tests**: mixed statuses, single status, filtered (no note), all 5 statuses, source-only filter (no note)
- **`crates/mika-agent/CLAUDE.md`**: Document output enrichment in Work Item Tracking section
- **`docs/architecture.md`**: Update tool table entry
- **`docs/solutions/best-practices/`**: New compound doc for the pattern

## Test plan

- [x] `cargo test -p mika-agent --lib tools::list_work_items` — 10 tests pass (6 existing + 4 new)
- [x] `cargo clippy -p mika-agent` — clean
- [x] Pre-commit hooks (fmt, clippy, no-secrets) — all pass
- [x] Doc sync via `scripts/sync-agent-docs.sh`

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>