### PR TITLE
feat(skills): migrate resolve-pr-conflicts and self-check (completes #604 scope)

### DIFF
--- a/docs/plans/2026-04-16-005-feat-migrate-3-more-engine-coupled-skills-plan.md
+++ b/docs/plans/2026-04-16-005-feat-migrate-3-more-engine-coupled-skills-plan.md
@@ -1,20 +1,22 @@
 ---
-title: Migrate 3 more engine-coupled skills into skills/bundled/
+title: Migrate 5 more engine-coupled skills into skills/bundled/
 date: 2026-04-16
 status: implemented
 ---
 
-# Migrate 3 more engine-coupled skills into skills/bundled/
+# Migrate 5 more engine-coupled skills into skills/bundled/
 
 ## Why
 
-Follow-up to mika#601. The initial bundling migration missed three engine-coupled skills:
+Follow-up to mika#601. The initial bundling migration missed five engine-coupled skills:
 
 - `qa-review-build-callback` — build callback resumption for qa-review. Tightly paired with the qa-review verdict/callback flow in the engine.
 - `self-dev-iterate` — self-dev variant for PR iteration mode (Step 3a/3b). Depends on the same run_claude_pilot contract that self-dev does.
 - `address-pr-comments` — launches a focused claude-pilot session to handle PR review comments. Engine-coupled via the same dispatch contract.
+- `resolve-pr-conflicts` — long-running exec handler with `task_id` schema parameter. Spawns claude-pilot. Same dispatch contract as run_claude_pilot; same fabrication-vector class as mika#595.
+- `self-check` — diagnostic skill that reads engine-owned DB schema (`tasks`, `audit_log`, `unified_timeline`, `sessions`, `team_runs`). When engine schema changes (like schema v23's `tasks.type` column), self-check's queries need to update in lockstep.
 
-They were flagged in mika-skills#152's PR body as a follow-up. This PR closes that gap.
+The first three were flagged in mika-skills#152's PR body. The last two were caught on a follow-up review pass — they both launch claude-pilot or query engine tables, which makes them engine-coupled by the same test that applied to self-dev and qa-review.
 
 ## Scope
 

--- a/docs/solutions/dev-loop/2026-04-16-pr-amend-after-merge-orphans-commits.md
+++ b/docs/solutions/dev-loop/2026-04-16-pr-amend-after-merge-orphans-commits.md
@@ -1,0 +1,38 @@
+---
+title: Pushing to a feature branch after its PR already merged orphans the commits
+date: 2026-04-16
+category: dev-loop
+status: applied
+---
+
+# Pushing to a feature branch after its PR already merged orphans the commits
+
+## What happened
+
+While working on PR #604 (migration of engine-coupled skills), three issues stacked:
+
+1. First push: 3 skills. PR #604 opened against that commit.
+2. PR #604 was merged (squash) as commit `68f1a64` on main. The feature branch lived on but was no longer backing an open PR.
+3. I then discovered two more engine-coupled skills (`resolve-pr-conflicts`, `self-check`) and **pushed a new commit to the same feature branch** — thinking it would "amend" the PR.
+4. GitHub doesn't reopen a merged PR for new commits. The commit became **orphaned**: present on the remote branch, not on main, not backing any PR.
+5. In parallel, I deleted those two skills from `mika-skills/main` thinking they were migrated — but they weren't on mika's main. Result: both skills briefly existed nowhere in production.
+
+## The recovery
+
+`git cherry-pick <orphaned-sha>` onto a fresh branch from main, then open a new PR. Cheap recovery, but the root cause was the assumption that pushing to a feature branch always "updates its PR."
+
+## The lesson
+
+**A feature branch is not the same thing as a PR.** GitHub's PR UI binds a PR to a branch at creation, but the binding is one-directional: the PR tracks the branch, the branch doesn't know about the PR. Once a PR is merged/closed, new commits on the branch are orphaned — they don't automatically open a new PR, and they don't show up on main.
+
+Before pushing an "amendment" to a feature branch, verify the PR is still `OPEN`. If it's `MERGED` or `CLOSED`, the correct move is always: **new branch from current main, open a new PR**.
+
+## Procedural change
+
+For future migrations or follow-ups that expand scope mid-PR:
+- If PR is still `OPEN`: push the new commit, optionally retitle/re-body the PR to reflect expanded scope.
+- If PR is `MERGED`: **always start a fresh branch from current main**. Do not push to the old feature branch. Cherry-pick orphaned work only if you already made the mistake.
+
+## The companion-cleanup corollary
+
+If the mistake has already happened and you also deleted upstream dependencies thinking the migration landed, fix mika first (restore the code on main), then mika-skills catches up. Never delete the source until the destination is confirmed on production main.

--- a/skills/bundled/resolve-pr-conflicts/handlers/run.sh
+++ b/skills/bundled/resolve-pr-conflicts/handlers/run.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+# Handler for the resolve-pr-conflicts skill (long-running exec).
+# Input: JSON on stdin with worktree_path and task_id.
+#        __mika_task_id and __mika_agent are injected by the executor.
+# Output: Delivers result via `mika ask --task-id` callback when done.
+#
+# Spawns claude-pilot with a focused conflict-resolution prompt (no --command).
+# The worktree must already exist — this handler does NOT create worktrees.
+
+set -e
+
+# Ensure ~/.local/bin is in PATH (mika CLI needed for callback delivery)
+export PATH="$HOME/.local/bin:$PATH"
+
+# Dependency checks
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed" >&2; exit 1; }
+command -v mika >/dev/null 2>&1 || { echo "Error: mika CLI is required but not in PATH" >&2; exit 1; }
+command -v claude-pilot >/dev/null 2>&1 || { echo "Error: claude-pilot CLI is required but not in PATH" >&2; exit 1; }
+
+# Read input JSON from stdin
+INPUT=$(cat)
+
+# Parse callback fields injected by the long-running executor
+TASK_ID=$(printf '%s\n' "$INPUT" | jq -r '.__mika_task_id // empty')
+AGENT=$(printf '%s\n' "$INPUT" | jq -r '.__mika_agent // empty')
+
+if [ -z "$TASK_ID" ]; then
+    echo "Error: no __mika_task_id in input (not running as long-running handler?)" >&2
+    exit 1
+fi
+
+# --- Crash-recovery EXIT trap ---
+# Ensures callback delivery on any exit (crash, set -e, signals).
+# Uses CALLBACK_SENT guard to prevent double delivery.
+CALLBACK_SENT=0
+
+deliver_callback() {
+    _EXIT_CODE=$?
+    [ "$CALLBACK_SENT" -eq 1 ] && { [ -n "$STDERR_FILE" ] && rm -f "$STDERR_FILE"; return; }
+    [ -z "$TASK_ID" ] && { [ -n "$STDERR_FILE" ] && rm -f "$STDERR_FILE"; return; }
+    # Capture stderr tail on crash path BEFORE deleting the file (#104)
+    if [ -z "$RESULT" ] && [ -n "$STDERR_FILE" ] && [ -f "$STDERR_FILE" ]; then
+        _STDERR_TAIL=$(tail -c 10000 "$STDERR_FILE" 2>/dev/null)
+        if [ -n "$_STDERR_TAIL" ]; then
+            RESULT="HANDLER CRASH (exit code ${_EXIT_CODE}). Script failed before building result.
+
+Stderr (last 10KB):
+${_STDERR_TAIL}"
+        fi
+    fi
+    # Clean up stderr temp file AFTER capture
+    [ -n "$STDERR_FILE" ] && rm -f "$STDERR_FILE"
+    if [ -z "$RESULT" ]; then
+        RESULT="HANDLER CRASH (exit code ${_EXIT_CODE}). Script failed before building result."
+    fi
+    RESULT=$(printf '%s' "$RESULT" | head -c 92000)
+    set +e
+    if [ -n "$AGENT" ]; then
+        mika ask --task-id "$TASK_ID" --task-complete --agent "$AGENT" -- "$RESULT"
+    else
+        mika ask --task-id "$TASK_ID" --task-complete -- "$RESULT"
+    fi
+    CALLBACK_SENT=1
+    set -e
+}
+trap deliver_callback EXIT
+
+# Parse user-provided fields
+WORKTREE_PATH=$(printf '%s\n' "$INPUT" | jq -r '.worktree_path // empty')
+USER_TASK_ID=$(printf '%s\n' "$INPUT" | jq -r '.task_id // empty')
+
+# mika-platform root — base for relay config resolution
+# Resolve symlinks so prefix checks work regardless of which path the caller uses
+PLATFORM_DIR="${MIKA_PLATFORM_DIR:-$HOME/workspace/mika-platform}"
+PLATFORM_DIR=$(cd "$PLATFORM_DIR" 2>/dev/null && pwd -P) || PLATFORM_DIR="${MIKA_PLATFORM_DIR:-$HOME/workspace/mika-platform}"
+
+if [ -z "$WORKTREE_PATH" ]; then
+    echo "Error: worktree_path is required" >&2
+    exit 1
+fi
+
+if [ -z "$USER_TASK_ID" ]; then
+    echo "Error: task_id is required" >&2
+    exit 1
+fi
+
+# Validate worktree_path is under the expected worktree root (defense-in-depth)
+# Canonicalize incoming path — callers may use either symlink or real path
+CANONICAL_WORKTREE=$(cd "$WORKTREE_PATH" 2>/dev/null && pwd -P) || CANONICAL_WORKTREE="$WORKTREE_PATH"
+EXPECTED_PREFIX="${PLATFORM_DIR}/.claude/worktrees/"
+case "$CANONICAL_WORKTREE" in
+    "$EXPECTED_PREFIX"*) ;; # OK — path is within the worktree directory
+    *) echo "Error: worktree_path must be under $EXPECTED_PREFIX" >&2; exit 1 ;;
+esac
+
+# Validate worktree_path is a git working tree
+if ! git -C "$WORKTREE_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: worktree_path '$WORKTREE_PATH' is not a valid git working tree" >&2
+    exit 1
+fi
+
+# Scrub sensitive env vars before spawning child processes
+unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY
+
+# Copy relay config into worktree if missing (required for claude-pilot permissions)
+# NOTE: Do NOT copy .claude/commands/ — Claude Code discovers commands from the
+# repo's own .claude/commands/. See: docs/solutions/integration-issues/worktree-handler-architecture-fixes.md
+mkdir -p "$WORKTREE_PATH/.claude"
+cp "$PLATFORM_DIR/.claude/claude-pilot.json" "$WORKTREE_PATH/.claude/" 2>/dev/null || true
+cp "$PLATFORM_DIR/.claude/settings.local.json" "$WORKTREE_PATH/.claude/" 2>/dev/null || true
+
+# Build --cwd and --relay-config args
+CWD_ARGS="--cwd $WORKTREE_PATH"
+if [ -f "$WORKTREE_PATH/.claude/claude-pilot.json" ]; then
+    CWD_ARGS="$CWD_ARGS --relay-config $WORKTREE_PATH/.claude/claude-pilot.json"
+elif [ -f "$PLATFORM_DIR/.claude/claude-pilot.json" ]; then
+    CWD_ARGS="$CWD_ARGS --relay-config $PLATFORM_DIR/.claude/claude-pilot.json"
+fi
+
+# Conflict resolution prompt — free-text mode (no --command to avoid /mika pipeline)
+PROMPT="Resolve merge conflicts on this branch. Steps:
+1. Run: git fetch origin
+2. Detect the base branch: run gh pr list --head \$(git branch --show-current) --json baseRefName --jq '.[0].baseRefName' — if empty, default to main
+3. Run: git rebase origin/<base_branch>
+4. If conflicts arise, resolve each one: read both sides, choose the correct resolution, git add the file, git rebase --continue
+5. After rebase completes, run the repo's test suite if one exists (check for Makefile, cargo, npm, etc.)
+6. Push: git push --force-with-lease
+7. If push fails, fetch and retry once. If still failing, report the error.
+If the rebase has conflicts you cannot confidently resolve, run git rebase --abort and report what conflicts were found."
+
+LOG_ID="$USER_TASK_ID"
+
+# Run claude-pilot
+# claude-pilot writes structured JSON result to stdout.
+# Streaming text, relay logs, and debug output go to stderr.
+STDERR_FILE=$(mktemp)
+set +e
+# CWD_ARGS is intentionally word-split (multiple flags)
+# shellcheck disable=SC2086
+PILOT_OUTPUT=$(claude-pilot --verbose --log-dir --task-id "$LOG_ID" $CWD_ARGS -- "$PROMPT" 2>"$STDERR_FILE")
+PILOT_EXIT=$?
+set -e
+
+# Build result message from structured stdout
+# Issue #135: extract first JSON-object line from stdout — skip non-JSON preamble
+# (dotenvx banner, debug output). claude-pilot emits single-line JSON via
+# JSON.stringify(). Keep raw output for error-reporting fallback.
+PILOT_OUTPUT_RAW="$PILOT_OUTPUT"
+PILOT_OUTPUT=$(printf '%s\n' "$PILOT_OUTPUT_RAW" | grep -m1 '^{' || true)
+: "${PILOT_OUTPUT:=$PILOT_OUTPUT_RAW}"
+
+if [ "$PILOT_EXIT" -eq 0 ]; then
+    # Try to extract structured fields from JSON stdout
+    STATUS=$(printf '%s\n' "$PILOT_OUTPUT" | jq -r '.status // empty' 2>/dev/null)
+    SESSION_ID=$(printf '%s\n' "$PILOT_OUTPUT" | jq -r '.session_id // empty' 2>/dev/null)
+    TURNS=$(printf '%s\n' "$PILOT_OUTPUT" | jq -r '.turns // empty' 2>/dev/null)
+    COST=$(printf '%s\n' "$PILOT_OUTPUT" | jq -r '.cost_usd // empty' 2>/dev/null)
+    DURATION=$(printf '%s\n' "$PILOT_OUTPUT" | jq -r '.duration_ms // empty' 2>/dev/null)
+
+    if [ -n "$STATUS" ]; then
+        RESULT="resolve-pr-conflicts completed (status: ${STATUS}).
+Session: ${SESSION_ID:-unknown}
+Turns: ${TURNS:-unknown}
+Cost: \$${COST:-unknown}
+Duration: ${DURATION:-unknown}ms"
+    else
+        RESULT="resolve-pr-conflicts completed (exit 0) but output was not structured JSON.
+
+Stdout:
+${PILOT_OUTPUT_RAW}"
+    fi
+else
+    RESULT="Log path: /var/log/claude-pilot/${LOG_ID}.log
+
+resolve-pr-conflicts FAILED (exit code ${PILOT_EXIT}).
+
+Stdout:
+${PILOT_OUTPUT_RAW}"
+fi
+
+# Append stderr tail for debugging context (last 10KB)
+if [ -s "$STDERR_FILE" ]; then
+    STDERR_TAIL=$(tail -c 10000 "$STDERR_FILE")
+    RESULT="${RESULT}
+
+Logs (last 10KB):
+${STDERR_TAIL}"
+fi
+rm -f "$STDERR_FILE"
+
+# Truncate to ~90KB to stay within the 100KB callback limit
+RESULT=$(printf '%s' "$RESULT" | head -c 92000)
+
+# Deliver result via mika callback
+set +e
+if [ -n "$AGENT" ]; then
+    mika ask --task-id "$TASK_ID" --task-complete --agent "$AGENT" -- "$RESULT"
+else
+    mika ask --task-id "$TASK_ID" --task-complete -- "$RESULT"
+fi
+CALLBACK_EXIT=$?
+CALLBACK_SENT=1
+set -e
+
+if [ "$CALLBACK_EXIT" -ne 0 ]; then
+    echo "ERROR: callback delivery failed (exit $CALLBACK_EXIT) for task $TASK_ID" >&2
+fi

