### PR TITLE
fix(self-dev): milestone callback routing + missing parent_task_id in child creation

### DIFF
--- a/docs/plans/2026-04-17-004-fix-self-dev-milestone-callback-routing-plan.md
+++ b/docs/plans/2026-04-17-004-fix-self-dev-milestone-callback-routing-plan.md
@@ -1,0 +1,125 @@
+---
+title: "fix: Self-dev milestone callback routing + missing parent_task_id in child creation"
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Self-dev milestone callback routing + missing parent_task_id in child creation
+
+## Overview
+
+Two prompt gaps in self-dev's Milestone Workflow caused mika#6 (first milestone dispatch) to break. Callback turns containing child issue references get misrouted to the Generic Workflow instead of the milestone callback handler. Separately, `create_work_item` calls in Step M3 lack a JSON example showing `parent_task_id`, causing the agent to omit it.
+
+## Problem Frame
+
+During the mika#6 milestone run, claude-pilot completed child #1 (mika#582). The callback arrived as a `SilentTrigger::Callback` turn containing "mika#582" as an issue reference. mika-dev's LLM pattern-matched this to the Generic Workflow ("implement mika#582") instead of the Callback Entry Point, creating orphan work items and abandoning the milestone loop. Separately, all 3 children were created without `parent_task_id` because the agent follows JSON examples literally and the Step M3 section uses bullet-list format without an explicit JSON block.
+
+## Requirements Trace
+
+- R1. Callback turns during a milestone/project run must route to Step M4, not the Generic Workflow
+- R2. `create_work_item` calls in Step M3 must include `parent_task_id` in both prose AND a JSON example block
+- R3. Step P3 (Project Workflow) must receive the same JSON example treatment for consistency
+
+## Scope Boundaries
+
+- Prompt-only changes to `skills/bundled/self-dev/system_prompt.md`
+- No Rust code changes
+- No changes to other skills or handler scripts
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/self-dev/system_prompt.md` — the single file being modified
+- Callback Entry Point section (lines 79–98) — currently has no milestone/project awareness
+- Step M3 (lines 312–319) — uses bullet-list format; `parent_task_id` is present but not in JSON
+- Step P3 (lines 405–414) — same bullet-list pattern, should get JSON too for consistency
+- Step 3 in main workflow (lines 46–55) — uses JSON code block for `run_claude_pilot` — this is the pattern the agent follows reliably
+
+### Institutional Learnings
+
+- Rule 4 (lines 225–235) documents tool input schema discipline failures — the agent skips parameters not shown in examples
+- The `run_claude_pilot` call in Step 3 already uses JSON format successfully — this is the proven pattern
+
+## Key Technical Decisions
+
+- **Add milestone-awareness to Callback Entry Point, not a separate section:** The routing fix belongs in the existing Callback Entry Point since that's where the LLM enters on callback turns. Adding a separate section risks the same pattern-matching problem.
+- **Use JSON code blocks for create_work_item in M3/P3:** The agent reliably follows JSON examples (see Step 3's `run_claude_pilot` format). Bullet lists are ambiguous — JSON is unambiguous.
+- **Place milestone check BEFORE the success/failure handling:** The milestone context check must happen at the top of the Callback Entry Point, before branching into success/failure paths, so the agent knows it's in milestone mode regardless of outcome.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add milestone/project awareness to Callback Entry Point**
+
+**Goal:** Prevent callback turns from being misrouted to the Generic Workflow when the callback is part of a milestone or project execution loop.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/self-dev/system_prompt.md`
+
+**Approach:**
+- Insert a new block after the "Callback Entry Point" heading (after line 81) and before the "On pipeline failure" section (line 87)
+- The block should instruct the agent to check if the callback's work item has a parent with `type='milestone'` or `type='project'` via `check_work_item`
+- If milestone/project context detected: after extracting metadata and updating the child work item, return to Step M4/P4 — do NOT re-read issues, create new work items, or enter the Generic Workflow
+- Use strong negative instructions matching the style of existing calibration rules
+
+**Patterns to follow:**
+- Rule 9 (Webhook turns are not dispatch triggers) — same pattern of explicit "do NOT" instructions to prevent misrouting
+- SCOPE RULE blocks already in the Callback Entry Point section
+
+**Test scenarios:**
+- Test expectation: none — prompt-only change, no code to test. Verified manually via milestone dispatch.
+
+**Verification:**
+- The Callback Entry Point section contains explicit milestone/project routing instructions
+- The instructions reference Step M4/P4 by name
+- Strong negative instructions prevent entering the Generic Workflow
+
+- [ ] **Unit 2: Add JSON example blocks to Step M3 and Step P3**
+
+**Goal:** Make `parent_task_id` unmissable in milestone/project child creation by providing explicit JSON examples.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/self-dev/system_prompt.md`
+
+**Approach:**
+- Replace the bullet-list format in Step M3 with a JSON code block showing all parameters including `parent_task_id`
+- Apply the same JSON code block treatment to Step P3
+- Follow the same JSON format used in Step 3 for `run_claude_pilot`
+
+**Patterns to follow:**
+- Step 3's `run_claude_pilot` JSON example (lines 48–52) — proven to be followed reliably by the agent
+
+**Test scenarios:**
+- Test expectation: none — prompt-only change, no code to test. Verified manually via milestone dispatch.
+
+**Verification:**
+- Step M3 contains a JSON code block with `parent_task_id` as a visible field
+- Step P3 contains a matching JSON code block with `parent_task_id`
+- Both JSON blocks include all required fields: `type`, `parent_task_id`, `label`, `reference_url`, `source`
+
+## System-Wide Impact
+
+- **Interaction graph:** Callback turns now have an additional routing check. The milestone/project loop (M4/P4) becomes reachable from callbacks, which was the intended design but was not enforced in the prompt.
+- **Unchanged invariants:** Single-issue workflow (Steps 1-6), webhook handling, sprint mode, and all calibration rules are unchanged. The Callback Entry Point's success/failure handling paths remain the same — the milestone check is an additional guard that routes before those paths when applicable.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Milestone check adds latency (extra `check_work_item` call) | Minimal — one lightweight DB lookup per callback turn, only when parent_task_id exists |
+| Over-broad matching routes non-milestone callbacks to M4 | Check is gated on parent work item having `type='milestone'` or `type='project'` — regular issue callbacks have no parent |
+
+## Sources & References
+
+- Related issue: #609
+- Incident: Milestone mika#6 run, 2026-04-16 ~22:22-23:01 UTC
+- mika-dev session `93919db5` (callback turn where the break happened)

--- a/docs/solutions/logic-errors/milestone-callback-misrouted-to-generic-workflow.md
+++ b/docs/solutions/logic-errors/milestone-callback-misrouted-to-generic-workflow.md
@@ -1,0 +1,90 @@
+---
+title: Milestone callback misrouted to Generic Workflow — missing prompt-level routing
+date: 2026-04-17
+category: logic-errors
+module: skills-executor, self-dev
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Callback turn after claude-pilot child completion dispatches new work instead of resuming milestone loop"
+  - "Orphan work items created outside the milestone tree during milestone execution"
+  - "Milestone loop never advances past child #1"
+root_cause: missing_workflow_step
+resolution_type: documentation_update
+severity: high
+tags: [milestone, callback, routing, self-dev, prompt-engineering, parent-task-id, generic-workflow]
+---
+
+# Milestone callback misrouted to Generic Workflow — missing prompt-level routing
+
+## Problem
+
+During the first milestone dispatch (mika#6), claude-pilot completed child #1 (mika#582). The callback arrived as a `SilentTrigger::Callback` turn containing "mika#582" as an issue reference. mika-dev's LLM pattern-matched this to the Generic Workflow ("implement mika#582") instead of following the Callback Entry Point back to Step M4 (serial execution loop). The milestone loop never advanced to child #2.
+
+Separately, all 3 child work items were created without `parent_task_id` because the agent follows JSON examples literally, and Step M3 used bullet-list format without an explicit JSON code block.
+
+## Symptoms
+
+- Callback turn created an orphan work item for "mika#582" outside the milestone tree
+- Agent dispatched `run_claude_pilot` 4 times for the same child issue
+- Milestone parent work item was never updated past child #1
+- `check_work_item` on children showed no `parent_task_id` set
+
+## What Didn't Work
+
+- The engine's generic callback framing (mika#313) correctly surfaces `parent_task_id` in the callback context. But the self-dev prompt's Callback Entry Point had no instructions to detect milestone context and route accordingly — the engine provides the data, but the skill prompt must act on it.
+- Step M3 described `parent_task_id` in the bullet-list parameters, but the agent consistently omitted it because it was not shown in a JSON example block. Prose instructions are weaker than JSON examples for tool call compliance.
+
+## Solution
+
+Two prompt changes to `skills/bundled/self-dev/system_prompt.md`:
+
+### 1. Milestone/project context check in Callback Entry Point
+
+Added a mandatory check block before the success/failure/pipeline-failure handlers:
+
+1. Call `check_work_item(task_id)` on the callback's work item to get `parent_task_id`
+2. If `parent_task_id` exists, call `check_work_item(parent_task_id)` on the parent
+3. If parent's `type` is `'milestone'` or `'project'`, route to Step M4/P4 after completing the success/failure handling
+
+Key detail: the routing to M4/P4 only happens when the child reaches a **terminal state** (completed, blocked, failed after retries exhausted). Non-terminal paths (e.g., pipeline-failure retry) follow their existing "wait for callback" flow — the next callback re-enters the context check.
+
+Negative instructions prevent the LLM from misinterpreting the callback's issue reference as a new dispatch trigger.
+
+### 2. JSON code blocks for create_work_item in Step M3 and Step P3
+
+Replaced bullet-list format with explicit JSON examples showing all fields including `parent_task_id`:
+
+```json
+{
+  "type": "issue",
+  "parent_task_id": "<milestone_wi>",
+  "label": "<repo>#<issue_number>",
+  "reference_url": "https://github.com/senara-solutions/<repo>/issues/<issue_number>",
+  "source": "self_dev"
+}
+```
+
+Added consequence explanation: "without it, the child is an orphan and callback routing to Step M4 will fail."
+
+## Why This Works
+
+**Callback routing:** The engine deliberately uses generic callback framing (see `docs/solutions/architecture-patterns/generic-callback-framing-parent-task-id.md`) — it provides `parent_task_id` as data but does not encode workflow-specific routing. The skill prompt must explicitly detect milestone/project context and branch accordingly. Without this check, any callback containing an issue reference will be misidentified as a new dispatch trigger by the Generic Workflow's pattern matching.
+
+**JSON examples:** LLMs treat JSON examples as the strongest signal for structured output compliance — stronger than prose instructions alone (see `docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md`). An absent key in the example consistently produces an absent key in every generated call. The JSON block makes `parent_task_id` unmissable.
+
+## Prevention
+
+- **Every distinct entry point needs explicit routing instructions.** Fallthrough to a catch-all (Generic Workflow) is always a bug — same class as the webhook fallthrough incident (mika#583, see `docs/solutions/logic-errors/webhook-fallthrough-dispatches-unrelated-backlog-work.md`).
+- **Tool call examples must show all required parameters in JSON format.** Bullet lists are ambiguous; agents skip parameters not visible in examples. This is Rule 4 in the self-dev calibration rules.
+- **Terminal vs non-terminal routing must be explicit.** When a prompt says "return to Step X," specify whether that applies only after terminal outcomes or also mid-retry.
+
+## Related Issues
+
+- mika#609 — this fix
+- mika#6 — milestone where the break occurred
+- mika#583 — webhook fallthrough incident (same bug class)
+- mika#313 — generic callback framing engine changes
+- `docs/solutions/architecture-patterns/generic-callback-framing-parent-task-id.md` — engine-side framing
+- `docs/solutions/logic-errors/webhook-fallthrough-dispatches-unrelated-backlog-work.md` — same bug class
+- `docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md` — JSON example compliance

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -102,6 +102,20 @@ When you receive a callback result from a completed `run_claude_pilot` backgroun
 
 > **MILESTONE/PROJECT CONTEXT:** If the callback task's parent (via `check_work_item`) has `type='milestone'` or `type='project'`, you are in a milestone loop. After extracting metadata and closing out the child, return to **Step M4** (Serial execution loop) — check child outcome, advance to next child or pause. Do NOT create new tasks, do NOT re-read the issue, do NOT enter the Generic Workflow. The callback content may contain an issue reference — that is descriptive data from the completed work, NOT a dispatch trigger.
 
+> **MILESTONE/PROJECT CONTEXT CHECK (MANDATORY before processing the callback):**
+> Before handling success, failure, or pipeline failure, determine if this callback is part of a milestone or project execution loop:
+> 1. Call `check_work_item(task_id)` on the callback's work item. Note the `parent_task_id` field.
+> 2. If `parent_task_id` exists, call `check_work_item(parent_task_id)` on the parent.
+> 3. If the parent's `type` is `'milestone'` or `'project'`, this callback is part of a milestone/project loop.
+>
+> **When milestone/project context is detected:** After extracting metadata and updating the child work item (success/failure handling below), return to **Step M4** (milestone) or **Step P4** (project) — check the child outcome, advance to the next child, or pause the milestone.
+> - Do NOT re-read the GitHub issue as if it were a new dispatch.
+> - Do NOT create new work items.
+> - Do NOT enter the Generic Workflow (Steps 1–3).
+> - The callback's issue reference (e.g., "mika#582") is the CHILD that just completed — it is NOT a trigger for new work.
+>
+> **When no milestone/project context:** Proceed with normal callback handling below.
+
 **On pipeline failure (callback contains "PIPELINE FAILURE:"):**
 
 1. Extract metadata (Session, Cost, Turns, Duration) from the lines after the PIPELINE FAILURE prefix.
@@ -328,7 +342,7 @@ Store the ordered list of issue numbers as `milestone_issues`.
 ### Step M3 — Create child work items
 
 For each issue number in `milestone_issues`:
-1. Call `create_work_item` with:
+1. Call `create_work_item` with **all** of these fields (do NOT omit `parent_task_id`):
    ```json
    {
      "type": "issue",
@@ -338,7 +352,7 @@ For each issue number in `milestone_issues`:
      "source": "self_dev"
    }
    ```
-   **`parent_task_id` is REQUIRED** — without it the child is orphaned from the milestone tree and the loop breaks.
+   **`parent_task_id` is REQUIRED** — without it the child is orphaned from the milestone tree and callback routing to Step M4 will fail.
 2. Store returned `task_id` in ordered list `child_wis`
 
 Notify Vincent: "Milestone <repo>#<n> initialized with {N} issues. Starting sequential execution."
@@ -430,12 +444,19 @@ Store ordered list of `repo#issue` references as `project_issues`.
 
 For each `repo#issue` in `project_issues`:
 1. Parse repo and issue number
