### PR TITLE
Gateway retries inbound GitHub webhook delivery on 429/5xx

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -23,6 +23,14 @@ HMAC-SHA256 signature validation via `X-Hub-Signature-256`. Event routing:
 - 256KB body limit
 - Multi-tenant routing via `github_repos` table lookup with `agent_base_url` fallback for single-tenant mode
 
+### Inbound delivery retry (#589)
+
+The spawned forwarding task retries on HTTP 429/5xx or request timeouts using the fixed schedule `[2s, 5s, 15s, 60s, 300s]` with ±25% per-attempt jitter (prevents synchronized retry bursts on the same agent). Permanent failures (HTTP 4xx other than 429, connection errors indicating the agent is offline, or unresolvable route) stop retries immediately. Route resolution (`github_repos` lookup + `agent_mapping`) is cached across retries — a single Postgres query per event regardless of retry count.
+
+Semaphore lifecycle during retry: the 30-permit `webhook_semaphore` (shared with Telegram) is released during each retry sleep and re-acquired via `try_acquire_owned` before the next attempt. If the semaphore is full on re-acquire, the retry is abandoned with a dedicated ERROR log (`semaphore at capacity during retry`), distinct from the `retry budget exhausted` ERROR emitted when all 6 attempts return a retryable failure.
+
+The delivery LRU cache has no TTL (size-based eviction only). Under extreme webhook volume (>10k deliveries during a single 300s retry sleep), the `X-GitHub-Delivery` entry may be evicted and a GitHub redelivery would bypass gateway dedup. Agent-side idempotency (work item unique index on `reference_url`) mitigates double-processing. Events that exhaust retries or are abandoned due to semaphore pressure are dropped with ERROR logs; persistent DLQ + replay CLI is tracked in #590.
+
 ## Agent Identification & Reply Routing
 
 - Outbound messages carry `agent_name` in the `/send` payload; gateway prepends `[agent_name]` to Telegram text and stores `(telegram_message_id, chat_id, agent_name)` in `outbound_messages` Postgres table

--- a/crates/mika-gateway/Cargo.toml
+++ b/crates/mika-gateway/Cargo.toml
@@ -37,8 +37,8 @@ sha2.workspace = true
 hmac.workspace = true
 hex.workspace = true
 lru.workspace = true
+rand = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }
 http-body-util = { workspace = true }
-rand = { workspace = true }

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -13,6 +13,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use bytes::Bytes;
 use hmac::{Hmac, Mac};
+use rand::Rng;
 use secrecy::ExposeSecret;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
@@ -332,7 +333,7 @@ pub fn new_delivery_cache() -> Arc<std::sync::Mutex<lru::LruCache<String, ()>>> 
 
 // -- Forwarding result type --
 
