### PR TITLE
fix(agent): dedup identical tool_use blocks within a single turn (#582)

### DIFF
--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/adversarial.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/adversarial.json
@@ -1,0 +1,113 @@
+{
+  "reviewer": "adversarial",
+  "findings": [
+    {
+      "id": "ADV-001",
+      "title": "send_message dedup silently swallows the second DB persist: message saved once but LLM receives two success results",
+      "severity": "P1",
+      "confidence": 0.95,
+      "files": [
+        "crates/mika-agent/src/tools/send_message.rs",
+        "crates/mika-agent/src/agent.rs"
+      ],
+      "evidence": [
+        "send_message.execute() has two side effects: (1) ctx.db.save_message(session_id, 'assistant', &cleaned) and (2) sender.send(&cleaned).",
+        "When dedup fires, cached.clone() is returned at agent.rs:1586. The cached ToolOutput is ToolOutput::success('Message sent.') from the first execution.",
+        "The second tool_use block receives that cached success result and the LLM sees 'Message sent.' for both IDs.",
+        "The DB persist (save_message) ran only once. The outbound sender.send() ran only once. Both are correct.",
+        "BUT: the conversation history now has one assistant message row in the messages table and two 'Message sent.' tool_result entries in the API conversation. These are out of sync: the LLM believes two sends succeeded, but the messages table has one row.",
+        "Consequence: if the user queries get_session_messages or if compaction summarises the conversation, the summary will reflect one sent message while the assistant's internal reasoning chain (preserved in the tool_result history) shows two successful sends. This creates a grounding inconsistency — the very thing the grounding rule is designed to prevent.",
+        "This is specifically bad for send_message because the grounding rule says 'the agent must not claim downstream state unless a tool result confirms it'. Both tool_results confirm a send, but only one is persisted. An auditor querying tool history sees 1 send; the LLM internal state says 2."
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "id": "ADV-002",
+      "title": "Image budget double-drained by dedup cache: duplicate image tool_use blocks consume budget twice for the same bytes",
+      "severity": "P2",
+      "confidence": 0.92,
+      "files": [
+        "crates/mika-agent/src/agent.rs"
+      ],
+      "evidence": [
+        "image_bytes_budget is initialized once at line 1561 (20 MB cap for the step).",
+        "When dedup fires, the cached ToolOutput (containing images) is cloned at line 1586. The clone has the full images Vec.",
+        "The image budget loop at lines 1677-1688 runs for EVERY tool_use block, including duplicates. Each duplicate iteration of `for img in output.images` decrements image_bytes_budget by img.data.len().",
+        "Scenario: an exec-handler skill tool returns 3 images totaling 15 MB. LLM emits two identical tool_use blocks for this tool. First block: budget 20 MB, 15 MB consumed, budget becomes 5 MB. Second block (dedup cache clone): budget 5 MB, first image >5 MB triggers the budget break, images are skipped for the duplicate result.",
+        "The duplicate tool_result sent to the LLM for the second block says '[N image(s) skipped: step memory budget exceeded]' even though the tool only ran once and the budget was not legitimately exhausted by distinct tool calls.",
+        "The LLM receives an inconsistent signal: identical tool calls, one with images, one without, with a budget-exceeded error. This may cause the LLM to conclude the tool is flaky or retry.",
+        "The correct behavior for dedup cache hits with images is to either: skip the budget decrement entirely (since the bytes are already in the first result), or serve a text-only copy of the cached result for duplicates."
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "id": "ADV-003",
+      "title": "Semantic equality bypass: provider key-order non-determinism defeats dedup for logically identical calls",
+      "severity": "P2",
+      "confidence": 0.82,
+      "files": [
+        "crates/mika-agent/src/agent.rs"
+      ],
+      "evidence": [
+        "The dedup key is serde_json::to_string(arguments).unwrap_or_default() at line 1577.",
+        "serde_json serializes serde_json::Value objects. The Value type's Object variant uses IndexMap (preserving insertion order), not BTreeMap. Key order in the JSON string depends on the order the provider emitted the keys in the original API response.",
+        "A non-Anthropic provider (the fix specifically targets non-Anthropic providers per CLAUDE.md) that emits {\"text\":\"hello\"} in one block and {\"text\":\"hello\"} in the same order would be deduped. But if the provider emits {\"text\":\"hello\"} in block 1 and the arguments parser reconstructs them with a different key insertion order producing {\"text\":\"hello\"} (same, fine), or different Unicode escaping ({'text': 'caf\\u00e9'} vs {'text': 'café'}), these are different strings but semantically identical.",
+        "More concretely: OpenRouter and other proxy providers sometimes normalize JSON differently (compact vs padded, Unicode escape vs literal, integer vs float: 1 vs 1.0). {\"n\":1} and {\"n\":1.0} are different serde_json strings but semantically the same argument to any tool.",
+        "The fix's stated purpose is to defend against provider-side duplication. The most dangerous duplication happens with providers that have slightly different JSON serialization per block. Those providers produce key='n' with value=Number(1) in block 1 and Number(1.0) in block 2 — different serde_json strings, dedup misses, tool executes twice.",
+        "For send_message this means two sends. The fix fails exactly where it's most needed: non-Anthropic providers that serialize ambiguously."
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "id": "ADV-004",
+      "title": "Test false-negative: regression test passes even if dedup is broken via DB error swallowing",
+      "severity": "P3",
+      "confidence": 0.85,
+      "files": [
+        "crates/mika-agent/tests/eval/test_tool_calling.rs",
+        "crates/mika-agent/src/agent.rs"
+      ],
+      "evidence": [
+        "The test at test_tool_calling.rs:56 asserts calls_for_tool('send_message').len() == 1.",
+        "calls_for_tool reads from the tool_calls DB table. The dedup guard prevents the second save_tool_call call. So the assertion passes when dedup works.",
+        "However: if dedup was removed but save_tool_call for the second block hit a transient DB error (warn! only at line 1644, execution continues), the second row would not be written. calls_for_tool would still return 1. The test would pass even though send_message.execute() ran twice, causing two save_message rows and two sender.send() calls.",
+        "The test does not assert: (a) how many times save_message was called in the messages table, (b) how many times the MockSender (if present — the eval harness uses no sender) was invoked.",
+        "The eval harness test for #582 specifically uses no message_sender (EvalHarness default), so the sender.send() double-fire path is never exercised by the regression test.",
+        "A correct regression test would also assert messages table row count == 1 for send_message dedup. Currently the test only validates the DB observability layer, not the tool's primary side effect."
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    },
+    {
+      "id": "ADV-005",
+      "title": "required_tools accounting inflated by dedup: tools_called HashSet marks tool as called even if dedup suppressed the second execution",
+      "severity": "P3",
+      "confidence": 0.88,
+      "files": [
+        "crates/mika-agent/src/agent.rs"
+      ],
+      "evidence": [
+        "At lines 970-974, tools_called.insert(name.clone()) runs for every tool_use block in response.content BEFORE process_tool_calls is called.",
+        "This is correct for normal operation: a tool appearing twice still 'counts' as called for required_tools purposes.",
+        "But the composition creates a subtle cross-direction problem: if a skill declares required_tools = ['send_message'] and the LLM emits send_message twice (duplicate), tools_called records it once (HashSet dedup), process_tool_calls executes it once (HashMap dedup). The required_tools check is satisfied.",
+        "The failure scenario goes the other direction: the LLM emits [A, B, A] where A is a required tool and B is a non-required tool. tools_called gets {A, B}. But process_tool_calls sees two A blocks — one executes, one is deduped. The ToolCallSummary is only pushed once (line 1658, inside the else branch). So all_tool_summaries has 2 entries (one A, one B) but the deduped A has no summary entry.",
+        "This means the tool_history context injected into subsequent messages will show A ran once and B ran once, even though A appeared twice in the LLM's output. The LLM's assistant message in the conversation contains two A tool_use blocks (correctly preserved at line 1724-1729), but tool_history shows one A. If the LLM introspects tool history to decide whether to retry, it sees one A where it intended two — potentially triggering another duplicate emission in the next step."
+      ],
+      "autofix_class": "advisory",
+      "owner": "human"
+    }
+  ],
+  "residual_risks": [
+    "Memory DoS via degenerate LLM output (10K identical blocks) is bounded by the HashMap staying at 1 entry but tool_results grows linearly. Each entry is a cloned ToolOutput (String + Vec<ImageData>). For text-only tools like send_message, 10K clones of a short string is ~10MB — within container limits. For image-returning exec handlers, 10K clones of a 5MB base64 string would be ~50GB — OOM. However, exec handler skills are excluded from silent mode (the mode where provider-side duplication is most likely), and 10K blocks in a single response would exceed API response size limits. Risk: low-moderate.",
+    "Cross-turn dedup is explicitly out of scope (HashMap scoped to process_tool_calls call). If the LLM retries the same tool in a subsequent step (e.g., after a required_tools rejection re-prompt), it will execute again. This is correct behavior but should be documented as an intentional scope boundary to avoid future confusion."
+  ],
+  "testing_gaps": [
+    "No test exercises dedup with a tool that has a message_sender attached — the primary regression (send_message sent twice) is not caught by the eval harness test because EvalHarness does not inject a sender.",
+    "No test exercises dedup when the first tool_use block's save_tool_call fails (DB error path). The current test only validates the happy path.",
+    "No test for semantic-equality bypass: two blocks with numerically equivalent but differently serialized arguments (e.g., integer vs float). Should be added for any provider that normalizes numbers differently.",
+    "No test for image budget interaction with dedup: a tool returning images where the duplicate block exhausts the budget for legitimate later tool calls."
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/agent-native.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/agent-native.json
@@ -1,0 +1,77 @@
+{
+  "run_id": "20260417-004247-b33f4a11",
+  "reviewer": "agent-native-architecture",
+  "subject": "Per-turn tool_use dedup guard (#582)",
+  "base_commit": "57417ab7abd7aba1778a636ed536ac23185c339b",
+  "verdict": "PASS",
+  "score": {
+    "high_priority_capabilities_agent_accessible": "N/A — no new user-facing capability added",
+    "parity_preserved": true
+  },
+  "analysis": {
+    "action_parity": {
+      "assessment": "preserved",
+      "detail": "Dedup is an engine-internal guard. No new user action is introduced. No corresponding agent tool gap is created. The LLM (agent) still receives both tool_result blocks in the conversation history (one real, one cached clone), preserving full API-level visibility into what the turn produced. The suppression is transparent to the LLM by design."
+    },
+    "context_parity": {
+      "assessment": "gap — low priority",
+      "detail": "When the guard fires, only a warn!() log is emitted (trace_id, tool, step). The LLM agent cannot discover that dedup occurred. The tool_calls DB table records the first execution only (save_tool_call is inside the else branch, not reached on the cache-hit path). No audit_event is written. Comparable engine-level events (webhook_deferred, webhook_replayed, verdict_handled) all write audit_events that are then queryable via list_audit_events and query_timeline. The dedup event is the only engine-level guard of comparable significance that lacks an audit_event entry.",
+      "comparable_guards_with_audit_events": [
+        "webhook_deferred (handlers.rs:156)",
+        "webhook_replayed (handlers.rs:655)",
+        "verdict_handled (verdict_handler.rs:276)"
+      ]
+    },
+    "tool_design": {
+      "assessment": "not applicable — no new tool",
+      "detail": "No tool was added or modified. The guard is purely internal."
+    },
+    "shared_workspace": {
+      "assessment": "preserved",
+      "detail": "Guard operates in the same process and DB as all other agent-turn logic. No separate sandbox or divergent data path introduced."
+    },
+    "autonomous_session_visibility": {
+      "assessment": "gap — low priority",
+      "detail": "Claude-pilot / mika-dev sessions have no structured channel to observe dedup firing. The warn!() log is written to the mika-server log file (MIKA_SERVER_LOG_FILE), which is not surfaced to the mika-dev permission callback (canUseTool). Autonomous agents using list_audit_events or query_timeline to self-diagnose anomalies would not see dedup suppression events, whereas they can see webhook_deferred, webhook_replayed, and verdict_handled. If a provider regression caused repeated dedup firing, autonomous sessions could not detect the pattern without parsing raw logs."
+    },
+    "documentation": {
+      "assessment": "adequate for operators; not agent-discoverable",
+      "detail": "CLAUDE.md (crates/mika-agent/CLAUDE.md line 15) has a clear paragraph documenting the guard: name, mechanism, scope, and warn! log fields. This is discoverable by Claude Code reading the codebase but is not injected into the agent system prompt and not reachable via any introspection tool."
+    }
+  },
+  "findings": [
+    {
+      "id": "AN-001",
+      "severity": "observation",
+      "priority": "low",
+      "title": "Dedup suppression not recorded as audit_event",
+      "location": "crates/mika-agent/src/agent.rs:1579-1586",
+      "description": "When the dedup cache hit fires, only warn!() is emitted. Comparable engine-level events (webhook_deferred, webhook_replayed, verdict_handled) write audit_events that agents can query via list_audit_events and query_timeline. A tool_use_dedup_suppressed audit event would make anomalous provider behaviour diagnosable by autonomous sessions without log access.",
+      "recommendation": "Consider calling db.log_audit_event on the cache-hit path with event_name='tool_use_dedup_suppressed', target_key=name, before_value=None, after_value=None, trace_id=tool_ctx.trace_id. Not required for correctness but would close the introspection gap.",
+      "confidence": 0.92
+    },
+    {
+      "id": "AN-002",
+      "severity": "observation",
+      "priority": "low",
+      "title": "Duplicate tool_use block not recorded in tool_calls table",
+      "location": "crates/mika-agent/src/agent.rs:1602-1645",
+      "description": "save_tool_call is inside the else branch; the cache-hit path skips DB persistence entirely. If an operator queries tool_calls history to investigate a provider regression, they see only one invocation per step, with no indication a second block was suppressed. This is consistent with the 'run once' semantics described in CLAUDE.md but creates a silent gap in the DB record of the turn.",
+      "recommendation": "Either document in save_tool_call's comment that duplicates are not recorded (for operator clarity), or save a second row with a suppressed=true flag or an error-like note in the output field. Low priority — the warn! log carries enough signal for debugging.",
+      "confidence": 0.85
+    }
+  ],
+  "what_is_working_well": [
+    "Dedup key is (name, serialized arguments) — precise and reproducible across providers.",
+    "Both tool_result blocks are still pushed to the LLM request, preserving API-level conversation pairing semantics.",
+    "CLAUDE.md documents the guard clearly with issue number, scope, and log fields.",
+    "warn!() includes trace_id, tool name, and step number — sufficient for operator log-based debugging.",
+    "Guard is scoped strictly to a single process_tool_calls invocation; cross-step and cross-turn dedup are explicitly excluded, preventing over-suppression."
+  ],
+  "no_action_needed": [
+    "No new user-facing action was added, so no tool gap exists.",
+    "Agent system prompt does not need updating — the guard is invisible to the LLM by design and there is no new capability to advertise.",
+    "No schema change, so no migration gap.",
+    "The LLM history has both tool_result blocks, so the LLM cannot observe the suppression and cannot be confused by it."
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/correctness.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/correctness.json
@@ -1,0 +1,46 @@
+{
+  "reviewer": "correctness",
+  "findings": [
+    {
+      "id": "COR-001",
+      "title": "Image budget double-charged on cache-hit path — duplicate tool_use with images drains budget twice",
+      "severity": "medium",
+      "confidence": 0.92,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1671-1714",
+      "description": "When a cached ToolOutput is returned on a dedup hit (lines 1579-1586), the shared image-budget block at lines 1671-1714 runs unconditionally for every tool_use block, including the duplicate. `output` is a full clone of the original, so `output.images` is a non-empty Vec. The loop at line 1677 walks the cloned images and subtracts `img_bytes` from `image_bytes_budget` for each one. This means an image-producing tool that appears twice in a single turn will consume 2× the budget even though the image data is sent as text or blocks twice anyway. For a turn where the image budget is already near the limit, the second (duplicate) result will be unnecessarily downgraded to a skip/text-fallback even though the budget has not literally been exceeded by new data — it was already accounted for. More importantly, the first call's budget path ran during the miss leg (inside the `else` branch — but wait: in the refactored code the miss leg does NOT run the image-budget path; that code was moved to after the if/else). Looking at the final code: the miss path builds the `ToolCallSummary` but then falls through to the shared block at line 1671. So BOTH the cache-hit AND cache-miss paths reach line 1671-1714. That means on a hit, `output.images` from the clone is non-empty and the budget loop runs again, spending the budget a second time.",
+      "steps_to_reproduce": "1. A tool returns 1 image with size = MAX_IMAGE_BYTES_PER_STEP / 2. 2. LLM emits two identical tool_use blocks for that tool. 3. First block: miss path, budget = MAX/2 after processing, image included. 4. Second block: hit path, clone has same images Vec, budget loop runs again, consumes MAX/2 more = 0 budget remaining. 5. Any subsequent tool in the same turn that also returns an image will be budget-blocked even though conceptually only one real tool call's worth of image data was produced.",
+      "recommendation": "In the cache-hit path, either (a) yield a ToolOutput with `images: vec![]` — the duplicate gets a text-only result citing the cache, which is correct since the actual image was already sent for the first tool_use id — or (b) track images as already-budgeted by key and skip the budget loop on hit. Option (a) is simplest: construct a stripped clone on cache hit: `ToolOutput { content: cached.content.clone(), is_error: cached.is_error, images: vec![] }`. The API still gets a valid tool_result for the duplicate id; the model already saw the image for the first id in the same turn."
+    },
+    {
+      "id": "COR-002",
+      "title": "serde_json::to_string on serde_json::Value is deterministic within a single parse but not across providers with different key orderings",
+      "severity": "low",
+      "confidence": 0.72,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1575-1578",
+      "description": "The dedup key for arguments is `serde_json::to_string(arguments).unwrap_or_default()`. `serde_json::Value::Object` is backed by an `IndexMap` (insertion-order-preserving). If a provider emits two tool_use blocks with logically-identical JSON objects but different key orderings (e.g., `{\"text\":\"x\",\"channel\":\"y\"}` vs `{\"channel\":\"y\",\"text\":\"x\"}`), the serialised strings differ, the dedup cache misses, and both executions proceed. This is a missed-dedup case (no incorrect execution, no data loss), but the guard will fail to fire for the exact case described in #582 if the second duplicate has reordered keys. The risk level is constrained because the observed #582 scenario was truly byte-identical blocks from the same LLM response; however the fix does not cover all logically-duplicate cases across providers known to shuffle keys.",
+      "recommendation": "For this issue's acceptance criteria (byte-identical payload), the current key is sufficient. Document the limitation in the CLAUDE.md note or add a normalisation step (sort object keys recursively before serialisation) if cross-provider coverage is desired. No code change required to meet the stated acceptance criteria."
+    },
+    {
+      "id": "COR-003",
+      "title": "tools_called set for required-tools enforcement counts duplicate tool_use blocks twice — inconsistency with dedup guard",
+      "severity": "low",
+      "confidence": 0.85,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "970-974",
+      "description": "At lines 970-974, `tools_called.insert(name.clone())` iterates all blocks including duplicates and inserts each tool name into a `HashSet`. Since it is a HashSet the insert of the duplicate is a no-op, so required-tools enforcement is unaffected. This is correct behaviour — a skill requiring `send_message` will see `send_message` in `tools_called` whether one or two blocks were emitted. No bug here; confirming it is safe as-is.",
+      "recommendation": "No action needed. The HashSet dedup is the correct semantic for required-tools tracking regardless of the new dedup guard."
+    }
+  ],
+  "residual_risks": [
+    "Error propagation on first-execution failure: when the cache-miss path produces `is_error=true`, the cached clone for a duplicate inherits `is_error=true`. This is intentional for a same-turn duplicate because there is no basis to expect a retry would succeed in the same turn (the inputs are identical and nothing has changed). The risk is acceptable and matches the stated design intent.",
+    "The `executed` HashMap is local to the `process_tool_calls` call and is not persisted across steps or turns. A duplicate emitted in step N+1 that is identical to one in step N will not be caught. This is explicitly called out in the comment and is the intended scope.",
+    "The regression test uses `MockLlmProvider` with `send_message` as the deduplicated tool. `send_message` is a builtin that writes to the database and fires outbound messages. The test asserts only one `tool_calls` DB row, which is the right correctness signal, but it does not assert that exactly one outbound message was sent. If `MessageSender` is wired in the test harness, a double-send bug at a lower layer would not be caught by this test alone."
+  ],
+  "testing_gaps": [
+    "No test covers the cache-hit path for a tool that returns images. The image budget double-charge (COR-001) would not be caught by any existing test.",
+    "No test verifies that the duplicate tool_use block receives a syntactically valid `tool_result` in the reconstructed conversation history (i.e., that the second tool_use id appears exactly once in the tool_results Vec). The test checks DB rows but not the API message construction.",
+    "No test exercises three or more identical blocks in one turn (N>2 duplicates). The current implementation handles this correctly via the HashMap, but it is untested."
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/maintainability.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/maintainability.json
@@ -1,0 +1,75 @@
+{
+  "reviewer": "maintainability",
+  "findings": [
+    {
+      "id": "M1",
+      "category": "unnecessary_indirection",
+      "title": "execute-path block is deep enough to warrant extraction",
+      "confidence": 0.72,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1587-1668",
+      "detail": "The else-branch of the cache-hit / execute split now contains the full original body: tool dispatch, DB record, image summary construction, ToolCallSummary push, and HashMap insert. That branch is ~82 lines at one extra level of indentation inside an already-large for-body. A private async helper `execute_and_record_tool(...)` returning `(ToolOutput, ToolCallSummary)` would let the cache-hit branch stay a three-liner and the execute path be navigable independently. The function was already around the readable limit before this change; the extra indentation level tips it past it.",
+      "suggested_fix": "Extract the else-branch into `async fn execute_and_record_tool(dispatch, name, arguments, db, store_tool_calls, step, ...) -> (ToolOutput, ToolCallSummary)`. The outer loop then reads: `let (output, summary) = if let Some(c) = executed.get(&key) { (c.clone(), None) } else { execute_and_record_tool(...).await }`."
+    },
+    {
+      "id": "M2",
+      "category": "naming_obscures_intent",
+      "title": "`executed` is an ambiguous name for a dedup cache",
+      "confidence": 0.65,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1567",
+      "detail": "`executed` reads as a past-tense verb (\"already executed\") but acts as a noun (a cache). A future reader scanning for the HashMap might look for `cache` or `dedup_cache`. `dedup_cache` or `tool_result_cache` would signal both the structure type (a cache) and its purpose (dedup) without requiring the reader to read the comment to understand intent. The variable `cached` used for the looked-up value is fine.",
+      "suggested_fix": "Rename `executed` to `dedup_cache`."
+    },
+    {
+      "id": "M3",
+      "category": "dead_or_unreachable_code",
+      "title": "Duplicate `output.clone()` at insert and at block exit — one is load-bearing but easily confused",
+      "confidence": 0.70,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1667-1668",
+      "detail": "`executed.insert(dedup_key, output.clone()); output` at the end of the else-branch requires two clones of ToolOutput per first-seen call (one into the map, one as the block's return value) because HashMap::insert takes ownership and the value is still needed. This is semantically correct but a reader will wonder why `output` is returned after being cloned into the map rather than retrieved from it. With the extraction suggested in M1 this becomes explicit; without it, a brief comment `// clone into cache, return original` would prevent the double-take.",
+      "suggested_fix": "Add a one-line comment above `executed.insert(...)` explaining both clones are intentional, or restructure so the final `output` is retrieved via `executed.get(&dedup_key).unwrap()` (single Clone, clearer ownership)."
+    },
+    {
+      "id": "M4",
+      "category": "premature_abstraction",
+      "title": "Clone derive on ToolOutput is appropriate but ImageData images field should be noted",
+      "confidence": 0.60,
+      "file": "crates/mika-agent/src/tools/mod.rs",
+      "lines": "140",
+      "detail": "Adding `#[derive(Clone)]` is the minimal correct change. ImageData already derived Clone so the derive chain is consistent. The cost of cloning a cached ToolOutput is bounded by image data (base64 strings), which in the dedup scenario means the tool ran once and the second clone is unavoidable to keep the API sound. The risk is that future callers see Clone available and reach for it in hot paths where Arc-wrapping would be cheaper. This is a low-severity latent concern rather than a current problem -- image tool results in a single response are not expected to be large enough to matter.",
+      "suggested_fix": "No immediate change required. If image-heavy tools become common, consider `Arc<ToolOutput>` in the HashMap value to share without copying."
+    },
+    {
+      "id": "M5",
+      "category": "naming_obscures_intent",
+      "title": "Comment block length is well-calibrated",
+      "confidence": 0.85,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1562-1566",
+      "detail": "The four-line comment accurately scopes the behavior (per-function-call, not cross-step), cites the issue number, and describes the defensive motivation. It is not over-long. No change needed.",
+      "suggested_fix": null
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "RR1",
+      "description": "Dedup silently suppresses the DB record for the second identical tool_use block. If a provider emits three identical blocks the first will be recorded once (correct) but the tool_results list will contain three entries with the same content. The conversation/API history will be well-formed (each tool_use id gets a paired tool_result), but the tool_calls table will under-count. Observability tooling that correlates tool_calls rows with LLM response block counts may surface anomalies."
+    },
+    {
+      "id": "RR2",
+      "description": "The dedup key serializes arguments via `serde_json::to_string`. JSON key ordering in serde_json is insertion-order for Value::Object. If two structurally identical tool calls arrive with differently-ordered keys at the JSON level (possible if arguments come from different codepaths in the provider), the dedup will miss. This is unlikely in practice but is a hidden fragility: the dedup is key-order-sensitive without documentation of that assumption."
+    }
+  ],
+  "testing_gaps": [
+    {
+      "id": "TG1",
+      "description": "No eval test exercises the dedup path directly: a MockLlmProvider sequence that emits two identical ToolCall blocks in a single response, verifying that the underlying tool executes once and both tool_use ids receive paired tool_results in the request messages. The CLAUDE.md eval harness in `crates/mika-agent/tests/eval/` is the right home for this."
+    },
+    {
+      "id": "TG2",
+      "description": "No test covers the warn! log emission: the dedup warn is the primary observability signal for the bug in production. A test asserting the warning fires (via tracing-test or log capture) would guard against the log being silently removed."
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/performance.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/performance.json
@@ -1,0 +1,34 @@
+{
+  "reviewer": "performance",
+  "findings": [
+    {
+      "id": "PERF-001",
+      "title": "Redundant serde_json serialization of arguments on non-duplicate path: dedup key (line 1577) and DB save (line 1619) are identical serializations",
+      "severity": "low",
+      "confidence": 0.68,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": [1577, 1589, 1619],
+      "description": "Each non-duplicate tool block serializes `arguments` (a &serde_json::Value) three times: line 1577 via serde_json::to_string for the dedup key string, line 1589 via arguments.to_string() (Display impl, equivalent to serialization) for input_summary, and line 1619 via serde_json::to_string for the DB save input_json. Lines 1577 and 1619 produce identical strings. The line-1577 serialization is the only new allocation introduced by this PR; lines 1589 and 1619 pre-existed. For typical tool arguments (small JSON objects, well under 1 KB), each serialization costs microseconds and a few hundred bytes. For the largest possible inputs near MAX_PAYLOAD_BYTES (200 KB, e.g. write_workspace content), three serializations allocate ~600 KB of short-lived intermediate strings per tool block. At max 20 tool steps per turn with up to 5 blocks per step (worst case 100 blocks), and with MIKA_STORE_TOOL_CALLS=true (production default), the worst-case transient overhead is ~60 MB of allocations per turn — all immediately freed per-block. This is bounded and not a leak. The function is not a hot loop: async I/O (execute_tool, DB save) dominates wall time between blocks.",
+      "impact": "Not production-observable under normal workloads. The extra allocation per block from line 1577 is completely masked by the execute_tool latency (30s timeout, async I/O). Only visible in allocation profiling under adversarial inputs at maximum payload size.",
+      "recommendation": "The dedup key string from line 1577 could be reused as input_json at line 1619, eliminating one serde_json::to_string call. This is a minor code tidy-up: hoist the dedup string binding before the if/else and shadow input_json with a reference to it inside the store_tool_calls block. Not a performance fix — do only if the three-serialization pattern is already flagged in an allocation profile."
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "RR-001",
+      "description": "The review brief's concern about 'clone TWICE on the duplicate path' does not match the implementation. On the cache-hit path (line 1586), there is exactly one clone: cached.clone() produces output, which is then moved into content-building at lines 1672-1677. On the cache-miss path (line 1667), there is exactly one clone into the executed map, then the original output is moved out and consumed. No double-clone occurs on either path.",
+      "severity": "informational"
+    },
+    {
+      "id": "RR-002",
+      "description": "Image-bearing ToolOutput clone into executed map (line 1667): if a tool returns images (up to 5x5 MB base64 strings per the exec handler protocol), the cache-miss clone doubles the image payload in memory for the function lifetime (until HashMap is dropped at line 1735). The per-step image budget is capped at MAX_IMAGE_BYTES_PER_STEP = 20 MB by the inclusion loop at lines 1677-1688, so actual peak overhead is bounded. Duplicate image-returning tool blocks are not a realistic scenario — the dedup guard is a defense against provider-side glitches, not repeated large-output tools.",
+      "severity": "informational"
+    },
+    {
+      "id": "RR-003",
+      "description": "HashMap vs Vec linear scan for dedup storage: at N=1-5 tool blocks per LLM response step (observed typical range), a Vec<((String,String), ToolOutput)> with linear key search would avoid the HashMap bucket allocation and hashing overhead. However the performance difference at N<20 is unmeasurable in practice, and HashMap degrades more gracefully if a provider ever emits a pathologically large number of duplicate blocks.",
+      "severity": "informational"
+    }
+  ],
+  "testing_gaps": []
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/project-standards.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/project-standards.json
@@ -1,0 +1,23 @@
+{
+  "reviewer": "project-standards",
+  "findings": [],
+  "residual_risks": [
+    {
+      "area": "serde_json::to_string silently swallowed on dedup key",
+      "detail": "Line 1577 uses serde_json::to_string(arguments).unwrap_or_default() to build the dedup key. If serialization produced an empty string for two semantically different Values (e.g., serde_json bug or future type change), two distinct tool calls would be incorrectly collapsed. In practice serde_json::Value serialization is infallible for any Value, so this is negligible. The same pattern already exists at line 1619 for the DB path, making this consistent with established codebase style. No standards rule is violated; risk is noted for awareness.",
+      "severity": "negligible"
+    },
+    {
+      "area": "ToolOutput::Clone adds image buffer clone cost",
+      "detail": "Images are base64 String fields already capped by MAX_IMAGE_BYTES_PER_STEP. Clone cost is bounded. Duplicate tool_use blocks with images are extremely rare. No standards violation; noted for awareness.",
+      "severity": "negligible"
+    }
+  ],
+  "testing_gaps": [
+    {
+      "gap": "No inline unit test for ToolOutput::Clone round-trip",
+      "detail": "The plan (Implementation Units, Unit 1, Test scenarios) listed a small inline #[cfg(test)] mod tests unit test for ToolOutput::Clone round-trip as optional. It was not added. Root CLAUDE.md convention is '#[cfg(test)] mod tests inline in each module'. Because the derive is mechanical and covered implicitly by the eval test, this is minor, but the stated plan intent was not fulfilled.",
+      "severity": "low"
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/reliability.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/reliability.json
@@ -1,0 +1,80 @@
+{
+  "reviewer": "reliability",
+  "findings": [
+    {
+      "id": "REL-001",
+      "title": "Duplicate tool_use with images double-decrements shared image_bytes_budget",
+      "severity": "medium",
+      "confidence": 0.92,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1561-1719",
+      "description": "image_bytes_budget is initialized once per process_tool_calls call (line 1561) and shared across all tool_use block iterations. When dedup fires (cached.clone() path, line 1586), the returned ToolOutput still contains the full images Vec (cloned from the cache). The image processing block at lines 1671-1713 runs unconditionally for every iteration — including cached ones — and decrements image_bytes_budget for each image in the cloned output. A single-step response with two identical tool_use blocks that produce images will consume the budget twice: the first block processes images normally, then the second (dedup) block re-enters the same loop and either exhausts the remaining budget prematurely (causing later legitimate tool results to get the 'budget exceeded' truncation message) or, if the first block already consumed most of the budget, the second block will emit '[N image(s) skipped: step memory budget exceeded]' in a tool_result that the LLM sees — causing confusion since the first result showed the image successfully.",
+      "impact": "If a deduplicated tool produces images (currently no builtin tool does, but exec-handler skills using the __mika_v1 image protocol can), the second tool_result in the LLM conversation will show images as budget-exceeded even though they were included in the first result. This can cause the LLM to misinterpret partial results. Additionally, subsequent tool_use blocks in the same step (non-duplicate) will have a deflated budget.",
+      "reproduction": "Craft an exec-handler skill that returns images via __mika_v1. Configure a non-Anthropic provider that emits duplicate tool_use blocks. The second duplicate result will show image-skip warnings.",
+      "recommendation": "Skip the image processing loop entirely for cached (dedup) results. Since the purpose of the dedup clone is to produce a matching tool_result for the LLM API's id-pairing requirement, the simplest fix is to strip images from the cloned output before the image loop: replace `cached.clone()` with a version that zeroes out the images field (e.g., `ToolOutput { images: vec![], ..cached.clone() }`). Alternatively, add a boolean `is_dedup: bool` flag to the output returned from the cache branch and skip the image processing block when it is true."
+    },
+    {
+      "id": "REL-002",
+      "title": "Error caching propagates send_message DB save failure to the duplicate as a phantom success",
+      "severity": "low",
+      "confidence": 0.78,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1579-1586",
+      "description": "When the first tool_use block for send_message fails at the DB save step (ctx.db.save_message returns Err), execute_tool propagates the anyhow::Error which becomes ToolOutput::error via the execute_tool wrapper. This error output IS cached in the executed HashMap. The duplicate block then receives a clone of the error output — which is correct for send_message (the message was not sent, so the duplicate should also reflect failure). However, the error in this case was a transient DB write failure, not a business-logic error. The duplicate inherits a non-retryable error string without any indication that retry might resolve the underlying condition.",
+      "impact": "If the DB layer was transiently unavailable during the first send_message execution, the duplicate silently inherits the failure rather than attempting a retry. For send_message specifically, this is actually the desired behavior (avoid double-send), but the logged warning at line 1580 only says 'duplicate tool_use block suppressed' with no indication that the underlying first execution also failed. This makes failure diagnosis harder in traces.",
+      "reproduction": "Simulate a transient SQLite lock error during save_message. Observe that both tool_result blocks in the LLM history show the DB error, but only one warn! log line mentions the suppression.",
+      "recommendation": "Low priority — the behavior (both blocks fail together) is actually correct for send_message semantics. Consider adding the first execution's is_error status to the dedup warning log line so operators can distinguish 'suppressed a success' from 'suppressed a failure': `warn!(trace_id, tool, step, cached_was_error = cached.is_error, \"duplicate tool_use block suppressed\")`."
+    },
+    {
+      "id": "REL-003",
+      "title": "Audit trail gap: duplicate tool_use produces two tool_result history entries but only one tool_calls DB row",
+      "severity": "low",
+      "confidence": 0.95,
+      "file": "crates/mika-agent/src/agent.rs",
+      "lines": "1602-1645",
+      "description": "The save_tool_call DB write (lines 1602-1646) is inside the non-cache branch of the if-let-else. When dedup fires, the duplicate tool_use id receives a tool_result pushed to the conversation history (line 1715) but no corresponding row is written to the tool_calls SQLite table. The dashboard API endpoints (handle_tool_calls, handle_trace_tool_calls, handle_session_tool_calls in server/dashboard.rs) query the tool_calls table for observability. An observer correlating LLM API history (which shows two tool_results) with the dashboard tool_calls list (which shows one row) will see a discrepancy. The warn! log at line 1580 does indicate suppression, but the dashboard UI has no visibility into this.",
+      "impact": "Observability gap: the dashboard tool-calls panel will show 1 row while the raw LLM conversation contains 2 tool_result blocks. For audit purposes (e.g., compliance review of how many times send_message was invoked) the DB count is correct (once), but operators may not know to look for the warn! log to explain the mismatch.",
+      "reproduction": "Trigger dedup via a non-Anthropic provider. Inspect /api/v1/sessions/{id}/tool-calls — it will show fewer rows than the actual LLM conversation turn count.",
+      "recommendation": "Document the intentional discrepancy in the code comment at line 1562. Optionally: write a second tool_calls row for the duplicate with a `dedup_of` column referencing the first tool_id, or add a `suppressed_count` column to the existing row. Lowest-effort: expand the existing warn! log to include the original tool_id so log-based auditing can reconstruct the full picture."
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "RR-001",
+      "description": "tools_called HashSet (line 972) iterates raw response.content before dedup runs in process_tool_calls. A duplicate tool_use block adds the tool name to the set twice — but HashSet.insert is idempotent, so required_tools enforcement, completion-claim guard, and fabricated-action guard all see the correct unique set. No accounting risk from this path.",
+      "confidence": 0.95
+    },
+    {
+      "id": "RR-002",
+      "description": "Partial-move of ToolOutput fields: in the image-present else branch, output.content is moved into blocks (line 1675) and output.images is moved by the for loop (line 1677). output.is_error is subsequently read at line 1718. Because bool is Copy, Rust allows reading Copy fields from a partially-moved struct. This compiles and runs correctly — no partial-move bug.",
+      "confidence": 0.98
+    },
+    {
+      "id": "RR-003",
+      "description": "Timeout non-re-entry: a cached dedup hit does not re-enter tokio::time::timeout. This is correct — cache lookup is microsecond-scale and cannot meaningfully hang. No timeout reliability concern.",
+      "confidence": 0.97
+    },
+    {
+      "id": "RR-004",
+      "description": "send_message under dedup: the first invocation runs ctx.db.save_message + sender.send exactly once. The cached clone returns ToolOutput::success(\"Message sent.\") with empty images, so the second tool_result block in the LLM history also says 'Message sent.' — which is correct (the message was sent once). The dedup guard achieves the desired behavior of preventing double delivery.",
+      "confidence": 0.97
+    }
+  ],
+  "testing_gaps": [
+    {
+      "id": "TG-001",
+      "description": "No eval harness test exercises the dedup path with a tool that returns images (ToolOutput::success_with_images). The image budget double-decrement (REL-001) is only observable in a test that: (1) configures MockLlmProvider to emit two identical tool_use blocks in one response, (2) uses an exec-handler or mock tool returning images, and (3) asserts that the second tool_result does NOT contain the budget-exceeded marker.",
+      "priority": "medium"
+    },
+    {
+      "id": "TG-002",
+      "description": "No test asserts that the tool_calls DB table contains exactly one row when dedup fires (as opposed to two). Adding such an assertion to an eval test would document the intentional audit-trail behavior described in REL-003 and prevent future regressions if the dedup path is accidentally changed to write two rows.",
+      "priority": "low"
+    },
+    {
+      "id": "TG-003",
+      "description": "No test covers the case where the first (real) invocation errors and the duplicate inherits that error. For send_message specifically: if save_message fails, both tool_results show the error, yet the warn! log only mentions suppression. A test asserting both the DB state (no message saved) and the tool_result content (error propagated) would close this gap.",
+      "priority": "low"
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/testing.json
+++ b/.context/compound-engineering/ce-review/20260417-004247-b33f4a11/testing.json
@@ -1,0 +1,76 @@
+{
+  "reviewer": "testing",
+  "findings": [
+    {
+      "id": "T001",
+      "category": "untested_branch",
+      "severity": "medium",
+      "confidence": 0.92,
+      "title": "N>2 identical blocks: dedup beyond the second duplicate is untested",
+      "description": "The dedup guard uses a HashMap that handles N duplicates correctly by design, but the test only feeds exactly two identical blocks. A three-block scenario (A, A, A) is not covered. If a future refactor changes the accumulation logic (e.g. early-exit after first duplicate) a three-copy case could break without the two-copy test catching it.",
+      "location": "crates/mika-agent/tests/eval/test_tool_calling.rs:56-87",
+      "fix_suggestion": "Add a test with three identical blocks using multi_tool_response with three identical entries and assert send_calls.len() == 1."
+    },
+    {
+      "id": "T002",
+      "category": "untested_branch",
+      "severity": "medium",
+      "confidence": 0.90,
+      "title": "Mixed-duplicate scenario (identical pair interleaved with distinct tool) is untested",
+      "description": "The dedup HashMap scope is per-call to process_tool_calls. The fix should only collapse identical (name, args) pairs and leave distinct tools untouched. No test feeds [send_message(A), search_memory(B), send_message(A)] and asserts send_message appears once AND search_memory appears once. Without this, a regression that accidentally widens the dedup key (e.g. deduplicating on name alone) would not be caught.",
+      "location": "crates/mika-agent/tests/eval/test_tool_calling.rs:56-87",
+      "fix_suggestion": "Add a test with multi_tool_response containing three entries where two are identical and one is different; assert per-tool call counts separately."
+    },
+    {
+      "id": "T003",
+      "category": "missing_assertion",
+      "severity": "high",
+      "confidence": 0.95,
+      "title": "Test does not verify that both tool_use IDs receive a tool_result in conversation history",
+      "description": "The core API contract of the fix is: the duplicate tool_use id must still receive a tool_result in the outgoing message (line 1715 in agent.rs pushes a LlmContentBlock::ToolResult for every block including cache hits). The test asserts only that calls_for_tool('send_message').len() == 1 (DB rows), which confirms the tool ran once, but does not confirm the second tool_use id was paired with a tool_result in the captured request. If the tool_result push was accidentally gated behind the executed.get() miss branch, the test would still pass while the API contract is broken. The captured_requests field in AgentTrace is available and contains the full message history.",
+      "location": "crates/mika-agent/tests/eval/test_tool_calling.rs:79-86",
+      "fix_suggestion": "After assert_eq on send_calls.len(), inspect trace.captured_requests[1].messages to count LlmContentBlock::ToolResult entries and assert there are 2 — one per tool_use id. Alternatively add an assertion helper assert_tool_result_count on AgentTrace."
+    },
+    {
+      "id": "T004",
+      "category": "missing_edge_case",
+      "severity": "low",
+      "confidence": 0.72,
+      "title": "Error-path behavior under dedup is unspecified and untested",
+      "description": "If the first execution of a duplicate tool errors (output.is_error == true), the cached ToolOutput carries the error. The second identical block will reuse that error output and also receive a tool_result with is_error: true. No test exercises this scenario. The behavior may be correct, but it is an implicit assumption. If the intent were instead 'retry once on error', the current implementation does not do that and there is no test to document the chosen semantics.",
+      "location": "crates/mika-agent/src/agent.rs:1579-1586",
+      "fix_suggestion": "Add a test where the first of two identical tool calls returns an error result (use a tool name not in the registry to produce an unknown-tool error), and assert both that only one DB row exists and that the tool_result blocks carry is_error: true."
+    },
+    {
+      "id": "T005",
+      "category": "implementation_coupled_test",
+      "severity": "low",
+      "confidence": 0.65,
+      "title": "Test relies on send_message silently succeeding without message_sender",
+      "description": "The test uses send_message as the duplicate tool. send_message with message_sender: None (the harness default) returns ToolOutput::success with a warning text rather than an error. This behavior is intentional and documented in send_message.rs:69-83, but it is not documented in the test. If the no-sender behavior is ever changed (e.g. to return an error when no sender is configured), the dedup test will break not because dedup is wrong but because the chosen tool's fallback behavior changed. The coupling is subtle.",
+      "location": "crates/mika-agent/tests/eval/test_tool_calling.rs:56-87",
+      "fix_suggestion": "Add a comment in the test noting that send_message is chosen because it succeeds gracefully without a configured sender (message_sender: None). Alternatively use a tool with no external side effects, such as search_memory with a mock DB result, to remove the dependency on send_message's fallback path."
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "R001",
+      "description": "The dedup key serializes serde_json::Value via serde_json::to_string. JSON object key ordering in serde_json is insertion-order stable, so two LLM-emitted argument objects with identical keys in different orders would produce different dedup keys and both tools would execute. This is a correctness edge case of the dedup logic itself, not the test. No test covers argument-order-variant duplicates.",
+      "severity": "low",
+      "confidence": 0.70
+    },
+    {
+      "id": "R002",
+      "description": "test_multiple_parallel_tool_calls uses assert!(search_calls.len() >= 2) — this is correct and not weakened by the dedup fix because the two search_memory calls have different arguments ({query: 'schedule'} vs {query: 'priorities'}), so dedup keys differ. The test continues to pass and serves as an implicit non-regression for distinct-args parallel calls. However the assertion is a lower-bound (>= 2) not an exact count, so it would pass even if a future change added spurious extra calls.",
+      "severity": "low",
+      "confidence": 0.80
+    }
+  ],
+  "testing_gaps": [
+    "No test for N>2 identical tool_use blocks in a single response (T001)",
+    "No test for mixed scenario: identical duplicates interleaved with a distinct tool call (T002)",
+    "No assertion verifying tool_result pairing in conversation history for both tool_use ids (T003 — highest priority gap given it is the stated API contract in the fix comment)",
+    "No test for dedup behavior when the first execution errors (T004)",
+    "No inline unit test for the dedup key construction (serde_json serialization determinism for serde_json::Value)"
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/adversarial.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/adversarial.json
@@ -1,0 +1,103 @@
+{
+  "reviewer": "adversarial",
+  "findings": [
+    {
+      "id": "ADV-001",
+      "title": "Image budget double-consumed by cached duplicate: single large image can exhaust 40 MB of the 20 MB step budget",
+      "severity": "medium",
+      "confidence": 0.95,
+      "autofix_class": "manual",
+      "owner": "downstream-resolver",
+      "evidence": [
+        "The image budget deduction block (agent.rs lines 1671-1682) is OUTSIDE the dedup branch. It runs for every tool_use block, whether the output came from cache or from a fresh execution.",
+        "Trigger: LLM emits two identical tool_use blocks for a vision/screenshot tool (e.g. browser-control) that returns a 15 MB base64 image in ToolOutput.images.",
+        "Step 1: First block executes, output with 15 MB image stored in `executed` cache, image_bytes_budget decremented from 20 MB to 5 MB.",
+        "Step 2: Second (duplicate) block hits the cache branch at line 1579, returns the cached ToolOutput (clone includes full 15 MB image Vec).",
+        "Step 3: Code falls through to line 1671 outside the branch — image_count is non-zero, the loop at line 1677 checks img_bytes (15 MB) > image_bytes_budget (5 MB), breaks immediately.",
+        "Step 4: included==0, so the fallback at line 1699 produces a text-only result for the SECOND tool_result, but still consumed 0 budget. Actually the first run already consumed 15 MB, so the second has only 5 MB left — this is fine for that specific case.",
+        "ACTUAL HARM PATH: LLM emits [A(img=11MB), B(img=11MB), A(img=11MB)]. First A executes, budget=9MB. B executes (different key), budget fails (11>9), B gets '[1 image skipped]'. Third block A hits cache — output.images still has the 11 MB clone — loop checks 11 MB > 9 MB, skips image, emits text-only tool_result. The LEGITIMATE tool B was starved because the duplicate A consumed budget on first run, leaving B unable to include its image. The duplicate then re-consumed 0 budget but the damage is already done via the initial execution path.",
+        "More precisely: the dedup guard prevents re-execution but the cached ToolOutput.images are still cloned and fed into the budget-check path, so N identical image-producing tool blocks will attempt (and fail) to each consume N*img_size against the 20 MB limit. Each failed attempt silently degrades the tool_result for legitimate downstream blocks."
+      ],
+      "suggested_fix": "After retrieving from cache, construct the tool_result using only the text content of the cached output (skip image blocks entirely or re-check against remaining budget before re-cloning images). Or: zero out images in the cached ToolOutput copy: `let mut output = cached.clone(); output.images.clear();` when constructing the duplicate result. The LLM already saw the image in the first tool_result — re-sending it is wasteful and budget-dangerous."
+    },
+    {
+      "id": "ADV-002",
+      "title": "send_message dedup silently suppresses DB persist + external delivery for duplicate: user never receives second notification",
+      "severity": "high",
+      "confidence": 0.92,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "evidence": [
+        "send_message.execute() has two side effects: (1) ctx.db.save_message() persists the outbound message to conversation history, and (2) sender.send() delivers it externally via Telegram gateway.",
+        "If an LLM emits two identical send_message({text: 'Your report is ready'}) blocks in one turn, the dedup guard executes the tool once, caches ToolOutput::success('Message sent.'), and returns the cached output for the duplicate.",
+        "The second send_message call never reaches execute(), so the second save_message() and sender.send() are both skipped.",
+        "The cached ToolOutput content is 'Message sent.' — the LLM sees this as success for both blocks and has no reason to retry.",
+        "The conversation history contains exactly one copy of the outbound message, and Telegram receives it exactly once. This is the intended behavior for the dedup guard.",
+        "HOWEVER: the scenario that triggered #582 is a provider bug where the LLM emitted send_message twice for ONE intended send. The guard correctly handles this. But consider a legitimate case: a skill that intentionally calls send_message({text:'Draft'}) then send_message({text:'Draft'}) to send the same notification to two different recipients — this is architecturally blocked. More realistically, a reminder skill that builds two reminders with identical text in the same turn will have the second delivery silently dropped with no error surfaced to the LLM.",
+        "The guard is correct for the bug case but creates a new behavioral assumption: any skill or agent pattern that legitimately sends identical messages twice in one turn is now broken without any warning visible in the tool_result. The LLM receives 'Message sent.' for both and has no signal that the second was suppressed."
+      ],
+      "suggested_fix": "Consider whether send_message should be exempt from dedup (stateful delivery tools differ from idempotent read tools). Alternatively, make the cached tool_result for send_message return a distinct content like 'Duplicate suppressed — message was already sent this turn.' so the LLM has an accurate model of what happened. The warn! log fires but the LLM never sees it."
+    },
+    {
+      "id": "ADV-003",
+      "title": "OpenAI-compatible provider key-order bypass: semantically identical args with different JSON key order produce different dedup keys",
+      "severity": "low",
+      "confidence": 0.88,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "evidence": [
+        "The dedup key is (name, serde_json::to_string(arguments).unwrap_or_default()).",
+        "serde_json::to_string on a serde_json::Value::Object preserves insertion order. Two Value::Object instances with the same keys and values but different insertion order produce different serialized strings.",
+        "For Anthropic (primary provider): the input field is deserialized from JSON and the key order is determined by the raw JSON bytes from the API. Claude API typically returns consistent key ordering within a single response, so two identical tool_use blocks will have identical byte-order and will be caught.",
+        "For OpenAI-compatible providers (openai.rs line 627-641): arguments are parsed from tc.function.arguments (a String) via serde_json::from_str::<Value>(). serde_json::Map preserves insertion order from the source string. If the provider returns two tool calls with identical parameters but one has {\"a\":1,\"b\":2} and the other has {\"b\":2,\"a\":1}, these produce different dedup keys.",
+        "Trigger: OpenRouter with a Mistral or GPT model emits two identical tool calls where arguments have different key ordering. The dedup guard misses the duplicate, the tool executes twice.",
+        "The plan explicitly accepts this as 'fail open' — the guard fires on byte-identical duplicates, not semantic-identical ones. This is documented. The risk is: for tools with side effects (send_message, store_fact, create_work_item), the second execution produces the harmful outcome the guard was designed to prevent.",
+        "This is not a regression (pre-fix also executed twice), but it means the guard's protection is provider-dependent. On non-Anthropic providers it may not fire for the exact bug class #582 was targeting."
+      ],
+      "suggested_fix": "Consider canonicalizing the arguments Value before serializing: sort object keys recursively before serde_json::to_string. This provides semantic dedup instead of byte-identical dedup. Cost: one extra allocation per tool call (negligible)."
+    },
+    {
+      "id": "ADV-004",
+      "title": "Interleaved duplicate pattern [A, B, A] emits one summary for A but two tool_results — conversation history has mismatched cardinality",
+      "severity": "low",
+      "confidence": 0.82,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "evidence": [
+        "When LLM emits [A, B, A]: first A executes, summary pushed, result pushed. B executes, summary pushed, result pushed. Second A hits cache — no summary pushed (summaries.push is inside the else branch at line 1658), but tool_result IS pushed (line 1715 is outside the branch).",
+        "Result: summaries vec has 2 entries [A, B], tool_results vec has 3 entries [A, B, A].",
+        "The tool_results are attached to the conversation via request.messages (line 1715 appends to tool_results which are later pushed). The assistant message contains 3 tool_use blocks (from response_content_to_blocks at line 1724). The subsequent user message must contain exactly 3 tool_result blocks to satisfy the API.",
+        "tool_results has 3 entries matching 3 assistant tool_use blocks — so the API pairing IS correct.",
+        "However, the summaries used for messages.metadata (line 892) has only 2 entries, not 3. The tool_call_summaries fed into format_step_exceeded_fallback (line 387) will not include the second A execution. This is cosmetic — observability shows one fewer tool invocation than actually occurred in the conversation.",
+        "The DB tool_calls table also has only 1 row for A (correct — tool ran once). The discrepancy is between: conversation history (3 tool_use/result pairs, semantically correct) vs metadata/DB (2 records). A human or agent reading the timeline will see 2 tool calls but the LLM turn had 3 tool_use blocks."
+      ],
+      "suggested_fix": "For the cached path, push a lightweight summary entry indicating suppression (e.g., ToolCallSummary with name=name, success=true, output_summary='[deduped]'). This keeps cardinality consistent between tool_results and summaries."
+    },
+    {
+      "id": "ADV-005",
+      "title": "Cascade: create_work_item duplicate guard bypassed if reference_url differs, but dedup guard fires — DB unique index and dedup guard operate on different keys",
+      "severity": "low",
+      "confidence": 0.72,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "evidence": [
+        "The dedup guard keys on (tool_name, full_args_json). create_work_item takes title, description, reference_url, and optionally type/parent_task_id.",
+        "If the LLM emits two identical create_work_item calls with the same title+reference_url, the dedup guard fires correctly — tool runs once, DB unique index on reference_url is never tested against the duplicate.",
+        "Inverse case: the DB has its own idempotency guard (idx_tasks_manual_active_ref_url partial unique index, and label case-insensitive pre-check). These guards exist precisely because the LLM might call create_work_item twice across separate TURNS. The dedup guard now handles the within-turn case.",
+        "Interaction risk: if two work items are created in the same turn with the SAME title but DIFFERENT reference_urls, the dedup key is different (args differ), both execute, and the DB label pre-check fires for the second one — returning a JSON error to the LLM. This is correct behavior, not a regression.",
+        "However: if the LLM emits [create_work_item(title=X, ref=Y), create_work_item(title=X, ref=Y)] — exactly identical — the dedup fires, only one DB row created, second gets cached 'Created.' response. LLM sees two successes but only one item exists. If the agent logic (e.g. a skill) then calls update_work_item_status on both 'created' items using the IDs from the responses, it will try to use the same ID twice — the second update will succeed (idempotent status transition) or fail depending on state. No data corruption, but the agent's mental model is wrong."
+      ],
+      "suggested_fix": "No code change required. Document in the warn! log that the LLM will receive 'success' for the duplicate with the same ID as the first execution. Skills that parse tool_result JSON to extract IDs should handle duplicate IDs in the same turn."
+    }
+  ],
+  "residual_risks": [
+    "The guard is strictly within one process_tool_calls invocation. A tool emitted in step N and again in step N+1 (across agent loop iterations) is not deduplicated. This is documented and intentional.",
+    "serde_json::Value never fails to serialize (all variants are representable as JSON), so the unwrap_or_default() fallback to empty string is unreachable in practice — but if it fires due to a future Value variant, two different-valued tools with unparseable args would share the key '' and the second would be incorrectly suppressed.",
+    "The executed HashMap is not bounded. An adversarial LLM emitting N distinct tool calls in one response accumulates N ToolOutput entries in memory. Each ToolOutput can hold up to MAX_PAYLOAD_BYTES (200 KB) of content. With 20 tool steps and no per-step cap on distinct tools, this is bounded by the tool step limit and existing tool output size caps — not a new risk introduced by this diff."
+  ],
+  "testing_gaps": [
+    "No eval test for [A, B, A] interleaved pattern — only back-to-back [A, A] is implied by the fix description.",
+    "No eval test for image-producing tools with duplicates verifying that budget accounting is correct.",
+    "No eval test for send_message dedup in silent mode (where the missing DB persist has observability consequences)."
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/agent-native.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/agent-native.json
@@ -1,0 +1,24 @@
+{
+  "review": "agent-native",
+  "issue": 582,
+  "branch": "feat/582/send-message-emitted-twice-in-same-turn-",
+  "base": "57417ab7abd7aba1778a636ed536ac23185c339b",
+  "verdict": "PASS",
+  "score": "no parity delta — engine-internal change only",
+  "summary": "The fix introduces a per-turn dedup HashMap inside process_tool_calls(). It adds Clone to ToolOutput, adds one warn! log, and adds a regression eval test. No user-facing actions were added. No agent tools were added, removed, or restricted. No system-prompt content was changed. The change is invisible above the tool-dispatch layer.",
+  "findings": {
+    "critical": [],
+    "warnings": [],
+    "observations": [
+      {
+        "id": "OBS-01",
+        "description": "The warn! log ('duplicate tool_use block suppressed') lands only in the structured log file. The dashboard has no warn-level anomaly surface. If provider-side duplication becomes frequent, operators have no automated alert path — they must grep logs. This is consistent with existing warn! usage in the codebase and is advisory only.",
+        "recommendation": "No action required now. If recurrence rate needs tracking, a counter in the llm_calls or a separate anomaly table could surface it in the dashboard Timeline view."
+      }
+    ]
+  },
+  "action_parity_delta": "none",
+  "context_parity_delta": "none",
+  "capability_removed": false,
+  "new_user_only_action": false
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/correctness.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/correctness.json
@@ -1,0 +1,50 @@
+{
+  "reviewer": "correctness",
+  "findings": [
+    {
+      "title": "Image bytes budget doubly consumed for deduplicated tool_use blocks with images",
+      "severity": "low",
+      "file": "crates/mika-agent/src/agent.rs",
+      "line": 1682,
+      "confidence": 0.85,
+      "autofix_class": "one-liner",
+      "owner": "agent-loop",
+      "requires_verification": false,
+      "pre_existing": false,
+      "why_it_matters": "When a tool that returns images is deduplicated, the cached ToolOutput is cloned and re-processed through the image_bytes_budget logic at line 1671-1713. The same image bytes are counted against the budget twice — once for the first (executing) occurrence and once for the duplicate (cached) occurrence. This can cause the second tool_result block (for the duplicate tool_use id) to have its images dropped with a '[skipped: step memory budget exceeded]' message appended, even when the budget was not actually exceeded by novel image data. The duplicate tool_result still satisfies the API contract (has content), but the LLM receives a degraded result for the second block and potentially a misleading budget-exceeded warning. In practice, the #582 regression involved send_message (no images), so this path is not exercised by the fix. The scenario requires: (a) a tool that returns images, (b) the LLM emitting it twice with identical arguments in one turn — an unusual combination.",
+      "evidence": [
+        "line 1579-1586: dedup hit returns cached.clone() — includes full images vec",
+        "line 1671-1713: image_bytes_budget is decremented for every image in output.images regardless of dedup path",
+        "line 1682: image_bytes_budget -= img_bytes — this runs for each image in the cloned output",
+        "const MAX_IMAGE_BYTES_PER_STEP: usize = 20 * 1024 * 1024 (line 53) — budget is per function call, shared across all tool results"
+      ],
+      "suggested_fix": "On the dedup path, either (a) pass empty images in the cloned output's tool_result (the LLM already has the image from the first result in context), or (b) skip the budget decrement for images when processing a cache hit. Option (a) is simplest: before the image_bytes_budget block, if the output came from the cache, replace output.images with an empty vec. This can be done by adding a boolean flag `is_cache_hit` or by zeroing images on the cached clone at line 1586."
+    }
+  ],
+  "residual_risks": [
+    {
+      "title": "JSON key-order sensitivity in dedup key may miss semantically equal arguments with different key ordering",
+      "description": "serde_json::to_string on a Value::Object produces keys in insertion order (IndexMap). Two LLM-generated argument objects that are semantically equal but have different key orderings will produce different dedup_key strings, causing the dedup guard to miss. This is a conservative false negative — the tool executes twice instead of once, reverting to pre-fix behavior for that case. Not a safety issue; acceptable.",
+      "confidence": 0.70
+    },
+    {
+      "title": "tools_called HashSet includes duplicate tool names from response.content before dedup",
+      "description": "At line 970-973, tools_called is populated from all ToolCall blocks in response.content, including duplicates. This is harmless because HashSet.insert is idempotent. The required-tools gate, completion-claim guard, and fabricated-action guard all function correctly. Not a bug.",
+      "confidence": 0.95
+    }
+  ],
+  "testing_gaps": [
+    {
+      "title": "No test for deduplicated tool with non-empty images — budget double-consumption path untested",
+      "description": "The regression test test_duplicate_tool_use_block_deduplicated uses send_message which returns no images. There is no test that covers a tool returning images being deduplicated, so the image budget double-consumption finding (finding #1) has no coverage."
+    },
+    {
+      "title": "No test verifying the second tool_result has content matching the first — API contract check for dedup path",
+      "description": "The test verifies DB row count == 1 but does not verify that the second tool_result block in the conversation history (for the duplicate tool_use id) actually contains the cached content. If the content were empty or wrong, the LLM would receive a malformed context. Adding an assertion on the final request.messages[last].content would close this gap."
+    },
+    {
+      "title": "No test for dedup with different argument key orderings — false negative path",
+      "description": "No test exercises the case where the same logical arguments arrive with different JSON key order, verifying the guard correctly does NOT fire (acceptable) and the tool executes twice."
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/maintainability.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/maintainability.json
@@ -1,0 +1,96 @@
+{
+  "reviewer": "maintainability",
+  "findings": [
+    {
+      "title": "Cache variable name `executed` does not communicate its role as a dedup cache",
+      "severity": "low",
+      "file": "crates/mika-agent/src/agent.rs",
+      "line": 1567,
+      "confidence": 0.70,
+      "autofix_class": "rename",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "Rename `executed` to `dedup_cache` (or `tool_output_cache`). The name `executed` reads as a past-tense predicate rather than a noun describing the cache's purpose. A future contributor landing on the `if let Some(cached) = executed.get(...)` branch must mentally re-map the name to its function; `dedup_cache` makes the intent legible at first read. Also rename the `dedup_key` binding at line 1575 to `cache_key` for consistency."
+    },
+    {
+      "title": "Image budget double-counted for deduplicated tool_use blocks that carry images",
+      "severity": "medium",
+      "file": "crates/mika-agent/src/agent.rs",
+      "line": 1671,
+      "confidence": 0.82,
+      "autofix_class": "logic-fix",
+      "owner": "author",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "The shared `image_bytes_budget` accounting block at lines 1671-1714 runs for BOTH the cache-hit (dedup) path and the miss (real execution) path. On a cache hit, `output` is a clone of the cached result including its `images` field. The budget decrement at line 1682 (`image_bytes_budget -= img_bytes`) will therefore consume budget a second time for the same image bytes. For the currently known issue (#582 with `send_message`), `images` is empty so this is latent. For any tool that returns images, a deduplicated block will incorrectly erode the per-step image budget. Fix: on the cache-hit path, pass an empty-images clone to the tool-result constructor (or skip image budget accounting), since the duplicate block adds no new visual data to the turn. Alternatively, gate image budget accounting on `!is_cache_hit` with a boolean tracked from the dedup branch."
+    },
+    {
+      "title": "`serde_json::to_string(arguments)` called twice on miss path — once for dedup key, once for DB record",
+      "severity": "low",
+      "file": "crates/mika-agent/src/agent.rs",
+      "line": 1619,
+      "confidence": 0.80,
+      "autofix_class": "dedup-expression",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "On the miss path, `serde_json::to_string(arguments).unwrap_or_default()` is called at line 1577 to build `dedup_key.1` and again at line 1619 to build `input_json` for `save_tool_call`. Extract the serialized string once (`let args_json = serde_json::to_string(arguments).unwrap_or_default();`) before the `if let Some(cached)` branch, reuse it as the second tuple element in `dedup_key`, and assign it to `input_json` on the miss path. This also removes the minor inconsistency where `input_summary` at line 1589 calls `arguments.to_string()` (which may differ from `serde_json::to_string`) while the DB record uses the `serde_json` variant."
+    },
+    {
+      "title": "Miss path nests three levels deep; `execute_and_record` helper would reduce cognitive load",
+      "severity": "low",
+      "file": "crates/mika-agent/src/agent.rs",
+      "line": 1587,
+      "confidence": 0.62,
+      "autofix_class": "extract-helper",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "The miss branch of the dedup `if/else` is ~80 lines nested inside `for block` → `if let LlmResponseContent::ToolCall` → `else`. This is the deepest structural nesting in the function. An `execute_and_record_tool_call(...)` async helper that takes `(name, arguments, dispatch_ctx, db, ...)` and returns `ToolOutput` would flatten the outer loop to ~20 lines and isolate the DB-recording logic. This is directional — the plan noted it as preferred but optional. The current inlined form is readable today but will become harder to modify if the DB-recording path grows (e.g., adding retry-count tracking, prompt-variant tagging). Flag for the next significant touch of `process_tool_calls`."
+    },
+    {
+      "title": "CLAUDE.md dedup guard paragraph not cross-referenced from the guard list in Post-Conditions section",
+      "severity": "low",
+      "file": "crates/mika-agent/CLAUDE.md",
+      "line": 14,
+      "confidence": 0.65,
+      "autofix_class": "doc-edit",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "The new paragraph is placed correctly — directly after the multi-modal tool result description and before the Post-Conditions section heading. However, the Post-Conditions section enumerates four numbered guards (text-based tool call detection, required-tools gate, completion-claim guard, fabricated action-claim guard). The dedup guard is a fifth guard on the _input_ side of the loop, not on EndTurn, so it correctly does not belong in that numbered list. However, no cross-reference links the two sections for a reader scanning the guard list. Adding a brief parenthetical — '(for a per-turn guard on the dispatch side, see the dedup guard note above)' — to the Post-Conditions header would help future contributors locate related code. The log key `\"duplicate tool_use block suppressed\"` is already mentioned in the paragraph, which is correct."
+    }
+  ],
+  "residual_risks": [
+    {
+      "description": "Canonical-JSON key reordering: if a future provider emits arguments with shuffled key order between two logically identical tool_use blocks, string comparison will fail open (both blocks execute). The plan acknowledges this and intentionally fails open over false-positive dedup. The risk is that the guard provides no protection for such providers. Observable via warn! logs being absent while the issue reoccurs.",
+      "severity": "low",
+      "likelihood": "low"
+    },
+    {
+      "description": "Image budget double-count (detailed in finding #2) is latent today because the known trigger tool (send_message) returns no images. If a future tool that returns images (e.g., browser-control screenshot tools) is deduplicated, the budget could be exhausted in a single turn leaving remaining legitimate tool results image-stripped without any warning connecting the cause to the dedup.",
+      "severity": "medium",
+      "likelihood": "low"
+    },
+    {
+      "description": "The dedup cache is scoped to `process_tool_calls` (one LLM response), not to a step. If `process_tool_calls` were ever called more than once per step (currently it is not), duplicates across those calls would not be caught. No structural protection prevents this; it relies on the single call-site in `run_loop`. If the call site is refactored, the guard's scope contract becomes implicit.",
+      "severity": "low",
+      "likelihood": "very-low"
+    }
+  ],
+  "testing_gaps": [
+    {
+      "description": "No test covers a cache-hit path where the cached ToolOutput contains non-empty `images`. This would expose the image-budget double-count risk identified in finding #2. The existing test uses `send_message` which has empty images.",
+      "suggested_test": "Add a test variant that mocks a tool returning an ImageData payload, feeds two identical tool_use blocks, and asserts that `image_bytes_budget` is decremented only once (i.e., the duplicate block does not consume additional budget)."
+    },
+    {
+      "description": "No test asserts the warn! log fires on a dedup hit. The regression test only checks `calls_for_tool().len() == 1`. A log-capture assertion (using `tracing-test` or similar) would lock in the observability contract so a future refactor that removes the warn! is caught.",
+      "suggested_test": "Use `tracing_test::traced_test` or a `tracing::subscriber::with_default` fixture to capture log events; assert that a record with message containing `\"duplicate tool_use block suppressed\"` and field `tool = \"send_message\"` is emitted exactly once."
+    },
+    {
+      "description": "No test exercises two tool_use blocks with the same name but different arguments to confirm they are NOT deduplicated (regression guard for the happy-path non-dedup case with same tool name).",
+      "suggested_test": "Feed `multi_tool_response(vec![(\"send_message\", json!({\"text\": \"a\"})), (\"send_message\", json!({\"text\": \"b\"}))])` and assert `calls_for_tool(\"send_message\").len() == 2`."
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/project-standards.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/project-standards.json
@@ -1,0 +1,18 @@
+{
+  "reviewer": "project-standards",
+  "findings": [],
+  "residual_risks": [
+    {
+      "id": "RR-PS-001",
+      "description": "The image_bytes_budget is consumed by the *first* execution of a duplicated tool_use block (images included in `output.images`). When the cached ToolOutput is cloned for duplicate blocks, `output.images` is a full clone and re-traverses the budget loop, potentially over-counting image bytes against the budget. This is an edge-case interaction (only affects turns where a tool with image output is duplicated) not covered by the dedup regression test.",
+      "severity": "low"
+    }
+  ],
+  "testing_gaps": [
+    {
+      "id": "TG-PS-001",
+      "description": "The plan doc (Unit 1, Test scenarios) calls for a unit test of `ToolOutput::clone()` round-tripping `content`, `is_error`, and `images` byte-for-byte (\"Small sanity test for the new derive\"). No such unit test was added — `#[cfg(test)] mod tests` in `tools/mod.rs` is not present in the diff. The testing convention in CLAUDE.md requires inline module tests for each module where test logic lives.",
+      "file": "crates/mika-agent/src/tools/mod.rs"
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/reliability.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/reliability.json
@@ -1,0 +1,72 @@
+{
+  "reviewer": "reliability",
+  "findings": [
+    {
+      "id": "REL-001",
+      "severity": "medium",
+      "confidence": 0.85,
+      "title": "Cached error output re-used for duplicate tool_use blocks without surfacing is_error to caller",
+      "description": "When execute_tool returns is_error=true for the first occurrence and the result is cached, the duplicate tool_use block receives a cloned ToolOutput with is_error=true. This is correct behavior — the LlmContentBlock::ToolResult at line 1718 faithfully propagates is_error from the clone. However, the ToolCallSummary (step, name, success, non_zero_exit) is only emitted for the first execution inside the else branch (line 1658–1665). The duplicate hit path (the warn! branch) does NOT push a ToolCallSummary. From the agent loop's perspective, tool_call_summaries for that step will have N-1 entries for N identical tool_use blocks. If downstream logic (required_tools gate, completion-claim guard, fabricated-action guard) counts tool call attempts by consulting summaries rather than tool_results, a duplicate of a required tool will appear to have been called only once in the summaries but twice in the tool_results history. In practice the guards use `tools_called` (a HashSet populated before process_tool_calls at lines 970–974 from response.content directly), so this does not cause a guard bypass. But the mismatch between summaries count and tool_results count is a latent observability inconsistency.",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/src/agent.rs",
+      "lines": "1579-1669",
+      "evidence": "The warn! (dedup-hit) branch exits after `cached.clone()` at line 1586 with no summaries.push(). The summaries.push() is inside the else (dedup-miss) branch at line 1658. The ToolCallSummary vector is used for persistence in messages.metadata and for all_tool_summaries aggregation across steps.",
+      "recommendation": "Consider emitting a ToolCallSummary for the dedup-hit path (with a marker like `success: cached_output.is_error == false`, possibly a `deduplicated: true` flag). At minimum, document the intentional asymmetry in a comment so future readers don't assume summaries.len() == tool_results.len()."
+    },
+    {
+      "id": "REL-002",
+      "severity": "low",
+      "confidence": 0.80,
+      "title": "Image budget double-debited when duplicate tool_use blocks return images",
+      "description": "When a cached ToolOutput contains images (exec handler or MCP tool returning success_with_images), both the first execution and each duplicate hit consume from `image_bytes_budget`. The first execution debits the budget during its tool_result construction (lines 1678–1683). The cloned ToolOutput handed to the duplicate path carries the same Vec<ImageData>, which also runs through the same budget-debit loop. In practice the duplicate always loses the budget race: the budget is already reduced by the first run, so images in the duplicate tool_result are dropped with a 'budget exceeded' text block. The LLM receives asymmetric tool_results: first call has images, second call says images were skipped. This is misleading rather than incorrect — the LLM action was already suppressed by dedup — but it produces a confusing assistant message history.",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/src/agent.rs",
+      "lines": "1671-1714",
+      "evidence": "image_bytes_budget is a single u64 counter initialized once per process_tool_calls() call. Both the first and duplicate tool_result constructions loop over output.images and debit image_bytes_budget -= img_bytes. Image-returning tools: skills/executor.rs:448, mcp/mod.rs:419.",
+      "recommendation": "For duplicate-hit tool_results that contain images: either strip images from the cloned output before budget processing, or set `content = LlmToolResultContent::Text(cached_output.content)` unconditionally for the dedup path (since the LLM already has the image in the first result for the same tool_call_id pairing). This is a low-priority fix since send_message — the triggering tool — returns no images."
+    },
+    {
+      "id": "REL-003",
+      "severity": "info",
+      "confidence": 0.75,
+      "title": "No observability counter for dedup firing rate — missing operator signal for provider health",
+      "description": "When dedup fires, a warn! log is emitted with trace_id, tool, and step. There is no metric counter or structured audit event. In production, dedup firing on send_message is a signal that the upstream LLM provider is exhibiting buggy behavior (emitting duplicate tool_use blocks). An operator currently has no way to query 'how many turns in the last 24h had a dedup suppression?' without grepping structured logs. A counter or a dedicated audit event would let operators detect provider degradation before it causes user-visible duplicate messages.",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/src/agent.rs",
+      "lines": "1580-1585",
+      "evidence": "warn!(trace_id = %tool_ctx.trace_id, tool = %name, step, \"duplicate tool_use block suppressed; reusing prior result\") — log only, no counter, no audit_events row.",
+      "recommendation": "Advisory P3. If tool_call telemetry is important for provider health monitoring, consider persisting a dedicated 'tool_use_dedup' audit event or incrementing a per-agent counter. The existing warn! is sufficient for individual incident investigation but not for trend detection."
+    }
+  ],
+  "residual_risks": [
+    {
+      "id": "RR-001",
+      "title": "send_message persists to DB before gateway delivery; dedup prevents double-DB-write for duplicate blocks",
+      "description": "The dedup cache correctly prevents a second invocation of send_message.execute(), which would have called db.save_message() and sender.send() a second time. The gateway /send endpoint has no content-based dedup — it carries a request_id but handle_send() does not deduplicate on request_id. The engine-side dedup in process_tool_calls() is therefore the sole defense against duplicate Telegram message delivery within a single turn. No gateway-side gap was found for this specific scenario.",
+      "residual_exposure": "None for within-turn duplicates. Cross-turn or cross-restart duplicates remain unaffected (by design — the dedup scope is explicitly per-function-call)."
+    },
+    {
+      "id": "RR-002",
+      "title": "Long-running tool dedup: dispatch_count prevents second real dispatch; cached ToolOutput echoes 'task started' text",
+      "description": "If the LLM emits duplicate tool_use blocks for a long_running: true skill tool, the dedup cache suppresses the second execute_tool() call entirely. The second block receives a cloned ToolOutput containing the 'Task submitted (long-running). ID: <task_id>' success message. Only one callback task is created (by the first execution). The dispatch_count AtomicU32 is incremented by the first execution inside execute_long_running() at line 842. The second execute_skill_tool() call is never made, so dispatch_count stays at 1. The dedup check at line 730 (dispatch_count > 0) is never reached for the duplicate. This is the correct behavior: one task, two matching tool_results. No reliability gap.",
+      "residual_exposure": "None. The dedup cache is an outer guard that fires before execute_tool(); the dispatch_count guard is an inner guard inside execute_long_running(). Both are independently correct."
+    },
+    {
+      "id": "RR-003",
+      "title": "serde_json key ordering in dedup key is stable",
+      "description": "The dedup key uses serde_json::to_string(arguments) where arguments is serde_json::Value. The workspace Cargo.toml uses serde_json = \"1\" without preserve_order feature, which means Map<String, Value> uses BTreeMap (sorted keys). JSON serialization is therefore deterministic regardless of the order in which the provider sent object keys. Two structurally identical argument objects will produce the same dedup key string.",
+      "residual_exposure": "None."
+    }
+  ],
+  "testing_gaps": [
+    {
+      "id": "TG-001",
+      "title": "No eval test for dedup-hit with is_error=true cached output",
+      "description": "The new test in tests/eval/test_tool_calling.rs covers the happy path (successful dedup suppression). There is no test verifying that when the first tool execution returns is_error=true, the duplicate tool_result also carries is_error=true. The LlmContentBlock::ToolResult construction at line 1718 uses output.is_error from the clone, which is correct, but it is untested.",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs"
+    },
+    {
+      "id": "TG-002",
+      "title": "No test verifying ToolCallSummary count asymmetry for dedup hits",
+      "description": "The eval harness could assert that all_tool_summaries contains exactly 1 entry (not 2) when 2 identical tool_use blocks are emitted. The existing test may implicitly cover this but the assertion is not documented. If a future refactor moves summaries.push() outside the else branch, the behavior changes silently.",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs"
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-review/20260417-004709-582/testing.json
+++ b/.context/compound-engineering/ce-review/20260417-004709-582/testing.json
@@ -1,0 +1,101 @@
+{
+  "reviewer": "testing",
+  "findings": [
+    {
+      "title": "No assertion that exactly two tool_result blocks are forwarded to the LLM in the follow-up request",
+      "severity": "medium",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "line": 56,
+      "confidence": 0.85,
+      "autofix_class": "test_addition",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "After the run, inspect trace.captured_requests[1] (the second LLM call) and count LlmContentBlock::ToolResult variants. Assert exactly 2 ToolResult blocks are present — one per original tool_use id. This is the core API-pairing contract: the LLM must receive a result for every tool_use id it emitted, even when deduped. The harness already exposes captured_requests on AgentTrace, so no new infrastructure is needed. Example: let tool_results: Vec<_> = trace.captured_requests[1].messages.iter().flat_map(...).filter(|b| matches!(b, LlmContentBlock::ToolResult {..})).collect(); assert_eq!(tool_results.len(), 2);"
+    },
+    {
+      "title": "No test for same-tool-different-args producing two DB rows (no-false-dedup guard)",
+      "severity": "low",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "line": 30,
+      "confidence": 0.80,
+      "autofix_class": "test_addition",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "test_multiple_parallel_tool_calls uses search_memory with different args and asserts >= 2 rows — this is close but the >= bound doesn't fail if the dedup guard incorrectly fires on same-name-different-args. Add a dedicated test: two send_message calls with different text values, assert calls_for_tool(\"send_message\").len() == 2. This pins the dedup key to (name, args) rather than (name) alone, which is the actual implementation contract."
+    },
+    {
+      "title": "No test for 3+ identical tool_use blocks in a single turn",
+      "severity": "low",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "line": 56,
+      "confidence": 0.75,
+      "autofix_class": "test_addition",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "The fix uses a HashMap cache that correctly handles N duplicates, but no test exercises N > 2. Add a variant with three identical blocks. Assert calls_for_tool(\"send_message\").len() == 1 and (once the tool_result pairing assertion is added) 3 ToolResult blocks in the follow-up request."
+    },
+    {
+      "title": "No test for duplicate tool_use blocks where the tool errors (is_error: true path cloned back)",
+      "severity": "low",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "line": 56,
+      "confidence": 0.72,
+      "autofix_class": "test_addition",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "When the first execution of a duplicated tool returns is_error:true, the cached ToolOutput (with is_error:true) is cloned back for the duplicate id. No test verifies that the error flag is faithfully propagated to both ToolResult blocks in the follow-up request. A test using a tool that always errors (or a custom ToolRegistry with a failing tool) and two identical blocks would cover this path."
+    },
+    {
+      "title": "ToolCallSummary emission count for duplicate blocks not asserted",
+      "severity": "info",
+      "file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "line": 78,
+      "confidence": 0.80,
+      "autofix_class": "test_addition",
+      "owner": "author",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "The plan calls out ToolCallSummary emission as part of the contract (one summary, not two). ToolCallSummary is persisted in messages.metadata JSON. The test does not assert the metadata on the step-2 message contains exactly one send_message summary entry. This is lower priority since the DB row count is the primary observable, but the metadata contract is still externally visible (cross-turn introspection tools rely on it)."
+    }
+  ],
+  "residual_risks": [
+    {
+      "description": "The test uses send_message which, in the harness, has message_sender: None. The tool writes to DB and returns success regardless. In production, send_message also dispatches to a GatewayMessageSender. The dedup guard fires before execute_tool(), so the side-effect suppression path is correctly exercised. However, the test cannot verify that no outbound message was sent twice — it only verifies the DB row count. In production, a provider emitting two identical send_message blocks would attempt one outbound delivery (correct), not two. This risk is low because the dedup guard is at the process_tool_calls layer, upstream of MessageSender.",
+      "severity": "low"
+    },
+    {
+      "description": "The dedup key is (name, serde_json::to_string(arguments)). Key stability depends on serde_json serializing identical JSON objects with identical byte sequences. For Value::Object, serde_json preserves insertion order, so two Value::Object constructed from the same json!() macro call will be equal. But providers that return semantically equivalent JSON objects with different key orderings would not be deduped. The test only exercises the exact same json!() args, so key-ordering divergence is untested. This is a known design limitation (documented as defending against provider-side duplication where the LLM emits byte-for-byte identical blocks).",
+      "severity": "low"
+    }
+  ],
+  "testing_gaps": [
+    {
+      "gap": "tool_result pairing: no assertion that the second LLM request contains 2 ToolResult blocks (one per original tool_use id)",
+      "importance": "high",
+      "test_file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "infrastructure_needed": "none — trace.captured_requests is already available on AgentTrace"
+    },
+    {
+      "gap": "no-false-dedup: no test that same-tool-different-args still produces 2 DB rows",
+      "importance": "medium",
+      "test_file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "infrastructure_needed": "none"
+    },
+    {
+      "gap": "3+ identical blocks in a single turn",
+      "importance": "low",
+      "test_file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "infrastructure_needed": "none"
+    },
+    {
+      "gap": "duplicate blocks where first execution errors — is_error flag propagated to both ToolResult blocks",
+      "importance": "low",
+      "test_file": "/data/workspace/mika-platform/.claude/worktrees/feat-582-send-message-emitted-twice-in-same-turn-/mika/crates/mika-agent/tests/eval/test_tool_calling.rs",
+      "infrastructure_needed": "custom ToolRegistry with a tool that always returns ToolOutput::error()"
+    }
+  ]
+}

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -12,6 +12,8 @@ Tool call summaries (name, truncated input/output, success, non_zero_exit) persi
 
 Compaction includes tool names in summarization. Multi-modal tool results: `ToolOutput` carries optional `images: Vec<ImageData>` (base64-encoded), converted to multi-block `tool_result` content arrays for the Claude API. Prior-turn images are stripped before each API call to prevent unbounded memory growth.
 
+**Per-turn tool_use dedup guard (#582):** `process_tool_calls()` deduplicates identical `(tool_name, arguments)` pairs emitted inside a single LLM response. The underlying tool runs once, the `tool_calls` DB row is saved once, one `ToolCallSummary` is emitted, and duplicate tool_use ids receive a `tool_result` built from the cached `ToolOutput` so the conversation/API history stays paired. Defends against provider-side duplication (observed with non-Anthropic providers). Logs `warn!` with `trace_id`, `tool`, and `step` when it fires.
+
 ### Post-Conditions (EndTurn Chain)
 
 Four sequential post-conditions on assistant text responses:

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -12,7 +12,7 @@ Tool call summaries (name, truncated input/output, success, non_zero_exit) persi
 
 Compaction includes tool names in summarization. Multi-modal tool results: `ToolOutput` carries optional `images: Vec<ImageData>` (base64-encoded), converted to multi-block `tool_result` content arrays for the Claude API. Prior-turn images are stripped before each API call to prevent unbounded memory growth.
 
-**Per-turn tool_use dedup guard (#582):** `process_tool_calls()` deduplicates identical `(tool_name, arguments)` pairs emitted inside a single LLM response. The underlying tool runs once, the `tool_calls` DB row is saved once, one `ToolCallSummary` is emitted, and duplicate tool_use ids receive a `tool_result` built from the cached `ToolOutput` so the conversation/API history stays paired. Defends against provider-side duplication (observed with non-Anthropic providers). Logs `warn!` with `trace_id`, `tool`, and `step` when it fires.
+**Per-turn tool_use dedup guard (#582):** `process_tool_calls()` deduplicates identical `(tool_name, arguments)` pairs emitted inside a single LLM response. The underlying tool runs once, the `tool_calls` DB row is saved once, one `ToolCallSummary` is emitted, and duplicate tool_use ids receive a `tool_result` built from the cached `ToolOutput` so the conversation/API history stays paired. Images on the cached result are stripped before reuse so the duplicate does not re-consume the shared `image_bytes_budget` (the LLM already received the images on the first duplicate's `tool_result`). Defends against provider-side duplication (observed with non-Anthropic providers). Logs `warn!` with `trace_id`, `tool`, `step`, and `cached_was_error` when it fires.
 
 ### Post-Conditions (EndTurn Chain)
 

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1559,6 +1559,12 @@ async fn process_tool_calls(
     let mut tool_results: Vec<LlmContentBlock> = Vec::new();
     let mut summaries = Vec::new();
     let mut image_bytes_budget = MAX_IMAGE_BYTES_PER_STEP;
+    // Per-turn dedup: if the LLM emits two tool_use blocks with identical
+    // (name, arguments) in a single response, execute the tool once and reuse
+    // the cached output for subsequent blocks. This defends the engine against
+    // provider-side tool_use duplication (see #582). Scope is strictly this
+    // function call — duplicates across steps or turns are unaffected.
+    let mut executed: HashMap<(String, String), ToolOutput> = HashMap::new();
     for block in &response_content {
         if let LlmResponseContent::ToolCall {
             id,
@@ -1566,85 +1572,103 @@ async fn process_tool_calls(
             arguments,
         } = block
         {
-            debug!(tool = %name, "executing tool");
-            let input_summary = truncate_summary(&arguments.to_string(), INPUT_SUMMARY_MAX);
-            let dispatch = ToolDispatchCtx {
-                tools,
-                skill_tools,
-                ctx: tool_ctx,
-                skill_timeout,
-                mcp_manager,
-                long_running_ctx,
-            };
-            let tool_start = std::time::Instant::now();
-            let output = execute_tool(&dispatch, name, arguments.clone()).await;
-            let tool_latency_ms = tool_start.elapsed().as_millis() as u64;
+            let dedup_key = (
+                name.clone(),
+                serde_json::to_string(arguments).unwrap_or_default(),
+            );
+            let output = if let Some(cached) = executed.get(&dedup_key) {
+                warn!(
+                    trace_id = %tool_ctx.trace_id,
+                    tool = %name,
+                    step,
+                    "duplicate tool_use block suppressed; reusing prior result"
+                );
+                cached.clone()
+            } else {
+                debug!(tool = %name, "executing tool");
+                let input_summary = truncate_summary(&arguments.to_string(), INPUT_SUMMARY_MAX);
+                let dispatch = ToolDispatchCtx {
+                    tools,
+                    skill_tools,
+                    ctx: tool_ctx,
+                    skill_timeout,
+                    mcp_manager,
+                    long_running_ctx,
+                };
+                let tool_start = std::time::Instant::now();
+                let output = execute_tool(&dispatch, name, arguments.clone()).await;
+                let tool_latency_ms = tool_start.elapsed().as_millis() as u64;
 
-            // Record full tool call in database
-            if store_tool_calls {
-                let tool_id = uuid::Uuid::new_v4().to_string();
-                let (tool_source, tool_skill_name) = if tools.get(name).is_some() {
-                    ("builtin", None)
-                } else if let Some(st) = skill_tools.get(name.as_str()) {
-                    let sn = st
-                        .skill_dir
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or("unknown")
-                        .to_string();
-                    ("skill", Some(sn))
-                } else {
-                    ("mcp", None)
-                };
-                let non_zero = !output.is_error && has_non_zero_exit_prefix(&output.content);
-                let input_json = serde_json::to_string(arguments).unwrap_or_default();
-                let err_msg = if output.is_error {
-                    Some(output.content.as_str())
-                } else {
-                    None
-                };
-                if let Err(e) = db
-                    .save_tool_call(
-                        &tool_id,
-                        session_id,
-                        Some(tool_ctx.trace_id),
-                        llm_call_id,
-                        step,
-                        name,
-                        tool_source,
-                        tool_skill_name.as_deref(),
-                        Some(&input_json),
-                        Some(&output.content),
-                        !output.is_error && !non_zero,
-                        non_zero,
-                        tool_latency_ms,
-                        err_msg,
-                    )
-                    .await
-                {
-                    warn!(tool = %name, error = %e, "failed to save tool_call record");
+                // Record full tool call in database
+                if store_tool_calls {
+                    let tool_id = uuid::Uuid::new_v4().to_string();
+                    let (tool_source, tool_skill_name) = if tools.get(name).is_some() {
+                        ("builtin", None)
+                    } else if let Some(st) = skill_tools.get(name.as_str()) {
+                        let sn = st
+                            .skill_dir
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        ("skill", Some(sn))
+                    } else {
+                        ("mcp", None)
+                    };
+                    let non_zero = !output.is_error && has_non_zero_exit_prefix(&output.content);
+                    let input_json = serde_json::to_string(arguments).unwrap_or_default();
+                    let err_msg = if output.is_error {
+                        Some(output.content.as_str())
+                    } else {
+                        None
+                    };
+                    if let Err(e) = db
+                        .save_tool_call(
+                            &tool_id,
+                            session_id,
+                            Some(tool_ctx.trace_id),
+                            llm_call_id,
+                            step,
+                            name,
+                            tool_source,
+                            tool_skill_name.as_deref(),
+                            Some(&input_json),
+                            Some(&output.content),
+                            !output.is_error && !non_zero,
+                            non_zero,
+                            tool_latency_ms,
+                            err_msg,
+                        )
+                        .await
+                    {
+                        warn!(tool = %name, error = %e, "failed to save tool_call record");
+                    }
                 }
-            }
+
+                let image_count = output.images.len();
+                let output_summary = if image_count > 0 {
+                    truncate_summary(
+                        &format!("{} [+{image_count} image(s)]", output.content),
+                        OUTPUT_SUMMARY_MAX,
+                    )
+                } else {
+                    truncate_summary(&output.content, OUTPUT_SUMMARY_MAX)
+                };
+                let non_zero_exit = !output.is_error && has_non_zero_exit_prefix(&output.content);
+                summaries.push(ToolCallSummary {
+                    step,
+                    name: name.clone(),
+                    input_summary,
+                    output_summary,
+                    success: !output.is_error && !non_zero_exit,
+                    non_zero_exit,
+                });
+
+                executed.insert(dedup_key, output.clone());
+                output
+            };
 
             let image_count = output.images.len();
-            let output_summary = if image_count > 0 {
-                truncate_summary(
-                    &format!("{} [+{image_count} image(s)]", output.content),
-                    OUTPUT_SUMMARY_MAX,
-                )
-            } else {
-                truncate_summary(&output.content, OUTPUT_SUMMARY_MAX)
-            };
-            let non_zero_exit = !output.is_error && has_non_zero_exit_prefix(&output.content);
-            summaries.push(ToolCallSummary {
-                step,
-                name: name.clone(),
-                input_summary,
-                output_summary,
-                success: !output.is_error && !non_zero_exit,
-                non_zero_exit,
-            });
-
             let content = if output.images.is_empty() {
                 LlmToolResultContent::Text(output.content)
             } else {

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1564,7 +1564,7 @@ async fn process_tool_calls(
     // the cached output for subsequent blocks. This defends the engine against
     // provider-side tool_use duplication (see #582). Scope is strictly this
     // function call — duplicates across steps or turns are unaffected.
-    let mut executed: HashMap<(String, String), ToolOutput> = HashMap::new();
+    let mut dedup_cache: HashMap<(String, String), ToolOutput> = HashMap::new();
     for block in &response_content {
         if let LlmResponseContent::ToolCall {
             id,
@@ -1576,14 +1576,23 @@ async fn process_tool_calls(
                 name.clone(),
                 serde_json::to_string(arguments).unwrap_or_default(),
             );
-            let output = if let Some(cached) = executed.get(&dedup_key) {
+            let output = if let Some(cached) = dedup_cache.get(&dedup_key) {
                 warn!(
                     trace_id = %tool_ctx.trace_id,
                     tool = %name,
                     step,
+                    cached_was_error = cached.is_error,
                     "duplicate tool_use block suppressed; reusing prior result"
                 );
-                cached.clone()
+                // Clone the cached result but strip images: the LLM already
+                // received them in the tool_result paired with the first
+                // duplicate's id, so re-emitting them would both waste the
+                // shared `image_bytes_budget` and send redundant bytes on
+                // the API request. Text content is preserved so the
+                // duplicate tool_use id still gets a meaningful pair.
+                let mut reused = cached.clone();
+                reused.images.clear();
+                reused
             } else {
                 debug!(tool = %name, "executing tool");
                 let input_summary = truncate_summary(&arguments.to_string(), INPUT_SUMMARY_MAX);
@@ -1664,7 +1673,7 @@ async fn process_tool_calls(
                     non_zero_exit,
                 });
 
-                executed.insert(dedup_key, output.clone());
+                dedup_cache.insert(dedup_key, output.clone());
                 output
             };
 

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -137,7 +137,7 @@ pub struct ImageData {
 }
 
 /// Result of a tool execution.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ToolOutput {
     pub content: String,
     pub is_error: bool,

--- a/crates/mika-agent/tests/eval/test_tool_calling.rs
+++ b/crates/mika-agent/tests/eval/test_tool_calling.rs
@@ -1,6 +1,7 @@
 //! Integration tests: tool calling scenarios.
 
 use mika_common::llm::mock::*;
+use mika_common::llm::{LlmContent, LlmContentBlock, LlmRole};
 use serde_json::json;
 
 use super::assertions::*;
@@ -83,6 +84,91 @@ async fn test_duplicate_tool_use_block_deduplicated() {
         "Expected exactly 1 send_message call, got {}: {:?}",
         send_calls.len(),
         send_calls.iter().map(|c| &c.input).collect::<Vec<_>>()
+    );
+
+    // API contract: every tool_use id the LLM emitted must have a matching
+    // tool_result block in the follow-up request, otherwise providers (notably
+    // Anthropic) reject the conversation. Count tool_result blocks in the
+    // second captured request (the one that carries the first turn's results).
+    let second_request = trace
+        .captured_requests
+        .get(1)
+        .expect("expected a follow-up LLM request after tool execution");
+    let tool_result_count: usize = second_request
+        .messages
+        .iter()
+        .filter(|m| m.role == LlmRole::Tool)
+        .map(|m| match &m.content {
+            LlmContent::Blocks(blocks) => blocks
+                .iter()
+                .filter(|b| matches!(b, LlmContentBlock::ToolResult { .. }))
+                .count(),
+            _ => 0,
+        })
+        .sum();
+    assert_eq!(
+        tool_result_count, 2,
+        "Both tool_use ids (original + duplicate) must receive a tool_result to satisfy the API contract, got {tool_result_count}"
+    );
+}
+
+#[tokio::test]
+async fn test_same_tool_different_args_not_deduplicated() {
+    // Guard against a regression where the dedup key drops the `arguments`
+    // component and keys only on tool name. Two `send_message` calls with
+    // different text must produce two tool_calls rows — they are legitimately
+    // distinct invocations, not a provider artifact.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            multi_tool_response(vec![
+                ("send_message", json!({"text": "sprint started"})),
+                ("send_message", json!({"text": "sprint ended"})),
+            ]),
+            text_response("Sent both updates."),
+        ])
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("send both updates").await.unwrap();
+
+    assert_has_output(&trace);
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        2,
+        "Same tool with different args must not be deduplicated, got {} calls: {:?}",
+        send_calls.len(),
+        send_calls.iter().map(|c| &c.input).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_three_identical_tool_use_blocks_deduplicated() {
+    // The dedup cache must collapse any N >= 2 identical blocks in a single
+    // turn to exactly one execution. Exercises the cache-hit path twice.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            multi_tool_response(vec![
+                ("send_message", json!({"text": "ping"})),
+                ("send_message", json!({"text": "ping"})),
+                ("send_message", json!({"text": "ping"})),
+            ]),
+            text_response("Pinged."),
+        ])
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("ping").await.unwrap();
+
+    assert_has_output(&trace);
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        1,
+        "Three identical blocks must still collapse to one tool_calls row, got {}",
+        send_calls.len()
     );
 }
 

--- a/crates/mika-agent/tests/eval/test_tool_calling.rs
+++ b/crates/mika-agent/tests/eval/test_tool_calling.rs
@@ -53,6 +53,40 @@ async fn test_multiple_parallel_tool_calls() {
 }
 
 #[tokio::test]
+async fn test_duplicate_tool_use_block_deduplicated() {
+    // Regression test for #582: when the LLM emits two tool_use blocks with
+    // identical (name, arguments) in a single response, the agent must
+    // execute the underlying tool only once and persist only one tool_calls
+    // row. The duplicate block still receives a tool_result (so the API
+    // contract holds), but it reuses the cached output rather than
+    // re-running the tool.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            multi_tool_response(vec![
+                ("send_message", json!({"text": "sprint started"})),
+                ("send_message", json!({"text": "sprint started"})),
+            ]),
+            text_response("Sprint kicked off."),
+        ])
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("start the sprint").await.unwrap();
+
+    assert_has_output(&trace);
+    // Two identical blocks should collapse to a single tool_calls row.
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        1,
+        "Expected exactly 1 send_message call, got {}: {:?}",
+        send_calls.len(),
+        send_calls.iter().map(|c| &c.input).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
 async fn test_tool_call_with_store_fact() {
     let harness = EvalHarness::builder()
         .responses(vec![

--- a/docs/plans/2026-04-17-001-fix-duplicate-tool-use-block-dedup-plan.md
+++ b/docs/plans/2026-04-17-001-fix-duplicate-tool-use-block-dedup-plan.md
@@ -1,0 +1,196 @@
+---
+title: "fix: Deduplicate identical tool_use blocks within a single agent turn"
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Deduplicate identical tool_use blocks within a single agent turn
+
+## Overview
+
+Guard the agent loop against LLM responses that contain two or more `tool_use` content blocks with an identical `(tool_name, arguments)` pair inside the same turn. Execute the tool once, cache the `ToolOutput`, reuse it for every duplicate block, and persist only one `tool_calls` row / one `ToolCallSummary` per unique call.
+
+## Problem Frame
+
+Issue #582: trace `d71cb2c2c4c54acb8b63ea15115c9900` recorded two `tool_calls` rows for `send_message` at the same second with byte-identical `input`. Research confirms the agent loop processes each `LlmResponseContent::ToolCall` block in order with no dedup (`crates/mika-agent/src/agent.rs:1562`). A duplicate block therefore runs the tool twice, saves two DB rows, and — once delivery is restored — will produce two outbound notifications. Duplicate emission is most likely an LLM-side artifact (the assistant message contains two `tool_use` entries); the dispatch path runs each block exactly once. The engine must defend itself regardless of which provider caused it.
+
+Grounding: the duplicate occurred in a kimi-k2.5 session. `mika-common` supports 11 providers, and recovery paths like `extract_xml_tool_calls` already cope with provider quirks — a per-turn dedup guard fits that pattern.
+
+## Requirements Trace
+
+- R1. Identical tool_use blocks within a single agent turn execute the underlying tool at most once.
+- R2. Only one row is written to `tool_calls` per unique `(tool_name, arguments)` pair per turn, regardless of how many duplicate blocks the LLM emitted.
+- R3. The assistant conversation history remains internally consistent: every tool_use id in the assistant message has a matching `tool_result` block in the same turn (API contract for all providers).
+- R4. Duplicate suppression is logged with `trace_id`, `tool_name`, and `step` for observability.
+- R5. Regression test feeds a response containing two identical tool_use blocks and asserts only one underlying call runs.
+
+## Scope Boundaries
+
+- No changes to LLM providers, prompt assembly, or retry policy.
+- No new config flag — dedup is always on (false positives are negligible; LLMs do not intentionally emit byte-identical tool_use blocks in a single turn).
+- No cross-turn dedup (each turn starts with a fresh state).
+- No cross-step dedup (step boundary = separate LLM response, legitimate to repeat a tool).
+- No changes to `send_message` tool behavior itself — the fix is at the loop layer.
+- No schema migration (dedup happens before `save_tool_call`; we simply skip the extra row).
+
+### Deferred to Separate Tasks
+
+- Companion silent-notification issue (chat_id=0) is tracked separately; this plan only addresses duplicate emission.
+- Any broader tool-use validation (e.g., schema conformance, hallucinated tool names) stays out of scope.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/agent.rs` — `process_tool_calls()` (line 1544) is the single dispatch point for every tool_use block; both the `execute_tool` invocation and the `db.save_tool_call` call live inside one `for block in &response_content` loop. Adding the guard here fixes both the execution and the storage paths in one place.
+- `crates/mika-agent/src/agent.rs:967` — `LlmStopReason::ToolUse` branch already iterates `response.content` once for `tools_called` tracking, providing the template for iterating tool_use blocks deterministically.
+- `crates/mika-agent/src/tools/mod.rs` — `ToolOutput { content, is_error, images }` and `ImageData` (already `#[derive(Debug, Clone)]`). `ToolOutput` is currently `#[derive(Debug)]` only; adding `Clone` is mechanical and unblocks reusing cached results for duplicate blocks.
+- `crates/mika-common/src/llm/types.rs:237` — `response_content_to_blocks()` turns the LLM response into assistant history; duplicate tool_use blocks in the assistant message are preserved as-is so the API history stays coherent when tool_results are emitted for both ids.
+- `crates/mika-agent/tests/eval/` — `EvalHarness`, `MockLlmProvider`, `multi_tool_response()` helper (`crates/mika-common/src/llm/mock.rs:237`) already support seeding a single response with multiple tool_use blocks. A test that passes two tuples with the same `(name, args)` is a one-line extension.
+- `crates/mika-agent/tests/eval/trace.rs:56` — `AgentTrace::calls_for_tool(name)` returns `tool_calls` rows by name; the regression test asserts `.len() == 1` after seeding two identical blocks.
+
+### Institutional Learnings
+
+- Guard-style defenses against provider artifacts are an established pattern in this codebase: `detect_text_based_tool_call`, `extract_xml_tool_calls`, required-tools retry, completion-claim guard, fabricated-action claim guard, phantom-retry guard. Adding a duplicate-tool_use guard fits that family — cheap, per-turn, observable via `warn!` logs.
+- Agent loop guards are scoped to a single turn and never persist state across calls (no cross-turn memory of what has run).
+
+### External References
+
+- None — this is an internal invariant, not dependent on provider-specific API shape.
+
+## Key Technical Decisions
+
+- **Dedup key: `(String, String)` where the second element is `serde_json::to_string(arguments)`.** The issue reports byte-identical `input`, so string equality is sufficient. Canonical-json normalization is not needed today; if future providers reorder keys between duplicates, the guard will fail open (no dedup) rather than false-positive (important invariant). Revisit if telemetry shows near-miss duplicates.
+- **Dedup is universal, not send_message-only.** An identical tool_use pair within a single turn is never a legitimate intent for any tool (the LLM can always vary arguments if it means distinct calls). Universal scope is simpler and avoids per-tool allow/deny lists.
+- **Cache the `ToolOutput` and reuse it for duplicate blocks.** The LLM's assistant message keeps both tool_use ids, so the API history requires both to receive a matching `tool_result`. Reusing the real output (clone) keeps the LLM's view consistent with the first execution and avoids leaking internal engine details (e.g., "duplicate suppressed") into the next turn's context.
+- **`ToolOutput` gains `#[derive(Clone)]`.** Fields (`String`, `bool`, `Vec<ImageData>`) are all `Clone`; image byte buffers are already `String`-backed base64. Clone cost is negligible at image sizes already capped by `MAX_IMAGE_BYTES_PER_STEP`.
+- **Save `tool_calls` row and emit `ToolCallSummary` exactly once per unique call.** The summary is what surfaces in `messages.metadata` and in history builder output; duplicating it would leak the bug into downstream context. Logging a `warn!` on suppression is the observability channel for operators.
+- **Preserve required-tools tracking as-is.** The pre-dispatch loop at line 970 that populates `tools_called` can keep iterating every block (recording `send_message` once is the same whether dedup catches it at dispatch or not — `HashSet::insert` already idempotent). No change needed there.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q: Should the duplicate's tool_result echo the original output, or a "suppressed" stub? — A: Echo the original. Keeps the assistant/tool history consistent and avoids surprising the LLM with differentiated results for what it emitted as two identical calls.
+- Q: Should `ToolCallSummary` include both entries? — A: No. Summaries feed back into `tool_history` context; a second identical summary would re-introduce the bug into the next turn.
+- Q: Why not dedup at DB layer via a unique index on `(trace_id, tool_name, input)`? — A: DB dedup cannot prevent the double execution of side-effectful tools (`send_message` has already dispatched before the INSERT). Loop-level dedup fixes execution, storage, and summary together.
+
+### Deferred to Implementation
+
+- None. Implementation is mechanical: add a `HashMap<(String, String), ToolOutput>` inside `process_tool_calls`, one `warn!` log line, one `#[derive(Clone)]` addition, and one eval test.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add per-turn dedup in `process_tool_calls`**
+
+**Goal:** Detect identical `(tool_name, arguments)` pairs within one turn and execute each unique pair at most once.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `crates/mika-agent/src/agent.rs`
+- Modify: `crates/mika-agent/src/tools/mod.rs` (add `#[derive(Clone)]` to `ToolOutput`)
+
+**Approach:**
+- Before the `for block in &response_content` loop, introduce `let mut executed: HashMap<(String, String), ToolOutput> = HashMap::new();` scoped to the function call.
+- Inside the `ToolCall` branch, compute `let dedup_key = (name.clone(), serde_json::to_string(arguments).unwrap_or_default());` and `executed.get(&dedup_key)`:
+  - On hit: emit `warn!(trace_id = %tool_ctx.trace_id, tool = %name, step = step, "duplicate tool_use block suppressed; reusing prior result");`, skip `execute_tool`, skip `save_tool_call`, do **not** push to `summaries`, but still push a `LlmContentBlock::ToolResult` for the duplicate `id` using a `Clone` of the cached `ToolOutput` so the assistant/tool history stays paired.
+  - On miss: run the existing path (execute, record DB row, push summary) and `executed.insert(dedup_key, output.clone())` before building the tool_result block. The clone is cheap — `ToolOutput` fields are `String`, `bool`, `Vec<ImageData>` and images are already base64 text.
+- Keep the existing tool_result construction (text vs. multi-block image handling) factored out so both the miss and hit paths produce identical shapes. Preferred shape: build the `LlmContentBlock::ToolResult` from a shared helper that takes `(tool_call_id: String, output: &ToolOutput, image_bytes_budget: &mut usize)` — this lets the duplicate reuse the helper with the cached output. Directional only; implementer may inline the branches if the helper adds no readability.
+- `#[derive(Clone)]` on `ToolOutput` is a one-line change; `ImageData` already derives `Clone`.
+
+**Technical design:** *(directional, not implementation spec)*
+
+    for block in &response_content {
+        if let LlmResponseContent::ToolCall { id, name, arguments } = block {
+            let key = (name.clone(), serde_json::to_string(arguments).unwrap_or_default());
+            let output = match executed.get(&key) {
+                Some(cached) => {
+                    warn!(trace_id = %..., tool = %name, step, "duplicate tool_use ...");
+                    cached.clone()
+                }
+                None => {
+                    let o = execute_tool(...).await;
+                    if store_tool_calls { db.save_tool_call(...).await; }
+                    summaries.push(ToolCallSummary { ... });
+                    executed.insert(key.clone(), o.clone());  // or insert a Clone
+                    o
+                }
+            };
+            tool_results.push(build_tool_result_block(id.clone(), &output, &mut image_bytes_budget));
+        }
+    }
+
+**Patterns to follow:**
+- Same guard style as `detect_text_based_tool_call`, `detect_completion_claim`, `detect_fabricated_action_claim` — a cheap per-turn check that logs `warn!` with `trace_id` when it fires (`crates/mika-agent/src/agent.rs`).
+- Same `HashMap`/`HashSet` scoping pattern already used at line 970 for `tools_called`.
+
+**Test scenarios:**
+- Integration (eval harness): LLM response containing `multi_tool_response(vec![("send_message", json!({"text": "hi"})), ("send_message", json!({"text": "hi"}))])` followed by a text_response → assert `trace.calls_for_tool("send_message").len() == 1`, assert final output present, assert `tools_called` summary shows `send_message` exactly once. (Covered by Unit 2.)
+- Integration (eval harness): LLM response with two `search_memory` blocks that have *different* `query` args → still produces two DB rows (no regression of `test_multiple_parallel_tool_calls`).
+- Unit (`#[cfg(test)]` inline in `agent.rs` or `tools/mod.rs`): `ToolOutput::clone()` round-trips `content`, `is_error`, and `images` byte-for-byte. Small sanity test for the new derive.
+
+**Verification:**
+- `cargo clippy -p mika-agent` is clean.
+- `cargo test -p mika-agent --test eval test_tool_calling` passes, including the new test and the unchanged parallel-tool test.
+- A grep of `warn!` new call site finds the `"duplicate tool_use block suppressed"` message with `trace_id`, `tool`, and `step` fields.
+
+- [ ] **Unit 2: Regression test for duplicate tool_use dedup**
+
+**Goal:** Lock in the invariant so future refactors of `process_tool_calls` cannot regress it.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `crates/mika-agent/tests/eval/test_tool_calling.rs`
+
+**Approach:**
+- Add `test_duplicate_tool_use_block_deduplicated` after `test_multiple_parallel_tool_calls`.
+- Feed the mock with a single `multi_tool_response` containing two tuples with identical `(name, args)` (use `send_message` as the canonical example to match the issue), followed by a `text_response`.
+- Assert `trace.calls_for_tool("send_message").len() == 1` (one DB row) and that the final agent output is present.
+- Optional secondary assertion: assert the `tool_call_summaries` count via whatever helper the harness exposes (`assert_exact_steps` or equivalent). Keep the assertion scoped and readable; do not over-assert implementation details.
+
+**Patterns to follow:**
+- `test_multiple_parallel_tool_calls` (same file, lines ~29–53) is the near-identical structural template.
+
+**Test scenarios:**
+- Happy path: two identical `send_message` blocks in one turn → exactly one `tool_calls` row. (This is the main assertion.)
+- Sanity: final text response still reaches the user.
+
+**Verification:**
+- `cargo test -p mika-agent --test eval test_duplicate_tool_use_block_deduplicated` passes.
+- Running with Unit 1 reverted makes the test fail with `.len() == 2` — proves it guards the invariant.
+
+## System-Wide Impact
+
+- **Interaction graph:** Only `process_tool_calls` is touched; callers (`run_loop`) are unaffected. `tools_called` tracking at line 970 keeps working because `HashSet::insert` ignores duplicates.
+- **Error propagation:** A duplicate that inherits a cached error output still produces an error `tool_result` for the duplicate id; the loop's error handling is unchanged.
+- **State lifecycle risks:** Zero — dedup state is stack-local to `process_tool_calls` and dies with the function. No DB state, no agent-level memory.
+- **API surface parity:** None. No tool schema changes, no config keys, no dashboard DTO changes.
+- **Integration coverage:** The eval test covers the full `run_agent → run_loop → process_tool_calls → save_tool_call` path under `MockLlmProvider`, which is the integration level at which the bug manifests.
+- **Unchanged invariants:** `tool_calls` schema, `save_tool_call` signature, `ToolOutput` field set, `LlmResponseContent` shape, `response_content_to_blocks` behavior, conversation history format, required-tools enforcement. The fix is purely additive.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| False positive dedup for a legitimate double-call with byte-identical args | Vanishingly rare; duplicate intent can be expressed with different args. If it occurs, `warn!` log surfaces it with `trace_id` for triage. |
+| Canonical-JSON reordering by a future provider produces byte-different strings for the same logical args | String comparison fails open (no dedup) — same behavior as today. Can revisit with canonicalization if telemetry shows near-misses. |
+| `ToolOutput::Clone` accidentally doubles memory for large outputs | Outputs are already truncated at the DB save path (50 KB content cap) and images cap at `MAX_IMAGE_BYTES_PER_STEP`; clone overhead is bounded. |
+| Cached result hides a tool flakiness that would retry on second call | Today's code does not retry duplicate-identical calls either — the second execution was never a retry mechanism. No behavior regression. |
+
+## Documentation / Operational Notes
+
+- `crates/mika-agent/CLAUDE.md` "Agent Loop" section already enumerates the four post-condition guards. Extend the guard list (or add a short bullet under "Post-Conditions" / nearby) to mention the duplicate-tool_use dedup guard so future contributors have a pointer. Keep it to one sentence.
+- No operational rollout concerns — the change is a pure in-process guard, no migrations, no feature flag. Logs will show `duplicate tool_use block suppressed` when the guard fires; grep-able for dashboards or alerting if needed.
+
+## Sources & References
+
+- **Issue:** senara-solutions/mika#582
+- Related code: `crates/mika-agent/src/agent.rs` (`process_tool_calls`, `run_loop::LlmStopReason::ToolUse` branch), `crates/mika-agent/src/tools/mod.rs` (`ToolOutput`), `crates/mika-common/src/llm/types.rs` (`LlmResponseContent`, `response_content_to_blocks`), `crates/mika-common/src/llm/mock.rs` (`multi_tool_response`), `crates/mika-agent/tests/eval/test_tool_calling.rs`, `crates/mika-agent/tests/eval/trace.rs` (`calls_for_tool`).
+- Related prior guards for pattern precedent: required-tools retry, completion-claim guard, fabricated-action claim guard, phantom-retry guard.

--- a/docs/solutions/architecture-patterns/per-turn-tool-use-dedup-guard.md
+++ b/docs/solutions/architecture-patterns/per-turn-tool-use-dedup-guard.md
@@ -1,0 +1,107 @@
+---
+title: "Per-Turn tool_use Dedup Guard"
+issue: "#582"
+date: "2026-04-17"
+tags: [agent-core, tool-dispatch, guard, defense-in-depth, provider-quirk]
+category: architecture-patterns
+problem_type: logic-error
+module: mika-agent
+component: process_tool_calls
+---
+
+# Per-Turn tool_use Dedup Guard
+
+## Problem
+
+A single mika-dev turn emitted two `send_message` tool_calls with byte-identical `input` in the same second (trace `d71cb2c2c4c54acb8b63ea15115c9900`, kimi-k2.5). The LLM's response contained two `tool_use` content blocks with the same `(name, arguments)`, and `process_tool_calls()` iterated them blindly — running the tool twice, saving two `tool_calls` rows, and (once delivery is restored) about to double-send every sprint-start notification. Acceptance from #582: "Identical tool_call from same turn is either deduped at emission time or executed once and cached."
+
+## Symptoms
+
+- Two rows in `tool_calls` with the same `trace_id`, same `tool_name`, identical `input` JSON, same `created_at` second, both `success=1`.
+- Observed with `kimi-k2.5` (via `OpenAiCompatibleProvider`); Anthropic provider never emitted this pattern in production traces.
+- Downstream risk: duplicate outbound notifications, duplicate `messages` rows for `send_message`, duplicate side effects for any tool the LLM redundantly emitted in one response.
+- Sibling `kimi-k2.5` behavior already documented in `best-practices/list-tool-status-summary-reduces-redundant-calls.md` (redundant *cross-turn* filtered calls). This incident is the *within-turn* variant of the same provider quirk family.
+
+## What Didn't Work
+
+- Prompt-only defense. The system prompt already has a grounding rule ("don't claim downstream state unless a tool result confirms it") and a confirmation-before-action rule. Neither prevents the provider from serializing two identical `tool_use` blocks into a single response — the harness is the only enforcement point.
+- DB-layer dedup. A unique index on `(trace_id, tool_name, input)` in the `tool_calls` table would suppress the second row, but the tool would already have executed (side effects delivered twice before the INSERT). Dedup must happen at execution dispatch time, not at persistence time.
+- Single-step scope only. Scoping dedup to a single `process_tool_calls()` call is correct; extending to cross-step or cross-turn would break legitimate retry flows (the agent can legitimately call the same tool with the same args across two different steps).
+
+## Solution
+
+Added a fifth entry to the agent-loop guard family (see Prevention for the family list): a per-turn dedup cache inside `process_tool_calls()` keyed on `(tool_name, serde_json::to_string(arguments))`. The first block executes the tool and persists one `tool_calls` row. Subsequent blocks with the same key reuse a clone of the cached `ToolOutput`. Each duplicate `tool_use_id` still gets its own `tool_result` in the conversation history so the API contract stays paired.
+
+```rust
+// crates/mika-agent/src/agent.rs — process_tool_calls()
+let mut dedup_cache: HashMap<(String, String), ToolOutput> = HashMap::new();
+for block in &response_content {
+    if let LlmResponseContent::ToolCall { id, name, arguments } = block {
+        let dedup_key = (name.clone(), serde_json::to_string(arguments).unwrap_or_default());
+        let output = if let Some(cached) = dedup_cache.get(&dedup_key) {
+            warn!(
+                trace_id = %tool_ctx.trace_id,
+                tool = %name,
+                step,
+                cached_was_error = cached.is_error,
+                "duplicate tool_use block suppressed; reusing prior result"
+            );
+            // Strip images on reuse — the LLM already received them on the
+            // first duplicate's tool_result; re-emitting would double-charge
+            // the shared `image_bytes_budget` and inflate the API payload.
+            let mut reused = cached.clone();
+            reused.images.clear();
+            reused
+        } else {
+            let output = execute_tool(&dispatch, name, arguments.clone()).await;
+            // … save_tool_call, push ToolCallSummary …
+            dedup_cache.insert(dedup_key, output.clone());
+            output
+        };
+        // … build LlmContentBlock::ToolResult with this output …
+    }
+}
+```
+
+Also required: `#[derive(Clone)]` on `ToolOutput` (fields are `String`, `bool`, `Vec<ImageData>`; `ImageData` was already `Clone`).
+
+## Why This Works
+
+- **Correct enforcement point.** The guard lives one level above `execute_tool` but below the loop's iteration. Nothing can route around it — every tool_use block from any provider funnels through `process_tool_calls`.
+- **Scope matches intent.** The `HashMap` is function-local and dropped at function return. Cross-step and cross-turn duplicates are unaffected (the agent can legitimately retry an identical call across different steps).
+- **API contract preserved.** Each `tool_use_id` still receives a matching `tool_result` — the LLM's conversation history stays internally consistent, and Anthropic won't reject the follow-up request for unpaired ids.
+- **Observability built in.** `warn!` carries `trace_id`, `tool`, `step`, and `cached_was_error` — enough to grep production logs, correlate with a specific turn, and distinguish suppressed successes from suppressed failures.
+- **Image budget stays honest.** Stripping `images` on the cache-hit path prevents the shared `image_bytes_budget` from being double-charged for bytes the LLM already received on the first duplicate's tool_result. Latent today for `send_message` (no images) but correct for any image-returning exec-handler skill.
+
+## Prevention
+
+Join the existing agent-loop guard family when defending against provider quirks — code enforcement beats prompt instructions when LLM nonconformance can cause real harm:
+
+1. **Text-based tool call detection** — catches XML tool calls emitted as text (`detect_text_based_tool_call`).
+2. **Required-tools gate** — keyword-matched skills declaring `[constraints] required_tools` block EndTurn without the tool call (#265).
+3. **Completion-claim guard** — blocks EndTurn text claiming completion keywords without `update_work_item_status` (#483).
+4. **Fabricated action-claim guard** — blocks EndTurn claiming a GitHub resource URL with zero tool calls (#308).
+5. **Per-turn tool_use dedup guard (this doc)** — dispatch-layer, suppresses byte-identical tool_use blocks within one response (#582).
+
+Regression tests (see `crates/mika-agent/tests/eval/test_tool_calling.rs`):
+
+- `test_duplicate_tool_use_block_deduplicated` — two identical blocks → one `tool_calls` row, two paired `tool_result` blocks in the follow-up LLM request.
+- `test_three_identical_tool_use_blocks_deduplicated` — N ≥ 2 still collapses to one execution; exercises the cache-hit path multiple times.
+- `test_same_tool_different_args_not_deduplicated` — guards against a regression that keys dedup on name alone; two `send_message` calls with different `text` must still produce two rows.
+- `test_multiple_parallel_tool_calls` — pre-existing; asserts genuinely distinct parallel tools still execute normally.
+
+Known limitations (intentionally in scope for later work, not for this PR):
+
+- **Key-order sensitivity.** `serde_json::to_string` on `Value::Object` preserves insertion order. A provider that emits logically-identical arguments with different key orderings (or int-vs-float number representations) between two blocks will miss the cache. Document if observed; revisit with canonical serialization if telemetry shows near-misses.
+- **No `tool_calls` row for suppressed duplicates.** The dashboard API counts DB rows, not LLM conversation blocks. Observers correlating raw LLM history with dashboard will see fewer rows than `tool_use` blocks. The `warn!` log is the primary audit trail; add an `audit_events` entry if dashboard visibility becomes important.
+- **Error caching.** If the first block errors, the duplicate inherits the same error via clone. This matches the intended semantics (duplicate inputs, no basis for a different result) but is worth noting.
+
+## When to Add a Similar Guard
+
+Any time a provider quirk can cause a side-effectful tool to fire twice from a single LLM turn. The pattern:
+
+1. Identify the dispatch choke point (`process_tool_calls`, `run_gh`, webhook handler — wherever execution actually happens).
+2. Scope the defense to the smallest unit that preserves intent (per-turn here; per-request elsewhere).
+3. Preserve the API contract downstream (emit tool_results / response pairs even when suppressing).
+4. Log `warn!` with `trace_id` so operators can grep for it.
+5. Write a regression test in the eval harness (`multi_tool_response` with duplicates) plus a counter-test that guards against the dedup widening (same tool, different args).

--- a/docs/solutions/logic-errors/duplicate-tool-use-block-within-turn.md
+++ b/docs/solutions/logic-errors/duplicate-tool-use-block-within-turn.md
@@ -1,0 +1,109 @@
+---
+title: "Provider emits duplicate tool_use blocks in a single agent turn — engine dispatches each one"
+category: logic-errors
+date: 2026-04-17
+module: mika-agent
+problem_type: logic_error
+component: assistant
+symptoms:
+  - "Two `tool_calls` rows with same trace_id, tool_name, and byte-identical input at the same second"
+  - "send_message executed twice per turn — duplicate outbound delivery once notifications are restored"
+  - "`messages.metadata` shows the same ToolCallSummary twice, leaking duplication into next-turn context"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - assistant
+  - tooling
+tags: [dedup, tool-use, provider-artifacts, agent-loop, kimi, non-anthropic]
+related_issues: ["#582"]
+---
+
+# Provider emits duplicate tool_use blocks in a single agent turn — engine dispatches each one
+
+## Problem
+
+A single agent turn (trace `d71cb2c2c4c54acb8b63ea15115c9900`, kimi-k2.5) produced two `tool_calls` rows for `send_message` with byte-identical `input` at the same second. The engine's dispatch loop had no guard over duplicate `tool_use` content blocks inside a single LLM response, so it executed the tool twice, saved two DB rows, emitted two `ToolCallSummary` entries, and — once the companion silent-notification bug (chat_id=0) is fixed — would deliver two outbound messages per sprint start / retry / close-out.
+
+The duplication is a provider-side artifact (the assistant message carried two tool_use blocks with the same `(name, arguments)`). mika supports 11 LLM providers; the engine must defend against this regardless of which one misbehaves.
+
+## Symptoms
+
+- Two `tool_calls` rows with same `trace_id`, `tool_name=send_message`, `tool_source=builtin`, identical `input`, both `success=1`, both `created_at = 2026-04-15T16:18:44Z`.
+- `summaries.push(ToolCallSummary { ... })` fired twice, so `messages.metadata` carries the same summary twice and re-injects the duplicate into the next turn's `<context type="tool_history">` block.
+- Agent's conversation history builder round-trips both tool_use blocks and both tool_results back to the provider.
+
+## What Didn't Work
+
+- **Prompt instruction.** Telling the model "do not emit the same tool call twice" is unreliable — the failure is a provider-side artifact, not a reasoning mistake. mika has hit this class of bug repeatedly with non-Anthropic models (see Related).
+- **DB-level uniqueness on `(trace_id, tool_name, input)`.** The UNIQUE constraint would catch the second INSERT but by then `send_message` has already dispatched. DB dedup cannot prevent double execution of side-effectful tools.
+- **Per-tool opt-in dedup (send_message only).** Considered and rejected. Any tool with identical `(name, arguments)` in the same turn is never a legitimate distinct intent — the LLM can always vary arguments if it means two calls. Universal dispatch-loop dedup is simpler and avoids per-tool allowlists.
+
+## Solution
+
+Per-turn dedup guard inside `process_tool_calls()` in `crates/mika-agent/src/agent.rs`. Executes the underlying tool once per unique `(tool_name, arguments)` pair, caches the `ToolOutput`, and reuses it for duplicate `tool_use` ids so the provider's API contract — every tool_use id must have a matching tool_result — still holds.
+
+```rust
+// Scope: function-local, one invocation per LLM response
+let mut dedup_cache: HashMap<(String, String), ToolOutput> = HashMap::new();
+
+for block in &response_content {
+    if let LlmResponseContent::ToolCall { id, name, arguments } = block {
+        let dedup_key = (
+            name.clone(),
+            serde_json::to_string(arguments).unwrap_or_default(),
+        );
+        let output = if let Some(cached) = dedup_cache.get(&dedup_key) {
+            warn!(
+                trace_id = %tool_ctx.trace_id,
+                tool = %name,
+                step,
+                cached_was_error = cached.is_error,
+                "duplicate tool_use block suppressed; reusing prior result"
+            );
+            // Clear images on reuse — the LLM already received them in the
+            // first duplicate's tool_result. Re-emitting wastes the shared
+            // `image_bytes_budget` and inflates the API request body.
+            let mut reused = cached.clone();
+            reused.images.clear();
+            reused
+        } else {
+            // ...execute_tool, save_tool_call, summaries.push...
+            dedup_cache.insert(dedup_key, output.clone());
+            output
+        };
+
+        tool_results.push(LlmContentBlock::ToolResult { tool_call_id: id.clone(), ... });
+    }
+}
+```
+
+Supporting changes:
+- `ToolOutput` gains `#[derive(Clone)]` (fields were already clonable: `String`, `bool`, `Vec<ImageData>`).
+- Three regression tests in `crates/mika-agent/tests/eval/test_tool_calling.rs`:
+  - `test_duplicate_tool_use_block_deduplicated` — two identical `send_message` blocks → one DB row, two tool_result blocks in the follow-up request.
+  - `test_same_tool_different_args_not_deduplicated` — two `send_message` blocks with different text → two DB rows (pins the dedup key to `(name, arguments)`, not name alone).
+  - `test_three_identical_tool_use_blocks_deduplicated` — exercises the cache-hit path twice.
+
+## Why This Works
+
+- **Dispatch-layer guard is the only layer that fixes execution, storage, and summary together.** Tools with side effects (`send_message` → gateway delivery, `store_fact` → memory write, `create_work_item` → DB row) have fired their effect before any DB constraint can trip. Guarding at the dispatch loop prevents the second execution entirely.
+- **Per-turn scope matches the actual fault.** The provider emits duplicates inside one response; across turns or steps, repeating a tool with identical arguments is legitimate (a recurring reminder, a polling loop). The `HashMap` lives one `process_tool_calls` call and dies with it.
+- **Clearing `images` on the reuse path preserves the per-step image budget.** The first duplicate's tool_result already delivered the images to the LLM; re-sending them would waste `MAX_IMAGE_BYTES_PER_STEP` and, worse, could starve a subsequent legitimate tool_result in the same turn of its image slot.
+- **Fail-open JSON comparison is deliberate.** `serde_json::to_string(arguments)` is byte-equal, not canonical. If a future provider reorders object keys between otherwise-identical duplicates, the guard misses the match and the tool executes twice — same behavior as today's pre-fix code. This is safer than canonicalizing and risking a false-positive dedup that silently drops a legitimate distinct call. Revisit with canonicalization only if telemetry on `"duplicate tool_use block suppressed"` shows near-misses on OpenAI-compatible routes.
+
+## Prevention
+
+- **Guard pattern for provider-side artifacts.** Non-Anthropic models regularly emit structural artifacts Anthropic does not — prior cases include text-wrapped tool calls, malformed closing tags, XML-format tool calls, fabricated URL claims, phantom retries after callback, and hallucinated `canUseTool` denials. The established mika response is a cheap loop-level guard that logs `warn!` with `trace_id`, not prompt engineering. New providers should be assumed to produce their own artifacts until proven otherwise; add guards defensively.
+- **Guard-reuse invariant.** When you reuse a cached result for a duplicate, clear fields whose bytes the LLM already received. Shared per-step budgets (image bytes, token limits, API request body size) otherwise silently double-count.
+- **Post-condition for new write/dispatch tools.** If a tool has side effects, DB uniqueness is necessary but not sufficient. Also guard at dispatch so the side effect does not fire twice when the LLM emits identical calls.
+- **Observability hook.** The `warn!` log field `duplicate tool_use block suppressed` is grep-able. Consider adding a counter metric or audit event if telemetry wants a rate trend for provider-health dashboards.
+
+## Related
+
+- [agent-creates-duplicates-after-compaction.md](agent-creates-duplicates-after-compaction.md) — canonical three-layer defense (prompt soft layer → DB hard constraint → tool-level graceful catch). This fix adds the loop-level layer above all three, for cases where the duplicate originates at the LLM dispatch boundary, not at the tool or DB.
+- [create-work-item-duplicate-on-retry.md](create-work-item-duplicate-on-retry.md) — DB-level vs tool-level dedup trade-offs. Parallel insight: DB dedup alone is insufficient when the duplication source is upstream of storage.
+- [../ui-bugs/malformed-closing-tags-non-anthropic-models.md](../ui-bugs/malformed-closing-tags-non-anthropic-models.md) — prior non-Anthropic provider structural artifact, fixed with a loop-level normalizer. Same pattern as this dedup guard.
+- [../architecture-patterns/fabricated-action-claim-guard.md](../architecture-patterns/fabricated-action-claim-guard.md) — precedent for post-condition loop guards that catch provider-emitted anomalies before committing the turn.
+- **Sibling guards in `process_tool_calls` / EndTurn chain:** `detect_text_based_tool_call`, `extract_xml_tool_calls`, required-tools gate, `detect_completion_claim`, `detect_fabricated_action_claim`, phantom-retry guard. This dedup joins that family as a dispatch-time (not EndTurn) check.
+- **Issue:** [senara-solutions/mika#582](https://github.com/senara-solutions/repo/issues/582)


### PR DESCRIPTION
## Summary

When the LLM emits two or more `tool_use` content blocks with identical `(tool_name, arguments)` inside a single response, the agent now executes the underlying tool once, saves one `tool_calls` DB row, emits one `ToolCallSummary`, and reuses the cached `ToolOutput` for duplicate `tool_use` ids so every id still gets a paired `tool_result` (API contract preserved).

Root cause: `process_tool_calls()` in `crates/mika-agent/src/agent.rs` dispatched every block in order with no dedup. A single kimi-k2.5 turn (trace `d71cb2c2c4c54acb8b63ea15115c9900`) produced two byte-identical `send_message` rows — once the companion silent-notification issue is fixed, this would send duplicate outbound notifications.

## Changes

- **Loop-level dedup guard** in `process_tool_calls`: `HashMap<(name, json-args), ToolOutput>` cached inside the function; on hit, `warn!` logs `trace_id`/`tool`/`step`/`cached_was_error`, the cached output is cloned and its `images` cleared (the LLM already received those bytes in the first duplicate's `tool_result` — re-sending would double-consume `image_bytes_budget` and inflate the API body).
- **`ToolOutput` gains `#[derive(Clone)]`** (`crates/mika-agent/src/tools/mod.rs`). Fields were already clonable.
- **Three regression tests** in `crates/mika-agent/tests/eval/test_tool_calling.rs`:
  - `test_duplicate_tool_use_block_deduplicated` — two identical blocks → one DB row + two paired `tool_result` blocks in the follow-up request.
  - `test_same_tool_different_args_not_deduplicated` — pins the dedup key to `(name, arguments)`, not name alone.
  - `test_three_identical_tool_use_blocks_deduplicated` — exercises the cache-hit path twice.
- **Docs:** plan (`docs/plans/2026-04-17-001-fix-duplicate-tool-use-block-dedup-plan.md`), compound learning (`docs/solutions/logic-errors/duplicate-tool-use-block-within-turn.md`), `crates/mika-agent/CLAUDE.md` Agent Loop section.

## Design notes

- **Per-turn scope.** Dedup state lives inside `process_tool_calls` and dies with the call. Across turns or steps, repeating a tool with identical args is legitimate (polling, recurring reminders).
- **Fail-open JSON compare.** `serde_json::to_string(arguments)` is byte-equal, not canonical. If a future provider reorders keys between otherwise-identical duplicates the guard misses — same behavior as before this fix. Safer than canonicalizing and risking a false-positive dedup that silently drops a legitimate distinct call. Revisit only if telemetry on `"duplicate tool_use block suppressed"` shows near-misses on OpenAI-compatible routes.
- **Sibling guards.** Joins the existing family of provider-artifact defenses (`detect_text_based_tool_call`, `extract_xml_tool_calls`, completion-claim, fabricated-action-claim, phantom-retry). This one fires at dispatch time, not EndTurn.

## Test plan

- [x] `cargo build -p mika-agent` — clean
- [x] `cargo clippy -p mika-agent --all-targets` — clean
- [x] `cargo test -p mika-agent --test eval` — 52/52 pass (includes 3 new tests)
- [x] `cargo test -p mika-agent --test eval test_tool_calling` — 7/7 pass
- [x] `scripts/verify-pipeline.sh` — plan + code + compound doc all present
- [x] `scripts/sync-agent-docs.sh` — no drift
- [x] `/ce:review` — all findings resolved or deferred (advisory). Image-budget double-consumption (cross-reviewer consensus P2) fixed; additional test coverage added.

## Review findings resolved in this PR

| Finding | Status |
|---|---|
| Image budget double-consumed on dedup-hit path (correctness + maintainability + adversarial + reliability) | Fixed — images cleared on reused clone |
| No `==` assertion for same-tool-different-args (testing) | Fixed — `test_same_tool_different_args_not_deduplicated` |
| No coverage for N ≥ 3 identical blocks (testing) | Fixed — `test_three_identical_tool_use_blocks_deduplicated` |
| No assertion on tool_result pairing (testing) | Fixed — counts `ToolResult` blocks in captured request |
| Variable name `executed` unclear (maintainability) | Fixed — renamed to `dedup_cache` |
| No `cached_was_error` observability on warn log (reliability) | Fixed — field added |
| JSON key-order sensitivity (adversarial P3) | Deferred — documented in plan and compound doc as deliberate fail-open |
| No counter/audit event for dedup firing rate (reliability P3) | Deferred — `warn!` is grep-able; add metric if telemetry asks |
| Helper extraction `execute_and_record_tool_call` (maintainability P3) | Deferred — flag for next significant touch of `process_tool_calls` |

Closes #582