### PR TITLE
fix(tools): reject retry metadata writes during active dispatch (#579)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -55,6 +55,8 @@ Tool trait uses `#[async_trait]` (Send futures). Per-tool timeout override via `
 
 **Status transition state machine:** `pending` -> any; `in_progress` -> blocked/completed/cancelled; `blocked` -> in_progress/completed/cancelled. Terminal states cannot transition.
 
+**Phantom retry guard (#579):** `update_work_item_status` rejects retry-semantic metadata writes (any top-level key containing "retry", case-insensitive) when the work item has an active callback child task (`trigger_type="callback"` in `pending` or `in_progress` status). Returns structured JSON error `retry_metadata_rejected_active_dispatch`. Fail-open on `get_child_tasks` DB error — the dispatch readiness guard (#525) is the primary defense against re-dispatch. Non-retry metadata writes are unaffected.
+
 **Idempotent creation:** Deduplicates on `reference_url` (DB partial unique index `idx_tasks_manual_active_ref_url`) and on label (case-insensitive pre-check). Five loop-prevention guards. Max 5 agent-created items per session (user_request exempt).
 
 ### PR Merge Gate

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -41,7 +41,7 @@ mod update_core_memory;
 mod update_fact;
 mod update_skill;
 mod update_team;
-mod update_work_item_status;
+pub mod update_work_item_status;
 mod write_agent_file;
 mod write_workspace;
 

--- a/crates/mika-agent/src/tools/update_work_item_status.rs
+++ b/crates/mika-agent/src/tools/update_work_item_status.rs
@@ -155,6 +155,41 @@ impl Tool for UpdateWorkItemStatusTool {
 
         let old_status = task.status.clone();
 
+        // Phantom retry guard (#579): reject retry-semantic metadata writes when the
+        // work item has an active callback child task (i.e., a dispatch is still running).
+        // This prevents the LLM from fabricating pipeline failures and polluting retry
+        // budget before any callback has returned. Only fires when metadata contains
+        // retry-related keys — non-retry metadata writes are unaffected.
+        if let Some(meta) = metadata_input
+            && has_retry_semantic_keys(meta)
+            && let Ok(children) = ctx.db.get_child_tasks(task_id).await
+        {
+            let active_callback = children.iter().find(|c| {
+                c.trigger_type == "callback"
+                    && matches!(c.status.as_str(), "pending" | "in_progress")
+            });
+            if let Some(child) = active_callback {
+                return Ok(ToolOutput::error(
+                    serde_json::json!({
+                        "error": "retry_metadata_rejected_active_dispatch",
+                        "task_id": task_id,
+                        "active_child_id": child.id,
+                        "active_child_status": child.status,
+                        "reason": format!(
+                            "Cannot write retry-related metadata while a dispatch is \
+                             still running (callback task '{}' is '{}'). Retry decisions \
+                             must wait for the callback to complete. If you are seeing \
+                             this error, the pipeline has NOT failed yet — do not retry.",
+                            child.id, child.status
+                        )
+                    })
+                    .to_string(),
+                ));
+            }
+            // If get_child_tasks fails (caught by let-else above), allow the write
+            // (fail-open) — the dispatch readiness guard is the primary defense.
+        }
+
         // Same-status is a no-op (skip transition validation)
         if old_status == status {
             if let Some(new_meta) = metadata_input {
@@ -215,6 +250,18 @@ impl Tool for UpdateWorkItemStatusTool {
         }
 
         Ok(ToolOutput::success(response))
+    }
+}
+
+/// Check whether metadata contains any retry-semantic keys (case-insensitive).
+///
+/// Returns `true` if any top-level key contains the substring "retry" (case-insensitive).
+/// This catches `pipeline_retry_count`, `qa_retry_count`, `retry_attempt`, etc.
+fn has_retry_semantic_keys(meta: &Value) -> bool {
+    if let Some(obj) = meta.as_object() {
+        obj.keys().any(|k| k.to_ascii_lowercase().contains("retry"))
+    } else {
+        false
     }
 }
 
@@ -862,6 +909,350 @@ mod tests {
                 result.content
             );
         }
+    }
+
+    // -- Phantom retry guard tests (#579) --
+
+    /// Helper: create a callback child task for a work item.
+    async fn create_callback_child(harness: &TestHarness, parent_id: &str, status: &str) -> String {
+        let child_id = harness
+            .db
+            .create_task(NewTask {
+                agent_id: harness.db.agent_id.clone(),
+                team_run_id: None,
+                parent_task_id: Some(parent_id.to_string()),
+                depth: 1,
+                label: "run_claude_pilot".to_string(),
+                trigger_type: "callback".to_string(),
+                cron_expr: None,
+                event_source: None,
+                event_offset_secs: None,
+                condition_expr: None,
+                next_fire_at: None,
+                timeout_at: None,
+                action_type: "resume_agent".to_string(),
+                action_config: "{}".to_string(),
+                input_context: None,
+                created_by_session: Some("test-session".to_string()),
+                created_trace_id: None,
+                reference_url: None,
+                source: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+
+        if status != "pending" {
+            harness
+                .db
+                .update_task_status(&child_id, status)
+                .await
+                .unwrap();
+        }
+        child_id
+    }
+
+    #[tokio::test]
+    async fn test_retry_metadata_succeeds_without_active_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "No callback item").await;
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"pipeline_retry_count": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "should succeed: {}", result.content);
+        assert!(result.content.contains("pending → in_progress"));
+    }
+
+    #[tokio::test]
+    async fn test_non_retry_metadata_allowed_during_active_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Active dispatch item").await;
+
+        // Transition to in_progress so we can add a callback child
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "pending").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        // Non-retry metadata should succeed even with active callback
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"claude_pilot": {"branch": "feat/test"}}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "non-retry metadata should succeed: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_metadata_rejected_with_pending_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Pending callback item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "pending").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"pipeline_retry_count": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error, "should reject: {}", result.content);
+        assert!(
+            result
+                .content
+                .contains("retry_metadata_rejected_active_dispatch"),
+            "expected structured error, got: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_metadata_rejected_with_in_progress_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "In-progress callback item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "in_progress").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"pipeline_retry_count": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error, "should reject: {}", result.content);
+        assert!(
+            result
+                .content
+                .contains("retry_metadata_rejected_active_dispatch")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_variant_key_rejected_with_active_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Variant key item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "pending").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        // "retry_attempt" also matches the retry-semantic check
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"retry_attempt": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "variant key should be rejected: {}",
+            result.content
+        );
+        assert!(
+            result
+                .content
+                .contains("retry_metadata_rejected_active_dispatch")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_status_only_update_allowed_during_active_callback() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Status only item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "pending").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        // Status-only update (no metadata) should succeed
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "blocked",
+                    "note": "Waiting for callback"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "status-only update should succeed: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_metadata_allowed_after_callback_completed() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Completed callback item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "completed").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        // Callback is completed, so retry metadata should be allowed
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"pipeline_retry_count": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "should allow after completed callback: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_metadata_rejected_on_same_status_path() {
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "Same status retry item").await;
+
+        harness
+            .db
+            .update_manual_task_status(&id, "in_progress")
+            .await
+            .unwrap();
+        create_callback_child(&harness, &id, "pending").await;
+
+        let ctx = harness.ctx();
+        let tool = UpdateWorkItemStatusTool;
+
+        // Same-status path with retry metadata should still be caught
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "task_id": id,
+                    "status": "in_progress",
+                    "metadata": {"pipeline_retry_count": 1}
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "same-status path should also enforce guard: {}",
+            result.content
+        );
+        assert!(
+            result
+                .content
+                .contains("retry_metadata_rejected_active_dispatch")
+        );
+    }
+
+    #[test]
+    fn test_has_retry_semantic_keys() {
+        assert!(has_retry_semantic_keys(
+            &serde_json::json!({"pipeline_retry_count": 1})
+        ));
+        assert!(has_retry_semantic_keys(
+            &serde_json::json!({"qa_retry_count": 0})
+        ));
+        assert!(has_retry_semantic_keys(
+            &serde_json::json!({"retry_attempt": 1})
+        ));
+        assert!(has_retry_semantic_keys(
+            &serde_json::json!({"RETRY_COUNT": 3})
+        ));
+        assert!(!has_retry_semantic_keys(
+            &serde_json::json!({"claude_pilot": {"branch": "main"}})
+        ));
+        assert!(!has_retry_semantic_keys(
+            &serde_json::json!({"ci_fix_count": 2})
+        ));
+        assert!(!has_retry_semantic_keys(&serde_json::json!({})));
+        assert!(!has_retry_semantic_keys(&serde_json::json!(
+            "not an object"
+        )));
+        // Nested retry keys are intentionally excluded — only top-level keys trigger the guard
+        assert!(!has_retry_semantic_keys(
+            &serde_json::json!({"dispatch_info": {"retry_count": 1}})
+        ));
     }
 
     #[test]

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -13,6 +13,7 @@ mod eval {
     mod test_error_handling;
     mod test_internal_tagging;
     mod test_multi_step;
+    mod test_phantom_retry_guard;
     mod test_tool_calling;
     mod test_verdict_handler;
     mod test_webhook_queue;

--- a/crates/mika-agent/tests/eval/test_phantom_retry_guard.rs
+++ b/crates/mika-agent/tests/eval/test_phantom_retry_guard.rs
@@ -1,0 +1,203 @@
+//! Integration tests: phantom retry guard (#579).
+//!
+//! Verifies that the agent loop's `update_work_item_status` tool rejects
+//! retry-semantic metadata writes when the work item has an active callback
+//! child task (i.e., a dispatch is still running).
+
+use mika_agent::db::NewTask;
+use mika_agent::tools::{default_tools, update_work_item_status::UpdateWorkItemStatusTool};
+use mika_common::llm::mock::*;
+use serde_json::json;
+
+use super::assertions::*;
+use super::harness::EvalHarness;
+
+/// Build a tool registry that includes `update_work_item_status`.
+fn tools_with_update_work_item_status() -> mika_agent::tools::ToolRegistry {
+    let mut tools = default_tools();
+    tools.register(Box::new(UpdateWorkItemStatusTool));
+    tools
+}
+
+/// Helper: insert a manual work item and return its ID.
+async fn seed_work_item(harness: &EvalHarness, label: &str) -> String {
+    harness
+        .db
+        .create_task(NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: label.to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("eval-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: Some("self_dev".to_string()),
+            metadata: None,
+        })
+        .await
+        .unwrap()
+}
+
+/// Helper: create a callback child task for a work item.
+async fn create_callback_child(harness: &EvalHarness, parent_id: &str, status: &str) -> String {
+    let child_id = harness
+        .db
+        .create_task(NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.to_string()),
+            depth: 1,
+            label: "run_claude_pilot".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("eval-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    if status != "pending" {
+        harness
+            .db
+            .update_task_status(&child_id, status)
+            .await
+            .unwrap();
+    }
+    child_id
+}
+
+/// Guard rejects retry metadata when active callback child exists.
+/// Simulates the phantom retry: LLM calls update_work_item_status with
+/// pipeline_retry_count while a dispatch is still running.
+#[tokio::test]
+async fn phantom_retry_rejected_during_active_dispatch() {
+    // We need to know the work item ID for the mock response, but the ID is
+    // generated at DB insert time. Use a placeholder UUID — the mock response
+    // includes the task_id in the tool call, but we need the real ID from the DB.
+    // Solution: build harness first, seed data, then use mock_provider's
+    // `push_response` to add responses dynamically.
+
+    // Build harness with a dummy response first — we'll replace it
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            // Placeholder — will be consumed by the agent loop
+            tool_call_response(
+                "update_work_item_status",
+                json!({"task_id": "placeholder", "status": "in_progress", "metadata": {"pipeline_retry_count": 1}}),
+            ),
+            text_response("The dispatch is still running. I'll wait for the callback."),
+        ])
+        .tools(tools_with_update_work_item_status())
+        .build()
+        .await
+        .unwrap();
+
+    // Seed the work item and active callback in THIS harness's DB
+    let work_item_id = seed_work_item(&harness, "Implement feature #334").await;
+    harness
+        .db
+        .update_manual_task_status(&work_item_id, "in_progress")
+        .await
+        .unwrap();
+    create_callback_child(&harness, &work_item_id, "pending").await;
+
+    // Replace the mock responses with ones that use the real work item ID
+    harness.mock_provider.clear_and_set(vec![
+        tool_call_response(
+            "update_work_item_status",
+            json!({
+                "task_id": &work_item_id,
+                "status": "in_progress",
+                "metadata": {"pipeline_retry_count": 1}
+            }),
+        ),
+        text_response("The dispatch is still running. I'll wait for the callback."),
+    ]);
+
+    let trace = harness
+        .run("Pipeline produced no commits for mika#334 — retrying")
+        .await
+        .unwrap();
+
+    assert_has_output(&trace);
+    // Tool was called and returned the guard's error
+    assert_tools_include(&trace, &["update_work_item_status"]);
+    assert_tool_output_contains(
+        &trace,
+        "update_work_item_status",
+        0,
+        "retry_metadata_rejected_active_dispatch",
+    );
+}
+
+/// Guard allows retry metadata when callback child is completed.
+#[tokio::test]
+async fn retry_metadata_allowed_after_callback_completes() {
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            // Placeholder
+            tool_call_response(
+                "update_work_item_status",
+                json!({"task_id": "placeholder", "status": "in_progress", "metadata": {"pipeline_retry_count": 1}}),
+            ),
+            text_response("Retry count updated. Launching retry."),
+        ])
+        .tools(tools_with_update_work_item_status())
+        .build()
+        .await
+        .unwrap();
+
+    // Seed with completed callback child
+    let work_item_id = seed_work_item(&harness, "Implement feature #335").await;
+    harness
+        .db
+        .update_manual_task_status(&work_item_id, "in_progress")
+        .await
+        .unwrap();
+    create_callback_child(&harness, &work_item_id, "completed").await;
+
+    // Replace with real IDs
+    harness.mock_provider.clear_and_set(vec![
+        tool_call_response(
+            "update_work_item_status",
+            json!({
+                "task_id": &work_item_id,
+                "status": "in_progress",
+                "metadata": {"pipeline_retry_count": 1}
+            }),
+        ),
+        text_response("Retry count updated. Launching retry."),
+    ]);
+
+    let trace = harness
+        .run("PIPELINE FAILURE: no commits for mika#335")
+        .await
+        .unwrap();
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["update_work_item_status"]);
+    // The tool should NOT have returned the guard's error
+    assert_output_contains(&trace, "Retry count updated");
+}