--- a/skills/bundled/resolve-pr-conflicts/skill.toml
+++ b/skills/bundled/resolve-pr-conflicts/skill.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "resolve-pr-conflicts"
+description = "Resolve PR merge conflicts by rebasing onto the base branch via claude-pilot"
+version = "0.1.0"
+always_on = false
+timeout_secs = 600
+
+[triggers]
+keywords = ["resolve conflicts", "resolve pr conflicts", "rebase", "sync main", "merge main"]

--- a/skills/bundled/resolve-pr-conflicts/system_prompt.md
+++ b/skills/bundled/resolve-pr-conflicts/system_prompt.md
@@ -1,0 +1,60 @@
+## resolve-pr-conflicts
+
+Resolve PR merge conflicts by rebasing the branch onto its base branch. This is a tactical operation — not a feature development workflow.
+
+## Tool: `resolve_pr_conflicts`
+
+Spawns a claude-pilot session that fetches origin, rebases the PR branch onto the base branch, resolves any conflicts, and pushes with `--force-with-lease`.
+
+### When to Use
+
+Use `resolve_pr_conflicts` when:
+- A PR has merge conflicts that need resolving before merge or CI can pass
+- A branch needs to be synced with main (or another base branch) after upstream changes
+- mika-dev detects a PR's `mergeable` state is `CONFLICTING`
+
+### When NOT to Use
+
+Do **not** use `resolve_pr_conflicts` for:
+- Feature development, bug fixes, or any code changes beyond conflict resolution → use `run_claude_pilot` (self-dev) instead
+- Creating new branches or worktrees → the worktree must already exist
+- Force-pushing without rebase → this tool always rebases first
+
+### Routing Decision (mika-dev)
+
+| Situation | Route to |
+|-----------|----------|
+| PR has merge conflicts | `resolve_pr_conflicts` (pass existing worktree path) |
+| New feature or bug fix | `run_claude_pilot` via self-dev |
+| PR needs code changes from review feedback | `run_claude_pilot` with iteration context |
+| Branch just needs to be up-to-date with main | `resolve_pr_conflicts` |
+
+### Inputs
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `worktree_path` | Yes | Absolute path to the existing git worktree for the PR branch |
+| `task_id` | Yes | UUID from `create_work_item` for log correlation |
+
+### Behavior
+
+1. Validates the worktree path exists and is a git working tree
+2. Copies relay config (`.claude/claude-pilot.json`) into the worktree if missing
+3. Spawns claude-pilot with a conflict-resolution prompt (no `/mika` pipeline)
+4. Claude Code inside the session: fetches origin, detects base branch from PR metadata, rebases, resolves conflicts, runs tests, pushes with `--force-with-lease`
+5. Delivers result via `mika ask --task-id` callback
+
+### Expected Outcomes
+
+- **Success:** Branch is rebased onto the base branch, conflicts resolved, tests pass, branch pushed
+- **Partial failure:** Conflicts were too complex to resolve automatically — rebase aborted, report delivered with details of which files conflicted
+- **Push failure:** Rebase succeeded but push was rejected (concurrent push) — retried once, then reported
+
+### Example
+
+```
+resolve_pr_conflicts(
+  worktree_path: "/home/user/workspace/mika-platform/.claude/worktrees/feat-42-add-health-endpoint/mika",
+  task_id: "15383984-a3e7-41bf-ac6f-630ba9a89d63"
+)
+```