-/// Outcome of a single `forward_github_event` attempt.
+/// Outcome of a single forwarding attempt to an agent container.
 /// Used by the retry wrapper to decide whether to retry, abandon, or succeed.
 #[derive(Debug)]
 pub(crate) enum ForwardResult {
@@ -365,6 +366,7 @@ impl ForwardResult {
     }
 
     /// Returns the reason string for non-success results.
+    #[cfg(test)]
     fn reason(&self) -> Option<&str> {
         match self {
             Self::Success => None,
@@ -377,6 +379,9 @@ impl ForwardResult {
 
 /// Delays between retry attempts for GitHub webhook delivery.
 /// Total worst-case wall time: 2 + 5 + 15 + 60 + 300 = 382 seconds (+ request timeouts).
+///
+/// Each delay gets jitter applied (see [`apply_jitter`]) to prevent synchronized
+/// retry bursts when many events hit the same 429/5xx response simultaneously.
 pub(crate) const RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(2),
     Duration::from_secs(5),
@@ -384,6 +389,20 @@ pub(crate) const RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(60),
     Duration::from_secs(300),
 ];
+
+/// Apply ±25% random jitter to a retry delay to prevent thundering-herd effects
+/// when many in-flight retries wake up at the same instant.
+fn apply_jitter(delay: Duration) -> Duration {
+    let base_ms = delay.as_millis() as i64;
+    // Jitter in ±25% of the base delay. Uses inclusive range so both bounds can hit.
+    let jitter_range = base_ms / 4;
+    if jitter_range == 0 {
+        return delay;
+    }
+    let offset: i64 = rand::rng().random_range(-jitter_range..=jitter_range);
+    let jittered = (base_ms + offset).max(0) as u64;
+    Duration::from_millis(jittered)
+}
 
 // -- Webhook handler --
 
@@ -624,30 +643,18 @@ async fn resolve_github_container_url(
     }
 }
 
-/// Forward a GitHub event to the agent container via `POST {container_url}/message`.
+/// Forward a GitHub event to a pre-resolved agent container route.
 ///
-/// Single-attempt function — no retry logic. Returns a [`ForwardResult`] so the
-/// caller (`deliver_with_retry`) can decide whether to retry.
-///
-/// Uses `channel: "github"` and `chat_id: 0` (no reply channel).
-/// Multi-tenant routing: looks up `github_repos` table first, falls back to `agent_base_url`.
-/// Per-repo agent name overrides are applied from the `agent_mapping` column.
-async fn forward_github_event(
+/// Used by [`deliver_with_retry`] so the route (Postgres lookup + agent mapping)
+/// is resolved exactly once, regardless of how many retries occur.
+async fn forward_to_resolved_route(
     state: &AppState,
+    route: &ResolvedRoute,
     default_agent: &str,
     text: &str,
     request_id: &str,
     repo_full_name: Option<&str>,
 ) -> ForwardResult {
-    let route = match resolve_github_container_url(state, repo_full_name).await {
-        Some(r) => r,
-        None => {
-            return ForwardResult::Permanent {
-                reason: "no route resolved (repo not registered and no fallback)".to_string(),
-            };
-        }
-    };
-
     let target_agent = apply_agent_mapping(&route.agent_mapping, default_agent);
     if target_agent != default_agent {
         info!(
@@ -658,7 +665,7 @@ async fn forward_github_event(
         );
     }
 
-    let url = route.container_url;
+    let url = &route.container_url;
     let payload = serde_json::json!({
         "text": text,
         "chat_id": 0,
@@ -677,9 +684,8 @@ async fn forward_github_event(
         .await;
 
     match result {
-        Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 202 => {
-            ForwardResult::Success
-        }
+        // `is_success()` returns true for 2xx (including 202 Accepted).
+        Ok(resp) if resp.status().is_success() => ForwardResult::Success,
         Ok(resp) => {
             let status = resp.status().as_u16();
             if status == 429 || (500..=599).contains(&status) {
@@ -710,14 +716,25 @@ async fn forward_github_event(
 
 /// Retry wrapper for GitHub webhook delivery.
 ///
-/// Calls `forward_github_event` once using the caller's semaphore permit. On a
-/// retryable failure (429, 5xx, or request timeout), releases the permit, sleeps
-/// for the next delay in [`RETRY_DELAYS`], re-acquires a permit, and retries.
+/// Calls [`forward_to_resolved_route`] once using the caller's semaphore permit.
+/// On a retryable failure (429, 5xx, or request timeout), releases the permit,
+/// sleeps for the next delay in [`RETRY_DELAYS`] (with jitter), re-acquires a
+/// permit, and retries.
+///
+/// **Route caching:** The container URL and agent mapping are resolved once at
+/// the start (single Postgres query), then reused for every retry. This avoids
+/// hitting Postgres up to 6 times per event during sustained agent failure.
 ///
 /// **Semaphore lifecycle:** The permit is released during sleep to prevent
 /// cross-channel starvation (the 30-permit semaphore is shared with Telegram).
-/// If the semaphore is full when re-acquiring, the retry is abandoned — the
-/// system is legitimately overloaded.
+/// If the semaphore is full when re-acquiring, the retry is abandoned with a
+/// dedicated ERROR log — the event is dropped because the system is overloaded,
+/// not because retries were exhausted. These two failure modes are logged
+/// separately so operators can distinguish them.
+///
+/// **Jitter:** Each retry delay gets ±25% random jitter (see [`apply_jitter`])
+/// so that many in-flight retries don't synchronize on the same wakeup instant
+/// and recreate the original burst.
 ///
 /// **Dedup LRU interaction:** The `X-GitHub-Delivery` ID is inserted into the
 /// in-memory LRU cache (10k entries, size-based eviction, no TTL) *before* this
@@ -735,73 +752,83 @@ async fn deliver_with_retry(
     initial_permit: tokio::sync::OwnedSemaphorePermit,
     semaphore: &Arc<tokio::sync::Semaphore>,
 ) {
-    // Attempt 0: use the caller's permit.
-    let result = forward_github_event(state, target_agent, text, request_id, repo_full_name).await;
-
-    match &result {
-        ForwardResult::Success => {
-            info!(
-                target_agent,
-                request_id, "GitHub event forwarded to agent container"
-            );
-            drop(initial_permit);
-            return;
-        }
-        ForwardResult::Permanent { reason } => {
+    // Resolve the route once. Cached across all retry attempts.
+    let route = match resolve_github_container_url(state, repo_full_name).await {
+        Some(r) => r,
+        None => {
             error!(
                 target_agent,
-                request_id, reason = %reason, "GitHub event delivery failed (permanent, no retry)"
+                request_id,
+                "GitHub event delivery failed — no route resolved (repo not registered and no fallback), event dropped"
             );
             drop(initial_permit);
             return;
         }
-        ForwardResult::Retryable { reason } => {
-            warn!(
-                target_agent,
-                request_id,
-                attempt = 1,
-                reason = %reason,
-                "GitHub event delivery failed, will retry"
-            );
-        }
-    }
+    };
 
-    // Release the initial permit during the retry sleep window.
-    drop(initial_permit);
+    // Run the full attempt sequence: initial + up to RETRY_DELAYS.len() retries.
+    // `attempts_made` tracks how many HTTP calls were actually issued, which is
+    // used for accurate logging on any terminal outcome.
+    let mut attempts_made: u32 = 0;
+    let mut last_reason: String = String::new();
+    let mut current_permit = Some(initial_permit);
 
-    let mut last_reason = result.reason().unwrap_or("unknown").to_string();
+    for (retry_idx, delay) in std::iter::once(None)
+        .chain(RETRY_DELAYS.iter().map(Some))
+        .enumerate()
+    {
+        // The first iteration (retry_idx=0) has `delay = None` and uses the caller's permit.
+        // Subsequent iterations sleep then re-acquire a permit.
+        if let Some(delay) = delay {
+            tokio::time::sleep(apply_jitter(*delay)).await;
 
-    for (i, delay) in RETRY_DELAYS.iter().enumerate() {
-        let attempt = i + 2; // attempt 1 was the initial, retries start at 2
-
-        tokio::time::sleep(*delay).await;
-
-        // Re-acquire a semaphore permit before retrying.
-        let permit = match semaphore.clone().try_acquire_owned() {
-            Ok(p) => p,
-            Err(_) => {
-                warn!(
-                    target_agent,
-                    request_id, attempt, "GitHub event retry abandoned — semaphore at capacity"
-                );
-                break;
+            match semaphore.clone().try_acquire_owned() {
+                Ok(p) => {
+                    current_permit = Some(p);
+                }
+                Err(_) => {
+                    error!(
+                        target_agent,
+                        request_id,
+                        attempts_made,
+                        last_reason = %last_reason,
+                        "GitHub event delivery abandoned — gateway semaphore at capacity during retry, event dropped"
+                    );
+                    return;
+                }
             }
-        };
+        }
 
-        let result =
-            forward_github_event(state, target_agent, text, request_id, repo_full_name).await;
+        let attempt = retry_idx as u32 + 1;
+        let result = forward_to_resolved_route(
+            state,
+            &route,
+            target_agent,
+            text,
+            request_id,
+            repo_full_name,
+        )
+        .await;
+        attempts_made = attempt;
 
-        // Release the permit immediately after the attempt (before sleeping again).
-        drop(permit);
+        // Release the permit immediately after the attempt, before the next sleep.
+        current_permit.take();
 
-        match &result {
+        match result {
             ForwardResult::Success => {
-                info!(
-                    target_agent,
-                    request_id,
-                    attempt,
-                    "GitHub event forwarded to agent container (retry succeeded)"
-                );
+                if attempt == 1 {
+                    info!(
+                        target_agent,
+                        request_id, "GitHub event forwarded to agent container"
+                    );
+                } else {
+                    info!(
+                        target_agent,
+                        request_id,
+                        attempt,
+                        "GitHub event forwarded to agent container (retry succeeded)"
+                    );
+                }
                 return;
             }
             ForwardResult::Permanent { reason } => {
@@ -810,29 +837,30 @@ async fn deliver_with_retry(
                     request_id,
                     attempt,
                     reason = %reason,
-                    "GitHub event delivery failed (permanent, stopping retries)"
+                    "GitHub event delivery failed (permanent, no further retries)"
                 );
                 return;
             }
             ForwardResult::Retryable { reason } => {
-                last_reason = reason.clone();
+                let remaining = RETRY_DELAYS.len().saturating_sub(retry_idx);
                 warn!(
                     target_agent,
                     request_id,
                     attempt,
-                    remaining_retries = RETRY_DELAYS.len() - i - 1,
+                    remaining_retries = remaining,
                     reason = %reason,
                     "GitHub event delivery failed, will retry"
                 );
+                last_reason = reason;
             }
         }
     }
 
-    // All retries exhausted.
+    // All retries exhausted — every attempt returned Retryable.
     error!(
         target_agent,
         request_id,
-        total_attempts = RETRY_DELAYS.len() + 1,
+        total_attempts = attempts_made,
         last_reason = %last_reason,
         "GitHub event delivery failed — retry budget exhausted, event dropped (DLQ: #590)"
     );
@@ -1545,11 +1573,16 @@ mod tests {
     // agent container responses. Since we don't have wiremock as a dependency,
     // we test the retry logic using a real Axum server bound to an ephemeral port.
 
-    /// Spin up a minimal Axum server that returns a sequence of status codes.
-    /// Returns the base URL (e.g., "http://127.0.0.1:12345").
-    async fn mock_agent_server(responses: Vec<StatusCode>) -> String {
-        use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Spin up a minimal Axum server that returns a sequence of status codes.
+    /// Returns `(base_url, call_count)` so tests can assert how many HTTP calls
+    /// were actually made — essential for verifying the no-retry contract.
+    ///
+    /// When `responses` is exhausted, falls back to `StatusCode::OK`. Tests that
+    /// rely on "no retry" must therefore assert `call_count == expected` rather
+    /// than relying on default behavior.
+    async fn mock_agent_server(responses: Vec<StatusCode>) -> (String, Arc<AtomicUsize>) {
         let call_count = Arc::new(AtomicUsize::new(0));
         let responses = Arc::new(responses);
 
@@ -1573,7 +1606,7 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
 
-        format!("http://127.0.0.1:{}", addr.port())
+        (format!("http://127.0.0.1:{}", addr.port()), call_count)
     }
 
     /// Build an AppState pointing to a mock agent server.
@@ -1607,7 +1640,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_success_on_first_attempt() {
-        let base_url = mock_agent_server(vec![StatusCode::OK]).await;
+        let (base_url, call_count) = mock_agent_server(vec![StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
         let permit = semaphore.clone().try_acquire_owned().unwrap();
@@ -1623,6 +1656,11 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "success on first attempt should make exactly 1 HTTP call"
+        );
         // Permit was consumed (dropped inside deliver_with_retry on success)
         assert_eq!(semaphore.available_permits(), 30);
     }
@@ -1630,14 +1668,14 @@ mod tests {
     #[tokio::test]
     async fn test_deliver_retry_on_429_then_success() {
         // First call returns 429, second returns 200
-        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        let (base_url, call_count) =
+            mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
         let permit = semaphore.clone().try_acquire_owned().unwrap();
 
-        // Use a custom short delay schedule for testing (don't wait real 2s)
-        // We can't easily override RETRY_DELAYS, so we test with the real function
-        // but accept the 2s wait for the first retry.
+        // Accepts the real 2s wait for the first retry — RETRY_DELAYS is a
+        // compile-time const so we can't easily inject shorter delays.
         deliver_with_retry(
             &state,
             "mika-dev",
@@ -1649,13 +1687,18 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "429-then-success should make exactly 2 HTTP calls"
+        );
         // Should succeed after one retry — all permits returned
         assert_eq!(semaphore.available_permits(), 30);
     }
 
     #[tokio::test]
     async fn test_deliver_retry_on_503_then_success() {
-        let base_url =
+        let (base_url, call_count) =
             mock_agent_server(vec![StatusCode::SERVICE_UNAVAILABLE, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
@@ -1672,13 +1715,17 @@ mod tests {
         )
         .await;
 
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
         assert_eq!(semaphore.available_permits(), 30);
     }
 
     #[tokio::test]
     async fn test_deliver_no_retry_on_400() {
-        // 400 is permanent — should not retry
-        let base_url = mock_agent_server(vec![StatusCode::BAD_REQUEST]).await;
+        // 400 is permanent — should not retry. Queue OK as fallback so a
+        // regression that retries would mask itself with success, making the
+        // call_count assertion the sole guarantee of no-retry.
+        let (base_url, call_count) =
+            mock_agent_server(vec![StatusCode::BAD_REQUEST, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
         let permit = semaphore.clone().try_acquire_owned().unwrap();
@@ -1694,13 +1741,18 @@ mod tests {
         )
         .await;
 
-        // Should return immediately without retry — all permits returned
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "400 is permanent — must make exactly 1 HTTP call, no retry"
+        );
         assert_eq!(semaphore.available_permits(), 30);
     }
 
     #[tokio::test]
     async fn test_deliver_no_retry_on_404() {
-        let base_url = mock_agent_server(vec![StatusCode::NOT_FOUND]).await;
+        let (base_url, call_count) =
+            mock_agent_server(vec![StatusCode::NOT_FOUND, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
         let permit = semaphore.clone().try_acquire_owned().unwrap();
@@ -1716,13 +1768,74 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "404 is permanent — must make exactly 1 HTTP call, no retry"
+        );
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    #[ignore = "takes ~6.5 minutes of wall time (RETRY_DELAYS total 382s); run with --ignored"]
+    async fn test_deliver_retry_budget_exhausted_after_six_attempts() {
+        // All 6 attempts (initial + 5 retries) return 429 — retry budget exhausted,
+        // ERROR logged, event dropped. This is the plan's Unit 2 required scenario.
+        //
+        // Wall-clock cost: 2 + 5 + 15 + 60 + 300 = 382s (±25% jitter per step).
+        // Marked #[ignore] so normal `cargo test` skips it; run with:
+        //   cargo test -p mika-gateway -- --ignored test_deliver_retry_budget_exhausted
+        //
+        // Queue 6 explicit 429s so every attempt is Retryable. Uses tokio::time::timeout
+        // to cap the test wall-clock in case of test infra issues.
+        let (base_url, call_count) = mock_agent_server(vec![
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::TOO_MANY_REQUESTS,
+        ])
+        .await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        // Total wall time: 2 + 5 + 15 + 60 + 300 = 382s base. Cap at 500s via timeout.
+        // NOTE: This test takes ~6.5 minutes of real time because RETRY_DELAYS is
+        // a compile-time const. Marked #[ignore] by default — run with `cargo test
+        // -- --ignored test_deliver_retry_budget_exhausted` for coverage.
+        let result = tokio::time::timeout(
+            Duration::from_secs(500),
+            deliver_with_retry(
+                &state,
+                "mika-dev",
+                "test event",
+                "delivery-exhausted",
+                Some("org/repo"),
+                permit,
+                &semaphore,
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "deliver_with_retry did not return within 500s"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            6,
+            "all retries should be exhausted — expected 6 HTTP calls"
+        );
         assert_eq!(semaphore.available_permits(), 30);
     }
 
     #[tokio::test]
     async fn test_deliver_semaphore_released_during_retry_sleep() {
         // 429 on first attempt — during the 2s sleep, the permit should be released
-        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        let (base_url, _call_count) =
+            mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = Arc::new(tokio::sync::Semaphore::new(1)); // Only 1 permit!
         let permit = semaphore.clone().try_acquire_owned().unwrap();
@@ -1741,8 +1854,11 @@ mod tests {
             .await;
         });
 
-        // Give the first attempt time to fail and release the permit
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Give the first attempt time to fail and release the permit.
+        // The 429 response comes back quickly (localhost Axum), then the retry
+        // path enters tokio::time::sleep(2s +/- jitter). 500ms gives ample margin
+        // over the HTTP round-trip on any reasonable CI host.
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // The permit should be available during the retry sleep window
         let available = semaphore.available_permits();
@@ -1753,8 +1869,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_deliver_abandoned_when_semaphore_full() {
-        // 429 on first attempt, then semaphore is full on retry
-        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        // 429 on first attempt, then semaphore is full on retry.
+        // Queue an OK as fallback to prove the retry path was NOT taken —
+        // the mock server would return OK if the retry fired, but the test
+        // asserts call_count == 1 to prove only the initial attempt ran.
+        let (base_url, call_count) =
+            mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
 
         // Semaphore with 1 permit — we'll hold the spare one to block retry
@@ -1777,19 +1897,33 @@ mod tests {
         });
 
         // Wait for the first attempt to fail and release the permit
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Grab the permit before the retry can — this blocks the retry
         let _blocker = semaphore.clone().try_acquire_owned().unwrap();
 
-        // The retry should be abandoned because the semaphore is full
-        handle.await.unwrap();
-        // Test passes if deliver_with_retry returns without hanging
+        // The retry should be abandoned because the semaphore is full.
+        // Wrap in timeout to catch the race where _blocker wasn't grabbed in
+        // time: if the retry succeeded, deliver_with_retry returns quickly
+        // (still within timeout); if _blocker was grabbed, deliver_with_retry
+        // abandons and returns immediately.
+        tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("deliver_with_retry should not hang")
+            .unwrap();
+
+        // Assert exactly one HTTP call was made. If the retry happened
+        // (the abandon path didn't fire), call_count would be 2.
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "semaphore-full abandonment should result in exactly 1 HTTP call"
+        );
     }
 
     #[tokio::test]
     async fn test_deliver_accepts_202() {
-        let base_url = mock_agent_server(vec![StatusCode::ACCEPTED]).await;
+        let (base_url, call_count) = mock_agent_server(vec![StatusCode::ACCEPTED]).await;
         let state = test_state_with_base_url(&base_url);
         let semaphore = state.webhook_semaphore.clone();
         let permit = semaphore.clone().try_acquire_owned().unwrap();
@@ -1805,6 +1939,40 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "202 is success — no retry"
+        );
         assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    // -- Jitter tests --
+
+    #[test]
+    fn test_apply_jitter_within_bounds() {
+        let base = Duration::from_secs(10);
+        // Run many times to exercise the full jitter range. ±25% of 10s = [7.5s, 12.5s].
+        for _ in 0..200 {
+            let jittered = apply_jitter(base);
+            assert!(
+                jittered >= Duration::from_millis(7500) && jittered <= Duration::from_millis(12500),
+                "jittered delay {jittered:?} out of [7.5s, 12.5s]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_jitter_small_delay() {
+        // A 3ms delay has jitter_range = 0 (3/4 truncates to 0), so passes through unchanged.
+        let d = Duration::from_millis(3);
+        assert_eq!(apply_jitter(d), d);
+    }
+
+    #[test]
+    fn test_apply_jitter_zero_delay() {
+        // A 0ms delay should pass through unchanged (jitter_range = 0).
+        let d = Duration::from_millis(0);
+        assert_eq!(apply_jitter(d), d);
     }
 }

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -1909,12 +1909,17 @@ mod tests {
 
         let sem_clone = semaphore.clone();
         let handle = tokio::spawn(async move {
+            // Pass repo_full_name=None to skip the resolve_github_container_url
+            // SQL lookup. test_state_with_base_url uses a lazy fake Postgres
+            // pool whose first connection attempt blocks for sqlx's default
+            // connect_timeout (~30s) on CI hosts where localhost:5432 doesn't
+            // RST-fast — that's what was eating our timing budget.
             deliver_with_retry_inner(
                 &state,
                 "mika-dev",
                 "test event",
                 "delivery-sem",
-                Some("org/repo"),
+                None,
                 permit,
                 &sem_clone,
                 &TEST_DELAYS_OBSERVE_ONLY,
@@ -1952,12 +1957,14 @@ mod tests {
         let sem_clone = semaphore.clone();
         let state_clone = state.clone();
         let handle = tokio::spawn(async move {
+            // Pass repo_full_name=None to skip the resolve_github_container_url
+            // SQL lookup (see sibling test for rationale).
             deliver_with_retry_inner(
                 &state_clone,
                 "mika-dev",
                 "test event",
                 "delivery-blocked",
-                Some("org/repo"),
+                None,
                 permit,
                 &sem_clone,
                 &TEST_DELAYS_OBSERVE_AND_ABANDON,

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -16,7 +16,7 @@ use hmac::{Hmac, Mac};
 use secrecy::ExposeSecret;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::routes::AppState;
 
@@ -330,6 +330,61 @@ pub fn new_delivery_cache() -> Arc<std::sync::Mutex<lru::LruCache<String, ()>>> 
     )))
 }
 
+// -- Forwarding result type --
+
+/// Outcome of a single `forward_github_event` attempt.
+/// Used by the retry wrapper to decide whether to retry, abandon, or succeed.
+#[derive(Debug)]
+pub(crate) enum ForwardResult {
+    /// 200 or 202 — agent accepted the event.
+    Success,
+    /// 429 or 5xx, or a request timeout — transient, worth retrying.
+    Retryable {
+        /// Human-readable description for logging (e.g. "HTTP 429" or "request timeout").
+        reason: String,
+    },
+    /// 4xx (other than 429), connection error (agent offline), or unresolvable route —
+    /// retrying will not help.
+    Permanent {
+        /// Human-readable description for logging.
+        reason: String,
+    },
+}
+
+impl ForwardResult {
+    /// Returns `true` if the result indicates a retryable failure.
+    #[cfg(test)]
+    fn is_retryable(&self) -> bool {
+        matches!(self, Self::Retryable { .. })
+    }
+
+    /// Returns `true` if the forwarding succeeded.
+    #[cfg(test)]
+    fn is_success(&self) -> bool {
+        matches!(self, Self::Success)
+    }
+
+    /// Returns the reason string for non-success results.
+    fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Success => None,
+            Self::Retryable { reason } | Self::Permanent { reason } => Some(reason),
+        }
+    }
+}
+
+// -- Retry schedule --
+
+/// Delays between retry attempts for GitHub webhook delivery.
+/// Total worst-case wall time: 2 + 5 + 15 + 60 + 300 = 382 seconds (+ request timeouts).
+pub(crate) const RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(15),
+    Duration::from_secs(60),
+    Duration::from_secs(300),
+];
+
 // -- Webhook handler --
 
 /// POST /webhook/github — receive GitHub App webhook events.
@@ -478,18 +533,22 @@ pub(crate) async fn handle_github_webhook(
         delivery_id.clone()
     };
 
-    // 12. Async dispatch — return 200 to GitHub immediately
+    // 12. Async dispatch with retry — return 200 to GitHub immediately.
+    // Retry budget: initial attempt + up to 5 retries with backoff [2s, 5s, 15s, 60s, 300s].
+    // DLQ for events that exhaust retries is tracked in #590.
     let forwarding_state = state.clone();
     let target = target_agent.to_string();
     let repo_name = event.repository.as_ref().and_then(|r| r.full_name.clone());
+    let semaphore = state.webhook_semaphore.clone();
     tokio::spawn(async move {
-        let _permit = permit; // held until task completes
-        forward_github_event(
+        deliver_with_retry(
             &forwarding_state,
             &target,
             &text,
             &request_id,
             repo_name.as_deref(),
+            permit,
+            &semaphore,
         )
         .await;
     });
@@ -567,6 +626,9 @@ async fn resolve_github_container_url(
 
 /// Forward a GitHub event to the agent container via `POST {container_url}/message`.
 ///
+/// Single-attempt function — no retry logic. Returns a [`ForwardResult`] so the
+/// caller (`deliver_with_retry`) can decide whether to retry.
+///
 /// Uses `channel: "github"` and `chat_id: 0` (no reply channel).
 /// Multi-tenant routing: looks up `github_repos` table first, falls back to `agent_base_url`.
 /// Per-repo agent name overrides are applied from the `agent_mapping` column.
@@ -576,10 +638,14 @@ async fn forward_github_event(
     text: &str,
     request_id: &str,
     repo_full_name: Option<&str>,
-) {
+) -> ForwardResult {
     let route = match resolve_github_container_url(state, repo_full_name).await {
         Some(r) => r,
-        None => return,
+        None => {
+            return ForwardResult::Permanent {
+                reason: "no route resolved (repo not registered and no fallback)".to_string(),
+            };
+        }
     };
 
     let target_agent = apply_agent_mapping(&route.agent_mapping, default_agent);
@@ -612,29 +678,164 @@ async fn forward_github_event(
 
     match result {
         Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 202 => {
+            ForwardResult::Success
+        }
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            if status == 429 || (500..=599).contains(&status) {
+                ForwardResult::Retryable {
+                    reason: format!("HTTP {status}"),
+                }
+            } else {
+                ForwardResult::Permanent {
+                    reason: format!("HTTP {status}"),
+                }
+            }
+        }
+        Err(e) => {
+            if e.is_connect() {
+                // Connection refused / DNS failure — agent is offline, retrying won't help.
+                ForwardResult::Permanent {
+                    reason: format!("connection error: {e}"),
+                }
+            } else {
+                // Timeout or other transient network error — worth retrying.
+                ForwardResult::Retryable {
+                    reason: format!("network error: {e}"),
+                }
+            }
+        }
+    }
+}
+
+/// Retry wrapper for GitHub webhook delivery.
+///
+/// Calls `forward_github_event` once using the caller's semaphore permit. On a
+/// retryable failure (429, 5xx, or request timeout), releases the permit, sleeps
+/// for the next delay in [`RETRY_DELAYS`], re-acquires a permit, and retries.
+///
+/// **Semaphore lifecycle:** The permit is released during sleep to prevent
+/// cross-channel starvation (the 30-permit semaphore is shared with Telegram).
+/// If the semaphore is full when re-acquiring, the retry is abandoned — the
+/// system is legitimately overloaded.
+///
+/// **Dedup LRU interaction:** The `X-GitHub-Delivery` ID is inserted into the
+/// in-memory LRU cache (10k entries, size-based eviction, no TTL) *before* this
+/// function is called. Under extreme webhook volume (>10k deliveries during a
+/// single 300s retry sleep), the LRU may evict the entry. If GitHub redelivers
+/// the same event, the gateway would treat it as new. Agent-side idempotency
+/// (work item unique index) prevents duplicate processing. A TTL on the LRU
+/// cache would close this gap but is deferred (see #590 for DLQ).
+async fn deliver_with_retry(
+    state: &AppState,
+    target_agent: &str,
+    text: &str,
+    request_id: &str,
+    repo_full_name: Option<&str>,
+    initial_permit: tokio::sync::OwnedSemaphorePermit,
+    semaphore: &Arc<tokio::sync::Semaphore>,
+) {
+    // Attempt 0: use the caller's permit.
+    let result = forward_github_event(state, target_agent, text, request_id, repo_full_name).await;
+
+    match &result {
+        ForwardResult::Success => {
             info!(
                 target_agent,
                 request_id, "GitHub event forwarded to agent container"
             );
+            drop(initial_permit);
+            return;
         }
-        Ok(resp) => {
-            let status = resp.status().as_u16();
-            warn!(
-                status,
-                target_agent, request_id, "agent container returned error for GitHub event"
+        ForwardResult::Permanent { reason } => {
+            error!(
+                target_agent,
+                request_id, reason = %reason, "GitHub event delivery failed (permanent, no retry)"
             );
+            drop(initial_permit);
+            return;
         }
-        Err(e) => {
-            let is_connect = e.is_connect();
+        ForwardResult::Retryable { reason } => {
             warn!(
-                error = %e,
                 target_agent,
                 request_id,
-                is_connect,
-                "agent container unreachable for GitHub event"
+                attempt = 1,
+                reason = %reason,
+                "GitHub event delivery failed, will retry"
             );
         }
     }
+
+    // Release the initial permit during the retry sleep window.
+    drop(initial_permit);
+
+    let mut last_reason = result.reason().unwrap_or("unknown").to_string();
+
+    for (i, delay) in RETRY_DELAYS.iter().enumerate() {
+        let attempt = i + 2; // attempt 1 was the initial, retries start at 2
+
+        tokio::time::sleep(*delay).await;
+
+        // Re-acquire a semaphore permit before retrying.
+        let permit = match semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                warn!(
+                    target_agent,
+                    request_id, attempt, "GitHub event retry abandoned — semaphore at capacity"
+                );
+                break;
+            }
+        };
+
+        let result =
+            forward_github_event(state, target_agent, text, request_id, repo_full_name).await;
+
+        // Release the permit immediately after the attempt (before sleeping again).
+        drop(permit);
+
+        match &result {
+            ForwardResult::Success => {
+                info!(
+                    target_agent,
+                    request_id,
+                    attempt,
+                    "GitHub event forwarded to agent container (retry succeeded)"
+                );
+                return;
+            }
+            ForwardResult::Permanent { reason } => {
+                error!(
+                    target_agent,
+                    request_id,
+                    attempt,
+                    reason = %reason,
+                    "GitHub event delivery failed (permanent, stopping retries)"
+                );
+                return;
+            }
+            ForwardResult::Retryable { reason } => {
+                last_reason = reason.clone();
+                warn!(
+                    target_agent,
+                    request_id,
+                    attempt,
+                    remaining_retries = RETRY_DELAYS.len() - i - 1,
+                    reason = %reason,
+                    "GitHub event delivery failed, will retry"
+                );
+            }
+        }
+    }
+
+    // All retries exhausted.
+    error!(
+        target_agent,
+        request_id,
+        total_attempts = RETRY_DELAYS.len() + 1,
+        last_reason = %last_reason,
+        "GitHub event delivery failed — retry budget exhausted, event dropped (DLQ: #590)"
+    );
 }
 
 #[cfg(test)]
@@ -1266,5 +1467,344 @@ mod tests {
         assert!(!is_valid_agent_name("has spaces"));
         assert!(!is_valid_agent_name("special@chars"));
         assert!(!is_valid_agent_name(&"a".repeat(64))); // too long
+    }
+
+    // -- ForwardResult classification tests --
+
+    #[test]
+    fn test_forward_result_success_classification() {
+        let r = ForwardResult::Success;
+        assert!(r.is_success());
+        assert!(!r.is_retryable());
+        assert!(r.reason().is_none());
+    }
+
+    #[test]
+    fn test_forward_result_retryable_429() {
+        let r = ForwardResult::Retryable {
+            reason: "HTTP 429".to_string(),
+        };
+        assert!(r.is_retryable());
+        assert!(!r.is_success());
+        assert_eq!(r.reason(), Some("HTTP 429"));
+    }
+
+    #[test]
+    fn test_forward_result_retryable_5xx() {
+        for status in [500, 502, 503, 504] {
+            let r = ForwardResult::Retryable {
+                reason: format!("HTTP {status}"),
+            };
+            assert!(r.is_retryable(), "HTTP {status} should be retryable");
+        }
+    }
+
+    #[test]
+    fn test_forward_result_permanent_4xx() {
+        for status in [400, 404, 405, 422] {
+            let r = ForwardResult::Permanent {
+                reason: format!("HTTP {status}"),
+            };
+            assert!(!r.is_retryable(), "HTTP {status} should NOT be retryable");
+            assert!(!r.is_success());
+        }
+    }
+
+    #[test]
+    fn test_forward_result_permanent_connection_error() {
+        let r = ForwardResult::Permanent {
+            reason: "connection error: connection refused".to_string(),
+        };
+        assert!(!r.is_retryable());
+        assert_eq!(r.reason(), Some("connection error: connection refused"));
+    }
+
+    #[test]
+    fn test_forward_result_retryable_timeout() {
+        let r = ForwardResult::Retryable {
+            reason: "network error: request timeout".to_string(),
+        };
+        assert!(r.is_retryable());
+    }
+
+    // -- Retry schedule tests --
+
+    #[test]
+    fn test_retry_delays_schedule() {
+        assert_eq!(RETRY_DELAYS.len(), 5);
+        assert_eq!(RETRY_DELAYS[0], Duration::from_secs(2));
+        assert_eq!(RETRY_DELAYS[1], Duration::from_secs(5));
+        assert_eq!(RETRY_DELAYS[2], Duration::from_secs(15));
+        assert_eq!(RETRY_DELAYS[3], Duration::from_secs(60));
+        assert_eq!(RETRY_DELAYS[4], Duration::from_secs(300));
+    }
+
+    // -- deliver_with_retry tests --
+    //
+    // These tests use a mock HTTP server (wiremock or similar) to simulate
+    // agent container responses. Since we don't have wiremock as a dependency,
+    // we test the retry logic using a real Axum server bound to an ephemeral port.
+
+    /// Spin up a minimal Axum server that returns a sequence of status codes.
+    /// Returns the base URL (e.g., "http://127.0.0.1:12345").
+    async fn mock_agent_server(responses: Vec<StatusCode>) -> String {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let responses = Arc::new(responses);
+
+        let cc = call_count.clone();
+        let resps = responses.clone();
+        let app = axum::Router::new().route(
+            "/message",
+            post(move || {
+                let cc = cc.clone();
+                let resps = resps.clone();
+                async move {
+                    let idx = cc.fetch_add(1, Ordering::SeqCst);
+                    resps.get(idx).copied().unwrap_or(StatusCode::OK)
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    /// Build an AppState pointing to a mock agent server.
+    fn test_state_with_base_url(base_url: &str) -> AppState {
+        use crate::telegram::TelegramClient;
+        use secrecy::SecretString;
+        use std::sync::atomic::{AtomicBool, AtomicU64};
+
+        let http_client = reqwest::Client::new();
+        let telegram =
+            TelegramClient::new(http_client.clone(), SecretString::from("fake-bot-token"));
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("lazy pool");
+
+        AppState {
+            pool,
+            telegram,
+            http_client,
+            internal_token: SecretString::from("a".repeat(64)),
+            webhook_secret: SecretString::from("b".repeat(64)),
+            ready: Arc::new(AtomicBool::new(true)),
+            webhook_semaphore: Arc::new(tokio::sync::Semaphore::new(30)),
+            agent_base_url: Some(base_url.to_string()),
+            agents_namespace: "test".to_string(),
+            webhook_counter: Arc::new(AtomicU64::new(0)),
+            github_webhook_secret: Some(SecretString::from("test-secret")),
+            github_delivery_cache: new_delivery_cache(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deliver_success_on_first_attempt() {
+        let base_url = mock_agent_server(vec![StatusCode::OK]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-1",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        // Permit was consumed (dropped inside deliver_with_retry on success)
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_retry_on_429_then_success() {
+        // First call returns 429, second returns 200
+        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        // Use a custom short delay schedule for testing (don't wait real 2s)
+        // We can't easily override RETRY_DELAYS, so we test with the real function
+        // but accept the 2s wait for the first retry.
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-429",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        // Should succeed after one retry — all permits returned
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_retry_on_503_then_success() {
+        let base_url =
+            mock_agent_server(vec![StatusCode::SERVICE_UNAVAILABLE, StatusCode::OK]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-503",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_no_retry_on_400() {
+        // 400 is permanent — should not retry
+        let base_url = mock_agent_server(vec![StatusCode::BAD_REQUEST]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-400",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        // Should return immediately without retry — all permits returned
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_no_retry_on_404() {
+        let base_url = mock_agent_server(vec![StatusCode::NOT_FOUND]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-404",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        assert_eq!(semaphore.available_permits(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_deliver_semaphore_released_during_retry_sleep() {
+        // 429 on first attempt — during the 2s sleep, the permit should be released
+        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1)); // Only 1 permit!
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        let sem_clone = semaphore.clone();
+        let handle = tokio::spawn(async move {
+            deliver_with_retry(
+                &state,
+                "mika-dev",
+                "test event",
+                "delivery-sem",
+                Some("org/repo"),
+                permit,
+                &sem_clone,
+            )
+            .await;
+        });
+
+        // Give the first attempt time to fail and release the permit
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // The permit should be available during the retry sleep window
+        let available = semaphore.available_permits();
+        assert_eq!(available, 1, "permit should be released during retry sleep");
+
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_deliver_abandoned_when_semaphore_full() {
+        // 429 on first attempt, then semaphore is full on retry
+        let base_url = mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
+        let state = test_state_with_base_url(&base_url);
+
+        // Semaphore with 1 permit — we'll hold the spare one to block retry
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        let sem_clone = semaphore.clone();
+        let state_clone = state.clone();
+        let handle = tokio::spawn(async move {
+            deliver_with_retry(
+                &state_clone,
+                "mika-dev",
+                "test event",
+                "delivery-blocked",
+                Some("org/repo"),
+                permit,
+                &sem_clone,
+            )
+            .await;
+        });
+
+        // Wait for the first attempt to fail and release the permit
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Grab the permit before the retry can — this blocks the retry
+        let _blocker = semaphore.clone().try_acquire_owned().unwrap();
+
+        // The retry should be abandoned because the semaphore is full
+        handle.await.unwrap();
+        // Test passes if deliver_with_retry returns without hanging
+    }
+
+    #[tokio::test]
+    async fn test_deliver_accepts_202() {
+        let base_url = mock_agent_server(vec![StatusCode::ACCEPTED]).await;
+        let state = test_state_with_base_url(&base_url);
+        let semaphore = state.webhook_semaphore.clone();
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+
+        deliver_with_retry(
+            &state,
+            "mika-dev",
+            "test event",
+            "delivery-202",
+            Some("org/repo"),
+            permit,
+            &semaphore,
+        )
+        .await;
+
+        assert_eq!(semaphore.available_permits(), 30);
     }
 }

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -752,6 +752,33 @@ async fn deliver_with_retry(
     initial_permit: tokio::sync::OwnedSemaphorePermit,
     semaphore: &Arc<tokio::sync::Semaphore>,
 ) {
+    deliver_with_retry_inner(
+        state,
+        target_agent,
+        text,
+        request_id,
+        repo_full_name,
+        initial_permit,
+        semaphore,
+        &RETRY_DELAYS,
+    )
+    .await
+}
+
+/// Inner retry loop with the delay schedule injected. Production callers go
+/// through [`deliver_with_retry`] which uses [`RETRY_DELAYS`]. Tests pass a
+/// custom schedule so timing assertions don't race the production 2s sleep.
+#[allow(clippy::too_many_arguments)]
+async fn deliver_with_retry_inner(
+    state: &AppState,
+    target_agent: &str,
+    text: &str,
+    request_id: &str,
+    repo_full_name: Option<&str>,
+    initial_permit: tokio::sync::OwnedSemaphorePermit,
+    semaphore: &Arc<tokio::sync::Semaphore>,
+    retry_delays: &[Duration],
+) {
     // Resolve the route once. Cached across all retry attempts.
     let route = match resolve_github_container_url(state, repo_full_name).await {
         Some(r) => r,
@@ -774,7 +801,7 @@ async fn deliver_with_retry(
     let mut current_permit = Some(initial_permit);
 
     for (retry_idx, delay) in std::iter::once(None)
-        .chain(RETRY_DELAYS.iter().map(Some))
+        .chain(retry_delays.iter().map(Some))
         .enumerate()
     {
         // The first iteration (retry_idx=0) has `delay = None` and uses the caller's permit.
@@ -842,7 +869,7 @@ async fn deliver_with_retry(
                 return;
             }
             ForwardResult::Retryable { reason } => {
-                let remaining = RETRY_DELAYS.len().saturating_sub(retry_idx);
+                let remaining = retry_delays.len().saturating_sub(retry_idx);
                 warn!(
                     target_agent,
                     request_id,
@@ -1832,9 +1859,10 @@ mod tests {
     }
 
     /// Polls `semaphore.available_permits()` until it reaches `target`, up to `budget`.
-    /// Returns the elapsed wait. Used to replace fixed `sleep(N)` timing assumptions
-    /// that flake on slow CI runners — the production retry sleep is ≥1.5s, so a
-    /// 1s+ poll budget catches the released-permit window with margin.
+    /// Returns the elapsed wait. Used in conjunction with the test-only long
+    /// retry-delay schedule below — once the first HTTP attempt completes
+    /// (whenever that is on slow CI), the retry sleep is long enough that the
+    /// poll has a wide window to observe the released permit.
     async fn wait_for_permits(
         semaphore: &Arc<tokio::sync::Semaphore>,
         target: usize,
@@ -1852,9 +1880,27 @@ mod tests {
         }
     }
 
+    /// Test-only retry-delay schedules. Production uses 2s for the first delay;
+    /// these tests need the released-permit window to be wide enough for the
+    /// polling assertion to land regardless of how slow the CI runner's HTTP
+    /// roundtrip is. Two schedules:
+    ///
+    /// - `OBSERVE_ONLY`: very long first delay (60s). The test observes the
+    ///   released permit, then aborts the spawned task. Used by the
+    ///   "permit released during retry sleep" test where we don't need the
+    ///   retry to fire — only to observe the released state.
+    /// - `OBSERVE_AND_ABANDON`: 5s first delay. The test observes release,
+    ///   steals the permit, then waits for the retry to attempt re-acquire
+    ///   and abandon. 5s leaves 4s polling headroom on slow CI plus enough
+    ///   time for the abandon path to fire within the test timeout.
+    const TEST_DELAYS_OBSERVE_ONLY: [Duration; 1] = [Duration::from_secs(60)];
+    const TEST_DELAYS_OBSERVE_AND_ABANDON: [Duration; 1] = [Duration::from_secs(5)];
+
     #[tokio::test]
     async fn test_deliver_semaphore_released_during_retry_sleep() {
-        // 429 on first attempt — during the 2s retry sleep, the permit should be released.
+        // 429 on first attempt — during the retry sleep, the permit must be released.
+        // Uses a 60s test-only retry delay (vs production's 2s) so the polling
+        // assertion isn't racing the retry sleep window.
         let (base_url, _call_count) =
             mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
@@ -1863,7 +1909,7 @@ mod tests {
 
         let sem_clone = semaphore.clone();
         let handle = tokio::spawn(async move {
-            deliver_with_retry(
+            deliver_with_retry_inner(
                 &state,
                 "mika-dev",
                 "test event",
@@ -1871,29 +1917,30 @@ mod tests {
                 Some("org/repo"),
                 permit,
                 &sem_clone,
+                &TEST_DELAYS_OBSERVE_ONLY,
             )
             .await;
         });
 
-        // Poll for permit release rather than sleeping a fixed window.
-        // Budget is 1.4s — the production retry sleep is ≥1.5s with jitter,
-        // so this stays well inside the released-permit window even on slow CI.
-        let waited = wait_for_permits(&semaphore, 1, Duration::from_millis(1400)).await;
+        // Poll for permit release with a 10s budget — generous on any CI runner.
+        // The retry sleep is 60s so we have 60s once first attempt completes.
+        let waited = wait_for_permits(&semaphore, 1, Duration::from_secs(10)).await;
         assert_eq!(
             semaphore.available_permits(),
             1,
             "permit should be released during retry sleep (waited {waited:?})"
         );
 
-        handle.await.unwrap();
+        // Don't wait for the spawned task to finish (it's now in a 60s sleep).
+        // Aborting is safe: deliver_with_retry has no shared state to clean up.
+        handle.abort();
     }
 
     #[tokio::test]
     async fn test_deliver_abandoned_when_semaphore_full() {
-        // 429 on first attempt, then semaphore is full on retry.
-        // Queue an OK as fallback to prove the retry path was NOT taken —
-        // the mock server would return OK if the retry fired, but the test
-        // asserts call_count == 1 to prove only the initial attempt ran.
+        // 429 on first attempt, then semaphore is full on retry → abandon path.
+        // Uses 60s test-only retry delay so the test has plenty of time to
+        // steal the permit between first-attempt-end and retry-reacquire.
         let (base_url, call_count) =
             mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
@@ -1905,7 +1952,7 @@ mod tests {
         let sem_clone = semaphore.clone();
         let state_clone = state.clone();
         let handle = tokio::spawn(async move {
-            deliver_with_retry(
+            deliver_with_retry_inner(
                 &state_clone,
                 "mika-dev",
                 "test event",
@@ -1913,14 +1960,16 @@ mod tests {
                 Some("org/repo"),
                 permit,
                 &sem_clone,
+                &TEST_DELAYS_OBSERVE_AND_ABANDON,
             )
             .await;
         });
 
-        // Poll for the first attempt to release the permit (rather than
-        // sleeping a fixed window that flakes when the localhost HTTP roundtrip
-        // takes longer than expected on a loaded CI runner).
-        wait_for_permits(&semaphore, 1, Duration::from_millis(1400)).await;
+        // Wait for the first attempt to release the permit. Budget 4s — the
+        // 5s retry delay leaves us 1s margin to steal the permit before the
+        // retry tries to re-acquire it. Generous compared to the prior 1.4s
+        // budget that flaked in CI, but bounded by the retry delay.
+        wait_for_permits(&semaphore, 1, Duration::from_secs(4)).await;
         assert_eq!(
             semaphore.available_permits(),
             1,
@@ -1928,6 +1977,7 @@ mod tests {
         );
 
         // Grab the permit before the retry can — this blocks the retry.
+        // Retry sleep is 60s, so we have a huge window to do this.
         let _blocker = semaphore
             .clone()
             .try_acquire_owned()

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -1831,9 +1831,30 @@ mod tests {
         assert_eq!(semaphore.available_permits(), 30);
     }
 
+    /// Polls `semaphore.available_permits()` until it reaches `target`, up to `budget`.
+    /// Returns the elapsed wait. Used to replace fixed `sleep(N)` timing assumptions
+    /// that flake on slow CI runners — the production retry sleep is ≥1.5s, so a
+    /// 1s+ poll budget catches the released-permit window with margin.
+    async fn wait_for_permits(
+        semaphore: &Arc<tokio::sync::Semaphore>,
+        target: usize,
+        budget: Duration,
+    ) -> Duration {
+        let start = std::time::Instant::now();
+        loop {
+            if semaphore.available_permits() >= target {
+                return start.elapsed();
+            }
+            if start.elapsed() >= budget {
+                return start.elapsed();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
     #[tokio::test]
     async fn test_deliver_semaphore_released_during_retry_sleep() {
-        // 429 on first attempt — during the 2s sleep, the permit should be released
+        // 429 on first attempt — during the 2s retry sleep, the permit should be released.
         let (base_url, _call_count) =
             mock_agent_server(vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::OK]).await;
         let state = test_state_with_base_url(&base_url);
@@ -1854,15 +1875,15 @@ mod tests {
             .await;
         });
 
-        // Give the first attempt time to fail and release the permit.
-        // The 429 response comes back quickly (localhost Axum), then the retry
-        // path enters tokio::time::sleep(2s +/- jitter). 500ms gives ample margin
-        // over the HTTP round-trip on any reasonable CI host.
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        // The permit should be available during the retry sleep window
-        let available = semaphore.available_permits();
-        assert_eq!(available, 1, "permit should be released during retry sleep");
+        // Poll for permit release rather than sleeping a fixed window.
+        // Budget is 1.4s — the production retry sleep is ≥1.5s with jitter,
+        // so this stays well inside the released-permit window even on slow CI.
+        let waited = wait_for_permits(&semaphore, 1, Duration::from_millis(1400)).await;
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "permit should be released during retry sleep (waited {waited:?})"
+        );
 
         handle.await.unwrap();
     }
@@ -1896,11 +1917,21 @@ mod tests {
             .await;
         });
 
-        // Wait for the first attempt to fail and release the permit
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        // Poll for the first attempt to release the permit (rather than
+        // sleeping a fixed window that flakes when the localhost HTTP roundtrip
+        // takes longer than expected on a loaded CI runner).
+        wait_for_permits(&semaphore, 1, Duration::from_millis(1400)).await;
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "first attempt should release the permit before the retry sleep"
+        );
 
-        // Grab the permit before the retry can — this blocks the retry
-        let _blocker = semaphore.clone().try_acquire_owned().unwrap();
+        // Grab the permit before the retry can — this blocks the retry.
+        let _blocker = semaphore
+            .clone()
+            .try_acquire_owned()
+            .expect("test must hold the only permit before retry tries to re-acquire");
 
         // The retry should be abandoned because the semaphore is full.
         // Wrap in timeout to catch the race where _blocker wasn't grabbed in

--- a/docs/plans/2026-04-16-003-feat-gateway-retry-inbound-webhook-delivery-plan.md
+++ b/docs/plans/2026-04-16-003-feat-gateway-retry-inbound-webhook-delivery-plan.md
@@ -1,0 +1,240 @@
+---
+title: "feat: Gateway retries inbound webhook delivery on 429/5xx"
+type: feat
+status: active
+date: 2026-04-16
+---
+
+# feat: Gateway retries inbound webhook delivery on 429/5xx
+
+## Overview
+
+Add retry-with-backoff to the gateway's GitHub webhook delivery path. When the spawned forwarding task gets HTTP 429 or 5xx from the agent container, it retries with the schedule `[2s, 5s, 15s, 60s, 300s]` before logging an ERROR and dropping the event. No DLQ (separate ticket #590).
+
+## Problem Frame
+
+The gateway returns 200 OK to GitHub immediately, then spawns a task to forward the event to the agent container. If that forwarding fails (429 busy, 5xx transient), the task logs a WARN and silently drops the event. GitHub already got its 200, so it won't retry. The event is permanently lost.
+
+Real-world impact: on 2026-04-15, a `pull_request_review.submitted` event for PR #588 was dropped because mika-dev returned 429 (busy processing a claude-pilot callback). The PR sat APPROVED+green CI but was never auto-merged.
+
+## Requirements Trace
+
+- R1. Retry forwarding on HTTP 429 and 5xx with backoff schedule `[2s, 5s, 15s, 60s, 300s]`
+- R2. Do NOT retry on 4xx (other than 429) -- permanent client errors
+- R3. Do NOT retry on connection errors (agent offline) -- retries will all fail
+- R4. Retry on request timeouts -- transient overload is the most likely cause
+- R5. After retry budget exhausted, log ERROR with `delivery_id`, `target_agent`, and last status/error
+- R6. Keep `forward_github_event` as a single-attempt function; retry policy in a wrapper
+- R7. Document the dedup LRU eviction edge case (late retries may cause duplicates)
+- R8. Release semaphore permit during retry sleeps to prevent cross-channel starvation
+
+## Scope Boundaries
+
+- No dead-letter queue or replay CLI (mika#590)
+- No LRU TTL changes
+- No circuit breaker per agent
+- No `Retry-After` header respect (fixed schedule only)
+- No Telegram forwarding retry (Telegram has its own retry via `reset_dedup`)
+- No replacement of the spawn-per-event model
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-gateway/src/github.rs` -- `forward_github_event()` (lines 573-638), `handle_github_webhook()` spawn task (lines 485-495), delivery cache (lines 322-331)
+- `crates/mika-gateway/src/routes.rs` -- `AppState` (lines 84-104), `handle_forward_result()` (lines 467-492), `forward_error_message()` (line 1026)
+- `crates/mika-common/src/claude.rs` -- existing retry pattern: `for attempt in 0..=MAX_RETRIES` with `500ms * 2^(attempt-1)` backoff, `is_retryable()` check (lines 452-480, 628-632)
+- `crates/mika-common/src/embedding.rs` -- same retry pattern (lines 127-152)
+
+### Institutional Learnings
+
+- **P2-529 tight retry loop** (`docs/solutions/code-review-patterns/async-callbacks-long-running-review-findings.md`): When `dispatch_resume_agent` failed because the agent was busy, the task was immediately re-queued with no delay. Exponential backoff is mandatory from the start.
+- **Gateway offline agent classification** (`docs/solutions/ux-improvements/gateway-offline-agent-error-message.md`): Use `reqwest::Error::is_connect()` to distinguish connection errors (agent offline, DNS failure) from transient errors (timeout, broken pipe). Connection errors should NOT be retried.
+- **Webhook deferral queue** (`docs/solutions/architecture-patterns/webhook-deferral-queue-callback-sequencing.md`): Agent-side has 60s deferral timeout. Gateway retry window extends well beyond this, which is fine since 429 means the agent rejected the request entirely (not deferred).
+- **Duplicate work item on retry** (`docs/solutions/logic-errors/create-work-item-duplicate-on-retry.md`): Retries require idempotency at the receiver. The agent's GitHub message processing is idempotent by design (webhook dedup + work item unique index).
+- **HTTP client timeouts** (`docs/solutions/cross-repo-patterns/rust-axum-security-hardening-playbook.md`): Always set both `connect_timeout` and `timeout`. The existing 5s per-request timeout in `forward_github_event` is appropriate.
+
+## Key Technical Decisions
+
+- **Release semaphore during retry sleep**: The 30-permit semaphore is shared between Telegram and GitHub. Holding a permit for up to ~382s during retries would cause cross-channel starvation. Release the permit after each failed attempt, re-acquire before retrying. If the semaphore is full on re-acquire, abandon the retry (the system is legitimately overloaded).
+- **Retry timeouts**: `reqwest::Error` timeouts (5s per-request) are retried. Timeouts are more likely caused by transient overload than by the agent having processed-but-not-responded. The small duplicate risk is acceptable given agent-side idempotency.
+- **No connection error retry**: `reqwest::Error::is_connect()` (DNS failure, connection refused) means the agent is offline. Retrying with backoff won't help -- the agent needs to be started. Log ERROR immediately.
+- **ForwardResult enum**: Change `forward_github_event` from returning `()` to returning a `ForwardResult` enum so the retry wrapper can classify the outcome without duplicating HTTP response parsing.
+- **No new dependencies**: Follow the codebase's hand-rolled retry pattern (for loop with backoff) rather than adding a retry crate. The schedule is fixed, not exponential, so a simple slice iteration suffices.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should timeouts be retried?** Yes. Timeouts are classified as retryable (R4). The codebase's existing retry patterns in `claude.rs` and `embedding.rs` retry on timeouts. Agent-side idempotency mitigates the small duplicate risk.
+- **Should the semaphore be released during sleep?** Yes (R8). Without this, 30 concurrent 429 responses would block ALL webhook processing (Telegram included) for up to 6 minutes. Re-acquiring the permit before each retry attempt provides natural backpressure.
+- **Should each retry refresh the LRU cache entry?** No. The delivery_id was inserted before forwarding. Refreshing on each retry would require passing the cache into the retry wrapper, adding complexity for an edge case that only matters under extreme volume (>10k deliveries during a single 300s sleep). Documented as a known edge case per R7.
+
+### Deferred to Implementation
+
+- Exact `ForwardResult` enum variant names -- the important thing is the 4-way classification (success, retryable HTTP, permanent HTTP, network error)
+- Whether the retry wrapper lives in `github.rs` or a new `retry.rs` module -- depends on size
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+forward_github_event(state, ...) -> ForwardResult
+  |
+  +-- Success / Accepted  -> ForwardResult::Success
+  +-- HTTP 429 / 5xx      -> ForwardResult::Retryable { status }
+  +-- HTTP 4xx (not 429)   -> ForwardResult::Permanent { status }
+  +-- reqwest timeout       -> ForwardResult::Retryable { ... }
+  +-- reqwest connect error -> ForwardResult::Permanent { ... }
+  +-- reqwest other error   -> ForwardResult::Retryable { ... }
+
+
+handle_github_webhook:
+  tokio::spawn(async {
+      let _permit = permit;
+      deliver_with_retry(
+          state, target, text, request_id, repo_name,
+          &RETRY_DELAYS,  // [2s, 5s, 15s, 60s, 300s]
+      ).await;
+  });
+
+
+deliver_with_retry:
+  attempt 0: forward_github_event() using initial permit
+  if retryable:
+      drop permit
+      for delay in RETRY_DELAYS:
+          sleep(delay)
+          re-acquire permit (try_acquire_owned)
+          if no permit available: log WARN, abandon retry
+          forward_github_event()
+          if success: return
+          if permanent: return
+          drop permit, continue
+      log ERROR (budget exhausted)
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Define ForwardResult enum and refactor forward_github_event return type**
+
+**Goal:** Change `forward_github_event` from returning `()` to returning a typed result so the retry wrapper can classify outcomes.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs`
+- Test: `crates/mika-gateway/src/github.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Define a `ForwardResult` enum with variants for success, retryable error (429/5xx/timeout), and permanent error (4xx/connect). Include the HTTP status code or error description for logging.
+- Refactor the existing match arms in `forward_github_event` (lines 613-637) to return the appropriate variant instead of logging and returning `()`.
+- Move the logging from `forward_github_event` into the caller (the spawn task) so it can log once after retry exhaustion rather than on every attempt.
+- Keep `forward_github_event` as a pure single-attempt function per R6.
+
+**Patterns to follow:**
+- `ClaudeApiError` in `crates/mika-common/src/claude.rs` -- typed error enum with `is_retryable()` method
+- `TelegramApiError` in `crates/mika-gateway/src/telegram.rs` -- enum with variant-based classification
+- `forward_error_message(is_connect)` in `routes.rs` -- existing error classification pattern
+
+**Test scenarios:**
+- Happy path: ForwardResult classifies 200 and 202 as success
+- Happy path: ForwardResult classifies 429 as retryable
+- Happy path: ForwardResult classifies 500, 502, 503 as retryable
+- Error path: ForwardResult classifies 400, 404 as permanent
+- Error path: ForwardResult classifies connection errors (`is_connect()`) as permanent
+- Edge case: ForwardResult classifies timeout errors as retryable
+
+**Verification:**
+- `forward_github_event` returns `ForwardResult` instead of `()`
+- Existing spawn task in `handle_github_webhook` still compiles and behaves identically (log on non-success, no retry yet)
+- All existing tests pass unchanged
+
+- [x] **Unit 2: Implement deliver_with_retry wrapper**
+
+**Goal:** Add the retry-with-backoff wrapper that calls `forward_github_event` up to 6 times (initial + 5 retries) with the specified delay schedule, releasing the semaphore during sleeps.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs`
+- Test: `crates/mika-gateway/src/github.rs` (inline tests)
+
+**Approach:**
+- Define `const RETRY_DELAYS: [Duration; 5]` with the schedule `[2s, 5s, 15s, 60s, 300s]`.
+- Implement `deliver_with_retry` as an async function that takes the same arguments as `forward_github_event` plus a reference to the semaphore and the delay schedule.
+- On the initial attempt, the caller's permit is used. On retryable failure, drop the permit, sleep, then `try_acquire_owned` before retrying. If the semaphore is full, log WARN and abandon (the system is overloaded).
+- After exhausting retries, log ERROR with `delivery_id`, `target_agent`, attempt count, and last error description.
+- Intermediate retry attempts log WARN with attempt number, delay, and reason.
+- Replace the `tokio::spawn` body in `handle_github_webhook` to call `deliver_with_retry`.
+
+**Execution note:** The retry wrapper does not need to be generic -- it is specific to GitHub webhook delivery. If Telegram or other channels need retry later, extract then.
+
+**Patterns to follow:**
+- `for attempt in 0..=MAX_RETRIES` pattern from `crates/mika-common/src/claude.rs` (lines 452-480)
+- Structured logging with `delivery_id`, `target_agent`, `attempt` fields matching the existing tracing conventions in `github.rs`
+
+**Test scenarios:**
+- Happy path: first attempt succeeds, no retry, no extra logging
+- Happy path: first attempt returns 429, second attempt succeeds after 2s delay -- verify only 2 calls made
+- Happy path: first attempt returns 503, second attempt succeeds -- verify retry behavior
+- Error path: 400 on first attempt -- no retry, WARN logged immediately
+- Error path: connection error on first attempt -- no retry, ERROR logged
+- Error path: all 6 attempts return 429 -- ERROR logged with delivery_id and target_agent after exhaustion
+- Edge case: semaphore unavailable on retry -- WARN logged, retry abandoned
+- Edge case: timeout on first attempt -- classified as retryable, retry occurs
+- Integration: deliver_with_retry called from `handle_github_webhook` spawn task -- verify permit is held during attempt, released during sleep
+
+**Verification:**
+- `cargo test -p mika-gateway` passes
+- `cargo clippy -p mika-gateway` clean
+- The retry schedule matches `[2s, 5s, 15s, 60s, 300s]` exactly
+
+- [x] **Unit 3: Add inline documentation for dedup LRU eviction edge case**
+
+**Goal:** Document the known interaction between late retries and the LRU delivery cache for future maintainers.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs`
+
+**Approach:**
+- Add a doc comment on `deliver_with_retry` explaining: the delivery_id is inserted into the LRU cache before forwarding. Under extreme volume (>10k deliveries during a single 300s retry sleep), the LRU may evict the entry. If GitHub redelivers the same event, the gateway would accept it as new. Agent-side idempotency (work item unique index) prevents duplicate processing. A TTL on the LRU cache would fix this but is deferred to a separate ticket.
+- Add a brief comment in the spawn task noting the retry budget and cross-referencing #590 (DLQ).
+
+**Test expectation:** none -- documentation only
+
+**Verification:**
+- Comments exist on `deliver_with_retry` and the spawn task explaining the dedup edge case and the DLQ cross-reference
+
+## System-Wide Impact
+
+- **Interaction graph:** The retry wrapper interacts with: (1) semaphore shared with Telegram webhooks -- releasing during sleep prevents starvation; (2) delivery LRU cache -- read-only during retry, known eviction edge case documented; (3) agent container's `/message` endpoint -- receives the same payload on each attempt with the same `request_id`.
+- **Error propagation:** `forward_github_event` now returns `ForwardResult` to the retry wrapper. The wrapper decides whether to retry or log and stop. No error propagation beyond the spawned task (it's fire-and-forget from the handler's perspective).
+- **State lifecycle risks:** Semaphore permits are released during sleep, creating a window where another task could use the permit. This is intentional -- it prevents starvation. The re-acquisition via `try_acquire_owned` handles the overload case gracefully.
+- **API surface parity:** The Telegram forwarding path (`handle_forward_result` in `routes.rs`) does NOT need this change -- Telegram has built-in retry via `reset_dedup()`. The A2A proxy path does not use webhook forwarding.
+- **Unchanged invariants:** The handler still returns 200 to GitHub immediately. The delivery cache dedup logic is unchanged. The semaphore capacity (30) is unchanged. The per-request 5s timeout on `forward_github_event` is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Semaphore contention increases under sustained 429s (permits released and re-acquired more frequently) | Natural backpressure: if semaphore is full on re-acquire, retry is abandoned. 30 permits is generous for the current webhook volume. |
+| Late retry (300s) delivers duplicate if LRU evicted the delivery_id | Agent-side idempotency (work item unique index). Documented as known edge case. TTL on LRU deferred. |
+| Gateway restart during retry loop loses the event | Acceptable for MVP. DLQ in #590 provides persistence. |
+| Retry wrapper holds tokio task alive for up to ~382s | This is a lightweight async sleep, not a thread. Tokio handles thousands of sleeping tasks efficiently. |
+
+## Sources & References
+
+- Related issues: #589 (this), #590 (DLQ -- gated on this), #583/PR #586 (engine-side dispatch guards), #571/PR #587 (check_suite handler)
+- Existing retry pattern: `crates/mika-common/src/claude.rs` lines 452-480
+- Learnings: `docs/solutions/code-review-patterns/async-callbacks-long-running-review-findings.md` (P2-529 tight retry)
+- Learnings: `docs/solutions/ux-improvements/gateway-offline-agent-error-message.md` (error classification)

--- a/docs/solutions/integration-issues/gateway-inbound-webhook-retry-on-429-5xx.md
+++ b/docs/solutions/integration-issues/gateway-inbound-webhook-retry-on-429-5xx.md
@@ -1,0 +1,201 @@
+---
+module: gateway
+date: 2026-04-16
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "Gateway forwards GitHub webhook to agent, agent returns HTTP 429 (busy), gateway logs WARN and silently drops the event"
+  - "PR sits APPROVED + green CI + mergeable but never auto-merges because the pull_request_review.submitted verdict was lost"
+  - "GitHub already received 200 OK from the gateway, so it does not redeliver — the event is permanently gone"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+tags:
+  - gateway
+  - webhook
+  - github
+  - retry
+  - resilience
+  - backoff
+related_components:
+  - mika-gateway/github
+  - mika-agent/server/handlers
+---
+
+# Gateway silently drops inbound webhooks when agent returns 429/5xx
+
+## Problem
+
+The mika-gateway receives a GitHub webhook, HMAC-validates it, routes it to the correct customer container, returns 200 OK to GitHub, and then `tokio::spawn`s a task to forward the event to the agent container via `POST /message`. If that forward gets HTTP 429 (agent busy) or 5xx (transient), the task logs a WARN and returns — no retry.
+
+Because the gateway already returned 200 to GitHub at the entry point, GitHub does not retry either. The webhook is lost.
+
+## Symptoms
+
+**2026-04-15 22:35:00 UTC** — `pull_request_review.submitted` for mika#588 (mika-qa's approving verdict):
+
+```
+22:35:00 INFO  GitHub webhook routing event to agent
+              event_type=pull_request_review action=submitted
+              target_agent=mika-dev delivery_id=3c7b98c2-391b-11f1-...
+22:35:00 WARN  agent container returned error for GitHub event
+              status=429 target_agent=mika-dev request_id=3c7b98c2-...
+```
+
+mika-dev returned 429 because she was busy processing a claude-pilot callback for mika#579 (well-behaved backpressure). The gateway logged WARN and gave up. PR #588 sat APPROVED with green CI but was never auto-merged — the verdict handler never ran.
+
+## What Didn't Work
+
+Relying on GitHub's retry mechanism. The gateway returns 200 OK to GitHub the instant HMAC validates, before the spawned forwarding task even starts. GitHub treats the event as delivered — it does not retry on the basis of gateway-internal failures.
+
+Relying on agent-side deferral queues. mika-agent has a 60s webhook deferral queue for callback sequencing, but it only activates for events that *arrive* at the agent. An event that returns 429 at the agent's HTTP handler never enters the queue.
+
+## Solution
+
+Add retry-with-backoff in the spawned forwarding task. Keep the single-attempt forwarding function pure; put the retry policy in a wrapper.
+
+### Retry schedule
+
+Fixed delays `[2s, 5s, 15s, 60s, 300s]` (initial attempt + 5 retries). Each delay gets ±25% jitter to prevent synchronized retry bursts when many events hit the same 429 simultaneously.
+
+### What is retryable
+
+- HTTP 429 (rate-limited / busy)
+- HTTP 5xx (transient server error)
+- Request timeouts (`reqwest::Error` that is not `is_connect()`) — transient overload
+
+### What is NOT retryable
+
+- HTTP 4xx other than 429 — client error, retry won't help
+- Connection errors (`e.is_connect()`) — agent is offline, retry won't help
+- Unresolvable routes (repo not registered + no fallback) — permanent config error
+
+### Semaphore lifecycle
+
+The 30-permit `webhook_semaphore` is shared between Telegram and GitHub forwarders. A naive implementation that holds the permit for the entire ~382s retry window would starve Telegram during sustained failures. Instead:
+
+- Hold the caller's permit during the initial attempt
+- Release during every retry sleep
+- Re-acquire via `try_acquire_owned` before each retry attempt
+- If the semaphore is full on re-acquire, abandon the retry with a **distinct** ERROR log (`semaphore at capacity during retry`) — do not fall through to the `retry budget exhausted` log, which would misrepresent attempt count and cause
+
+### Route caching
+
+`resolve_github_container_url` (Postgres query) runs once before the retry loop. The resolved `ResolvedRoute` is passed into every attempt. Without this, a single failing event hit the DB up to 6 times.
+
+### Code shape
+
+```rust
+// crates/mika-gateway/src/github.rs
+
+pub(crate) const RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(15),
+    Duration::from_secs(60),
+    Duration::from_secs(300),
+];
+
+enum ForwardResult {
+    Success,
+    Retryable { reason: String },  // 429, 5xx, timeout
+    Permanent { reason: String },  // 4xx, connection error
+}
+
+async fn deliver_with_retry(
+    state: &AppState,
+    target_agent: &str,
+    text: &str,
+    request_id: &str,
+    repo_full_name: Option<&str>,
+    initial_permit: OwnedSemaphorePermit,
+    semaphore: &Arc<Semaphore>,
+) {
+    // Resolve route ONCE, cached across all retries.
+    let route = match resolve_github_container_url(state, repo_full_name).await {
+        Some(r) => r,
+        None => { /* log and return */ return; }
+    };
+
+    let mut attempts_made = 0;
+    let mut last_reason = String::new();
+    let mut current_permit = Some(initial_permit);
+
+    for (retry_idx, delay) in std::iter::once(None)
+        .chain(RETRY_DELAYS.iter().map(Some))
+        .enumerate()
+    {
+        if let Some(delay) = delay {
+            tokio::time::sleep(apply_jitter(*delay)).await;
+            match semaphore.clone().try_acquire_owned() {
+                Ok(p) => current_permit = Some(p),
+                Err(_) => {
+                    error!(/* distinct "semaphore at capacity" log */);
+                    return;
+                }
+            }
+        }
+
+        let result = forward_to_resolved_route(...).await;
+        attempts_made = retry_idx + 1;
+        current_permit.take();  // release before next sleep
+
+        match result {
+            ForwardResult::Success => return,
+            ForwardResult::Permanent { .. } => return,
+            ForwardResult::Retryable { reason } => { last_reason = reason; }
+        }
+    }
+
+    error!(total_attempts = attempts_made, last_reason, "retry budget exhausted");
+}
+```
+
+## Why This Works
+
+**Classification at the attempt boundary.** `ForwardResult` turns the inner `reqwest` result into three categories the retry loop can match on without re-parsing HTTP status codes or error types. This keeps the single-attempt function pure and makes the retry decision explicit.
+
+**Permit release prevents cross-channel starvation.** The semaphore throttles in-flight HTTP calls, not sleeping tasks. Releasing during sleep means a 10/sec webhook burst during a 6-min agent outage holds ~60 live tokio tasks at most but only 30 concurrent HTTP calls at any instant — Telegram traffic still flows.
+
+**Distinct error logs preserve observability.** An event dropped because "we exhausted 6 attempts" has different operational meaning than one dropped because "the gateway ran out of permits". Conflating them (fall-through to a single ERROR) misleads incident response with wrong `total_attempts` and wrong `last_reason`.
+
+**Jitter prevents self-reinforcing bursts.** Without jitter, 30 tasks that all got 429 at T=0 all wake at T=2s and re-hit the agent simultaneously — recreating the exact overload condition that caused the original 429. ±25% jitter spreads the retry window.
+
+**Route caching bounds DB load.** Under sustained agent failure, retry amplifies Postgres load. Resolving once removes that amplification without changing correctness (the `github_repos` row is unlikely to change between retries seconds apart).
+
+## Prevention
+
+**Test the no-retry contract explicitly.** Tests for "no retry on 400" must assert `call_count == 1`, not just `available_permits == 30`. A regression that adds retries on 4xx would silently pass the permit assertion because the mock server falls back to 200.
+
+```rust
+assert_eq!(
+    call_count.load(Ordering::SeqCst),
+    1,
+    "400 is permanent — must make exactly 1 HTTP call, no retry"
+);
+```
+
+**Mark long-wall-clock tests `#[ignore]`.** The retry budget exhaustion test takes 2+5+15+60+300 = 382 seconds because `RETRY_DELAYS` is a compile-time const. Mark it `#[ignore]` and document how to run it:
+
+```rust
+#[tokio::test]
+#[ignore = "takes ~6.5 minutes of wall time; run with --ignored"]
+async fn test_deliver_retry_budget_exhausted_after_six_attempts() { ... }
+```
+
+**Use `tokio::time::timeout` to bound test wall time.** Any test that spawns `deliver_with_retry` and depends on timing should wrap `handle.await` in `tokio::time::timeout` so a race (semaphore blocker grabbed too late, etc.) produces a clean failure instead of a 5+ minute silent hang.
+
+**When adding new classifications to the outcome enum, add tests on both sides.** Pure data-constructor tests (build the enum and check `is_retryable()`) prove the helper works. They do NOT prove that the single-attempt function produces the right variant. Add integration tests that drive real HTTP responses through the actual classification code.
+
+**Document the dedup LRU interaction.** The gateway's 10k-entry LRU cache has no TTL. Under extreme webhook volume during a 300s retry sleep, an entry can be evicted, allowing GitHub redelivery to bypass dedup. Agent-side idempotency (work item unique index) mitigates double-processing, but this is a known edge case — future work should add TTL (#590).
+
+## References
+
+- Issue: senara-solutions/mika#589
+- Follow-up (DLQ): senara-solutions/mika#590
+- Plan: `docs/plans/2026-04-16-003-feat-gateway-retry-inbound-webhook-delivery-plan.md`
+- Related:
+  - `docs/solutions/code-review-patterns/async-callbacks-long-running-review-findings.md` (P2-529 tight retry loop anti-pattern — avoided here)
+  - `docs/solutions/ux-improvements/gateway-offline-agent-error-message.md` (error classification via `is_connect()`)
+  - `docs/solutions/architecture-patterns/webhook-deferral-queue-callback-sequencing.md` (agent-side 60s queue — orthogonal to this retry)
+  - `docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md` (prior silent-drop incident in the same handler)


### PR DESCRIPTION
## Summary

When the gateway forwards a GitHub webhook to an agent container and the agent returns HTTP 429 (busy) or 5xx (transient), the gateway previously logged a WARN and silently dropped the event. GitHub already received the gateway's 200 OK at the entry point, so it doesn't redeliver. The event was permanently lost.

Real-world impact (2026-04-15 22:35 UTC): `pull_request_review.submitted` for mika#588 hit mika-dev while she was busy processing a claude-pilot callback for #579. mika-dev correctly returned 429. Gateway gave up. PR #588 sat APPROVED + green CI but was never auto-merged.

This PR adds retry-with-backoff to the spawned forwarding task.

## What changed

- **New `ForwardResult` enum** in `crates/mika-gateway/src/github.rs` — typed outcome of a single forwarding attempt (`Success` / `Retryable { reason }` / `Permanent { reason }`).
- **New `deliver_with_retry` wrapper** around the single-attempt `forward_to_resolved_route`. Retry schedule `[2s, 5s, 15s, 60s, 300s]` with ±25% jitter per attempt.
- **Retry on 429/5xx and request timeouts.** No retry on 4xx (other than 429) or connection errors (agent offline, retry won't help).
- **Semaphore released during retry sleep** to prevent cross-channel starvation with Telegram. Re-acquired via `try_acquire_owned` before each retry; abandoned with a **distinct** ERROR log if the semaphore is full (not conflated with the "retry budget exhausted" ERROR).
- **Route resolution cached across retries** — Postgres query runs once at the start of the retry loop, not per-attempt (avoided 6× DB amplification under sustained failure).
- **Structured ERROR logs** differentiate "retry budget exhausted" (all 6 attempts failed), "semaphore at capacity during retry" (gateway overloaded), and "no route resolved" (config error).

## Test plan

- [x] `cargo test -p mika-gateway` — 140 pass, 2 ignored (retry-budget-exhausted test takes 6.5min; run with `--ignored`)
- [x] `cargo clippy -p mika-gateway --tests` — clean
- [x] `cargo fmt -p mika-gateway` — clean
- [x] Unit tests for ForwardResult classification (429, 5xx, 4xx, connection error, timeout)
- [x] Integration tests via mock Axum server:
  - 200/202 success on first attempt (1 HTTP call)
  - 429 → success after 1 retry (2 HTTP calls)
  - 503 → success after 1 retry (2 HTTP calls)
  - 400 → no retry (1 HTTP call, asserted via call_count)
  - 404 → no retry (1 HTTP call, asserted via call_count)
  - All 6 attempts return 429 → retry budget exhausted (ignored; 6.5min wall time)
  - Semaphore released during retry sleep
  - Semaphore full on retry → abandoned (1 HTTP call, no retry fires)
- [x] Jitter tests: `apply_jitter` stays within ±25% of base, pass-through for zero/sub-4ms delays
- [x] Pre-commit hooks pass (lefthook: fmt, clippy, secrets, large files, toml)

## Out of scope (deferred)

- **DLQ + replay CLI** — tracked in #590. Events that exhaust retries or are abandoned due to semaphore pressure are still dropped, with actionable ERROR logs that operators can alert on.
- **LRU TTL** — the in-memory `X-GitHub-Delivery` dedup cache is size-based only. Under extreme volume during a 300s retry sleep, an entry could be evicted and a GitHub redelivery would bypass dedup. Agent-side work item unique index mitigates double-processing. TTL work is batched into #590.
- **Graceful shutdown tracking of in-flight retry tasks** — retry tasks are currently `tokio::spawn`ed without a JoinSet. On SIGTERM, sleeping tasks are cancelled silently. The existing spawn-per-event model predates this PR; changing it requires a JoinSet + CancellationToken architecture change. Deferred — DLQ (#590) provides the persistence backstop.

## Documentation

- Plan: `docs/plans/2026-04-16-003-feat-gateway-retry-inbound-webhook-delivery-plan.md`
- Compound solution doc: `docs/solutions/integration-issues/gateway-inbound-webhook-retry-on-429-5xx.md`
- Updated `crates/mika-gateway/CLAUDE.md` with new "Inbound delivery retry" subsection

Closes #589