### PR TITLE
fix(agent): surface gateway non-2xx as send_message tool errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 ## Commands
 
 - `cargo build` — Build all crates
-- `cargo test` — Run all tests (~2270 tests)
+- `cargo test` — Run all tests (~2430 tests)
 - `cargo test -p mika-agent --test eval` — Run agent loop integration tests (eval harness)
 - `cargo run --bin mika` — Run TUI CLI (default: chat, or `mika status`, `mika memory`, etc.)
 - `cargo run --bin mika-server` — Run HTTP server (requires `MIKA_ROUTING_URL` and `MIKA_INTERNAL_TOKEN`)

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -121,7 +121,9 @@ Background tasks (heartbeat, reminders) where text output is NOT delivered. Agen
 
 ## MessageSender Trait
 
-`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender`. Team engine agents intentionally have `message_sender: None`.
+`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Returns `Result<SendOutcome>` where `SendOutcome` is `Delivered` (gateway 2xx) or `Failed { reason }` (non-2xx after retry, saved to `failed_sends`). `Err` is reserved for infrastructure failures (chat_id resolution, DB errors). Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender` (one retry after 2s, error classification: connection/timeout/HTTP status with body snippet). Team engine agents intentionally have `message_sender: None`.
+
+**Callsite handling policy:** The `send_message` tool surfaces `Failed` as `ToolOutput::error` so the LLM knows delivery failed. The task-engine dispatcher absorbs `Failed` with a warning (fire-and-forget for scheduled sends). Server handlers and notification paths (verdict, CI success) log warnings on `Failed` but continue. The `failed_sends` flush path increments retry count on `Failed`.
 
 ## Conversation Compaction & Rewind
 

--- a/crates/mika-agent/src/messaging.rs
+++ b/crates/mika-agent/src/messaging.rs
@@ -6,6 +6,19 @@ use tracing::warn;
 
 use crate::async_db::AsyncDatabase;
 
+/// Outcome of a message delivery attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// Message was delivered successfully (gateway returned 2xx).
+    Delivered,
+    /// Delivery failed after retries. The message was saved to `failed_sends`
+    /// for later flush, but the agent should treat this as a failure.
+    Failed {
+        /// Human-readable reason including HTTP status or network error classification.
+        reason: String,
+    },
+}
+
 /// Trait for sending outbound messages to the user.
 /// CLI mode uses the fallback in send_message tool; HTTP mode will POST to the gateway.
 ///
@@ -20,14 +33,14 @@ use crate::async_db::AsyncDatabase;
 /// Send + Sync bounds allow `Arc<dyn MessageSender>` in AppState and ToolContext.
 #[async_trait]
 pub trait MessageSender: Send + Sync {
-    async fn send(&self, text: &str) -> Result<()>;
+    async fn send(&self, text: &str) -> Result<SendOutcome>;
 }
 
 /// Sends outbound messages by POSTing to the gateway's /send endpoint.
 ///
 /// On failure, retries once after 2s. If both attempts fail, saves to