--- a/skills/bundled/resolve-pr-conflicts/tools.json
+++ b/skills/bundled/resolve-pr-conflicts/tools.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "resolve_pr_conflicts",
+    "description": "Resolve merge conflicts on a PR branch by rebasing onto the base branch. Long-running — returns a task ID immediately, results arrive via callback when claude-pilot finishes.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "worktree_path": {
+          "type": "string",
+          "description": "Absolute path to the existing git worktree for the PR branch. The worktree must already exist (created by self-dev or manually)."
+        },
+        "task_id": {
+          "type": "string",
+          "description": "The UUID returned by create_work_item (36-char format like '15383984-a3e7-41bf-ac6f-630ba9a89d63'). Used for log filename and task correlation at /var/log/claude-pilot/{task_id}.log."
+        }
+      },
+      "required": ["worktree_path", "task_id"]
+    },
+    "handler": {
+      "type": "exec",
+      "command": "handlers/run.sh",
+      "long_running": true,
+      "estimated_duration_secs": 600
+    }
+  }
+]

--- a/skills/bundled/self-check/skill.toml
+++ b/skills/bundled/self-check/skill.toml
@@ -1,0 +1,31 @@
+[skill]
+name = "self-check"
+description = "Diagnose errors, review conversations, audit tasks and team runs, and track behavioral trends across Mika's operation."
+version = "0.3.0"
+always_on = false
+timeout_secs = 30
+
+[triggers]
+keywords = [
+    "check logs",
+    "check log",
+    "my logs",
+    "your logs",
+    "log file",
+    "what happened",
+    "diagnose yourself",
+    "check yourself",
+    "check conversations",
+    "review conversations",
+    "how am I doing",
+    "performance review",
+    "audit trail",
+    "audit log",
+    "check tasks",
+    "task health",
+    "orphaned tasks",
+    "check teams",
+    "team runs",
+    "trace_id",
+    "missing trace",
+]

