### PR TITLE
feat(agent): add tasks.type column and create_work_item support (#595)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -169,12 +169,13 @@ All SQLite timestamp columns use ISO 8601 TEXT format (`%Y-%m-%dT%H:%M:%SZ`). Th
 
 ## Schema Version
 
-**Current: v22.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides, tasks (with manual/callback/a2a trigger types), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
+**Current: v23.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides, tasks (with manual/callback/a2a trigger types and a `type` column distinguishing `issue`/`milestone`/`project`), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
 
 Recent migrations:
 - v18->v19: `sessions.task_id` column for reverse session->task lookups. `get_sessions_for_task_tree()`.
 - v19->v20: `skill_overrides.llm_provider` and `skill_overrides.llm_model` for per-skill LLM override.
 - v20->v21: `llm_calls.prompt_variant` for skill prompt variant recording.
 - v21->v22: `messages.internal` column (`INTEGER NOT NULL DEFAULT 0`) for agent-to-agent message visibility. TUI inbox mode filters internal messages at the DB level. Set by `delegate_task` tool and by `mika ask --task-id` relay sessions (without `--task-complete`). `AgentParams.internal` threads the flag through `run_loop` to all message save paths.
+- v22->v23: `tasks.type` column (`TEXT NOT NULL DEFAULT 'issue' CHECK (type IN ('issue', 'milestone', 'project'))`). Foundational for milestone/project dispatch (mika#595): `create_work_item` accepts an optional `type` parameter; `list_work_items` and `check_work_item` surface it. mika core stays a dumb work-item store — orchestration logic lives in self-dev (mika-skills#149). `NewTask.r#type: Option<String>` defaults to `'issue'` via SQL DEFAULT when `None`. Constants: `TASK_TYPE_ISSUE`/`TASK_TYPE_MILESTONE`/`TASK_TYPE_PROJECT`/`VALID_TASK_TYPES` in `db.rs`.
 
 Full migration history: see `docs/runtime-structure.md`.

--- a/crates/mika-agent/docs/runtime-structure.md
+++ b/crates/mika-agent/docs/runtime-structure.md
@@ -75,7 +75,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **PRAGMAs:** `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`, `busy_timeout=5000`, `auto_vacuum=INCREMENTAL`
 
-**Current schema version:** 22
+**Current schema version:** 23
 
 **Timestamp format:** All timestamp columns use ISO 8601 TEXT (`%Y-%m-%dT%H:%M:%SZ`) — not Unix epoch integers. SQL defaults use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`. Fixed-width UTC format ensures correct lexicographic ordering.
 
@@ -107,7 +107,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 ### Task Engine
 
-**tasks** — `id TEXT PK`, `agent_id FK`, `team_run_id FK→team_runs`, `parent_task_id FK→tasks(self)`, `depth INTEGER CHECK(0..3)`, `label TEXT`, `trigger_type TEXT CHECK(time|recurring|callback|user_reply|event|condition|manual|a2a)`, `cron_expr TEXT`, `event_source TEXT`, `event_offset_secs INTEGER`, `condition_expr TEXT`, `next_fire_at TEXT`, `timeout_at TEXT`, `action_type TEXT CHECK(send_message|resume_agent|inject_context|run_skill|invoke_orchestrator|none)`, `action_config TEXT DEFAULT '{}'`, `status TEXT CHECK(pending|in_progress|completed|failed|cancelled|expired|recurring_active|delivered|blocked)`, `process_id INTEGER`, `input_context TEXT`, `result TEXT`, `created_by_session TEXT`, `created_trace_id TEXT`, `execution_trace_id TEXT`, `reference_url TEXT`, `source TEXT`, `metadata TEXT`, `created_at TEXT`, `updated_at TEXT`, `fired_at TEXT`, `completed_at TEXT`. The metadata column (v14) stores opaque JSON; for dev runs (source IN ('self_dev', 'github_issue')), expected shape: `{"claude_pilot": {"branch", "repo", "pr_number", "pr_url", "cost_usd", "duration_ms", "turns", "session_id", "log_path"}}`
+**tasks** — `id TEXT PK`, `agent_id FK`, `team_run_id FK→team_runs`, `parent_task_id FK→tasks(self)`, `depth INTEGER CHECK(0..3)`, `label TEXT`, `trigger_type TEXT CHECK(time|recurring|callback|user_reply|event|condition|manual|a2a)`, `cron_expr TEXT`, `event_source TEXT`, `event_offset_secs INTEGER`, `condition_expr TEXT`, `next_fire_at TEXT`, `timeout_at TEXT`, `action_type TEXT CHECK(send_message|resume_agent|inject_context|run_skill|invoke_orchestrator|none)`, `action_config TEXT DEFAULT '{}'`, `status TEXT CHECK(pending|in_progress|completed|failed|cancelled|expired|recurring_active|delivered|blocked)`, `process_id INTEGER`, `input_context TEXT`, `result TEXT`, `created_by_session TEXT`, `created_trace_id TEXT`, `execution_trace_id TEXT`, `reference_url TEXT`, `source TEXT`, `metadata TEXT`, `type TEXT NOT NULL DEFAULT 'issue' CHECK(issue|milestone|project)` (v23), `created_at TEXT`, `updated_at TEXT`, `fired_at TEXT`, `completed_at TEXT`. The metadata column (v14) stores opaque JSON; for dev runs (source IN ('self_dev', 'github_issue')), expected shape: `{"claude_pilot": {"branch", "repo", "pr_number", "pr_url", "cost_usd", "duration_ms", "turns", "session_id", "log_path"}}`. The type column (v23, mika#595) distinguishes regular work items (`issue`) from parent containers (`milestone`, `project`) that aggregate child issues via `parent_task_id`.
 
 ### Team Tables
 

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -2136,6 +2136,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         let t = db.get_task(&id).await.unwrap().unwrap();

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -22,7 +22,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 22;
+pub const CURRENT_SCHEMA_VERSION: i64 = 23;
 
 /// SQL for the unified_timeline VIEW — cross-subsystem event correlation.
 /// Used in both clean-slate schema creation and incremental migration.
@@ -76,6 +76,16 @@ pub fn is_unique_violation(err: &anyhow::Error) -> bool {
 }
 
 pub const COMMITMENT_STATUSES: &[&str] = &["pending", "completed", "cancelled"];
+
+/// Default value for the `tasks.type` column. New work items default to `"issue"`
+/// unless the caller explicitly requests `"milestone"` or `"project"`.
+pub const TASK_TYPE_ISSUE: &str = "issue";
+pub const TASK_TYPE_MILESTONE: &str = "milestone";
+pub const TASK_TYPE_PROJECT: &str = "project";
+
+/// All valid values for the `tasks.type` column. Enforced by SQLite CHECK and by
+/// the `create_work_item` tool boundary. Order is the documented enum order.
+pub const VALID_TASK_TYPES: &[&str] = &[TASK_TYPE_ISSUE, TASK_TYPE_MILESTONE, TASK_TYPE_PROJECT];
 
 pub const CORE_MEMORY_SECTIONS: &[(&str, &str)] = &[
     ("user_summary", "No information about the user yet."),
@@ -150,6 +160,10 @@ pub struct Task {
     pub reference_url: Option<String>,
     pub source: Option<String>,
     pub metadata: Option<String>,
+    /// Work item kind: `"issue"`, `"milestone"`, or `"project"`. NOT NULL in the DB,
+    /// defaulted to `"issue"` for backward compatibility (added in schema v23). See
+    /// [`VALID_TASK_TYPES`].
+    pub r#type: String,
 }
 
 #[derive(Debug, Clone)]
@@ -174,6 +188,11 @@ pub struct NewTask {
     pub reference_url: Option<String>,
     pub source: Option<String>,
     pub metadata: Option<String>,
+    /// Work item kind. `None` (or an empty string) means "use the SQL default"
+    /// (`"issue"`), preserving backward compatibility for existing callers. Values
+    /// other than those in [`VALID_TASK_TYPES`] are rejected by the DB CHECK
+    /// constraint; prefer validating at the tool boundary before INSERT.
+    pub r#type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -747,6 +766,10 @@ impl Database {
             self.migrate_v21_to_v22()?;
             info!(version = 22, "database migrated to v22");
         }
+        if (3..=22).contains(&version) {
+            self.migrate_v22_to_v23()?;
+            info!(version = 23, "database migrated to v23");
+        }
         Ok(())
     }
 
@@ -803,7 +826,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (22);
+            INSERT INTO schema_version (version) VALUES (23);
 
             CREATE TABLE agents (
                 id TEXT PRIMARY KEY,
@@ -871,6 +894,9 @@ impl Database {
                 reference_url TEXT,
                 source TEXT,
                 metadata TEXT,
+                type TEXT NOT NULL DEFAULT 'issue' CHECK (
+                    type IN ('issue', 'milestone', 'project')
+                ),
                 created_by_session TEXT,
                 created_trace_id TEXT,
                 execution_trace_id TEXT,
@@ -2516,6 +2542,26 @@ impl Database {
         Ok(())
     }
 
+    fn migrate_v22_to_v23(&self) -> Result<()> {
+        info!("migrating database schema v22 → v23 (tasks: type column)");
+
+        let has_col = self.column_exists("tasks", "type")?;
+
+        let mut sql = String::from("BEGIN IMMEDIATE;\n");
+        if !has_col {
+            // SQLite 3.37+ supports CHECK constraints in ALTER TABLE ADD COLUMN.
+            // The DEFAULT backfills all existing rows to 'issue', preserving behavior.
+            sql.push_str(
+                "ALTER TABLE tasks ADD COLUMN type TEXT NOT NULL DEFAULT 'issue' \
+                 CHECK (type IN ('issue', 'milestone', 'project'));\n",
+            );
+        }
+        sql.push_str("INSERT INTO schema_version (version) VALUES (23);\nCOMMIT;");
+
+        self.conn.execute_batch(&sql)?;
+        Ok(())
+    }
+
     /// Check if a column exists on a table (used for idempotent migrations).
     fn column_exists(&self, table: &'static str, column: &'static str) -> Result<bool> {
         let mut stmt = self
@@ -2709,19 +2755,27 @@ impl Database {
 
     pub fn create_task(&self, task: &NewTask) -> Result<String> {
         let id = uuid::Uuid::new_v4().to_string();
+        // `type` defaults to "issue" when the caller passes None or an empty string.
+        // The DB CHECK constraint enforces the same allowlist as VALID_TASK_TYPES.
+        let task_type = task
+            .r#type
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(TASK_TYPE_ISSUE);
         self.conn.execute(
             "INSERT INTO tasks (
                 id, agent_id, team_run_id, parent_task_id, depth, label,
                 trigger_type, cron_expr, event_source, event_offset_secs, condition_expr,
                 next_fire_at, timeout_at, action_type, action_config,
                 input_context, created_by_session, created_trace_id,
-                reference_url, source, metadata
+                reference_url, source, metadata, type
              ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6,
                 ?7, ?8, ?9, ?10, ?11,
                 ?12, ?13, ?14, ?15,
                 ?16, ?17, ?18,
-                ?19, ?20, ?21
+                ?19, ?20, ?21, ?22
              )",
             params![
                 id,
@@ -2745,6 +2799,7 @@ impl Database {
                 task.reference_url,
                 task.source,
                 task.metadata,
+                task_type,
             ],
         )?;
         Ok(id)
@@ -2754,14 +2809,20 @@ impl Database {
     /// trigger_type='recurring' exists. Returns the task ID if created, None if already existed.
     pub fn create_recurring_task_if_absent(&self, task: NewTask) -> Result<Option<String>> {
         let id = uuid::Uuid::new_v4().to_string();
+        let task_type = task
+            .r#type
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(TASK_TYPE_ISSUE);
         let n = self.conn.execute(
             "INSERT OR IGNORE INTO tasks
              (id, agent_id, team_run_id, parent_task_id, depth, label,
               trigger_type, cron_expr, event_source, event_offset_secs,
               condition_expr, next_fire_at, timeout_at, action_type,
               action_config, status, input_context, created_by_session, created_trace_id,
-              reference_url, source, metadata)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,'recurring_active',?16,?17,?18,?19,?20,?21)",
+              reference_url, source, metadata, type)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,'recurring_active',?16,?17,?18,?19,?20,?21,?22)",
             params![
                 id, task.agent_id, task.team_run_id, task.parent_task_id,
                 task.depth, task.label, task.trigger_type, task.cron_expr,
@@ -2769,7 +2830,7 @@ impl Database {
                 task.next_fire_at, task.timeout_at, task.action_type,
                 task.action_config, task.input_context, task.created_by_session,
                 task.created_trace_id, task.reference_url, task.source,
-                task.metadata
+                task.metadata, task_type
             ],
         )?;
         if n > 0 {
@@ -2848,6 +2909,7 @@ impl Database {
             reference_url: r.get(26)?,
             source: r.get(27)?,
             metadata: r.get(28)?,
+            r#type: r.get(29)?,
         })
     }
 
@@ -2856,7 +2918,7 @@ impl Database {
          next_fire_at, timeout_at, action_type, action_config,
          status, process_id, input_context, result, created_by_session,
          created_trace_id, execution_trace_id, created_at, updated_at, fired_at, completed_at,
-         reference_url, source, metadata";
+         reference_url, source, metadata, type";
 
     pub fn get_task(&self, id: &str, agent_id: &str) -> Result<Option<Task>> {
         let sql = format!(
@@ -3055,7 +3117,7 @@ impl Database {
     }
 
     /// Number of columns in TASK_COLUMNS (used for child_count ordinal in list_manual_tasks).
-    const TASK_COLUMN_COUNT: usize = 29;
+    const TASK_COLUMN_COUNT: usize = 30;
 
     /// List manual (work item) tasks for an agent with optional filters.
     /// Uses parameterized NULL checks to avoid dynamic SQL construction.
@@ -3125,55 +3187,16 @@ impl Database {
         agent_id: &str,
         reference_url: &str,
     ) -> Result<Option<Task>> {
+        let sql = format!(
+            "SELECT {} FROM tasks
+             WHERE agent_id = ?1 AND reference_url = ?2
+               AND trigger_type = 'manual'
+               AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
+             LIMIT 1",
+            Self::TASK_COLUMNS
+        );
         self.conn
-            .query_row(
-                "SELECT id, agent_id, team_run_id, parent_task_id, depth, label,
-                        trigger_type, cron_expr, event_source, event_offset_secs,
-                        condition_expr, next_fire_at, timeout_at, action_type,
-                        action_config, status, process_id, input_context, result,
-                        created_by_session, created_trace_id, execution_trace_id,
-                        created_at, updated_at, fired_at, completed_at,
-                        reference_url, source, metadata
-                 FROM tasks
-                 WHERE agent_id = ?1 AND reference_url = ?2
-                   AND trigger_type = 'manual'
-                   AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
-                 LIMIT 1",
-                params![agent_id, reference_url],
-                |r| {
-                    Ok(Task {
-                        id: r.get(0)?,
-                        agent_id: r.get(1)?,
-                        team_run_id: r.get(2)?,
-                        parent_task_id: r.get(3)?,
-                        depth: r.get(4)?,
-                        label: r.get(5)?,
-                        trigger_type: r.get(6)?,
-                        cron_expr: r.get(7)?,
-                        event_source: r.get(8)?,
-                        event_offset_secs: r.get(9)?,
-                        condition_expr: r.get(10)?,
-                        next_fire_at: r.get(11)?,
-                        timeout_at: r.get(12)?,
-                        action_type: r.get(13)?,
-                        action_config: r.get(14)?,
-                        status: r.get(15)?,
-                        process_id: r.get(16)?,
-                        input_context: r.get(17)?,
-                        result: r.get(18)?,
-                        created_by_session: r.get(19)?,
-                        created_trace_id: r.get(20)?,
-                        execution_trace_id: r.get(21)?,
-                        created_at: r.get(22)?,
-                        updated_at: r.get(23)?,
-                        fired_at: r.get(24)?,
-                        completed_at: r.get(25)?,
-                        reference_url: r.get(26)?,
-                        source: r.get(27)?,
-                        metadata: r.get(28)?,
-                    })
-                },
-            )
+            .query_row(&sql, params![agent_id, reference_url], Self::row_to_task)
             .optional()
             .map_err(Into::into)
     }
@@ -3232,55 +3255,16 @@ impl Database {
         agent_id: &str,
         label: &str,
     ) -> Result<Option<Task>> {
+        let sql = format!(
+            "SELECT {} FROM tasks
+             WHERE agent_id = ?1 AND label = ?2 COLLATE NOCASE
+               AND trigger_type = 'manual'
+               AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
+             LIMIT 1",
+            Self::TASK_COLUMNS
+        );
         self.conn
-            .query_row(
-                "SELECT id, agent_id, team_run_id, parent_task_id, depth, label,
-                        trigger_type, cron_expr, event_source, event_offset_secs,
-                        condition_expr, next_fire_at, timeout_at, action_type,
-                        action_config, status, process_id, input_context, result,
-                        created_by_session, created_trace_id, execution_trace_id,
-                        created_at, updated_at, fired_at, completed_at,
-                        reference_url, source, metadata
-                 FROM tasks
-                 WHERE agent_id = ?1 AND label = ?2 COLLATE NOCASE
-                   AND trigger_type = 'manual'
-                   AND status NOT IN ('completed', 'cancelled', 'failed', 'delivered')
-                 LIMIT 1",
-                params![agent_id, label],
-                |r| {
-                    Ok(Task {
-                        id: r.get(0)?,
-                        agent_id: r.get(1)?,
-                        team_run_id: r.get(2)?,
-                        parent_task_id: r.get(3)?,
-                        depth: r.get(4)?,
-                        label: r.get(5)?,
-                        trigger_type: r.get(6)?,
-                        cron_expr: r.get(7)?,
-                        event_source: r.get(8)?,
-                        event_offset_secs: r.get(9)?,
-                        condition_expr: r.get(10)?,
-                        next_fire_at: r.get(11)?,
-                        timeout_at: r.get(12)?,
-                        action_type: r.get(13)?,
-                        action_config: r.get(14)?,
-                        status: r.get(15)?,
-                        process_id: r.get(16)?,
-                        input_context: r.get(17)?,
-                        result: r.get(18)?,
-                        created_by_session: r.get(19)?,
-                        created_trace_id: r.get(20)?,
-                        execution_trace_id: r.get(21)?,
-                        created_at: r.get(22)?,
-                        updated_at: r.get(23)?,
-                        fired_at: r.get(24)?,
-                        completed_at: r.get(25)?,
-                        reference_url: r.get(26)?,
-                        source: r.get(27)?,
-                        metadata: r.get(28)?,
-                    })
-                },
-            )
+            .query_row(&sql, params![agent_id, label], Self::row_to_task)
             .optional()
             .map_err(Into::into)
     }
@@ -7709,6 +7693,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(&task).unwrap();
         let t = db.get_task(&id, "mika").unwrap().unwrap();
@@ -7741,6 +7726,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(&task).unwrap();
         assert!(db.cancel_task(&id, "mika").unwrap());
@@ -7945,6 +7931,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         db.create_task(&task).unwrap();
         assert_eq!(db.count_pending_tasks("mika").unwrap(), 1);
@@ -7972,6 +7959,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         }
     }
 
@@ -8208,6 +8196,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id1 = db.create_task(&task).unwrap();
         assert!(!id1.is_empty());
@@ -8239,6 +8228,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id2 = db.create_task(&task2).unwrap();
         assert!(!id2.is_empty());
@@ -8272,6 +8262,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         }
     }
 
@@ -8545,6 +8536,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let _id = db.create_task(&reminder).unwrap();
 
@@ -8660,6 +8652,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         db.create_task(&task).unwrap();
 
@@ -8867,6 +8860,91 @@ mod tests {
         assert!(db.column_exists("sessions", "parent_session_id").unwrap());
     }
 
+    // ===== `tasks.type` column tests (issue #595, schema v23) =====
+
+    #[test]
+    fn test_tasks_type_column_exists() {
+        let db = db();
+        assert!(db.column_exists("tasks", "type").unwrap());
+    }
+
+    #[test]
+    fn test_tasks_type_defaults_to_issue() {
+        // Inserting via NewTask with r#type: None should backfill to 'issue'
+        // via the SQL DEFAULT.
+        let db = db();
+        let task = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "default-type".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+        };
+        let id = db.create_task(&task).unwrap();
+        let t = db.get_task(&id, "mika").unwrap().unwrap();
+        assert_eq!(t.r#type, "issue");
+    }
+
+    #[test]
+    fn test_tasks_type_round_trips_milestone() {
+        let db = db();
+        let task = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "milestone-type".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: Some("milestone".to_string()),
+        };
+        let id = db.create_task(&task).unwrap();
+        let t = db.get_task(&id, "mika").unwrap().unwrap();
+        assert_eq!(t.r#type, "milestone");
+    }
+
+    #[test]
+    fn test_tasks_type_check_constraint_rejects_invalid() {
+        // Direct INSERT bypassing the tool boundary should still be blocked by
+        // the SQLite CHECK constraint.
+        let db = db();
+        let result = db.conn.execute(
+            "INSERT INTO tasks (id, agent_id, label, trigger_type, action_type, type)
+             VALUES ('00000000-0000-0000-0000-000000000099', 'mika', 'bad', 'manual', 'none', 'epic')",
+            [],
+        );
+        assert!(result.is_err(), "CHECK should reject 'epic'");
+    }
+
     #[test]
     fn test_update_task_execution_trace_id() {
         let db = db();
@@ -8891,6 +8969,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(&task).unwrap();
 
@@ -8935,6 +9014,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(&task).unwrap();
 
@@ -9136,6 +9216,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(&task).unwrap();
 
@@ -9582,6 +9663,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         }
     }
 

--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -1682,6 +1682,7 @@ notify = true
                 reference_url: Some("https://github.com/org/repo/issues/42".to_string()),
                 source: None,
                 metadata: None,
+                r#type: "issue".to_string(),
             }],
             anomalies: vec![TaskHealthAnomaly {
                 task_id: "def-456".to_string(),

--- a/crates/mika-agent/src/server/dashboard.rs
+++ b/crates/mika-agent/src/server/dashboard.rs
@@ -491,6 +491,9 @@ pub struct TaskResponse {
     pub updated_at: String,
     pub action_config_preview: Option<String>,
     pub result_preview: Option<String>,
+    /// Work item kind: `"issue"`, `"milestone"`, or `"project"`. Default `"issue"`.
+    /// Added in schema v23 (mika#595).
+    pub r#type: String,
 }
 
 impl From<Task> for TaskResponse {
@@ -525,6 +528,7 @@ impl From<Task> for TaskResponse {
             updated_at: t.updated_at,
             action_config_preview,
             result_preview,
+            r#type: t.r#type,
         }
     }
 }
@@ -606,6 +610,9 @@ pub struct TaskDetailResponse {
     pub updated_at: String,
     pub action_config: String,
     pub result: Option<String>,
+    /// Work item kind: `"issue"`, `"milestone"`, or `"project"`. Default `"issue"`.
+    /// Added in schema v23 (mika#595).
+    pub r#type: String,
 }
 
 impl From<Task> for TaskDetailResponse {
@@ -633,6 +640,7 @@ impl From<Task> for TaskDetailResponse {
             updated_at: t.updated_at,
             action_config: t.action_config,
             result: t.result,
+            r#type: t.r#type,
         }
     }
 }
@@ -1187,5 +1195,63 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert!(clause.contains("created_at >= ?1"));
         assert!(clause.contains("created_at <= ?2"));
+    }
+
+    // ===== Task DTO `type` serialization tests (issue #595) =====
+
+    fn sample_task_with_type(t: &str) -> Task {
+        Task {
+            id: "task-id".to_string(),
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "sample".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            status: "pending".to_string(),
+            process_id: None,
+            input_context: None,
+            result: None,
+            created_by_session: None,
+            created_trace_id: None,
+            execution_trace_id: None,
+            created_at: "2026-04-16T00:00:00Z".to_string(),
+            updated_at: "2026-04-16T00:00:00Z".to_string(),
+            fired_at: None,
+            completed_at: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: t.to_string(),
+        }
+    }
+
+    #[test]
+    fn task_response_serializes_type_as_type_key() {
+        let resp = TaskResponse::from(sample_task_with_type("milestone"));
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["type"], "milestone");
+    }
+
+    #[test]
+    fn task_detail_response_serializes_type_as_type_key() {
+        let resp = TaskDetailResponse::from(sample_task_with_type("project"));
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["type"], "project");
+    }
+
+    #[test]
+    fn task_response_serializes_default_issue_type() {
+        let resp = TaskResponse::from(sample_task_with_type("issue"));
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert_eq!(json["type"], "issue");
     }
 }

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -1420,6 +1420,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         })
         .await
         .unwrap()
@@ -1597,6 +1598,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -796,6 +796,7 @@ async fn execute_long_running(
         reference_url: None,
         source: None,
         metadata: None,
+        r#type: None,
     };
 
     let task_id = match ctx.db.create_task(task).await {
@@ -1888,6 +1889,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let child_id = db.create_task(task).await.unwrap();
         if status != "pending" {
@@ -2175,6 +2177,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         async_db.create_task(non_callback).await.unwrap();
 

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -990,6 +990,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         let result = dispatcher.dispatch(&id).await;
@@ -1023,6 +1024,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         let result = dispatcher.dispatch(&id).await;
@@ -1055,6 +1057,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         let result = dispatcher.dispatch(&id).await;
@@ -1087,6 +1090,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         // Callback with no result should error
@@ -1129,6 +1133,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
         // Should not error — reminder path reads from action_config
@@ -1242,6 +1247,7 @@ mod tests {
             reference_url: None,
             source: Some("self_dev".to_string()),
             metadata: None,
+            r#type: None,
         };
         let parent_id = db.create_task(parent).await.unwrap();
 
@@ -1267,6 +1273,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let callback_id = db.create_task(callback).await.unwrap();
 
@@ -1325,6 +1332,7 @@ mod tests {
             reference_url: None,
             source: Some("self_dev".to_string()),
             metadata: Some(r#"{"pipeline_retry_count": 1}"#.to_string()),
+            r#type: None,
         };
         let parent_id = db.create_task(parent).await.unwrap();
 
@@ -1350,6 +1358,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let callback_id = db.create_task(callback).await.unwrap();
 
@@ -1404,6 +1413,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let callback_id = db.create_task(callback).await.unwrap();
         db.update_task_completed(&callback_id, Some("Session: abc\nTurns: 10"))

--- a/crates/mika-agent/src/task_engine/engine.rs
+++ b/crates/mika-agent/src/task_engine/engine.rs
@@ -682,6 +682,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         }
     }
 
@@ -836,6 +837,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
 
@@ -873,6 +875,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let id = db.create_task(task).await.unwrap();
 
@@ -910,6 +913,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let parent_id = db.create_task(parent).await.unwrap();
 
@@ -935,6 +939,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let c1_id = db.create_task(child1).await.unwrap();
         db.update_task_completed(&c1_id, Some("done"))
@@ -962,6 +967,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         let c2_id = db.create_task(child2).await.unwrap();
         // Mark expired manually (in real flow, expire_timed_out_tasks does this)
@@ -1033,6 +1039,7 @@ mod tests {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         }
     }
 

--- a/crates/mika-agent/src/task_engine/mod.rs
+++ b/crates/mika-agent/src/task_engine/mod.rs
@@ -59,6 +59,7 @@ pub async fn ensure_recurring_task(
         reference_url: None,
         source: None,
         metadata: None,
+        r#type: None,
     };
 
     match db.create_recurring_task_if_absent(task).await {

--- a/crates/mika-agent/src/teams/engine.rs
+++ b/crates/mika-agent/src/teams/engine.rs
@@ -849,6 +849,7 @@ impl TeamEngine {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
 
         let parent_task_id = self
@@ -884,6 +885,7 @@ impl TeamEngine {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             };
 
             match self.team_db.create_task(child_task).await {

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -203,6 +203,7 @@ pub mod test_helpers {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
         db.create_task(task).await.unwrap()
     }

--- a/crates/mika-agent/src/tools/cancel_reminder.rs
+++ b/crates/mika-agent/src/tools/cancel_reminder.rs
@@ -66,6 +66,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()

--- a/crates/mika-agent/src/tools/cancel_task.rs
+++ b/crates/mika-agent/src/tools/cancel_task.rs
@@ -109,6 +109,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()

--- a/crates/mika-agent/src/tools/check_work_item.rs
+++ b/crates/mika-agent/src/tools/check_work_item.rs
@@ -222,6 +222,9 @@ impl Tool for CheckWorkItemTool {
         writeln!(output, "Work item: {}", task.id).unwrap();
         writeln!(output, "Label: {}", task.label).unwrap();
         writeln!(output, "Status: {}", task.status).unwrap();
+        // Always emit Type for single-item inspection — disambiguates milestone
+        // and project parents from regular issues at a glance.
+        writeln!(output, "Type: {}", task.r#type).unwrap();
 
         if let Some(ref src) = task.source {
             writeln!(output, "Source: {src}").unwrap();
@@ -347,6 +350,7 @@ mod tests {
                 reference_url: reference_url.map(|s| s.to_string()),
                 source: source.map(|s| s.to_string()),
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()
@@ -493,6 +497,7 @@ mod tests {
                     reference_url: None,
                     source: None,
                     metadata: None,
+                    r#type: None,
                 })
                 .await
                 .unwrap();
@@ -603,5 +608,92 @@ mod tests {
     fn test_parse_http_url_rejected() {
         // Only HTTPS supported
         assert_eq!(parse_github_ref("http://github.com/org/repo/pull/1"), None);
+    }
+
+    // ===== `type` rendering tests (issue #595) =====
+
+    /// Helper: create a manual task with an explicit type override.
+    async fn create_typed_work_item(harness: &TestHarness, label: &str, task_type: &str) -> String {
+        harness
+            .db
+            .create_task(NewTask {
+                agent_id: harness.db.agent_id.clone(),
+                team_run_id: None,
+                parent_task_id: None,
+                depth: 0,
+                label: label.to_string(),
+                trigger_type: trigger_type::MANUAL.to_string(),
+                cron_expr: None,
+                event_source: None,
+                event_offset_secs: None,
+                condition_expr: None,
+                next_fire_at: None,
+                timeout_at: None,
+                action_type: action_type::NONE.to_string(),
+                action_config: "{}".to_string(),
+                input_context: None,
+                created_by_session: Some("test-session".to_string()),
+                created_trace_id: None,
+                reference_url: None,
+                source: Some("user_request".to_string()),
+                metadata: None,
+                r#type: Some(task_type.to_string()),
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_check_shows_default_type() {
+        // Single-item inspection always shows Type, even for the default.
+        let harness = TestHarness::new();
+        let id = create_work_item(&harness, "default issue", None, Some("user_request")).await;
+        let ctx = harness.ctx();
+        let tool = CheckWorkItemTool;
+
+        let result = tool
+            .execute(serde_json::json!({"task_id": id}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(
+            result.content.contains("Type: issue"),
+            "should always show Type line: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_shows_milestone_type() {
+        let harness = TestHarness::new();
+        let id = create_typed_work_item(&harness, "milestone parent", "milestone").await;
+        let ctx = harness.ctx();
+        let tool = CheckWorkItemTool;
+
+        let result = tool
+            .execute(serde_json::json!({"task_id": id}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(
+            result.content.contains("Type: milestone"),
+            "milestone type should be visible: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_shows_project_type() {
+        let harness = TestHarness::new();
+        let id = create_typed_work_item(&harness, "project parent", "project").await;
+        let ctx = harness.ctx();
+        let tool = CheckWorkItemTool;
+
+        let result = tool
+            .execute(serde_json::json!({"task_id": id}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert!(result.content.contains("Type: project"));
     }
 }

--- a/crates/mika-agent/src/tools/complete_task.rs
+++ b/crates/mika-agent/src/tools/complete_task.rs
@@ -138,6 +138,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()

--- a/crates/mika-agent/src/tools/create_reminder.rs
+++ b/crates/mika-agent/src/tools/create_reminder.rs
@@ -263,6 +263,7 @@ impl Tool for CreateReminderTool {
             reference_url: None,
             source: None,
             metadata,
+            r#type: None,
         };
 
         let id = match ctx.db.create_task(task).await {

--- a/crates/mika-agent/src/tools/create_task.rs
+++ b/crates/mika-agent/src/tools/create_task.rs
@@ -217,6 +217,7 @@ impl Tool for CreateTaskTool {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         };
 
         let id = ctx.db.create_task(task).await?;

--- a/crates/mika-agent/src/tools/create_work_item.rs
+++ b/crates/mika-agent/src/tools/create_work_item.rs
@@ -4,7 +4,7 @@ use mika_common::claude::ToolDefinition;
 use serde_json::Value;
 
 use super::{MAX_INPUT_LEN, Tool, ToolContext, ToolOutput};
-use crate::db::{NewTask, Task, is_unique_violation};
+use crate::db::{NewTask, TASK_TYPE_ISSUE, Task, VALID_TASK_TYPES, is_unique_violation};
 use crate::task_engine::types::{action_type, trigger_type};
 
 /// Format a success response for a deduplicated work item (already exists).
@@ -15,6 +15,9 @@ fn format_dedup_response(existing: &Task) -> String {
          Status: {}",
         existing.id, existing.label, existing.status
     );
+    if existing.r#type != TASK_TYPE_ISSUE {
+        response.push_str(&format!("\nType: {}", existing.r#type));
+    }
     if let Some(url) = &existing.reference_url {
         response.push_str(&format!("\nReference: {url}"));
     }
@@ -46,7 +49,8 @@ impl Tool for CreateWorkItemTool {
                 and progressed through status stages. Use for significant tasks like \
                 feature implementation, research projects, or items waiting on external input. \
                 Cannot be used during callback turns. Max 5 agent-created items per session. \
-                Max nesting depth of 3."
+                Max nesting depth of 3. Set 'type' to 'milestone' or 'project' to mark a parent \
+                container that aggregates child 'issue' work items via parent_task_id."
                 .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -67,6 +71,12 @@ impl Tool for CreateWorkItemTool {
                     "parent_task_id": {
                         "type": "string",
                         "description": "Optional parent work item ID for subtask nesting"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["issue", "milestone", "project"],
+                        "description": "Work item kind. Defaults to 'issue'. Use 'milestone' or 'project' \
+                                        for parent containers that group child issues via parent_task_id."
                     }
                 },
                 "required": ["label"]
@@ -85,6 +95,11 @@ impl Tool for CreateWorkItemTool {
             .map(|s| s.trim())
             .filter(|s| !s.is_empty());
         let parent_task_id = input["parent_task_id"]
+            .as_str()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+        // Empty/whitespace-only `type` falls back to the default ("issue").
+        let task_type_input = input["type"]
             .as_str()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty());
@@ -113,6 +128,17 @@ impl Tool for CreateWorkItemTool {
                 VALID_SOURCES.join(", ")
             )));
         }
+        if let Some(t) = task_type_input
+            && !VALID_TASK_TYPES.contains(&t)
+        {
+            return Ok(ToolOutput::error(format!(
+                "Invalid type '{}'. Must be one of: {}",
+                t,
+                VALID_TASK_TYPES.join(", ")
+            )));
+        }
+        // Resolved type used both for the row and for the response message.
+        let task_type = task_type_input.unwrap_or(TASK_TYPE_ISSUE);
 
         // Guard 3: Callback turns block ALL work item creation
         if ctx.is_callback_turn {
@@ -229,6 +255,7 @@ impl Tool for CreateWorkItemTool {
             reference_url: reference_url.map(|s| s.to_string()),
             source: source.map(|s| s.to_string()),
             metadata: None,
+            r#type: Some(task_type.to_string()),
         };
 
         // Dedup path A (reference_url provided): attempt INSERT, catch UNIQUE violation
@@ -262,6 +289,11 @@ impl Tool for CreateWorkItemTool {
                 }
                 if let Some(pid) = parent_task_id {
                     response.push_str(&format!("\nParent: {pid}"));
+                }
+                // Surface non-default types so the caller can confirm. Hide for "issue"
+                // to keep the common-case response compact.
+                if task_type != TASK_TYPE_ISSUE {
+                    response.push_str(&format!("\nType: {task_type}"));
                 }
                 Ok(ToolOutput::success(response))
             }
@@ -306,6 +338,7 @@ impl Tool for CreateWorkItemTool {
                         reference_url: Some(url.to_string()),
                         source: source.map(|s| s.to_string()),
                         metadata: None,
+                        r#type: Some(task_type.to_string()),
                     };
                     let id = ctx.db.create_task(retry_task).await?;
                     let after_value =
@@ -329,6 +362,9 @@ impl Tool for CreateWorkItemTool {
                     }
                     if let Some(pid) = parent_task_id {
                         response.push_str(&format!("\nParent: {pid}"));
+                    }
+                    if task_type != TASK_TYPE_ISSUE {
+                        response.push_str(&format!("\nType: {task_type}"));
                     }
                     Ok(ToolOutput::success(response))
                 }
@@ -967,5 +1003,233 @@ mod tests {
             over_cap.content
         );
         assert!(over_cap.content.contains("Maximum"));
+    }
+
+    // ===== `type` column tests (issue #595) =====
+
+    /// Helper: extract the new work-item ID from a successful create response.
+    fn extract_id(content: &str) -> &str {
+        content
+            .lines()
+            .next()
+            .unwrap()
+            .strip_prefix("Work item created: ")
+            .expect("response should start with 'Work item created: '")
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_defaults_to_issue() {
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({"label": "no type", "source": "user_request"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        // Default type should NOT appear in the response message — it's the common case.
+        assert!(
+            !result.content.contains("Type:"),
+            "default type should be hidden in response: {}",
+            result.content
+        );
+
+        // Row should persist with type='issue'.
+        let id = extract_id(&result.content);
+        let task = ctx
+            .db
+            .get_manual_task(id)
+            .await
+            .unwrap()
+            .expect("just-created work item should be retrievable");
+        assert_eq!(task.r#type, "issue");
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_milestone() {
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "label": "milestone parent",
+                    "source": "user_request",
+                    "type": "milestone"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(
+            result.content.contains("Type: milestone"),
+            "non-default type should appear in response: {}",
+            result.content
+        );
+
+        let id = extract_id(&result.content);
+        let task = ctx.db.get_manual_task(id).await.unwrap().unwrap();
+        assert_eq!(task.r#type, "milestone");
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_project() {
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "label": "project parent",
+                    "source": "user_request",
+                    "type": "project"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(result.content.contains("Type: project"));
+
+        let id = extract_id(&result.content);
+        let task = ctx.db.get_manual_task(id).await.unwrap().unwrap();
+        assert_eq!(task.r#type, "project");
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_explicit_issue_hidden() {
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "label": "explicit issue",
+                    "source": "user_request",
+                    "type": "issue"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        // Explicit "issue" should be treated identically to omitted: hidden.
+        assert!(
+            !result.content.contains("Type:"),
+            "explicit issue type should be hidden: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_invalid() {
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "label": "bad type",
+                    "source": "user_request",
+                    "type": "epic"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_error, "should reject invalid type");
+        assert!(
+            result.content.contains("Invalid type 'epic'"),
+            "error should name the offending value: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("issue, milestone, project"),
+            "error should list valid types: {}",
+            result.content
+        );
+
+        // Verify no row was created.
+        let count = ctx
+            .db
+            .count_session_work_items(ctx.session_id)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "invalid type should not insert a row");
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_type_empty_string_defaults() {
+        // Whitespace-only `type` should fall back to the default rather than error.
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "label": "whitespace type",
+                    "source": "user_request",
+                    "type": "   "
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        let id = extract_id(&result.content);
+        let task = ctx.db.get_manual_task(id).await.unwrap().unwrap();
+        assert_eq!(task.r#type, "issue");
+    }
+
+    #[tokio::test]
+    async fn test_create_work_item_milestone_with_parent() {
+        // Existing depth/parent guards should still apply with non-default types.
+        let harness = TestHarness::new();
+        let ctx = harness.ctx();
+        let tool = CreateWorkItemTool;
+
+        let parent = tool
+            .execute(
+                serde_json::json!({
+                    "label": "milestone container",
+                    "source": "user_request",
+                    "type": "milestone"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        let parent_id = extract_id(&parent.content).to_string();
+
+        let child = tool
+            .execute(
+                serde_json::json!({
+                    "label": "child issue",
+                    "source": "user_request",
+                    "parent_task_id": parent_id,
+                    "type": "issue"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!child.is_error, "got error: {}", child.content);
+        let child_id = extract_id(&child.content);
+        let child_task = ctx.db.get_manual_task(child_id).await.unwrap().unwrap();
+        assert_eq!(child_task.r#type, "issue");
+        assert_eq!(
+            child_task.parent_task_id.as_deref(),
+            Some(parent_id.as_str())
+        );
     }
 }

--- a/crates/mika-agent/src/tools/get_task.rs
+++ b/crates/mika-agent/src/tools/get_task.rs
@@ -107,6 +107,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()

--- a/crates/mika-agent/src/tools/list_reminders.rs
+++ b/crates/mika-agent/src/tools/list_reminders.rs
@@ -113,6 +113,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()
@@ -172,6 +173,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();
@@ -212,6 +214,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();

--- a/crates/mika-agent/src/tools/list_tasks.rs
+++ b/crates/mika-agent/src/tools/list_tasks.rs
@@ -97,6 +97,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()

--- a/crates/mika-agent/src/tools/list_work_items.rs
+++ b/crates/mika-agent/src/tools/list_work_items.rs
@@ -4,7 +4,7 @@ use mika_common::claude::ToolDefinition;
 use serde_json::Value;
 
 use super::{Tool, ToolContext, ToolOutput};
-use crate::db::format_ts;
+use crate::db::{TASK_TYPE_ISSUE, format_ts};
 
 pub struct ListWorkItemsTool;
 
@@ -141,12 +141,19 @@ impl Tool for ListWorkItemsTool {
                 .as_deref()
                 .map(|s| format!(" src:{s}"))
                 .unwrap_or_default();
+            // Hide the default ("issue") to keep the common case compact;
+            // surface "milestone"/"project" so parent containers stand out.
+            let task_type = if task.r#type == TASK_TYPE_ISSUE {
+                String::new()
+            } else {
+                format!(" type:{}", task.r#type)
+            };
             let children = child_count
                 .map(|c| format!(" children:{c}"))
                 .unwrap_or_default();
 
             lines.push(format!(
-                "- [{status}] {id} {label} (created:{created}{ref_url}{src}{children})",
+                "- [{status}] {id} {label} (created:{created}{ref_url}{src}{task_type}{children})",
                 status = task.status,
                 id = task.id,
                 label = task.label,
@@ -202,6 +209,7 @@ mod tests {
                 reference_url: reference_url.map(|s| s.to_string()),
                 source: source.map(|s| s.to_string()),
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()
@@ -315,6 +323,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();
@@ -490,6 +499,91 @@ mod tests {
         );
     }
 
+    // ===== `type` rendering tests (issue #595) =====
+
+    /// Helper: create a manual task with an explicit type override.
+    async fn create_typed_work_item(harness: &TestHarness, label: &str, task_type: &str) -> String {
+        harness
+            .db
+            .create_task(NewTask {
+                agent_id: harness.db.agent_id.clone(),
+                team_run_id: None,
+                parent_task_id: None,
+                depth: 0,
+                label: label.to_string(),
+                trigger_type: trigger_type::MANUAL.to_string(),
+                cron_expr: None,
+                event_source: None,
+                event_offset_secs: None,
+                condition_expr: None,
+                next_fire_at: None,
+                timeout_at: None,
+                action_type: action_type::NONE.to_string(),
+                action_config: "{}".to_string(),
+                input_context: None,
+                created_by_session: Some("test-session".to_string()),
+                created_trace_id: None,
+                reference_url: None,
+                source: Some("user_request".to_string()),
+                metadata: None,
+                r#type: Some(task_type.to_string()),
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_list_hides_default_type() {
+        // Default-type ("issue") rows should NOT have `type:` in their line —
+        // matches the existing pattern of hiding default values.
+        let harness = TestHarness::new();
+        create_work_item(&harness, "Plain issue", Some("user_request"), None).await;
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error, "got error: {}", result.content);
+        assert!(result.content.contains("Plain issue"));
+        assert!(
+            !result.content.contains("type:issue"),
+            "default type should be hidden in line: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_shows_milestone_type() {
+        let harness = TestHarness::new();
+        create_typed_work_item(&harness, "Q2 milestone", "milestone").await;
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(
+            result.content.contains("type:milestone"),
+            "milestone type should be visible in line: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_shows_mixed_types() {
+        let harness = TestHarness::new();
+        create_work_item(&harness, "Plain issue", Some("user_request"), None).await;
+        create_typed_work_item(&harness, "Sprint container", "milestone").await;
+        create_typed_work_item(&harness, "Q1 project", "project").await;
+
+        let ctx = harness.ctx();
+        let tool = ListWorkItemsTool;
+        let result = tool.execute(serde_json::json!({}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        // milestone + project visible; default issue still hidden
+        assert!(result.content.contains("type:milestone"));
+        assert!(result.content.contains("type:project"));
+        assert!(!result.content.contains("type:issue"));
+    }
+
     #[tokio::test]
     async fn test_list_excludes_non_manual_tasks() {
         let harness = TestHarness::new();
@@ -517,6 +611,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();

--- a/crates/mika-agent/src/tools/update_work_item_status.rs
+++ b/crates/mika-agent/src/tools/update_work_item_status.rs
@@ -324,6 +324,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap()
@@ -468,6 +469,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();
@@ -938,6 +940,7 @@ mod tests {
                 reference_url: None,
                 source: None,
                 metadata: None,
+                r#type: None,
             })
             .await
             .unwrap();

--- a/crates/mika-agent/tests/eval/test_completion_claim_guard.rs
+++ b/crates/mika-agent/tests/eval/test_completion_claim_guard.rs
@@ -67,6 +67,7 @@ async fn seed_work_item(harness: &EvalHarness, label: &str) -> String {
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         })
         .await
         .unwrap()

--- a/crates/mika-agent/tests/eval/test_phantom_retry_guard.rs
+++ b/crates/mika-agent/tests/eval/test_phantom_retry_guard.rs
@@ -44,6 +44,7 @@ async fn seed_work_item(harness: &EvalHarness, label: &str) -> String {
             reference_url: None,
             source: Some("self_dev".to_string()),
             metadata: None,
+            r#type: None,
         })
         .await
         .unwrap()
@@ -74,6 +75,7 @@ async fn create_callback_child(harness: &EvalHarness, parent_id: &str, status: &
             reference_url: None,
             source: None,
             metadata: None,
+            r#type: None,
         })
         .await
         .unwrap();

--- a/crates/mika-agent/tests/eval/test_verdict_handler.rs
+++ b/crates/mika-agent/tests/eval/test_verdict_handler.rs
@@ -58,6 +58,7 @@ async fn create_work_item_with_pr_url(db: &AsyncDatabase, pr_url: &str) -> Strin
             reference_url: Some(pr_url.to_string()),
             source: Some("github_issue".to_string()),
             metadata: Some(serde_json::to_string(&metadata).unwrap()),
+            r#type: None,
         })
         .await
         .expect("create task");
@@ -311,6 +312,7 @@ async fn verdict_pass_pending_work_item_passes_through() -> Result<()> {
             reference_url: Some(pr_url.to_string()),
             source: Some("github_issue".to_string()),
             metadata: Some(serde_json::to_string(&metadata).unwrap()),
+            r#type: None,
         })
         .await
         .expect("create task");

--- a/crates/mika-agent/tests/eval/test_webhook_queue.rs
+++ b/crates/mika-agent/tests/eval/test_webhook_queue.rs
@@ -57,6 +57,7 @@ async fn create_work_item(db: &AsyncDatabase, pr_url: &str, branch: &str) -> Str
             reference_url: Some(pr_url.to_string()),
             source: Some("github_issue".to_string()),
             metadata: Some(serde_json::to_string(&metadata).unwrap()),
+            r#type: None,
         })
         .await
         .expect("create work item");
@@ -91,6 +92,7 @@ async fn create_callback_task(db: &AsyncDatabase, parent_id: &str) -> String {
         reference_url: None,
         source: None,
         metadata: None,
+        r#type: None,
     })
     .await
     .expect("create callback task")
@@ -399,6 +401,7 @@ async fn fallback_defers_when_sole_inflight_callback() {
             reference_url: None,
             source: None,
             metadata: Some(serde_json::to_string(&metadata).unwrap()),
+            r#type: None,
         })
         .await
         .expect("create work item");

--- a/docs/plans/2026-04-16-003-feat-tasks-type-column-and-create-work-item-support-plan.md
+++ b/docs/plans/2026-04-16-003-feat-tasks-type-column-and-create-work-item-support-plan.md
@@ -1,0 +1,317 @@
+---
+title: "feat(agent): tasks.type column + create_work_item support"
+type: feat
+status: active
+date: 2026-04-16
+origin: ../../mika-platform/docs/brainstorms/2026-04-15-milestones-and-projects-as-sprints-brainstorm.md
+issue: senara-solutions/mika#595
+---
+
+# feat(agent): tasks.type column + create_work_item support
+
+## Overview
+
+Add a `type` column to the `tasks` table with three valid values (`issue`, `milestone`, `project`) and accept an optional `type` parameter in the `create_work_item` tool. Default to `'issue'` so existing callers and rows are unaffected. This is the foundational schema + tool piece that unblocks mika-dev's milestone/project orchestration (mika-skills#149); mika core stays a dumb work-item store.
+
+## Problem Frame
+
+mika-dev needs to express "this work item is a milestone or project (a parent), not an individual issue" so that:
+- Self-dev can fetch the milestone/project, expand it into child `type=issue` work items linked via `parent_task_id`, and dispatch each child via `run_claude_pilot`.
+- Audits and TUI can distinguish parent containers ("N of M children completed") from leaf work.
+- mika-platform's renamed `mika-milestone-audit` command can navigate the tree by `parent_task_id` + `type=milestone` instead of label matching.
+
+Today there is no way to mark a work item as a parent container. The only differentiator between a milestone parent and a regular issue would be the presence of children — fragile and undiscoverable. See origin brainstorm for full architecture context.
+
+## Requirements Trace
+
+- **R1.** `tasks.type` column added with CHECK constraint `type IN ('issue', 'milestone', 'project')` and DEFAULT `'issue'`. (Issue: Schema)
+- **R2.** Existing rows backfill to `'issue'` via the column DEFAULT. (Issue: Schema acceptance)
+- **R3.** `Task` and `NewTask` structs in `crates/mika-agent/src/db.rs` carry `type` through to row reads and writes. (Issue: Schema)
+- **R4.** `create_work_item` tool accepts an optional `type` parameter (string), defaults to `'issue'`, validates against the three allowed values, and returns a structured error for invalid input. (Issue: Tool)
+- **R5.** `list_work_items` and `check_work_item` surface `type` in their output. (Issue: Queries / audits)
+- **R6.** Unit tests cover the four `create_work_item` cases (no type, three valid types, invalid type) plus `list_work_items` / `check_work_item` rendering. (Issue: Acceptance)
+- **R7.** No new orchestration logic, dispatch guards, or auto-close behavior in mika core. (Issue: Non-goals)
+
+## Scope Boundaries
+
+- No changes to `validate_dispatch_readiness` — it stays type-agnostic. Dispatch readiness still works on status alone.
+- No auto-close logic for milestone/project parents. Closing happens explicitly from self-dev.
+- No new database query endpoints. Existing `parent_task_id` traversal already supports walking the tree.
+- No CLI flag for `mika tasks list` to filter by type in this PR (defer until self-dev actually consumes it).
+- No A2A protocol surface change — A2A tasks remain `type='issue'` by default; A2A clients have no concept of milestone/project.
+
+### Deferred to Separate Tasks
+
+- Self-dev milestone/project workflow branches: **mika-skills#149**.
+- Retire `/mika-sprint`, rename audit command to `mika-milestone-audit`: **mika-platform#41**.
+- Live end-to-end acceptance test (`implement milestone mika#6`): **mika-platform#42**.
+- Dashboard UI surfacing of `type`: separate ticket if/when needed (the field will be present in the API response so the UI can adopt it without re-shipping the agent).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/db.rs` — schema definition (clean-slate `migrate_v1`, line 841), migration ladder (line 700+), `Task`/`NewTask` structs (line 122+), `row_to_task` (line 2820), `TASK_COLUMNS` const (line 2854), `create_task` INSERT (line 2710), helper queries `find_active_work_item_by_ref_url` / `_by_label` / `_by_pr_url` / `_by_branch` (line 3120+). All hand-written column lists need updating in lockstep.
+- `crates/mika-agent/src/db.rs` `migrate_v21_to_v22` (line 2504) — most recent migration; uses `ALTER TABLE … ADD COLUMN` guarded by `column_exists`. CHECK constraint on a new column requires the same guard pattern (SQLite supports `CHECK` on `ADD COLUMN` in 3.37+ which we ship).
+- `crates/mika-agent/src/tools/create_work_item.rs` — input validation pattern (label, source enum, `validate_uuid`), dedup paths, audit logging, response formatting. New `type` parameter follows the existing source-enum validation pattern.
+- `crates/mika-agent/src/tools/list_work_items.rs` — line-based output formatter with status/source/children fields. New `type` field appended to the per-item line.
+- `crates/mika-agent/src/tools/check_work_item.rs` — `writeln!`-based output. New `Type:` line slots in alongside `Status:` / `Source:` / `Reference:`.
+- `crates/mika-agent/src/server/dashboard.rs` `TaskResponse` (line 471) and `TaskDetailResponse` (line 586) — both DTOs need the `type` field for API consumers.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/work-item-tracking-manual-task-reuse.md` — the "manual" trigger_type + "none" action_type is the existing work-item shape; new `type` column is orthogonal and slots cleanly.
+- `docs/solutions/logic-errors/create-work-item-duplicate-on-retry.md` — dedup is a known sharp edge. New `type` column does not affect dedup keys (still `(agent_id, reference_url)` and `(agent_id, label COLLATE NOCASE)`); a milestone and an issue with the same `reference_url` would still dedup. This is acceptable: in practice the brainstorm shows milestone/project parents have distinct labels (`mika#6` for the milestone vs. `mika#581` for an issue), and a `reference_url` collision between a milestone and a child issue is not realistic.
+- Schema-version pattern: every migration bumps `CURRENT_SCHEMA_VERSION`, adds itself to the migration ladder, updates the clean-slate `migrate_v1` baseline, and is logged in `MEMORY.md` + `crates/mika-agent/CLAUDE.md` + `docs/runtime-structure.md`.
+
+### External References
+
+None — straightforward SQLite ALTER TABLE + tool wiring.
+
+## Key Technical Decisions
+
+- **Rust field name uses `r#type`.** The SQL column, JSON serialization name, and tool parameter name are all `type` (per the issue and brainstorm). Rust requires `r#type` as a raw identifier. This keeps the external surface clean while paying the small Rust syntactic cost in the struct/SQL bindings.
+- **Migration uses `ALTER TABLE … ADD COLUMN` with the CHECK constraint inline.** SQLite 3.37+ supports adding CHECK constraints via `ADD COLUMN`. We ship rusqlite-bundled (3.45+), so this is safe. No table rebuild required, which keeps the migration trivially fast on production DBs and avoids touching foreign keys.
+- **Validate `type` at the tool boundary, not just at the DB CHECK.** The DB CHECK is defense-in-depth; the tool returns a structured human-readable error before INSERT to give the LLM an actionable message.
+- **Dedup keys do not include `type`.** Adding `type` would let an agent accidentally create both `type=issue` and `type=milestone` rows pointing at the same `reference_url`. The brainstorm's mental model treats `reference_url` and `label` as identifying the *underlying object* — not its role in the work-item tree.
+- **No new query helpers.** `list_work_items` already returns all manual tasks; `check_work_item` already loads a single task. The new `type` field flows through the existing `Task` struct without new SELECT shapes.
+- **Schema bump is v22 → v23.** Aligns with the existing migration ladder.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `type` be on `tasks` or only on manual work items?** On `tasks`. The CHECK constraint applies to all rows, and non-manual tasks (callback, recurring, a2a) all default to `'issue'` — they're not surfaced in `list_work_items`/`check_work_item` and the value is inert for them. Keeps the schema simple.
+- **Should we add a partial index on `(agent_id, type)`?** No — the only foreseeable filter (`type='milestone'`) will hit a small subset and existing `idx_tasks_agent_status` already narrows result sets. Add later if mika-dev's milestone audits get slow.
+
+### Deferred to Implementation
+
+- Whether to expose `type` in the dashboard `TaskFilters` query string. Likely yes for parity, but this PR scopes to the response DTO only; query-string filtering can land in a follow-up if dashboard needs it.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `type` column via migration v22 → v23**
+
+**Goal:** Schema and `Task`/`NewTask` Rust types carry the new `type` field. Existing data backfills to `'issue'` automatically.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs`
+  - Bump `CURRENT_SCHEMA_VERSION` to 23.
+  - Add `type` column with CHECK to clean-slate `migrate_v1` (the `CREATE TABLE tasks (…)` block at line 841).
+  - Add `migrate_v22_to_v23` method using `ALTER TABLE tasks ADD COLUMN type TEXT NOT NULL DEFAULT 'issue' CHECK (type IN ('issue', 'milestone', 'project'))`, guarded by `column_exists`.
+  - Wire into the migration ladder (after the existing `migrate_v21_to_v22` block, line 746).
+  - Add `r#type: String` to `Task` and `NewTask` structs (line 122-177).
+  - Update `TASK_COLUMNS` const (line 2854) to include `type` as the final column.
+  - Update `row_to_task` (line 2820) — bump `r.get(N)` ordinals; add `r#type` read at the new ordinal.
+  - Bump `TASK_COLUMN_COUNT` (line 3058) from 29 → 30.
+  - Update `create_task` INSERT (line 2710) — add `type` to the column list and bind `task.r#type`.
+  - Update `create_recurring_task_if_absent` similarly (line 2755+).
+  - Update `find_active_work_item_by_ref_url` and `find_active_work_item_by_label` (line 3123, 3230) — both use hand-written SELECT lists and inline row construction; add `type` to both.
+  - Audit any other inline `SELECT` against `tasks` that reconstructs a `Task` struct outside `row_to_task` and add `type` there too.
+- Test: `crates/mika-agent/src/db.rs` (existing inline `#[cfg(test)] mod tests` if present; otherwise covered by integration tests in Unit 4)
+
+**Approach:**
+- Migration order: 1) bump version constant, 2) add migration method, 3) wire into ladder, 4) update clean-slate `migrate_v1` schema. Doing them together ensures fresh DBs and migrated DBs end up with identical shape.
+- The `type` column is appended at the end of the column list everywhere — last position in `TASK_COLUMNS`, last `r.get(…)` in `row_to_task`. This minimizes ordinal churn for existing reads but every hand-written SELECT/INSERT still has to be updated.
+
+**Patterns to follow:**
+- `migrate_v21_to_v22` (db.rs:2504) — idempotent `column_exists` guard, single `ALTER TABLE`, version insert.
+- `messages.internal` field added in v22 (Schema v22 in `MEMORY.md`) — same pattern of "add column with NOT NULL DEFAULT, propagate through structs".
+
+**Test scenarios:**
+- Happy path: Fresh DB created via `migrate_v1` has the `type` column with DEFAULT `'issue'`. (Verify by inserting a task without `type` and reading back `type='issue'`.)
+- Happy path: Migration on a v22 DB with existing rows leaves all rows with `type='issue'`.
+- Edge case: Calling the migration twice (idempotency) does not error — `column_exists` guard short-circuits.
+- Error path: Direct INSERT with `type='garbage'` fails with the SQLite CHECK constraint error.
+- Integration: `create_task` round-trips `type='milestone'` correctly through `row_to_task`.
+
+**Verification:**
+- `cargo test -p mika-agent` passes.
+- `sqlite3 mika.db "PRAGMA table_info(tasks)"` shows the `type` column with NOT NULL and DEFAULT `'issue'`.
+- `sqlite3 mika.db "SELECT DISTINCT type FROM tasks"` returns `'issue'` only on a freshly migrated production DB.
+
+- [ ] **Unit 2: Accept `type` parameter in `create_work_item`**
+
+**Goal:** Tool accepts an optional `type` parameter, validates it, defaults to `'issue'`, and persists on the row.
+
+**Requirements:** R4, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/create_work_item.rs`
+  - Add `VALID_TYPES: &[&str] = &["issue", "milestone", "project"]` constant near `VALID_SOURCES`.
+  - Extend `input_schema` with a `type` property (enum of the three values, optional).
+  - Parse `input["type"]` similar to `input["source"]`, default to `"issue"`, validate against `VALID_TYPES`, return structured error on invalid value.
+  - Set `r#type` on the `NewTask` struct in both code paths (initial INSERT and the post-dedup-race retry block).
+  - Include `Type: <value>` in the success response when type != `"issue"` (omit for default to keep messages compact for the common case).
+- Test: `crates/mika-agent/src/tools/create_work_item.rs` (extend existing `#[cfg(test)] mod tests` block).
+
+**Approach:**
+- Validation runs after `label` validation, before guards, mirroring `source` validation.
+- Default-to-issue handling lives in one place: a `let task_type = input["type"].as_str().unwrap_or("issue").trim()` line, then validate.
+- Audit log `after_value` does not need to mention `type` — the row carries it; the response message is enough for the LLM to confirm.
+
+**Patterns to follow:**
+- `source` validation block (create_work_item.rs:107) — same shape: optional, enum-validated, persisted on `NewTask`.
+
+**Test scenarios:**
+- Happy path: No `type` parameter → row created with `type='issue'`, response omits the `Type:` line. (Verify via `ctx.db.get_task` or by extracting the new ID.)
+- Happy path: `type='milestone'` → row created with `type='milestone'`, response includes `Type: milestone`.
+- Happy path: `type='project'` → row created with `type='project'`, response includes `Type: project`.
+- Happy path (explicit default): `type='issue'` → row created with `type='issue'`, response omits the `Type:` line (consistent with absent param).
+- Error path: `type='epic'` → returns error with `Invalid type 'epic'. Must be one of: issue, milestone, project`, no row inserted (verify via row count).
+- Error path: `type=''` (empty string) → treat as absent (defaults to `'issue'`); avoids gratuitous error on whitespace-only input.
+- Integration: A `type='milestone'` row created with a `parent_task_id` correctly nests under the parent (existing depth/parent guards still apply).
+
+**Verification:**
+- `cargo test -p mika-agent --lib tools::create_work_item` passes.
+- All four issue acceptance cases (no type, three valid, invalid) covered by named tests.
+
+- [ ] **Unit 3: Surface `type` in `list_work_items` and `check_work_item`**
+
+**Goal:** Both query tools include `type` in their output so agents can distinguish milestones from issues.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/list_work_items.rs`
+  - In the per-item line formatter, append `type:<value>` to the trailing parenthetical (alongside `created:`, `ref:`, `src:`, `children:`). Omit when `type='issue'` (the default) to keep output compact for the common case.
+- Modify: `crates/mika-agent/src/tools/check_work_item.rs`
+  - Insert `Type: <value>` line right after `Status:`, before `Source:`. Always emit (since this tool inspects a single item, the explicit field aids clarity).
+- Test: extend `#[cfg(test)] mod tests` blocks in both files.
+
+**Approach:**
+- `list_work_items`: hide `type:issue` from the listing (matches the pattern of hiding empty `ref_url`/`source`). Show `type:milestone` and `type:project` to make non-default rows visually distinct in long listings.
+- `check_work_item`: always show `Type:` for unambiguous single-item inspection.
+
+**Patterns to follow:**
+- Existing trailing-field assembly in `list_work_items.rs:130-153` (the `ref_url`, `src`, `children` formatting).
+- Existing `writeln!(output, "Status: …")` chain in `check_work_item.rs:222-244`.
+
+**Test scenarios:**
+- `list_work_items`: Items with default `type='issue'` produce no `type:` segment in the output (regression check on existing tests).
+- `list_work_items`: A `type='milestone'` row produces `type:milestone` in its line.
+- `list_work_items`: Mixed list (issue + milestone + project) renders all three correctly.
+- `check_work_item`: Default `type='issue'` row shows `Type: issue`.
+- `check_work_item`: `type='milestone'` row shows `Type: milestone`.
+
+**Verification:**
+- `cargo test -p mika-agent --lib tools::list_work_items` passes (existing + new tests).
+- `cargo test -p mika-agent --lib tools::check_work_item` passes (existing + new tests).
+
+- [ ] **Unit 4: Propagate `type` through dashboard DTOs**
+
+**Goal:** `TaskResponse` and `TaskDetailResponse` include the `type` field so the dashboard API exposes it without breaking existing clients.
+
+**Requirements:** R3 (carrying through to API surface)
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/dashboard.rs`
+  - Add `pub r#type: String` (or `#[serde(rename = "type")] pub r#type: String`) to `TaskResponse` (line 471) and `TaskDetailResponse` (line 586). With raw identifiers, serde's default name is `"type"` — no rename needed; verify this in tests if uncertain.
+  - Update the two `From<Task>` impls (line 496, 611) to copy `t.r#type`.
+- Modify: `docs/openapi/mika-server.yaml` (and the build-time crate copy via `scripts/sync-agent-docs.sh`) — regenerate or hand-update the `TaskResponse` / `TaskDetailResponse` schemas to add the `type` property.
+- Test: covered by `cargo test -p mika-agent` build + serde derive — no separate test file, but verify a snapshot test exists for the API or add a smoke test that serializes a `TaskResponse` and asserts `"type"` appears in the JSON.
+
+**Approach:**
+- Two-line change per DTO (add field, copy in `From`).
+- OpenAPI doc regen happens in `/mika-doc-audit` step of the pipeline, but list it explicitly here so the implementer doesn't forget.
+
+**Patterns to follow:**
+- Existing optional fields (e.g. `source`, `reference_url`) in both DTOs.
+
+**Test scenarios:**
+- Happy path: Serializing a `TaskResponse` with `r#type = "milestone"` produces a JSON object containing `"type":"milestone"` (asserted via `serde_json::to_value`).
+- Happy path: Default-typed task (`r#type = "issue"`) serializes with `"type":"issue"`.
+
+**Verification:**
+- `cargo build -p mika-agent` succeeds.
+- `cargo test -p mika-agent` passes.
+
+- [ ] **Unit 5: Documentation updates**
+
+**Goal:** Schema docs and per-crate CLAUDE.md reflect v23 and the new `type` column. `MEMORY.md` records the migration.
+
+**Requirements:** R1, R2 (documentation aspect)
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/runtime-structure.md` — add v22→v23 line to the migration history table (mirroring the v21→v22 entry); update the schema description for `tasks`.
+- Modify: `crates/mika-agent/CLAUDE.md` — bump "Schema Version: v22" → "v23"; add a v22→v23 bullet under "Recent migrations".
+- Modify: `~/.claude/projects/-data-workspace-mika-platform-mika/memory/MEMORY.md` — add v22→v23 entry under Schema Evolution; update "Current: Schema v22" → "v23".
+- Run: `bash scripts/sync-agent-docs.sh` to copy `docs/runtime-structure.md` into the crate-local copy at `crates/mika-agent/docs/`. CI's `docs-sync` job enforces this.
+
+**Approach:**
+- Pure prose; no behavioral risk.
+- The doc-audit pipeline step (`/mika-doc-audit`) will catch additional drift, but capturing the schema-version bump and the new column in this unit prevents `cargo build` ↔ docs lag during review.
+
+**Patterns to follow:**
+- v21→v22 entry in `MEMORY.md` and `crates/mika-agent/CLAUDE.md`.
+
+**Test scenarios:**
+- Test expectation: none — documentation unit, no behavioral change.
+
+**Verification:**
+- `bash scripts/sync-agent-docs.sh` produces no untracked diff in `crates/mika-agent/docs/`.
+- CI `docs-sync` job passes locally (or is anticipated to pass on the PR).
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - `tasks` table: column added — every read path that returns a `Task` struct must read the new column. Inline SELECT lists in `find_active_work_item_*` are the most fragile spots; the centralized `TASK_COLUMNS` const + `row_to_task` covers the rest.
+  - `create_work_item` tool: parameter added — agents that don't pass `type` get `'issue'` (existing behavior).
+  - Dashboard API: field added — additive change; existing clients ignore unknown fields.
+- **Error propagation:** Validation error for invalid `type` returns `ToolOutput::error` (caught by the agent loop, surfaced to the LLM as a tool-call failure). DB CHECK constraint violation would surface as `anyhow::Error` from `create_task` — should never trigger in practice because tool-level validation catches it first.
+- **State lifecycle risks:** None. The new column is set once at INSERT and never mutated by the existing flow. self-dev (separate ticket) may eventually update `type` via direct SQL or a new tool; that's out of scope here.
+- **API surface parity:** Tool definition (`input_schema`) and response message both gain `type`. Dashboard DTO gains `type`. CLI commands like `mika tasks list` are unaffected (they don't filter or display type yet).
+- **Integration coverage:**
+  - End-to-end: create a milestone work item via `create_work_item type=milestone`, fetch via `check_work_item`, list via `list_work_items`, and confirm `type` round-trips correctly. Cover at least one integration test.
+  - Migration on a populated v22 DB: existing rows backfill to `'issue'`. Add a focused test if not already covered by the migration test pattern in db.rs.
+- **Unchanged invariants:**
+  - `validate_dispatch_readiness` does not change behavior — `type` is not a dispatch-readiness signal.
+  - Dedup behavior on `(agent_id, reference_url)` and `(agent_id, label)` is unchanged — `type` is not part of the dedup key.
+  - `list_work_items` filters by `status` and `source` — no new `type` filter (deferred).
+  - All existing `Task` consumers (CLI, TUI, server handlers) continue to work; they simply ignore the new field.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A hand-written `SELECT … FROM tasks` reconstructs a `Task` struct without using `TASK_COLUMNS`/`row_to_task` and silently drops the new column. | Grep for `Task \{` and inline `SELECT` patterns over `tasks` during Unit 1 (`find_active_work_item_by_ref_url`, `_by_label`, `_by_pr_url`, `_by_branch` are known sites). The compiler will catch missing struct fields once `Task` is updated, since Rust requires all fields in struct literals — this risk is structurally bounded. |
+| `r#type` ergonomics confuse contributors (`task.r#type` reads awkwardly). | Acceptable: every reference is one symbol; the SQL/JSON/tool name is the right user-facing surface. Document the choice in the Key Technical Decisions section. |
+| Migration runs on a DB where someone has manually inserted `type='other'` (theoretical only — no path to do this today). | The migration adds a CHECK constraint via `ALTER TABLE ADD COLUMN`; SQLite enforces CHECK on subsequent writes only. A pre-existing invalid value would persist but is not reachable via any code path. Acceptable. |
+| Dashboard clients that strictly validate API response shapes break on the added field. | Additive field on a response DTO is safe; serde clients ignore unknown fields. The dashboard at `dashboard/src/api/tasks.ts` uses TypeScript interfaces — adding a property to the API response does not break consumers that don't reference it. |
+
+## Documentation / Operational Notes
+
+- Migration runs automatically on agent startup. Zero-touch for operators.
+- The `bash scripts/sync-agent-docs.sh` step (Unit 5) is mandatory for CI green; the `docs-sync` job in `.github/workflows/ci.yml` enforces it.
+- No env vars added.
+- No rollout coordination needed — additive schema change with sane default.
+
+## Sources & References
+
+- **Origin document:** [`mika-platform/docs/brainstorms/2026-04-15-milestones-and-projects-as-sprints-brainstorm.md`](../../mika-platform/docs/brainstorms/2026-04-15-milestones-and-projects-as-sprints-brainstorm.md)
+- **GitHub issue:** senara-solutions/mika#595
+- **Related code:**
+  - `crates/mika-agent/src/db.rs` — schema, `Task`/`NewTask`, migrations
+  - `crates/mika-agent/src/tools/create_work_item.rs` — tool implementation
+  - `crates/mika-agent/src/tools/list_work_items.rs` — listing query
+  - `crates/mika-agent/src/tools/check_work_item.rs` — single-item query
+  - `crates/mika-agent/src/server/dashboard.rs` — `TaskResponse` / `TaskDetailResponse`
+- **Related issues / PRs:**
+  - mika-skills#149 — self-dev milestone/project workflow (depends on this)
+  - mika-platform#41 — retire `/mika-sprint`, rename audit (depends on this + #149)
+  - mika-platform#42 — live acceptance test (depends on all three)
+- **Related learnings:**
+  - `docs/solutions/architecture-patterns/work-item-tracking-manual-task-reuse.md`
+  - `docs/solutions/logic-errors/create-work-item-duplicate-on-retry.md`

--- a/docs/runtime-structure.md
+++ b/docs/runtime-structure.md
@@ -75,7 +75,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **PRAGMAs:** `journal_mode=WAL`, `synchronous=NORMAL`, `foreign_keys=ON`, `busy_timeout=5000`, `auto_vacuum=INCREMENTAL`
 
-**Current schema version:** 22
+**Current schema version:** 23
 
 **Timestamp format:** All timestamp columns use ISO 8601 TEXT (`%Y-%m-%dT%H:%M:%SZ`) — not Unix epoch integers. SQL defaults use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`. Fixed-width UTC format ensures correct lexicographic ordering.
 
@@ -107,7 +107,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 ### Task Engine
 
-**tasks** — `id TEXT PK`, `agent_id FK`, `team_run_id FK→team_runs`, `parent_task_id FK→tasks(self)`, `depth INTEGER CHECK(0..3)`, `label TEXT`, `trigger_type TEXT CHECK(time|recurring|callback|user_reply|event|condition|manual|a2a)`, `cron_expr TEXT`, `event_source TEXT`, `event_offset_secs INTEGER`, `condition_expr TEXT`, `next_fire_at TEXT`, `timeout_at TEXT`, `action_type TEXT CHECK(send_message|resume_agent|inject_context|run_skill|invoke_orchestrator|none)`, `action_config TEXT DEFAULT '{}'`, `status TEXT CHECK(pending|in_progress|completed|failed|cancelled|expired|recurring_active|delivered|blocked)`, `process_id INTEGER`, `input_context TEXT`, `result TEXT`, `created_by_session TEXT`, `created_trace_id TEXT`, `execution_trace_id TEXT`, `reference_url TEXT`, `source TEXT`, `metadata TEXT`, `created_at TEXT`, `updated_at TEXT`, `fired_at TEXT`, `completed_at TEXT`. The metadata column (v14) stores opaque JSON; for dev runs (source IN ('self_dev', 'github_issue')), expected shape: `{"claude_pilot": {"branch", "repo", "pr_number", "pr_url", "cost_usd", "duration_ms", "turns", "session_id", "log_path"}}`
+**tasks** — `id TEXT PK`, `agent_id FK`, `team_run_id FK→team_runs`, `parent_task_id FK→tasks(self)`, `depth INTEGER CHECK(0..3)`, `label TEXT`, `trigger_type TEXT CHECK(time|recurring|callback|user_reply|event|condition|manual|a2a)`, `cron_expr TEXT`, `event_source TEXT`, `event_offset_secs INTEGER`, `condition_expr TEXT`, `next_fire_at TEXT`, `timeout_at TEXT`, `action_type TEXT CHECK(send_message|resume_agent|inject_context|run_skill|invoke_orchestrator|none)`, `action_config TEXT DEFAULT '{}'`, `status TEXT CHECK(pending|in_progress|completed|failed|cancelled|expired|recurring_active|delivered|blocked)`, `process_id INTEGER`, `input_context TEXT`, `result TEXT`, `created_by_session TEXT`, `created_trace_id TEXT`, `execution_trace_id TEXT`, `reference_url TEXT`, `source TEXT`, `metadata TEXT`, `type TEXT NOT NULL DEFAULT 'issue' CHECK(issue|milestone|project)` (v23), `created_at TEXT`, `updated_at TEXT`, `fired_at TEXT`, `completed_at TEXT`. The metadata column (v14) stores opaque JSON; for dev runs (source IN ('self_dev', 'github_issue')), expected shape: `{"claude_pilot": {"branch", "repo", "pr_number", "pr_url", "cost_usd", "duration_ms", "turns", "session_id", "log_path"}}`. The type column (v23, mika#595) distinguishes regular work items (`issue`) from parent containers (`milestone`, `project`) that aggregate child issues via `parent_task_id`.
 
 ### Team Tables
 

--- a/docs/solutions/architecture-patterns/tasks-type-column-orthogonal-work-item-role.md
+++ b/docs/solutions/architecture-patterns/tasks-type-column-orthogonal-work-item-role.md
@@ -1,0 +1,201 @@
+---
+title: "Tasks.type Column: Orthogonal Work-Item Role for Milestone/Project Dispatch"
+date: 2026-04-16
+category: architecture-patterns
+module: crates/mika-agent/src/db.rs
+component: database
+problem_type: best_practice
+severity: medium
+tags:
+  - schema-migration
+  - work-items
+  - orthogonal-design
+  - sqlite
+  - check-constraint
+  - raw-identifier
+  - dedup-semantics
+related_components:
+  - crates/mika-agent/src/tools/create_work_item.rs
+  - crates/mika-agent/src/tools/list_work_items.rs
+  - crates/mika-agent/src/tools/check_work_item.rs
+  - crates/mika-agent/src/server/dashboard.rs
+applies_when:
+  - Adding a new categorical column to a widely-consumed SQLite table
+  - Extending a work-item primitive to support new orchestration without coupling core to that orchestration
+  - Introducing a tool parameter whose wire name collides with a Rust keyword
+---
+
+# Tasks.type Column: Orthogonal Work-Item Role for Milestone/Project Dispatch
+
+## Context
+
+mika-dev needed a way to distinguish work-item *containers* (milestones, projects) from work-item *leaves* (issues), so self-dev could expand a milestone into child issues and dispatch each child via `run_claude_pilot`. Without a first-class type field, the only way to recognize a parent was "it has children" — fragile (a parent with no expanded children yet looks identical to a leaf) and undiscoverable (audit tools had to label-match rather than query).
+
+The constraint was that **mika core must stay a dumb work-item store.** All orchestration logic (milestone expansion, project sprints, auto-close of parents when all children complete) lives in mika-skills/self-dev. mika core only provides the primitive: a column that distinguishes the three roles.
+
+See the [origin brainstorm](../../../../mika-platform/docs/brainstorms/2026-04-15-milestones-and-projects-as-sprints-brainstorm.md) and issue [#595](https://github.com/senara-solutions/mika/issues/595).
+
+## Guidance
+
+When introducing a new categorical column to the `tasks` table — or any widely-consumed SQLite table — follow this pattern:
+
+### 1. Orthogonal column, not parallel table
+
+A `type` column on the existing `tasks` row is cheaper than a sibling `milestones` table:
+
+- Children reuse the existing `parent_task_id` FK — no new edges to maintain.
+- Every existing query (`list_work_items`, `check_work_item`, dedup helpers, dashboard DTOs) continues to work — additive change.
+- The agent loop's `validate_dispatch_readiness` stays type-agnostic. Dispatch readiness remains a function of `status` alone.
+- Non-manual tasks (callback, recurring, a2a) receive `type='issue'` automatically via the SQL `DEFAULT`, and it stays inert for them — zero cost.
+
+### 2. Single-statement migration with inline CHECK
+
+SQLite 3.37+ (shipped by rusqlite's bundled feature) supports adding CHECK constraints via `ALTER TABLE ADD COLUMN`. No table rebuild needed:
+
+```rust
+fn migrate_v22_to_v23(tx: &rusqlite::Transaction) -> Result<()> {
+    if !column_exists(tx, "tasks", "type")? {
+        tx.execute(
+            "ALTER TABLE tasks ADD COLUMN type TEXT NOT NULL DEFAULT 'issue' \
+             CHECK (type IN ('issue', 'milestone', 'project'))",
+            [],
+        )?;
+    }
+    tx.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?1, ?2)",
+        params![23, crate::timestamp::now()],
+    )?;
+    Ok(())
+}
+```
+
+The `NOT NULL DEFAULT 'issue'` pair backfills every existing row atomically — no separate backfill step, no intermediate state where some rows are NULL. The `column_exists` guard makes the migration idempotent.
+
+### 3. Rust raw identifier (`r#type`) keeps the external surface clean
+
+The SQL column, JSON serialization name, tool parameter name, and response label are all `type`. Rust requires the raw identifier:
+
+```rust
+pub struct Task {
+    pub id: String,
+    // ... other fields
+    pub r#type: String,
+}
+```
+
+With `r#type`, serde auto-derives `"type"` as the JSON field name — no `#[serde(rename)]` needed. The small syntactic cost at construction sites (`NewTask { r#type: "milestone".into(), .. }`) is paid once per site; the external surface stays idiomatic.
+
+### 4. Two-layer validation: tool boundary + DB CHECK
+
+Validate at the tool boundary for an actionable error message to the LLM. Rely on the DB CHECK as defense-in-depth:
+
+```rust
+const VALID_TYPES: &[&str] = &["issue", "milestone", "project"];
+
+let task_type = input["type"].as_str().unwrap_or("issue").trim();
+let task_type = if task_type.is_empty() { "issue" } else { task_type };
+if !VALID_TYPES.contains(&task_type) {
+    return Ok(ToolOutput::error(format!(
+        "Invalid type '{}'. Must be one of: {}",
+        task_type,
+        VALID_TYPES.join(", ")
+    )));
+}
+```
+
+Empty-string input is treated as absent (defaults to `'issue'`), avoiding gratuitous errors on whitespace-only payloads. The DB CHECK never fires in practice — it exists to catch direct SQL writes from future code paths that bypass the tool layer.
+
+### 5. Dedup keys intentionally do NOT include type
+
+The existing dedup indexes `(agent_id, reference_url)` and `(agent_id, label COLLATE NOCASE)` identify the *underlying object*, not its role. A milestone and an issue pointing at the same `reference_url` would dedup — and that's correct: they describe the same GitHub issue, just viewed through different orchestration lenses. Including `type` in the dedup key would let an agent accidentally create two rows for the same GitHub issue under different type labels.
+
+In practice, milestone parents and their child issues have distinct `reference_url` values (e.g. `mika#6` for the milestone umbrella and `mika#581` for a child), so collision is not a real-world concern.
+
+### 6. Additive DTO fields are safe by construction
+
+Adding `pub r#type: String` to `TaskResponse` and `TaskDetailResponse` is a non-breaking API change. Serde-based Rust clients and TypeScript consumers that don't reference the field ignore it. The dashboard adopts the field on its own schedule without re-shipping the agent.
+
+### 7. Every hand-written SELECT site is a migration risk
+
+The most fragile part of adding a column to a large table is finding every place that builds a `Task` struct *outside* `row_to_task`. In mika-agent these were:
+
+- `find_active_work_item_by_ref_url` (db.rs:3123) — inline SELECT + manual struct literal
+- `find_active_work_item_by_label` (db.rs:3230) — same pattern
+- `find_active_work_item_by_pr_url` / `_by_branch` — same pattern
+
+Rust struct literals require all fields, so the **compiler catches these automatically** once you add `r#type` to `Task` — the build fails loudly at every forgotten site. This is structurally bounded risk, which is the point: lean on the type system, don't rely on grep.
+
+Also update:
+- `TASK_COLUMNS` const (ordered column list)
+- `TASK_COLUMN_COUNT` (29 → 30)
+- `create_task` and `create_recurring_task_if_absent` INSERTs
+- `row_to_task` ordinal reads
+
+## Why This Matters
+
+- **Future orchestration stays decoupled.** Milestone expansion, project sprints, and parent auto-close can evolve in mika-skills without touching agent core. The schema primitive is stable; policy lives where policy belongs.
+- **Zero-touch rollout.** The `NOT NULL DEFAULT 'issue'` migration runs in milliseconds on production DBs with no operator intervention. Existing rows are immediately valid under the new CHECK.
+- **Agent prompts don't need retraining for the default case.** An LLM that has never heard of `type='milestone'` keeps working — the parameter is optional and defaults to the old behavior.
+- **The "dumb store" discipline pays off long-term.** Every time mika core stays agnostic of a particular orchestration, it remains reusable for the *next* orchestration. The alternative (baking milestone semantics into core) would have forced a coupled migration the next time self-dev invents a new work-item role.
+
+## When to Apply
+
+This pattern applies whenever you need to:
+
+1. Add a categorical distinction to an existing primitive without committing core code to the downstream policy that consumes the distinction.
+2. Extend a widely-consumed SQLite table with a constrained-enum column that must preserve backward compatibility for every existing row and every existing query.
+3. Introduce a tool parameter whose natural wire name (`type`, `match`, `move`, `mod`) collides with a Rust keyword — the raw-identifier trick cleanly resolves it.
+
+Do **not** apply when:
+
+- The new dimension is relational (would produce many-to-one joins to a lookup table rather than a finite enum).
+- The downstream policy is already owned by the same crate (in that case the column can carry policy-specific semantics without violating decoupling).
+- Existing rows would need custom backfill logic that can't be expressed as a single SQL `DEFAULT`.
+
+## Examples
+
+### Schema migration checklist (what to update in lockstep)
+
+```
+1. Bump CURRENT_SCHEMA_VERSION (v22 → v23)
+2. Add migrate_vN_to_vN+1 method with column_exists guard
+3. Wire into the migration ladder in run_migrations
+4. Update clean-slate migrate_v1 baseline (CREATE TABLE tasks (...))
+5. Add the field to Task and NewTask structs (use r#type for Rust keywords)
+6. Update TASK_COLUMNS const
+7. Update TASK_COLUMN_COUNT
+8. Update row_to_task ordinal reads
+9. Update create_task INSERT
+10. Update create_recurring_task_if_absent INSERT
+11. Update every hand-written SELECT + struct literal (compiler catches these)
+12. Update DTOs: TaskResponse, TaskDetailResponse (+ their From<Task> impls)
+13. Update MEMORY.md Schema Evolution log
+14. Update crates/mika-agent/CLAUDE.md schema version
+15. Update docs/runtime-structure.md migration table
+16. Run scripts/sync-agent-docs.sh (docs-sync CI job enforces this)
+```
+
+### Tool response formatting: hide the default, show non-defaults
+
+```rust
+// list_work_items: append type only when it differs from the default
+let type_segment = if task.r#type != "issue" {
+    format!(" type:{}", task.r#type)
+} else {
+    String::new()
+};
+
+// check_work_item: always show type (single-item inspection benefits from explicitness)
+writeln!(output, "Type: {}", task.r#type)?;
+```
+
+This keeps output compact for the dominant `type='issue'` case while making milestone/project rows visually distinct in long listings.
+
+## Related Documentation
+
+- [`work-item-tracking-manual-task-reuse.md`](work-item-tracking-manual-task-reuse.md) — Established the `trigger_type='manual'` + `action_type='none'` shape that this column extends orthogonally.
+- [`create-work-item-duplicate-on-retry.md`](../logic-errors/create-work-item-duplicate-on-retry.md) — The dedup semantics rationale that informed why `type` is deliberately not a dedup key.
+- [`iso8601-timestamp-migration.md`](../database-issues/iso8601-timestamp-migration.md) — Contrasting pattern: a column *type change* across 17 tables required full-rebuild migrations. Column *addition* with `ALTER TABLE ADD COLUMN` is dramatically simpler and this doc explains when to reach for which.
+- `docs/plans/2026-04-16-003-feat-tasks-type-column-and-create-work-item-support-plan.md` — Implementation plan with full requirements trace and unit breakdown.
+- `docs/runtime-structure.md` — Schema v23 reference.
+- Companion ticket: [mika-skills#149](https://github.com/senara-solutions/mika-skills/issues/149) — self-dev milestone/project workflow that consumes this primitive.


### PR DESCRIPTION
## Summary

- Add `type` column to `tasks` table: `'issue' | 'milestone' | 'project'`
- Default `'issue'` preserves backward compatibility for all existing rows
- `create_work_item` tool accepts optional `type` parameter with validation
- `list_work_items` and `check_work_item` surface `type` in output
- Migration backfills existing rows to `'issue'`
- Dashboard updated to expose `type` in task queries

Foundational for milestone/project dispatch orchestrated by mika-dev (mika-skills#149). Parent work items use `type='milestone'` or `type='project'`; child work items stay `type='issue'` and reuse the existing per-issue flow.

Closes #595

## Background

See [brainstorm in mika-platform](https://github.com/senara-solutions/mika-platform/blob/main/docs/brainstorms/2026-04-15-milestones-and-projects-as-sprints-brainstorm.md).

## Salvage note

This PR recovers work from a claude-pilot run that crashed on the stall guardrail after an unrelated callback-routing bug (see separate ticket on run_claude_pilot tool schema fabrication). The code was complete and passed full validation before the crash; committed manually from the worktree.

## Test plan

- [x] `cargo check -p mika-agent` — clean
- [x] `cargo clippy -p mika-agent` — clean (1 pre-existing dashboard-assets warning, unrelated)
- [x] `cargo test -p mika-agent --lib` — **1651 passed, 0 failed**
- [x] `cargo fmt --check` — clean (via lefthook)
- [x] Pre-commit hooks pass (fmt, clippy, secrets, large files)
- [x] Plan doc committed at `docs/plans/2026-04-16-003-feat-tasks-type-column-and-create-work-item-support-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)