-/// `failed_sends` table for later flush — returns Ok so the agent loop
-/// doesn't think the tool failed.
+/// `failed_sends` table for later flush and returns `Ok(SendOutcome::Failed)`
+/// so the caller can surface the delivery failure to the LLM.
 pub struct GatewayMessageSender {
     client: reqwest::Client,
     gateway_url: String,
@@ -83,19 +96,43 @@ impl GatewayMessageSender {
             .json(payload)
             .timeout(Duration::from_secs(10))
             .send()
-            .await?;
+            .await
+            .map_err(Self::classify_reqwest_error)?;
 
         if resp.status().is_success() {
             Ok(())
         } else {
-            anyhow::bail!("gateway /send returned {}", resp.status())
+            let status = resp.status();
+            let body_snippet = resp
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(200)
+                .collect::<String>();
+            if body_snippet.is_empty() {
+                anyhow::bail!("gateway /send returned {status}")
+            } else {
+                anyhow::bail!("gateway /send returned {status}: {body_snippet}")
+            }
+        }
+    }
+
+    /// Classify a reqwest transport error into a human-readable message.
+    fn classify_reqwest_error(e: reqwest::Error) -> anyhow::Error {
+        if e.is_connect() {
+            anyhow::anyhow!("gateway unreachable (connection error): {e}")
+        } else if e.is_timeout() {
+            anyhow::anyhow!("gateway request timed out: {e}")
+        } else {
+            anyhow::anyhow!("gateway request failed: {e}")
         }
     }
 }
 
 #[async_trait]
 impl MessageSender for GatewayMessageSender {
-    async fn send(&self, text: &str) -> Result<()> {
+    async fn send(&self, text: &str) -> Result<SendOutcome> {
         let chat_id = self.resolve_chat_id().await?;
 
         tracing::debug!(
@@ -114,18 +151,24 @@ impl MessageSender for GatewayMessageSender {
 
         // First attempt
         match self.try_send(&payload).await {
-            Ok(()) => return Ok(()),
+            Ok(()) => return Ok(SendOutcome::Delivered),
             Err(e) => warn!(error = %e, "first /send attempt failed, retrying in 2s"),
         }
 
         // Retry after 2s
         tokio::time::sleep(Duration::from_secs(2)).await;
         match self.try_send(&payload).await {
-            Ok(()) => Ok(()),
+            Ok(()) => Ok(SendOutcome::Delivered),
             Err(e) => {
                 warn!(error = %e, "retry failed, saving to failed_sends");
-                self.db.save_failed_send(text, None).await?;
-                Ok(()) // Return Ok — message queued, don't confuse Claude
+                let reason = e.to_string();
+                // Capture the delivery failure reason before attempting DB write.
+                // If save_failed_send fails, we still surface the original gateway
+                // error to the caller (not the DB error).
+                if let Err(db_err) = self.db.save_failed_send(text, None).await {
+                    warn!(error = %db_err, "failed to save to failed_sends table");
+                }
+                Ok(SendOutcome::Failed { reason })
             }
         }
     }

--- a/crates/mika-agent/src/server/ci_success_handler.rs
+++ b/crates/mika-agent/src/server/ci_success_handler.rs
@@ -310,8 +310,14 @@ pub async fn try_handle_ci_success(
                      Merge initiated (squash, delete branch).",
                     pr.number, event.repo, verdict_review.reviewer
                 );
-                if let Err(e) = sender.send(&notification).await {
-                    warn!(error = %e, "Failed to send CI success merge notification");
+                match sender.send(&notification).await {
+                    Ok(crate::messaging::SendOutcome::Delivered) => {}
+                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                        warn!(reason = %reason, "CI success merge notification delivery failed");
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Failed to send CI success merge notification");
+                    }
                 }
             }
 

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -833,13 +833,25 @@ async fn run_agent_for_message(
         Ok(output) => {
             if let Some(response) = output.text {
                 info!("agent loop completed");
-                if let Err(e) = sender_arc.send(&response).await {
-                    error!(error = %e, "failed to send response");
+                match sender_arc.send(&response).await {
+                    Ok(crate::messaging::SendOutcome::Delivered) => {}
+                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                        warn!(reason = %reason, "response delivery failed, saved to failed_sends");
+                    }
+                    Err(e) => {
+                        error!(error = %e, "failed to send response");
+                    }
                 }
             } else {
                 info!("agent loop completed (no text response)");
-                if let Err(e) = sender_arc.send(agent::EMPTY_RESPONSE_FALLBACK).await {
-                    error!(error = %e, "failed to send fallback response");
+                match sender_arc.send(agent::EMPTY_RESPONSE_FALLBACK).await {
+                    Ok(crate::messaging::SendOutcome::Delivered) => {}
+                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                        warn!(reason = %reason, "fallback response delivery failed, saved to failed_sends");
+                    }
+                    Err(e) => {
+                        error!(error = %e, "failed to send fallback response");
+                    }
                 }
             }
         }
@@ -882,11 +894,16 @@ async fn flush_failed_sends(state: &AppState, agent_state: &AgentState) {
 
     for send in sends {
         match sender.send(&send.text).await {
-            Ok(()) => {
+            Ok(crate::messaging::SendOutcome::Delivered) => {
                 let _ = agent_state.db.delete_failed_send(send.id).await;
                 info!(id = send.id, "flushed failed send");
             }
-            Err(_) => {
+            Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                warn!(id = send.id, reason = %reason, "failed send flush: delivery failed again");
+                let _ = agent_state.db.increment_failed_send_retry(send.id).await;
+            }
+            Err(e) => {
+                warn!(id = send.id, error = %e, "failed send flush: sender error");
                 let _ = agent_state.db.increment_failed_send_retry(send.id).await;
             }
         }

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -303,8 +303,14 @@ async fn handle_pass_verdict(
                                 event.pr_number, event.repo, event.reviewer
                             )
                         };
-                        if let Err(e) = sender.send(&notification).await {
-                            warn!(error = %e, "Failed to send merge notification");
+                        match sender.send(&notification).await {
+                            Ok(crate::messaging::SendOutcome::Delivered) => {}
+                            Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                                warn!(reason = %reason, "Merge notification delivery failed");
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "Failed to send merge notification");
+                            }
                         }
                     }
 

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -141,7 +141,15 @@ impl TaskDispatcher {
         }
 
         if let Some(sender) = &self.message_sender {
-            sender.send(text).await?;
+            match sender.send(text).await? {
+                crate::messaging::SendOutcome::Delivered => {}
+                // Task-engine sends are fire-and-forget; delivery failure is logged
+                // but does not fail the dispatch (unlike the send_message tool path
+                // which surfaces Failed as ToolOutput::error for LLM awareness).
+                crate::messaging::SendOutcome::Failed { reason } => {
+                    warn!(task_id = %task.id, reason = %reason, "send_message task: delivery failed");
+                }
+            }
         } else {
             debug!(task_id = %task.id, "send_message: no sender configured, dropping message");
         }
@@ -926,15 +934,15 @@ mod tests {
     use super::*;
     use crate::async_db::AsyncDatabase;
     use crate::db::{Database, NewTask};
-    use crate::messaging::MessageSender;
+    use crate::messaging::{MessageSender, SendOutcome};
     use std::path::PathBuf;
     use std::sync::atomic::AtomicBool;
 
     struct NoopSender;
     #[async_trait::async_trait]
     impl MessageSender for NoopSender {
-        async fn send(&self, _text: &str) -> anyhow::Result<()> {
-            Ok(())
+        async fn send(&self, _text: &str) -> anyhow::Result<SendOutcome> {
+            Ok(SendOutcome::Delivered)
         }
     }
 

--- a/crates/mika-agent/src/task_engine/engine.rs
+++ b/crates/mika-agent/src/task_engine/engine.rs
@@ -634,8 +634,8 @@ mod tests {
     struct NoopSender;
     #[async_trait::async_trait]
     impl MessageSender for NoopSender {
-        async fn send(&self, _text: &str) -> anyhow::Result<()> {
-            Ok(())
+        async fn send(&self, _text: &str) -> anyhow::Result<crate::messaging::SendOutcome> {
+            Ok(crate::messaging::SendOutcome::Delivered)
         }
     }
 

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -4,6 +4,8 @@ use mika_common::claude::ToolDefinition;
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::messaging::SendOutcome;
+
 use super::{MAX_INPUT_LEN, Tool, ToolContext, ToolOutput};
 
 pub struct SendMessageTool;
@@ -62,9 +64,22 @@ impl Tool for SendMessageTool {
         match &ctx.message_sender {
             Some(sender) => {
                 debug!("send_message: delivering via configured sender");
-                sender.send(&cleaned).await?;
-                debug!("send_message: delivered successfully");
-                Ok(ToolOutput::success("Message sent."))
+                match sender.send(&cleaned).await {
+                    Ok(SendOutcome::Delivered) => {
+                        debug!("send_message: delivered successfully");
+                        Ok(ToolOutput::success("Message sent."))
+                    }
+                    Ok(SendOutcome::Failed { reason }) => {
+                        warn!(reason = %reason, "send_message: delivery failed");
+                        Ok(ToolOutput::error(format!(
+                            "Message delivery failed: {reason}"
+                        )))
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "send_message: sender error");
+                        Ok(ToolOutput::error(format!("Message delivery error: {e}")))
+                    }
+                }
             }
             // Intentionally returns success, not error. The message was persisted to the
             // conversation DB (line above), but external delivery was not attempted because
@@ -86,19 +101,43 @@ impl Tool for SendMessageTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::messaging::MessageSender;
+    use crate::messaging::{MessageSender, SendOutcome};
     use crate::test_utils::test_helpers::TestHarness;
     use std::sync::{Arc, Mutex};
 
-    /// Test sender that captures messages.
+    /// Test sender that captures messages and returns a configurable outcome.
     struct MockSender {
         messages: Mutex<Vec<String>>,
+        outcome: Mutex<Option<SendOutcome>>,
+        /// When set, `send()` returns `Err` instead of `Ok(outcome)`.
+        infra_error: Mutex<Option<String>>,
     }
 
     impl MockSender {
+        /// Create a sender that always succeeds.
         fn new() -> Self {
             Self {
                 messages: Mutex::new(Vec::new()),
+                outcome: Mutex::new(None),
+                infra_error: Mutex::new(None),
+            }
+        }
+
+        /// Create a sender that returns a specific `SendOutcome`.
+        fn with_outcome(outcome: SendOutcome) -> Self {
+            Self {
+                messages: Mutex::new(Vec::new()),
+                outcome: Mutex::new(Some(outcome)),
+                infra_error: Mutex::new(None),
+            }
+        }
+
+        /// Create a sender that returns an infrastructure error.
+        fn with_error(msg: impl Into<String>) -> Self {
+            Self {
+                messages: Mutex::new(Vec::new()),
+                outcome: Mutex::new(None),
+                infra_error: Mutex::new(Some(msg.into())),
             }
         }
 
@@ -109,9 +148,15 @@ mod tests {
 
     #[async_trait]
     impl MessageSender for MockSender {
-        async fn send(&self, text: &str) -> Result<()> {
+        async fn send(&self, text: &str) -> Result<SendOutcome> {
             self.messages.lock().unwrap().push(text.to_string());
-            Ok(())
+            if let Some(err) = self.infra_error.lock().unwrap().as_ref() {
+                return Err(anyhow::anyhow!("{}", err));
+            }
+            match self.outcome.lock().unwrap().clone() {
+                Some(outcome) => Ok(outcome),
+                None => Ok(SendOutcome::Delivered),
+            }
         }
     }
 
@@ -191,5 +236,141 @@ mod tests {
             .unwrap();
         assert!(result.is_error);
         assert!(result.content.contains("too long"));
+    }
+
+    #[tokio::test]
+    async fn test_send_message_gateway_failure() {
+        let harness = TestHarness::new();
+        let mock = Arc::new(MockSender::with_outcome(SendOutcome::Failed {
+            reason: "gateway /send returned 502 Bad Gateway".to_string(),
+        }));
+        let skills_dirty = std::sync::atomic::AtomicBool::new(false);
+        let ctx = crate::tools::ToolContext {
+            db: &harness.db,
+            session_id: "test-session",
+            trace_id: "00000000000000000000000000000000",
+            home_dir: std::path::Path::new("/tmp"),
+            global_home_dir: None,
+            core_memory_edit_count: &harness.counter,
+            is_onboarding: false,
+            message_sender: Some(mock.clone()),
+            embedding_client: None,
+            brave_api_key: None,
+            github_token: None,
+            skills_dirty: &skills_dirty,
+            is_reflection: false,
+            is_task_context: false,
+            is_callback_turn: false,
+            provider_name: "anthropic",
+            model_name: "claude-sonnet-4-6",
+        };
+        let tool = SendMessageTool;
+
+        let result = tool
+            .execute(serde_json::json!({"text": "Hello!"}), &ctx)
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "expected is_error=true for gateway failure"
+        );
+        assert!(
+            result.content.contains("502 Bad Gateway"),
+            "expected status in error: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("delivery failed"),
+            "expected 'delivery failed' in error: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_message_infra_error() {
+        let harness = TestHarness::new();
+        let mock = Arc::new(MockSender::with_error(
+            "chat_id not configured — no Telegram pairing yet",
+        ));
+        let skills_dirty = std::sync::atomic::AtomicBool::new(false);
+        let ctx = crate::tools::ToolContext {
+            db: &harness.db,
+            session_id: "test-session",
+            trace_id: "00000000000000000000000000000000",
+            home_dir: std::path::Path::new("/tmp"),
+            global_home_dir: None,
+            core_memory_edit_count: &harness.counter,
+            is_onboarding: false,
+            message_sender: Some(mock.clone()),
+            embedding_client: None,
+            brave_api_key: None,
+            github_token: None,
+            skills_dirty: &skills_dirty,
+            is_reflection: false,
+            is_task_context: false,
+            is_callback_turn: false,
+            provider_name: "anthropic",
+            model_name: "claude-sonnet-4-6",
+        };
+        let tool = SendMessageTool;
+
+        let result = tool
+            .execute(serde_json::json!({"text": "Hello!"}), &ctx)
+            .await
+            .unwrap();
+        assert!(result.is_error, "expected is_error=true for infra error");
+        assert!(
+            result.content.contains("delivery error"),
+            "expected 'delivery error' in error: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("chat_id not configured"),
+            "expected error details: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_message_connection_error() {
+        let harness = TestHarness::new();
+        let mock = Arc::new(MockSender::with_outcome(SendOutcome::Failed {
+            reason: "gateway unreachable (connection error): connection refused".to_string(),
+        }));
+        let skills_dirty = std::sync::atomic::AtomicBool::new(false);
+        let ctx = crate::tools::ToolContext {
+            db: &harness.db,
+            session_id: "test-session",
+            trace_id: "00000000000000000000000000000000",
+            home_dir: std::path::Path::new("/tmp"),
+            global_home_dir: None,
+            core_memory_edit_count: &harness.counter,
+            is_onboarding: false,
+            message_sender: Some(mock.clone()),
+            embedding_client: None,
+            brave_api_key: None,
+            github_token: None,
+            skills_dirty: &skills_dirty,
+            is_reflection: false,
+            is_task_context: false,
+            is_callback_turn: false,
+            provider_name: "anthropic",
+            model_name: "claude-sonnet-4-6",
+        };
+        let tool = SendMessageTool;
+
+        let result = tool
+            .execute(serde_json::json!({"text": "Hello!"}), &ctx)
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "expected is_error=true for connection error"
+        );
+        assert!(
+            result.content.contains("connection"),
+            "expected connection info in error: {}",
+            result.content
+        );
     }
 }

--- a/crates/mika-agent/tests/eval/harness.rs
+++ b/crates/mika-agent/tests/eval/harness.rs
@@ -10,6 +10,7 @@ use tempfile::TempDir;
 use mika_agent::agent::{AgentParams, run_agent};
 use mika_agent::async_db::AsyncDatabase;
 use mika_agent::db::Database;
+use mika_agent::messaging::MessageSender;
 use mika_agent::skills::SkillRegistry;
 use mika_agent::tools::{ToolRegistry, default_tools};
 use mika_common::config::Settings;
@@ -36,6 +37,7 @@ pub struct EvalHarness {
     is_callback_turn: bool,
     skip_compaction: bool,
     internal: bool,
+    message_sender: Option<Arc<dyn MessageSender>>,
 }
 
 impl EvalHarness {
@@ -56,7 +58,7 @@ impl EvalHarness {
             session_id: &self.session_id,
             home_dir: self.home_dir.path(),
             is_onboarding: self.is_onboarding,
-            message_sender: None,
+            message_sender: self.message_sender.clone(),
             skip_compaction: self.skip_compaction,
             embedding_client: None,
             thinking: None,
@@ -91,6 +93,7 @@ pub struct EvalHarnessBuilder {
     internal: bool,
     provider_name: Option<String>,
     model_name: Option<String>,
+    message_sender: Option<Arc<dyn MessageSender>>,
 }
 
 impl Default for EvalHarnessBuilder {
@@ -106,6 +109,7 @@ impl Default for EvalHarnessBuilder {
             internal: false,
             provider_name: None,
             model_name: None,
+            message_sender: None,
         }
     }
 }
@@ -171,6 +175,12 @@ impl EvalHarnessBuilder {
         self
     }
 
+    /// Set a custom message sender. Default: `None`.
+    pub fn message_sender(mut self, sender: Arc<dyn MessageSender>) -> Self {
+        self.message_sender = Some(sender);
+        self
+    }
+
     /// Build the harness, creating the in-memory DB and temp directories.
     pub async fn build(self) -> Result<EvalHarness> {
         // Create temp directory with minimal agent structure
@@ -219,6 +229,7 @@ impl EvalHarnessBuilder {
             is_callback_turn: self.is_callback_turn,
             skip_compaction: self.skip_compaction,
             internal: self.internal,
+            message_sender: self.message_sender,
         })
     }
 }

--- a/crates/mika-agent/tests/eval/test_tool_calling.rs
+++ b/crates/mika-agent/tests/eval/test_tool_calling.rs
@@ -1,5 +1,10 @@
 //! Integration tests: tool calling scenarios.
 
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use mika_agent::messaging::{MessageSender, SendOutcome};
 use mika_common::llm::mock::*;
 use mika_common::llm::{LlmContent, LlmContentBlock, LlmRole};
 use serde_json::json;
@@ -218,4 +223,90 @@ async fn test_text_based_tool_call_retry() {
     assert_tools_include(&trace, &["search_memory"]);
     // 3 steps: text (retry), tool call, final response
     assert_exact_steps(&trace, 3);
+}
+
+// --- send_message gateway error surfacing (#581) ---
+
+/// Test sender returning a configurable outcome for eval harness tests.
+struct EvalMockSender {
+    outcome: SendOutcome,
+}
+
+#[async_trait]
+impl MessageSender for EvalMockSender {
+    async fn send(&self, _text: &str) -> Result<SendOutcome> {
+        Ok(self.outcome.clone())
+    }
+}
+
+#[tokio::test]
+async fn test_send_message_gateway_failure_surfaces_error() {
+    // LLM calls send_message, sender returns Failed -> tool_call should record success=false
+    let sender = Arc::new(EvalMockSender {
+        outcome: SendOutcome::Failed {
+            reason: "gateway /send returned 502 Bad Gateway".to_string(),
+        },
+    });
+
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response("send_message", json!({"text": "Sprint started"})),
+            text_response("I tried to send the message but delivery failed."),
+        ])
+        .message_sender(sender)
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("Send a sprint update").await.unwrap();
+
+    assert_tools_include(&trace, &["send_message"]);
+
+    // The tool call should be recorded as a failure
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        1,
+        "expected exactly one send_message call"
+    );
+    assert!(
+        !send_calls[0].success,
+        "expected success=false for gateway failure, got success=true"
+    );
+    assert_tool_output_contains(&trace, "send_message", 0, "delivery failed");
+    assert_tool_output_contains(&trace, "send_message", 0, "502 Bad Gateway");
+}
+
+#[tokio::test]
+async fn test_send_message_gateway_success_records_success() {
+    // LLM calls send_message, sender returns Delivered -> tool_call should record success=true
+    let sender = Arc::new(EvalMockSender {
+        outcome: SendOutcome::Delivered,
+    });
+
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response("send_message", json!({"text": "Hello user"})),
+            text_response("Message sent successfully."),
+        ])
+        .message_sender(sender)
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("Send a hello message").await.unwrap();
+
+    assert_tools_include(&trace, &["send_message"]);
+
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        1,
+        "expected exactly one send_message call"
+    );
+    assert!(
+        send_calls[0].success,
+        "expected success=true for delivered message, got success=false"
+    );
+    assert_tool_output_contains(&trace, "send_message", 0, "Message sent.");
 }

--- a/docs/plans/2026-04-17-002-fix-send-message-gateway-error-reporting-plan.md
+++ b/docs/plans/2026-04-17-002-fix-send-message-gateway-error-reporting-plan.md
@@ -1,0 +1,197 @@
+---
+title: "fix: Surface gateway non-2xx responses as send_message tool errors"
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Surface gateway non-2xx responses as send_message tool errors
+
+## Overview
+
+The `send_message` tool always reports `success=true` / `"Message sent."` regardless of whether the gateway actually delivered the message. When the gateway returns non-2xx (e.g., 502), `GatewayMessageSender::send()` saves to `failed_sends` and returns `Ok(())`, hiding the failure from the agent. This fix makes the tool surface delivery failures as `ToolOutput::error` so agents can detect and respond to them.
+
+## Problem Frame
+
+Issue #581: mika-dev sent a sprint notification via `send_message`. The gateway returned 502, but the tool reported `success=1` / `"Message sent."`. The agent proceeded confidently, informed nobody of the failure, and had no path to retry. Every future gateway/channel failure would be equally invisible — this is the class fix.
+
+Institutional learnings confirm the design principle: HTTP status codes ARE well-defined errors (unlike exec handler exit codes) and must surface as `ToolOutput::error`, not `ToolOutput::success`. The grounding rule is the secondary defense; the primary defense must be at the tool output level.
+
+## Requirements Trace
+
+- R1. Non-2xx gateway response → `ToolOutput::error` with status code and body snippet
+- R2. 2xx gateway response → `ToolOutput::success("Message sent.")` (unchanged)
+- R3. Network/timeout errors → `ToolOutput::error` with classification
+- R4. `failed_sends` queue continues to be populated for server-side retry flush
+- R5. Regression tests cover 502 (failure) and 200 (success) scenarios
+
+## Scope Boundaries
+
+- Only the agent-side `send_message` tool and `GatewayMessageSender` are changed
+- Gateway-side behavior is not modified (companion issue for root cause of 502)
+- The `MessageSender` trait signature changes from `Result<()>` to `Result<SendOutcome>`
+- Retry logic (one retry after 2s) is preserved — errors surface only after both attempts fail
+
+### Deferred to Separate Tasks
+
+- Root cause of gateway 502 (chat_id=0 routing): separate issue
+- Silent mode dead-end handling when delivery channel itself fails: accepted for now — step limit bounds waste
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/messaging.rs` — `MessageSender` trait, `GatewayMessageSender` with `try_send()` retry logic
+- `crates/mika-agent/src/tools/send_message.rs` — `SendMessageTool::execute()` uses `sender.send().await?`
+- `crates/mika-agent/src/tools/a2a_call.rs:131-138` — reference pattern: catches `Err` and returns `ToolOutput::error(format!(...))`
+- `crates/mika-agent/src/tools/mod.rs` — `ToolOutput` struct with `success()`/`error()` constructors
+- `crates/mika-agent/src/server/handlers.rs` — failed_sends flush logic (up to 5 pending per inbound message)
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/tool-call-success-contradicts-non-zero-exit.md` — exact same pattern: derived `success` field didn't consider actual outcome
+- `docs/solutions/logic-errors/exec-handler-stdout-discarded-on-nonzero-exit.md` — explicit carve-out: "HTTP status codes are well-defined errors" — do NOT follow exec handler pattern
+- `docs/solutions/prompt-engineering/grounding-rule-downstream-state-hallucination.md` — grounding rule is secondary defense; primary defense must be tool-level accuracy
+- `docs/solutions/integration-issues/gateway-inbound-webhook-retry-on-429-5xx.md` — gateway uses `ForwardResult` enum with `Success`/`Retryable`/`Permanent` classification
+
+## Key Technical Decisions
+
+- **Richer return type over `Err` propagation:** `MessageSender::send()` returns `Result<SendOutcome>` (enum: `Delivered` / `Failed { reason: String }`) instead of `Result<()>`. This lets the tool distinguish "delivery confirmed" from "delivery failed, queued for retry" without breaking the trait's error semantics. `Err` remains reserved for infrastructure failures (chat_id resolution, DB errors). The `?` operator in the tool continues to work for infra errors; the `match` on `SendOutcome` handles delivery results.
+- **Keep `failed_sends` AND return `Failed`:** Belt-and-suspenders. The server-side flush logic still works. The agent also knows delivery failed and can inform the user or retry.
+- **Error message includes status code:** Following the gateway's own classification taxonomy, the error message distinguishes connection errors, HTTP status codes, and timeouts so the agent can make informed decisions.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the trait return `Err` or a richer type?** Richer type (`SendOutcome`). Returning `Err` after saving to `failed_sends` creates ambiguity — the tool's `?` operator would propagate it as an `anyhow::Error`, which the agent loop treats differently from `ToolOutput::error`. A `SendOutcome` enum keeps the success/failure decision at the tool level where it belongs.
+- **Should `failed_sends` still be populated?** Yes. The existing flush logic in `server/handlers.rs` provides automatic retry on next inbound message. Dropping it would make the agent solely responsible for retry.
+- **What about `resolve_chat_id` errors?** These are config errors, not delivery errors. They continue to propagate via `?` as before — they're infrastructure failures, not gateway response failures.
+
+### Deferred to Implementation
+
+- Exact error message wording — directional: include HTTP status code and truncated body (first ~200 chars)
+- Whether `MockSender` needs additional builder methods or if a simple closure-based approach suffices
+
+## Implementation Units
+
+- [x] **Unit 1: Add `SendOutcome` enum and update `MessageSender` trait**
+
+**Goal:** Change the `MessageSender` trait to return `Result<SendOutcome>` instead of `Result<()>`, where `SendOutcome` distinguishes successful delivery from queued-after-failure.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/messaging.rs`
+- Test: `crates/mika-agent/src/messaging.rs` (inline tests)
+
+**Approach:**
+- Define `SendOutcome` enum with `Delivered` and `Failed { reason: String }` variants
+- Update `MessageSender::send()` return type to `Result<SendOutcome>`
+- In `GatewayMessageSender::send()`: after both retries fail, save to `failed_sends` AND return `Ok(SendOutcome::Failed { reason })` instead of `Ok(())`
+- In `try_send()`: capture the response body (truncated) along with status code for the error message
+- On success path: return `Ok(SendOutcome::Delivered)`
+- Classify errors: connection (`is_connect()`), timeout (`is_timeout()`), HTTP status (from `try_send` bail)
+
+**Patterns to follow:**
+- Gateway's `ForwardResult` enum pattern (Success/Retryable/Permanent)
+- `a2a_call.rs` error message format
+
+**Test scenarios:**
+- Happy path: `resolve_chat_id` with explicit override returns `Delivered` (existing test adapted)
+- Happy path: `resolve_chat_id` from DB returns correct ID (existing test preserved)
+- Error path: `resolve_chat_id` with no config returns `Err` (existing test preserved, still an infra error)
+
+**Verification:**
+- `MessageSender` trait compiles with new return type
+- All existing `messaging.rs` tests pass (adapted for `SendOutcome`)
+
+- [x] **Unit 2: Update `SendMessageTool` to surface delivery failures**
+
+**Goal:** Replace the `?` operator on `sender.send()` with a `match` that converts `SendOutcome::Failed` to `ToolOutput::error`.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/send_message.rs`
+- Test: `crates/mika-agent/src/tools/send_message.rs` (inline tests)
+
+**Approach:**
+- Replace `sender.send(&cleaned).await?` with a `match` on the `Result<SendOutcome>`
+- `Ok(SendOutcome::Delivered)` → `ToolOutput::success("Message sent.")`
+- `Ok(SendOutcome::Failed { reason })` → `ToolOutput::error(format!("Message delivery failed: {reason}"))`
+- `Err(e)` → `ToolOutput::error(format!("Message delivery error: {e}"))` (infra failures like chat_id resolution)
+- Update `MockSender` to support configurable outcomes (return `SendOutcome` instead of always `Ok(())`)
+
+**Patterns to follow:**
+- `a2a_call.rs:131-138` — catches `Err` and returns `ToolOutput::error(format!(...))`
+
+**Test scenarios:**
+- Happy path: sender returns `Delivered` → `ToolOutput::success` with "Message sent." and `is_error: false`
+- Error path: sender returns `Failed { reason: "gateway /send returned 502 Bad Gateway" }` → `ToolOutput::error` with `is_error: true` and reason in content
+- Error path: sender returns `Failed { reason: "connection refused" }` → `ToolOutput::error` with network classification
+- Error path: sender returns `Err` (infra failure, e.g., chat_id not configured) → `ToolOutput::error` with infra error message
+- Happy path: no sender configured → `ToolOutput::success` with "NOT delivered" warning (unchanged behavior)
+- Edge case: empty text after stripping → `ToolOutput::success` with processing message (unchanged)
+
+**Verification:**
+- `send_message` tool returns `is_error: true` when sender reports failure
+- `send_message` tool returns `is_error: false` when sender reports delivery
+- All existing tool tests pass (adapted for new `MockSender`)
+
+- [x] **Unit 3: Integration test via eval harness**
+
+**Goal:** Add an eval harness test that verifies the agent receives a failure signal when `send_message` encounters a gateway error.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-agent/tests/eval/test_tool_calling.rs`
+- Read: `crates/mika-agent/tests/eval/harness.rs` (for `EvalHarness` builder API)
+
+**Approach:**
+- Add a test using `EvalHarness` with `MockLlmProvider` that exercises the `send_message` tool with a failing sender
+- The `EvalHarness` builder may need a method to inject a custom `MessageSender` — check existing builder API first
+- Verify the tool_call record in the DB has `success=0`
+
+**Execution note:** Check `EvalHarness` API for sender injection support before writing the test. If not supported, the unit test coverage from Unit 2 is sufficient and this unit pivots to adding sender injection to the harness.
+
+**Patterns to follow:**
+- Existing eval tests in `test_tool_calling.rs` — especially send_message dedup tests
+
+**Test scenarios:**
+- Integration: agent calls `send_message` with failing sender → tool_call DB record has `success=false` and output contains error message
+- Integration: agent calls `send_message` with succeeding sender → tool_call DB record has `success=true` and output is "Message sent."
+
+**Verification:**
+- `cargo test -p mika-agent --test eval` passes
+- New test exercises the full `run_agent()` path with `send_message` failure
+
+## System-Wide Impact
+
+- **Interaction graph:** `send_message` tool → `MessageSender::send()` → `failed_sends` table → server flush logic. The flush logic is unaffected (still reads from `failed_sends`). Tool callers now see failure when delivery fails.
+- **Error propagation:** Delivery failures flow as `SendOutcome::Failed` (not `Err`) through the tool to the agent as `ToolOutput::error`. Infrastructure failures (`Err`) are caught at the tool level and also surface as `ToolOutput::error`.
+- **State lifecycle risks:** None — `failed_sends` continues to be populated. No new state is introduced.
+- **API surface parity:** No other tools use `MessageSender`. The `send` method signature change is internal.
+- **Unchanged invariants:** The `None` sender path (no outbound configured) remains unchanged — intentionally returns success with warning text. The `failed_sends` flush logic in `server/handlers.rs` is unaffected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Agent retry loops when gateway is persistently down | Step limit (`SilentTrigger::max_steps()`) bounds the waste. Continuation turn fallback handles exhaustion. The agent sees the error and can choose to inform the user rather than blindly retry. |
+| Breaking other `MessageSender` implementations | Only two impls: `GatewayMessageSender` (updated) and test `MockSender` (updated). No external consumers. |
+| `try_send` response body read adds latency | Body is only read on error path (non-2xx). Truncated to ~200 chars. Negligible overhead. |
+
+## Sources & References
+
+- **Issue:** [#581 — send_message tool reports success on gateway non-2xx responses](https://github.com/senara-solutions/mika/issues/581)
+- Related code: `crates/mika-agent/src/messaging.rs`, `crates/mika-agent/src/tools/send_message.rs`
+- Related learnings: `docs/solutions/logic-errors/tool-call-success-contradicts-non-zero-exit.md`
+- Related learnings: `docs/solutions/logic-errors/exec-handler-stdout-discarded-on-nonzero-exit.md`

--- a/docs/solutions/logic-errors/send-message-tool-false-success-on-gateway-error.md
+++ b/docs/solutions/logic-errors/send-message-tool-false-success-on-gateway-error.md
@@ -1,0 +1,121 @@
+---
+title: send_message tool reports success on gateway non-2xx responses
+module: crates/mika-agent/src/tools/send_message.rs
+date: 2026-04-17
+problem_type: logic_error
+component: tooling
+severity: high
+symptoms:
+  - "send_message tool returns success=1 and 'Message sent.' when gateway responds with 502"
+  - "Agent proceeds confidently after failed delivery, no retry or user notification"
+  - "Gateway logs show non-2xx responses but tool_calls table shows success=true"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - send-message
+  - gateway
+  - tool-output
+  - error-handling
+  - message-sender
+  - false-success
+related_components:
+  - crates/mika-agent/src/messaging.rs
+  - crates/mika-agent/src/server/handlers.rs
+  - crates/mika-agent/src/task_engine/dispatcher.rs
+---
+
+# send_message tool reports success on gateway non-2xx responses
+
+## Problem
+
+The `send_message` tool returned `ToolOutput::success("Message sent.")` regardless of whether the gateway actually delivered the message. When the gateway returned non-2xx (e.g., 502 Bad Gateway), `GatewayMessageSender::send()` saved the message to `failed_sends` and returned `Ok(())`, hiding the delivery failure from the agent. The agent then claimed delivery succeeded, violating the grounding rule.
+
+## Symptoms
+
+- `send_message` tool_call records show `success=1` when gateway returns 502
+- Agent tells user "message sent" when the message was never delivered
+- Gateway logs contain `WARN response status=502` but tool telemetry shows no failure
+- No retry or error notification path activates because the tool reports success
+
+## What Didn't Work
+
+The original design intentionally returned `Ok(())` from `GatewayMessageSender::send()` on both retry failures, with a comment: "Return Ok — message queued, don't confuse Claude." This was based on the assumption that returning an error would cause the LLM to retry in a loop. However, the LLM can handle `ToolOutput::error` gracefully — it informs the user of the failure rather than blindly retrying.
+
+## Solution
+
+### 1. Rich return type instead of `Result<()>`
+
+Changed `MessageSender::send()` from `Result<()>` to `Result<SendOutcome>` where:
+
+```rust
+pub enum SendOutcome {
+    Delivered,           // Gateway returned 2xx
+    Failed { reason: String },  // Non-2xx after retries, saved to failed_sends
+}
+```
+
+`Err` is reserved for infrastructure failures (chat_id resolution, DB errors) — not delivery failures.
+
+### 2. Tool surfaces delivery failures
+
+```rust
+// Before: sender.send(&cleaned).await?;
+// After:
+match sender.send(&cleaned).await {
+    Ok(SendOutcome::Delivered) => Ok(ToolOutput::success("Message sent.")),
+    Ok(SendOutcome::Failed { reason }) => Ok(ToolOutput::error(
+        format!("Message delivery failed: {reason}")
+    )),
+    Err(e) => Ok(ToolOutput::error(format!("Message delivery error: {e}"))),
+}
+```
+
+### 3. Error classification in `try_send()`
+
+Gateway errors include HTTP status + truncated body snippet (first 200 chars). Network errors are classified:
+
+- Connection error: `"gateway unreachable (connection error): {e}"`
+- Timeout: `"gateway request timed out: {e}"`
+- Other: `"gateway request failed: {e}"`
+
+### 4. `save_failed_send` error does not mask gateway error
+
+The DB write for `failed_sends` uses `if let Err` instead of `?`, so a DB failure logs a warning but still returns the original gateway error reason to the caller:
+
+```rust
+let reason = e.to_string();
+if let Err(db_err) = self.db.save_failed_send(text, None).await {
+    warn!(error = %db_err, "failed to save to failed_sends table");
+}
+Ok(SendOutcome::Failed { reason })
+```
+
+### 5. All callsites updated
+
+| Callsite | Policy |
+|----------|--------|
+| `send_message` tool | Surfaces `Failed` as `ToolOutput::error` |
+| Task-engine dispatcher | Fire-and-forget — logs warning, returns `Ok(())` |
+| Server EndTurn handler | Logs warning on `Failed` |
+| Verdict/CI notification handlers | Log warning on `Failed` |
+| `failed_sends` flush | Increments retry count on `Failed` |
+
+## Why This Works
+
+The root cause was a `Result<()>` return type that conflated "delivery succeeded" with "delivery failed but we saved it for later." The `SendOutcome` enum makes the distinction explicit at the type level. Each callsite can then apply the appropriate policy: the tool surfaces errors to the LLM, while fire-and-forget paths absorb them.
+
+The `failed_sends` table continues to be populated for server-side retry flush, providing belt-and-suspenders recovery. The agent also knows delivery failed and can inform the user.
+
+## Prevention
+
+1. **HTTP status codes are well-defined errors.** Never swallow non-2xx responses as success. This is an explicit codebase convention — see `docs/solutions/logic-errors/exec-handler-stdout-discarded-on-nonzero-exit.md` for the carve-out that exec handler exit codes are ambiguous but HTTP status codes are not.
+2. **Use rich return types instead of `Result<()>` for operations with meaningful non-error outcomes.** A `Result<()>` that returns `Ok(())` for both "succeeded" and "failed but queued" is a lie at the type level. Use an enum.
+3. **When changing a trait return type, grep for all `impl` blocks and all callsites.** The `MessageSender` trait had implementations in 4 files and callsites in 7 files. Missing one (handlers.rs EndTurn path) was caught during review.
+4. **Never let a persistence error mask the original failure.** If `save_failed_send` fails, the caller should still see the gateway error, not a DB error. Use `if let Err` for best-effort persistence, not `?`.
+
+## Related
+
+- [tool-call-success-contradicts-non-zero-exit](tool-call-success-contradicts-non-zero-exit.md) — same class of bug: derived `success` field didn't consider actual outcome
+- [exec-handler-stdout-discarded-on-nonzero-exit](exec-handler-stdout-discarded-on-nonzero-exit.md) — establishes the "HTTP status codes are well-defined errors" convention
+- [grounding-rule-downstream-state-hallucination](../prompt-engineering/grounding-rule-downstream-state-hallucination.md) — grounding rule is secondary defense; primary defense must be tool-level accuracy
+- GitHub issue: [#581](https://github.com/senara-solutions/mika/issues/581)


### PR DESCRIPTION
## Summary

- **`SendOutcome` enum** replaces `Result<()>` on `MessageSender::send()` — `Delivered` vs `Failed { reason }` with `Err` reserved for infrastructure failures
- **`send_message` tool** now returns `ToolOutput::error` with status/body snippet when gateway returns non-2xx, enabling agents to detect and report delivery failures
- **Error classification** — connection errors, timeouts, and HTTP status codes with truncated body snippets surface actionable diagnostics
- **`save_failed_send` resilience** — DB write failure no longer masks the original gateway error (uses `if let Err` instead of `?`)
- **All callsites updated** — server EndTurn handler, task dispatcher (fire-and-forget with comment), verdict/CI notification handlers, and `failed_sends` flush path

## Test plan

- [x] Unit tests: `send_message` tool with `MockSender` returning `Delivered`, `Failed`, and `Err` variants
- [x] Integration tests: `EvalHarness` with `message_sender` builder exercising full `run_agent()` path for gateway failure (success=false, error message) and success (success=true, "Message sent.")
- [x] All 1720 mika-agent tests pass (1661 lib + 54 eval + 5 smoke)
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass (fmt, clippy, no-secrets, no-large-files)

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)