--- a/skills/bundled/self-check/system_prompt.md
+++ b/skills/bundled/self-check/system_prompt.md
@@ -1,0 +1,160 @@
+## Self-Check Skill
+
+Inspect your own runtime state — logs, conversations, tasks, audit trail, team runs — to diagnose issues and track quality trends. Produce structured JSON reports that accumulate over time.
+
+**Important:** Only run this workflow when the user is asking about *your own* operation, not about external performance reviews or project status.
+
+### Data sources
+
+- **Logs:** `~/.mika/agents/<agent>/logs/mika.log.YYYY-MM-DD`
+- **Conversations:** `sessions` + `messages` tables (SQLite: `~/.mika/mika.db`)
+- **Audit trail:** `audit_log` table — primary source for state mutations
+- **Unified timeline:** `unified_timeline` VIEW — cross-subsystem stream with trace_id
+- **Tasks:** `tasks` table (trigger_type: reminder/callback/recurring/manual)
+- **Teams:** `team_runs` + `team_workspace` tables
+- **Previous reports:** `data/self-check/` (relative to agent home)
+
+### Report storage
+
+- Path: `data/self-check/YYYY-MM-DDTHH-MM-SS.json` (relative to agent home, use `write_file`)
+- Each report is self-contained with `schema_version: 2`
+- Most recent file = last-check timestamp, no separate state file needed
+
+### Workflow
+
+1. **Find previous report** via `list_home_files` on `data/self-check/`. First run if empty.
+
+2. **Load previous report** via `read_home_file`. Extract `timestamp` for review window start.
+
+3. **Review window:** previous timestamp → now. Cap at 7 days; note if capped.
+
+4. **Analyze logs** — read `~/.mika/agents/<agent>/logs/mika.log.YYYY-MM-DD` for each day via `run_shell` (max 7 files). Look for: `ERROR`, `WARN`, failed tool calls, timeouts, panics.
+
+5. **Analyze conversations** via `run_shell` + `sqlite3 ~/.mika/mika.db`:
+   ```sql
+   -- Sessions in window
+   SELECT s.id, s.created_at, s.agent_id, COUNT(m.id) as msg_count
+   FROM sessions s JOIN messages m ON m.session_id = s.id
+   WHERE s.created_at >= '<start>' GROUP BY s.id ORDER BY s.created_at DESC;
+
+   -- Message detail for suspect sessions
+   SELECT role, content, created_at, metadata
+   FROM messages WHERE session_id = '<id>' ORDER BY created_at;
+   ```
+   Skip self-check sessions (first user message contains: "self-check", "check logs", "check log", "my logs", "your logs", "diagnose yourself", "check yourself", "check conversations", "review conversations", "performance review"). Look for: tool errors in `metadata`, user corrections, frustration signals, abandoned sessions.
+
+6. **Analyze audit trail**:
+   ```sql
+   SELECT event_type, entity_type, agent_id, trace_id, created_at, details
+   FROM audit_log WHERE created_at >= '<start>' ORDER BY created_at DESC LIMIT 200;
+
+   -- Flag missing trace_id (old code paths not yet updated)
+   SELECT COUNT(*) FROM audit_log
+   WHERE created_at >= '<start>' AND trace_id IS NULL;
+   ```
+   Flag: excessive core memory edits per session, failed mutations, trace_id gaps.
+
+7. **Analyze task health**:
+   ```sql
+   -- Failed/expired tasks
+   SELECT id, trigger_type, status, created_at, fire_at, result
+   FROM tasks WHERE status IN ('expired','failed') AND created_at >= '<start>';
+
+   -- Orphaned (pending, past fire_at)
+   SELECT id, trigger_type, status, created_at, fire_at FROM tasks
+   WHERE status = 'pending'
+     AND fire_at < datetime('now','-1 day')
+     AND created_at >= '<start>';
+
+   -- Completion rates by type
+   SELECT trigger_type, status, COUNT(*) as count FROM tasks
+   WHERE created_at >= '<start>' GROUP BY trigger_type, status;
+   ```
+   Once workflow tasks land, also check: `trigger_type = 'manual'` progression, `blocked` transitions in audit_log, parent-child depth (must be ≤ 3), session cap violations (max 5 agent-created work items per session).
+
+8. **Analyze unified timeline**:
+   ```sql
+   SELECT event_type, source_table, trace_id, agent_id, created_at, summary
+   FROM unified_timeline WHERE created_at >= '<start>'
+   ORDER BY created_at DESC LIMIT 100;
+   ```
+   Flag broken traces (start event with no completion), cross-subsystem threading issues.
+
+9. **Analyze team runs** (if applicable):
+   ```sql
+   SELECT tr.id, tr.team_name, tr.status, tr.created_at, tr.completed_at,
+          tw.context_from_previous_run IS NOT NULL as had_context
+   FROM team_runs tr LEFT JOIN team_workspace tw ON tw.run_id = tr.id
+   WHERE tr.created_at >= '<start>';
+   ```
+   Flag: failed runs, agents hitting tool step caps, missing context injection.
+
+10. **Compare with previous report** — note trends, recurring issues, improvements.
+
+11. **Write report** via `write_file` to `data/self-check/YYYY-MM-DDTHH-MM-SS.json`.
+
+12. **Present summary** — lead with most important findings, key metrics, recommendations.
+
+### Analysis categories
+
+**Failed interactions:** tool errors (log ERROR + messages.metadata), user corrections, repeated requests, abandoned sessions.
+
+**Behavioral patterns:** excessive clarification (>1 per topic per session), false positive skill triggers, memory misses, response length outliers.
+
+**Quality signals:** frustration signals (short replies, "never mind"), capability gaps ("I can't do that"), trace_id gaps in audit_log, channel-specific patterns.
+
+**Task health:** expired callbacks, orphaned pending tasks, loop guard violations, completion rate changes vs prior period.
+
+**Workflow task readiness** (post-feature): manual trigger_type tasks created and progressed correctly, blocked transitions in audit_log, reference_url/source populated, parent-child depth ≤ 3.
+
+### Report JSON schema
+
+```json
+{
+  "schema_version": 2,
+  "timestamp": "2026-03-03T14-30-00",
+  "agent_id": "mika-dev",
+  "period": { "from": "...", "to": "..." },
+  "logs": {
+    "files_reviewed": [],
+    "errors": 0, "warnings": 0, "failed_tool_calls": 0, "panics": 0,
+    "details": []
+  },
+  "conversations": {
+    "sessions_reviewed": 0, "skipped_self_check": 0,
+    "failed_interactions": 0, "user_corrections": 0,
+    "repeated_requests": 0, "frustration_signals": 0,
+    "abandoned_sessions": 0, "excessive_clarifications": 0,
+    "false_positive_triggers": 0, "skill_gaps": [], "memory_misses": []
+  },
+  "audit_trail": {
+    "total_events": 0, "missing_trace_id": 0,
+    "core_memory_edits": 0, "failed_mutations": 0,
+    "unusual_patterns": []
+  },
+  "tasks": {
+    "by_type": {
+      "reminder": {"completed": 0, "expired": 0, "pending": 0},
+      "callback": {"completed": 0, "expired": 0, "pending": 0},
+      "manual": {"completed": 0, "blocked": 0, "pending": 0}
+    },
+    "orphaned": 0, "loop_guard_violations": 0, "details": []
+  },
+  "teams": {
+    "runs_reviewed": 0, "completed": 0, "failed": 0,
+    "context_injected": 0, "details": []
+  },
+  "recommendations": [],
+  "trend_notes": "First self-check run — no prior data for comparison"
+}
+```
+
+All numeric fields should be integers. Array fields can be empty (`[]`) when no issues found.
+
+### Tips
+
+- Start with `unified_timeline` for the full picture before drilling into individual tables
+- trace_id gaps are a leading indicator of incomplete observability migration — flag every one
+- Orphaned `manual` tasks = blocked developer workflow — high priority flag
+- Every recommendation should suggest a concrete next step
+- Cross-reference log errors with `get_documentation` for architecture context