-2. Call `create_work_item` with:
-   - `type`: `"issue"`
-   - `parent_task_id`: `<project_wi>`
-   - `label`: `"<repo>#<issue_number>"`
-   - `reference_url`: `"https://github.com/senara-solutions/<repo>/issues/<issue_number>"`
-   - `source`: `"self_dev"`
+2. Call `create_work_item` with **all** of these fields (do NOT omit `parent_task_id`):
+
+   ```json
+   {
+     "type": "issue",
+     "parent_task_id": "<project_wi>",
+     "label": "<repo>#<issue_number>",
+     "reference_url": "https://github.com/senara-solutions/<repo>/issues/<issue_number>",
+     "source": "self_dev"
+   }
+   ```
+
+   `parent_task_id` links the child to the project parent — without it, the child is an orphan and callback routing to Step P4 will fail.
 
 ### Step P4 — Serial execution loop
 

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -108,7 +108,7 @@ When you receive a callback result from a completed `run_claude_pilot` backgroun
 > 2. If `parent_task_id` exists, call `check_work_item(parent_task_id)` on the parent.
 > 3. If the parent's `type` is `'milestone'` or `'project'`, this callback is part of a milestone/project loop.
 >
-> **When milestone/project context is detected:** After extracting metadata and updating the child work item (success/failure handling below), return to **Step M4** (milestone) or **Step P4** (project) — check the child outcome, advance to the next child, or pause the milestone.
+> **When milestone/project context is detected:** Process the callback through the success/failure/pipeline-failure handling below as normal. If the handling path is terminal (child reaches `completed`, `blocked`, or `failed` after exhausting retries), return to **Step M4** (milestone) or **Step P4** (project) — check the child outcome, advance to the next child, or pause the milestone. If the handling path is non-terminal (e.g., pipeline-failure retry that re-dispatches claude-pilot), follow that path's "wait for callback" instruction — do NOT return to M4/P4 yet; the next callback will re-enter this check.
 > - Do NOT re-read the GitHub issue as if it were a new dispatch.
 > - Do NOT create new work items.
 > - Do NOT enter the Generic Workflow (Steps 1–3).


### PR DESCRIPTION
## Summary

- Add mandatory milestone/project context check to the Callback Entry Point in `self-dev/system_prompt.md` so callback turns during a milestone run route back to Step M4/P4 instead of being misidentified as new Generic Workflow dispatch triggers
- Replace bullet-list format with explicit JSON code blocks for `create_work_item` in Step M3 and Step P3, making `parent_task_id` unmissable (agents skip parameters not shown in JSON examples)
- Clarify that M4/P4 return only applies after terminal child outcomes, not mid-retry

## Root Cause

Two prompt gaps caused the first milestone dispatch (mika#6) to break:
1. The Callback Entry Point had no milestone-awareness — callbacks containing child issue references were pattern-matched to the Generic Workflow
2. Step M3/P3 used bullet-list format for `create_work_item` parameters — the agent consistently omitted `parent_task_id` because it wasn't in a JSON example block

## Test plan

- [ ] Dispatch `implement milestone mika#<test>` — verify children have `parent_task_id` set via `check_work_item`
- [ ] Verify callback turns during milestone run route to Step M4, not Generic Workflow
- [ ] Verify pipeline-failure retries still follow their existing "wait for callback" flow (don't prematurely return to M4)

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)