--- a/crates/mika-common/CLAUDE.md
+++ b/crates/mika-common/CLAUDE.md
@@ -38,4 +38,4 @@ Multi-provider via `LlmProvider` trait — 11 supported providers, each with its
 
 ## MockLlmProvider
 
-`llm/mock.rs` — sequence-based mock for deterministic agent loop testing, gated behind `test-utils` feature (`#[cfg(any(test, feature = "test-utils"))]`). Used by the eval harness in `crates/mika-agent/tests/eval/`.
+`llm/mock.rs` — sequence-based mock for deterministic agent loop testing, gated behind `test-utils` feature (`#[cfg(any(test, feature = "test-utils"))]`). Used by the eval harness in `crates/mika-agent/tests/eval/`. Responses stored in `Mutex<Vec<MockResponse>>` for dynamic replacement via `clear_and_set()` — enables tests that need to seed DB data (generating IDs) before configuring mock responses that reference those IDs. Must be called before `.run()` (not safe during concurrent access).

--- a/crates/mika-common/src/llm/mock.rs
+++ b/crates/mika-common/src/llm/mock.rs
@@ -61,7 +61,7 @@ impl Default for MockProviderConfig {
 /// Returns pre-configured responses in order. Panics when the sequence is exhausted
 /// (fast failure for test debugging). Captures all received requests for post-run inspection.
 pub struct MockLlmProvider {
-    responses: Vec<MockResponse>,
+    responses: Mutex<Vec<MockResponse>>,
     cursor: AtomicUsize,
     captured_requests: Arc<Mutex<Vec<LlmRequest>>>,
     config: MockProviderConfig,
@@ -82,6 +82,16 @@ impl MockLlmProvider {
     pub fn calls_made(&self) -> usize {
         self.cursor.load(Ordering::SeqCst)
     }
+
+    /// Replace the response sequence and reset the cursor.
+    ///
+    /// Useful when the test needs to seed DB data (which generates IDs)
+    /// before configuring mock responses that reference those IDs.
+    /// Must be called before `.run()` — not safe during concurrent access.
+    pub fn clear_and_set(&self, responses: Vec<MockResponse>) {
+        *self.responses.lock().unwrap() = responses;
+        self.cursor.store(0, Ordering::SeqCst);
+    }
 }
 
 #[async_trait]
@@ -91,16 +101,17 @@ impl LlmProvider for MockLlmProvider {
         self.captured_requests.lock().unwrap().push(request.clone());
 
         let index = self.cursor.fetch_add(1, Ordering::SeqCst);
-        if index >= self.responses.len() {
+        let responses = self.responses.lock().unwrap();
+        if index >= responses.len() {
             panic!(
                 "MockLlmProvider: exhausted all {} responses at call {}. \
                  Add more responses or verify agent behavior.",
-                self.responses.len(),
+                responses.len(),
                 index + 1
             );
         }
 
-        match &self.responses[index] {
+        match &responses[index] {
             MockResponse::Success(resp) => Ok(resp.clone()),
             MockResponse::Error(err) => Err(err.clone()),
         }
@@ -188,7 +199,7 @@ impl MockLlmProviderBuilder {
     /// Build the `MockLlmProvider`.
     pub fn build(self) -> MockLlmProvider {
         MockLlmProvider {
-            responses: self.responses,
+            responses: Mutex::new(self.responses),
             cursor: AtomicUsize::new(0),
             captured_requests: Arc::new(Mutex::new(Vec::new())),
             config: self.config,

--- a/docs/plans/2026-04-16-001-fix-phantom-retry-active-dispatch-guard-plan.md
+++ b/docs/plans/2026-04-16-001-fix-phantom-retry-active-dispatch-guard-plan.md
@@ -1,0 +1,198 @@
+---
+title: "fix: Prevent phantom pipeline retries during active dispatch"
+type: fix
+status: active
+date: 2026-04-16
+---
+
+# fix: Prevent phantom pipeline retries during active dispatch
+
+## Overview
+
+Add a code-level guard to `update_work_item_status` that rejects retry-semantic metadata writes when the work item has an active callback child task (i.e., a claude-pilot session is still running). Harden the self-dev skill prompt as defense-in-depth. This prevents the LLM from fabricating pipeline failures and consuming retry budget before any callback has returned.
+
+## Problem Frame
+
+At 13:54:51 UTC, mika-dev sent "Pipeline produced no commits for mika#334 — retrying (1/2)" only 67 seconds after launching claude-pilot. No callback had returned — the pipeline was still running. The LLM hallucinated a failure, wrote fabricated `pipeline_retry_count` metadata, and attempted a re-dispatch. The re-dispatch was blocked by the existing `validate_dispatch_readiness` guard (#525), but the fabricated metadata persisted — polluting the retry budget for subsequent real callbacks.
+
+This is the same class of LLM nonconformance documented in `docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md` (#525) and `docs/solutions/architecture-patterns/fabricated-action-claim-guard.md` (#308): prompt-level contracts are not reliable under model drift. The established pattern is code guards at the tool boundary.
+
+## Requirements Trace
+
+- R1. Retry-semantic metadata writes on a work item are rejected when an active callback child task exists
+- R2. Non-retry metadata writes (notes, branch, pr_url) are unaffected during active dispatch
+- R3. Engine-internal metadata writes (`try_extract_callback_metadata` in dispatcher.rs) are unaffected
+- R4. Self-dev prompt contains explicit anti-hallucination guardrails for retry behavior
+- R5. Guard returns structured JSON errors consistent with existing dispatch guards
+
+## Scope Boundaries
+
+- The re-dispatch itself is already blocked by `validate_dispatch_readiness` (#525) — this fix addresses the metadata pollution vector
+- No schema changes required — `pipeline_retry_count` is a JSON metadata field, not a DB column
+- No changes to the task engine or callback lifecycle
+
+### Deferred to Separate Tasks
+
+- Telemetry audit of the 13:53-13:55 UTC window: separate investigation comment on #579
+- General LLM fabrication detection framework: future iteration
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/tools/update_work_item_status.rs` — the tool where the guard will be added
+- `crates/mika-agent/src/skills/executor.rs:562` — `validate_dispatch_readiness()` with active-callback-child query pattern to reuse
+- `crates/mika-agent/src/server/webhook_queue.rs:126` — `has_active_callback_child()` helper (same query pattern)
+- `crates/mika-agent/src/task_engine/dispatcher.rs` — engine-level `try_extract_callback_metadata()` writes to parent work item metadata (must NOT be affected)
+- `mika-skills/self-dev/system_prompt.md` — retry instructions at "On pipeline failure" section
+
+### Institutional Learnings
+
+- **Code guards over prompt instructions** — dominant pattern across 6 solutions (#308, #483, #525, #531, #377, callback-task-loop). Prompt enforcement is fragile under model drift.
+- **Structured JSON errors** — LLMs ignore plain-text advisories. Structured errors like `validate_dispatch_readiness` produces are more reliably consumed.
+- **Active-child detection** — `get_child_tasks()` + filter on `trigger_type="callback"` and `status in (pending, in_progress)` is the established query pattern.
+
+## Key Technical Decisions
+
+- **Guard in `update_work_item_status` tool, not in a shared layer:** Engine-internal metadata writes (`try_extract_callback_metadata`) must remain unaffected. The tool is the only LLM-facing metadata write path.
+- **Regex-based retry-semantic key detection:** Match metadata keys containing `retry` (case-insensitive) rather than checking only `pipeline_retry_count` exactly. The LLM could invent `retry_attempt`, `retry_count`, etc. A broader match with `/retry/i` catches these while remaining targeted.
+- **Error, not silent drop:** Return a structured JSON error consistent with the `work_item_active_dispatch` pattern. The LLM receives a clear signal to stop retrying.
+- **Reuse `get_child_tasks` query pattern:** Same async DB method already used by `validate_dispatch_readiness` and `has_active_callback_child`. No new DB queries needed.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the guard block all metadata writes during active dispatch?** No — only retry-semantic keys. Legitimate metadata writes (branch, notes, pr_url) must continue working. The engine also writes metadata on the parent work item during active dispatches.
+- **Where does the guard live?** In the `update_work_item_status` tool's `execute()` method, after fetching the task but before the metadata merge. This is the only LLM-facing path.
+- **Race condition: callback completes milliseconds before metadata write?** The guard sees no active child and allows the write. This is correct — the callback has actually returned, so a retry metadata write at that point is legitimate.
+
+### Deferred to Implementation
+
+- Exact regex pattern for retry-semantic key detection — may need tuning after seeing real metadata patterns
+
+## Implementation Units
+
+- [x] **Unit 1: Active-dispatch retry guard in update_work_item_status**
+
+**Goal:** Reject metadata writes containing retry-semantic keys when the work item has an active callback child task.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/update_work_item_status.rs`
+- Test: `crates/mika-agent/src/tools/update_work_item_status.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- After fetching the task (line 147) and before the same-status/transition-validation logic, add a new check:
+  1. If `metadata_input` is provided and contains any key matching `/retry/i` (case-insensitive substring on top-level keys)
+  2. Query `db.get_child_tasks(task_id)` and check for active callback children (same pattern as `validate_dispatch_readiness`)
+  3. If active callback child exists, return structured JSON error with `"error": "retry_metadata_rejected_active_dispatch"`
+- The check only fires when retry-semantic keys are present in the metadata — non-retry metadata writes are completely unaffected
+- Use `db.get_child_tasks()` (already available on `AsyncDatabase`) — no new DB methods needed
+
+**Patterns to follow:**
+- `validate_dispatch_readiness()` in `crates/mika-agent/src/skills/executor.rs:562` — same query pattern and structured JSON error format
+- Existing metadata validation in `update_work_item_status.rs:130-144` — same error handling style
+
+**Test scenarios:**
+- Happy path: metadata write with `pipeline_retry_count` succeeds when no active callback child exists
+- Happy path: metadata write with non-retry keys (e.g., `claude_pilot.branch`) succeeds even when active callback child exists (R2)
+- Error path: metadata write with `pipeline_retry_count` rejected when active callback child is pending
+- Error path: metadata write with `pipeline_retry_count` rejected when active callback child is in_progress
+- Edge case: metadata write with `retry_attempt` (variant key) rejected when active callback child exists
+- Edge case: metadata write with no metadata field at all succeeds during active dispatch (status-only update)
+- Edge case: metadata write with `pipeline_retry_count` succeeds when callback child is completed (no longer active)
+- Integration: same-status path (line 159) also enforces the guard — metadata-only updates on an in_progress work item are caught
+
+**Verification:**
+- All existing tests pass (no regression)
+- New tests cover each scenario above
+- `cargo test -p mika-agent -- update_work_item_status` passes
+
+- [x] **Unit 2: Self-dev prompt hardening**
+
+**Goal:** Add explicit anti-hallucination guardrails to the self-dev skill prompt to reduce the probability of phantom retries.
+
+**Requirements:** R4
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `mika-skills/self-dev/system_prompt.md` (in the mika-skills repo at `/data/workspace/mika-platform/mika-skills/`)
+
+**Approach:**
+- In the "Step 4 — Wait for the completion callback" section, add a prominently formatted guardrail block:
+  - "NEVER claim a pipeline has failed, mention retry counts, or write `pipeline_retry_count` to metadata unless a callback message containing 'PIPELINE FAILURE:' has been delivered in this conversation. Any retry decision before callback arrival is fabrication."
+- In the "On pipeline failure" section, add a prerequisite check:
+  - "PREREQUISITE: This section ONLY applies when you have received a callback result message in this conversation that contains the literal text 'PIPELINE FAILURE:'. If no such callback has been delivered, do NOT enter this section."
+- Add a new Calibration Rule (Rule 10) documenting the incident and the anti-pattern
+
+**Patterns to follow:**
+- Existing Calibration Rules format (Rules 4-9) — incident citation, concrete "Wrong/Right" examples
+- Existing "Do NOT" guardrails in Step 4 section
+
+**Test scenarios:**
+Test expectation: none -- prompt-only change, no code to test. Effectiveness is verified by the code guard in Unit 1 catching any prompt nonconformance.
+
+**Verification:**
+- Prompt file is valid markdown
+- New guardrail text is present in the expected sections
+- No existing instructions were accidentally removed
+
+- [x] **Unit 3: Eval test for phantom retry rejection**
+
+**Goal:** Add an agent loop eval test that exercises the full phantom retry scenario end-to-end via MockLlmProvider.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `crates/mika-agent/tests/eval/test_phantom_retry_guard.rs`
+- Modify: `crates/mika-agent/tests/eval/main.rs` (add `mod test_phantom_retry_guard;`)
+
+**Approach:**
+- Use `EvalHarness` builder with `MockLlmProvider` to set up:
+  1. A work item in `in_progress` status with an active callback child task (pending)
+  2. An LLM response sequence where the agent attempts to call `update_work_item_status` with `pipeline_retry_count` in metadata
+  3. Verify the tool returns a structured error with `retry_metadata_rejected_active_dispatch`
+- This tests the guard in the full `run_agent()` path, not just the unit tool test
+
+**Patterns to follow:**
+- Existing eval tests in `crates/mika-agent/tests/eval/` — `EvalHarness` builder pattern, `MockLlmProvider` sequence setup
+- `test_webhook_queue.rs` — similar pattern of pre-creating tasks and verifying guard behavior
+
+**Test scenarios:**
+- Integration: mock LLM attempts `update_work_item_status` with `pipeline_retry_count` during active callback -> guard rejects -> LLM receives error in tool result
+- Happy path: same scenario but callback child is completed -> guard allows the write
+
+**Verification:**
+- `cargo test -p mika-agent --test eval` passes
+- New test file is included in the eval test runner
+
+## System-Wide Impact
+
+- **Interaction graph:** The guard adds one async DB query (`get_child_tasks`) per `update_work_item_status` call that includes retry-semantic metadata keys. This is the same query already used by `validate_dispatch_readiness` — no new DB load pattern.
+- **Error propagation:** Structured JSON error returned to the LLM, same format as existing dispatch guards. The LLM receives a clear signal and should stop the retry attempt.
+- **State lifecycle risks:** None — the guard prevents bad metadata from being written, which is the correct behavior. The same-status path (metadata-only updates) is also guarded.
+- **API surface parity:** Only the `update_work_item_status` tool is affected. Engine-internal metadata writes (`try_extract_callback_metadata`) bypass this guard entirely since they go through `update_work_item_metadata` directly on the DB.
+- **Unchanged invariants:** All existing metadata write behavior for non-retry keys is unchanged. All existing status transition logic is unchanged. The dispatch guard in `validate_dispatch_readiness` remains the primary defense against re-dispatch.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| LLM invents a non-matching key name (e.g., `failed_attempts`) to store retry state | Regex `/retry/i` is the initial scope; can be broadened if new evasion patterns emerge. The dispatch guard (#525) remains the backstop. |
+| False positive: legitimate metadata key containing "retry" blocked | Review existing metadata patterns — no current keys match `/retry/i` except `pipeline_retry_count`, `qa_retry_count`, `ci_fix_count`. The `ci_fix_count` key does not match the regex so it's unaffected. |
+| Performance: extra DB query on every metadata write with retry keys | `get_child_tasks` is a simple indexed query. Only fires when retry-semantic keys are present — the vast majority of metadata writes don't match. |
+
+## Sources & References
+
+- Related issue: #579
+- Dispatch readiness guard: #525 — `docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md`
+- Fabricated action claim guard: #308 — `docs/solutions/architecture-patterns/fabricated-action-claim-guard.md`
+- Completion claim guard: #483 — `docs/solutions/architecture-patterns/completion-claim-guard-work-item-state-enforcement.md`
+- LLM nonconformance incident: `docs/solutions/integration-issues/2026-04-15-claude-pilot-relay-over-escalation-and-llm-nonconformance.md`

--- a/docs/solutions/architecture-patterns/phantom-retry-guard-active-dispatch-metadata-validation.md
+++ b/docs/solutions/architecture-patterns/phantom-retry-guard-active-dispatch-metadata-validation.md
@@ -1,0 +1,100 @@
+---
+module: task-engine
+date: 2026-04-16
+problem_type: logic_error
+component: tooling
+severity: high
+symptoms:
+  - "mika-dev sends 'Pipeline produced no commits' message 67 seconds after dispatch, before any callback returns"
+  - "pipeline_retry_count metadata written to work item while claude-pilot session is still running"
+  - "fabricated retry triggers cascade: concurrency-guard bypass and tool filter regression"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - phantom-retry
+  - llm-fabrication
+  - metadata-guard
+  - callback-lifecycle
+  - defense-in-depth
+  - tool-boundary-guard
+related_components:
+  - assistant
+---
+
+# Phantom Retry Guard: Active-Dispatch Metadata Validation
+
+## Problem
+
+mika-dev (the orchestrator agent) fabricated a pipeline failure 67 seconds after launching a claude-pilot session. No callback had returned yet -- the pipeline was still running. The LLM hallucinated "Pipeline produced no commits for mika#334 -- retrying (1/2)" and attempted to write `pipeline_retry_count` metadata to the work item, consuming retry budget before any real failure occurred.
+
+The existing `validate_dispatch_readiness` guard (#525) blocked the re-dispatch itself, but the fabricated metadata persisted -- polluting the retry budget so that when a real callback eventually returned, the agent believed it had already used one retry attempt.
+
+## Symptoms
+
+- mika-dev sends retry notifications within seconds of dispatch launch (real pipelines take minutes to hours)
+- `pipeline_retry_count` metadata appears on work items with active (pending/in_progress) callback children
+- Retry budget consumed before any callback-delivered failure signal
+- Cascade of secondary failures triggered by the phantom retry attempt
+
+## What Didn't Work
+
+- **Prompt-only enforcement**: The self-dev skill prompt already instructed mika-dev to "Wait for the completion callback" and "Do NOT proactively poll." The LLM ignored these instructions under model drift (same class of nonconformance as #308, #483, #525).
+- **Relying on dispatch guard alone**: `validate_dispatch_readiness` correctly blocked re-dispatch, but the metadata write succeeded via a separate tool call (`update_work_item_status`) that had no corresponding guard.
+
+## Solution
+
+Added a code-level guard in `update_work_item_status` tool that rejects retry-semantic metadata writes when the work item has an active callback child task:
+
+```rust
+// In update_work_item_status execute(), after fetching the task:
+if let Some(meta) = metadata_input
+    && has_retry_semantic_keys(meta)
+    && let Ok(children) = ctx.db.get_child_tasks(task_id).await
+{
+    let active_callback = children.iter().find(|c| {
+        c.trigger_type == "callback"
+            && matches!(c.status.as_str(), "pending" | "in_progress")
+    });
+    if let Some(child) = active_callback {
+        return Ok(ToolOutput::error(
+            serde_json::json!({
+                "error": "retry_metadata_rejected_active_dispatch",
+                "task_id": task_id,
+                "active_child_id": child.id,
+                "active_child_status": child.status,
+                "reason": "Cannot write retry-related metadata while a dispatch is still running."
+            }).to_string(),
+        ));
+    }
+}
+```
+
+The `has_retry_semantic_keys()` helper matches any top-level metadata key containing "retry" (case-insensitive), catching `pipeline_retry_count`, `qa_retry_count`, `retry_attempt`, etc.
+
+Defense-in-depth prompt hardening was added to the self-dev skill prompt:
+- Explicit prerequisite on the "On pipeline failure" section requiring a delivered callback with `PIPELINE FAILURE:` prefix
+- Anti-hallucination guardrail in Step 4 ("Wait for callback")
+- Calibration Rule 10 documenting the incident with Wrong/Right examples
+
+## Why This Works
+
+The guard operates at the tool boundary -- the only LLM-facing path for metadata writes. Engine-internal metadata writes (`try_extract_callback_metadata` in dispatcher.rs) bypass this guard since they go through `update_work_item_metadata` directly on the DB, not through the tool.
+
+The design is fail-open: if `get_child_tasks` returns an error, the write proceeds. This is intentional -- the dispatch readiness guard (#525) is the primary defense against re-dispatch (and is fail-closed). This guard prevents the secondary harm (metadata pollution) and fail-open avoids blocking legitimate metadata writes during transient DB issues.
+
+## Prevention
+
+1. **Code guards at tool boundaries, not prompt instructions** -- this is the dominant pattern across 6+ prior solutions (#308, #483, #525, #531, #377). When LLM nonconformance can cause real harm, enforce in the harness.
+2. **Structured JSON errors** -- LLMs reliably consume structured error responses (like `retry_metadata_rejected_active_dispatch`); they ignore plain-text advisories.
+3. **Independent retry budgets with metadata persistence** -- retry counters must only be written after a real callback signal, not based on LLM inference about pipeline state.
+4. **Active-child detection** -- the query pattern `get_child_tasks() + filter on trigger_type="callback" && status in (pending, in_progress)` is reusable across guards.
+
+## Related
+
+- #579 -- This issue
+- #525 -- Dispatch readiness guard (prevents re-dispatch, primary defense)
+- #308 -- Fabricated action-claim guard (same class: code guard over prompt)
+- #483 -- Completion-claim guard (same class: code guard over prompt)
+- `docs/solutions/architecture-patterns/dispatch-readiness-guard-long-running-status-validation.md`
+- `docs/solutions/architecture-patterns/fabricated-action-claim-guard.md`
+- `docs/solutions/architecture-patterns/completion-claim-guard-work-item-state-enforcement.md`


### PR DESCRIPTION
## Summary

- Add phantom retry guard to `update_work_item_status` that rejects retry-semantic metadata writes when the work item has an active callback child task (dispatch still running)
- Harden self-dev skill prompt with explicit anti-hallucination guardrails (Calibration Rule 10) and prerequisite checks on the "On pipeline failure" section
- Add `MockLlmProvider::clear_and_set()` for eval test infrastructure (responses stored in `Mutex<Vec>` for dynamic replacement after DB seeding)

## Context

At 13:54:51 UTC, mika-dev fabricated "Pipeline produced no commits for mika#334 — retrying (1/2)" only 67 seconds after launching claude-pilot. No callback had returned. The dispatch readiness guard (#525) blocked re-dispatch, but the fabricated `pipeline_retry_count` metadata persisted — polluting the retry budget.

The fix adds a code-level guard (following the established pattern from #308, #483, #525) that rejects retry-semantic metadata writes when an active callback child exists. Non-retry metadata writes are unaffected. Fail-open on DB errors (dispatch guard is the primary defense).

## Test plan

- [x] 8 new unit tests in `update_work_item_status.rs` covering happy path, rejection with pending/in_progress callbacks, variant keys, same-status path, completed callback, status-only updates
- [x] 9 assertions in `has_retry_semantic_keys` unit test (including nested key exclusion)
- [x] 2 new eval integration tests via `EvalHarness` + `MockLlmProvider`
- [x] All 1624 existing unit tests pass
- [x] All 49 eval tests pass (47 existing + 2 new)
- [x] Clippy clean
- [x] `cargo fmt` clean (enforced by pre-commit hook)

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)