### PR DESCRIPTION
## Summary

Completes the engine-coupled skill migration that was supposed to land in mika#604 but got stuck due to a sequencing error.

### The 2

- **resolve-pr-conflicts** — long-running exec handler with `task_id` schema parameter; spawns claude-pilot. Same dispatch contract as run_claude_pilot, same fabrication-vector class as mika#595.
- **self-check** — queries engine-owned DB schema (`tasks`, `audit_log`, `unified_timeline`, `sessions`, `team_runs`). Correctness depends on schema stability — must update in lockstep with engine schema changes.

## Why a separate PR

Operational error on my part: I pushed these 2 skills to PR #604's feature branch **after** #604 had already merged. GitHub doesn't reopen a merged PR for new commits — the commit became orphaned on the dead branch. Recovered via cherry-pick onto a fresh branch from current main.

Compound solution doc captures the lesson: [`docs/solutions/dev-loop/2026-04-16-pr-amend-after-merge-orphans-commits.md`](docs/solutions/dev-loop/2026-04-16-pr-amend-after-merge-orphans-commits.md).

## Test plan

- [x] `cargo check -p mika-agent` — clean
- [x] `cargo test -p mika-agent --lib` — 1658 passed
- [x] `verify-pipeline.sh` — passes

## Follow-up

Once merged, mika-skills main is already consistent (those 2 skills were deleted from mika-skills earlier in the same sequencing error — the recovery restores them into the correct home at `mika/skills/bundled/`, not back to mika-skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)