### PR TITLE
fix(self-dev): bump max_prompt_size to 49152 — unblock agent loading

### DIFF
--- a/docs/plans/2026-04-17-005-fix-bump-self-dev-max-prompt-size-plan.md
+++ b/docs/plans/2026-04-17-005-fix-bump-self-dev-max-prompt-size-plan.md
@@ -1,0 +1,89 @@
+---
+title: "fix: Bump self-dev max_prompt_size to unblock agent loading"
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Bump self-dev max_prompt_size to unblock agent loading
+
+## Overview
+
+Raise `max_prompt_size` in `skills/bundled/self-dev/skill.toml` from 32768 to 49152 so the engine stops refusing to load the self-dev skill. Emergency unblock; architectural cleanup lives in #629 and #630.
+
+## Problem Frame
+
+`skills/bundled/self-dev/system_prompt.md` is 33,868 bytes. The skill's `max_prompt_size = 32768` in `skill.toml` is now exceeded. Because self-dev is `always_on`, the engine refuses to load it entirely (`crates/mika-agent/src/skills/index.rs:488-540`). Self-dev is broken on both mika-dev and mika-qa, which blocks the dev loop orchestration (milestone/project workflows, callback routing, webhook handlers).
+
+## Requirements Trace
+
+- R1. mika-dev loads self-dev successfully after deploy (no "prompt exceeds size limit" ERROR at startup; name appears in `mika skills --agent mika-dev list`)
+- R2. mika-qa loads self-dev successfully after deploy
+- R3. Value stays well under the 64 KB engine ceiling with headroom for expected growth
+
+## Scope Boundaries
+
+- Does NOT restructure the self-dev prompt to reduce its size
+- Does NOT change the engine's overflow handling (that's #630)
+- Does NOT move `enabled` state to DB (that's #629)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/self-dev/skill.toml` — the file being modified
+- `crates/mika-agent/src/skills/index.rs:488-540` — the overflow check that rejects the skill today
+- Other bundled skills' `skill.toml` — reference for `max_prompt_size` conventions
+
+### Institutional Learnings
+
+- `docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md` — prompt size growth from iterative fixes is a recurring pattern
+
+## Key Technical Decisions
+
+- **Choose 49152 (48 KB) over a tighter bump like 36864 (36 KB):** Leaves real headroom — roughly 40% above current size — so the next incremental prompt change doesn't immediately trip the limit again. Still 25% below the 64 KB engine ceiling, which is the hard ceiling enforced in `index.rs`.
+- **Don't trim the prompt in this PR:** The size growth reflects genuine routing and callback guard content added in #626 and #627. Trimming under time pressure risks regression. #629 and #630 remove the need to police prompt size at the config level.
+
+## Implementation Units
+
+- [ ] **Unit 1: Raise max_prompt_size**
+
+**Goal:** self-dev loads at startup on both mika-dev and mika-qa.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/self-dev/skill.toml`
+
+**Approach:**
+- Change `max_prompt_size = 32768` to `max_prompt_size = 49152`
+
+**Patterns to follow:**
+- Other skills' `skill.toml` files for valid TOML syntax
+
+**Test scenarios:**
+- Test expectation: none — single-line config change with no behavioral code. Verified via runtime: after deploy, `mika skills --agent mika-dev list` and `mika skills --agent mika-qa list` both show `self-dev` in the `names` array without the "always_on skill prompt exceeds size limit" ERROR.
+
+**Verification:**
+- File diff is exactly the numeric change on the `max_prompt_size` line
+- Post-deploy runtime check: both agents load self-dev cleanly
+
+## System-Wide Impact
+
+- **Interaction graph:** self-dev is `always_on` — when loaded, its prompt is part of every mika-dev and mika-qa turn. Raising the limit doesn't change content, only admits the current content.
+- **Unchanged invariants:** No change to the engine's overflow handling, the matcher, the runtime filter, or any other skill's config.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Limit grows again on the next prompt change | Issues #629 (DB-backed state) and #630 (hard-skip + log split) remove the need to police size at the config level |
+
+## Sources & References
+
+- Related issue: #628
+- Related milestone: #12 (Skills loading cleanup)
+- Related issues: #629 (P1), #630 (P2)
+- Engine overflow logic: `crates/mika-agent/src/skills/index.rs:488-540`

--- a/docs/solutions/prompt-engineering/2026-04-17-always-on-skill-prompt-size-headroom.md
+++ b/docs/solutions/prompt-engineering/2026-04-17-always-on-skill-prompt-size-headroom.md
@@ -1,0 +1,94 @@
+---
+title: "always_on skill prompts need size headroom — iterative additions silently compound"
+date: 2026-04-17
+category: prompt-engineering
+module: skills-engine, self-dev
+problem_type: workflow_issue
+component: skill-loading
+applies_when:
+  - "Adding routing, callback guards, or workflow branches to an always_on skill's system_prompt.md"
+  - "Reviewing a stack of consecutive PRs that each add a few hundred bytes of prose to the same always_on skill"
+  - "Setting max_prompt_size in skill.toml for a new always_on skill"
+tags: [always-on, skill-loading, max-prompt-size, self-dev, size-budget, workflow]
+---
+
+# always_on skill prompts need size headroom — iterative additions silently compound
+
+## Context
+
+The self-dev prompt grew from ~29 KB to 33,868 bytes across two consecutive fixes (mika#626, mika#627). Both PRs added necessary content — routing table, callback context check, P3 JSON example, negative instructions. Each PR on its own looked modest (+20-67 lines). The running total crossed `max_prompt_size = 32768` in `skill.toml`, and on next deploy the engine refused to load the skill entirely.
+
+`always_on` skills are the critical case: when the prompt exceeds `max_prompt_size`, `crates/mika-agent/src/skills/index.rs` skips them entirely with an ERROR. Without self-dev loaded, mika-dev loses the whole dev-loop orchestration — milestone routing, callback handling, webhook dispatch — all gone.
+
+## Guidance
+
+1. **Set `max_prompt_size` with real headroom, not at the current size.** For always_on skills, target at least 40% above the current prompt size. 64 KB is the engine ceiling; going up to ~48 KB for a prompt that's 25-35 KB today is reasonable. Treating the limit as a tight budget guarantees the next prompt change will trip it.
+
+2. **When reviewing a PR that adds prose to an always_on skill's `system_prompt.md`, check the cumulative size.** `wc -c skills/bundled/<name>/system_prompt.md` against `max_prompt_size` in `skill.toml`. A PR that adds 600 bytes looks fine in isolation — but if it crosses the limit, CI happily merges it and the next deploy breaks production. This is a footgun until we replace size policing at the config level.
+
+3. **Iterative guard/routing additions are a recurring pattern.** When the same skill gets two or three consecutive PRs that each add explicit "do NOT" negative instructions for an edge case, treat size growth as a design smell: there's duplication to dedup, or the workflow needs restructuring, not more prose.
+
+4. **`always_on` and non-`always_on` fail differently.** Over-size `always_on` skills fail loudly (ERROR, skill not loaded). Over-size non-`always_on` skills fail silently — the prompt is emptied but the skill still loads with its tools defined. The silent failure is the worse case; it produces a skill that triggers and generates garbage. Track this class of bug under mika#630 (hard-skip symmetry).
+
+## Why This Matters
+
+`always_on` skills participate in every turn. When one doesn't load:
+- Downstream agents that depend on it (webhook handlers, callback routers) degrade or misroute
+- Test runs that exercise the workflow stop working
+- Live sessions silently lose capabilities with no warning — the only signal is an ERROR line at startup
+
+The cost of an emergency bump + redeploy is small (single-line change). The cost of not noticing until mika-dev misroutes a milestone is much larger. A review check that takes 10 seconds (`wc -c` vs `grep max_prompt_size`) prevents the whole class.
+
+## When to Apply
+
+- Editing `skills/bundled/<skill>/system_prompt.md` for any skill with `always_on = true`
+- Setting initial `max_prompt_size` on a new always_on skill
+- Reviewing PRs that add prose, negative instructions, or JSON examples to orchestration skills (self-dev, qa-review, permission-policy)
+- Diagnosing "skill not loaded" ERRORs at agent startup
+
+## Examples
+
+**Before the bump (mika#628 state):**
+
+```toml
+# skills/bundled/self-dev/skill.toml
+max_prompt_size = 32768
+```
+
+```
+wc -c skills/bundled/self-dev/system_prompt.md
+33868
+```
+
+Result: `ERROR always_on skill prompt exceeds size limit — skill NOT loaded.` on both mika-dev and mika-qa.
+
+**After the bump:**
+
+```toml
+max_prompt_size = 49152
+```
+
+~45% headroom above the current 33,868 bytes, 25% below the 64 KB engine ceiling. Good for several more iterations before needing to revisit.
+
+**Review-time check (drop into PR review checklists for `always_on` skill changes):**
+
+```bash
+# For each always_on skill's system_prompt.md modified in the diff:
+for f in $(git diff --name-only main...HEAD | grep 'system_prompt.md$'); do
+  skill_dir=$(dirname "$f")
+  if grep -q 'always_on = true' "$skill_dir/skill.toml" 2>/dev/null; then
+    limit=$(grep '^max_prompt_size' "$skill_dir/skill.toml" | awk '{print $3}')
+    size=$(wc -c < "$f")
+    printf "%s: %d / %d bytes (%d%% of limit)\n" "$f" "$size" "$limit" "$((size * 100 / limit))"
+  fi
+done
+```
+
+## Related
+
+- mika#628 — emergency bump (this solution)
+- mika#629 — move enabled state to DB (removes one category of silent filtering)
+- mika#630 — hard-skip non-always_on overflow symmetrically + split startup log (removes the silent-empty-prompt footgun)
+- mika#12 milestone — Skills loading cleanup (the architectural follow-up that removes the need to police size at the config level)
+- `crates/mika-agent/src/skills/index.rs:488-540` — overflow handling
+- `docs/solutions/prompt-engineering/2026-04-10-harden-skill-review-prompt-enforcement.md` — related prompt-engineering lesson on enforcement

--- a/skills/bundled/self-dev/skill.toml
+++ b/skills/bundled/self-dev/skill.toml
@@ -4,7 +4,7 @@ description = "Orchestrator: delegates implementation work to Claude Code via cl
 version = "0.2.0"
 always_on = true
 timeout_secs = 30
-max_prompt_size = 32768
+max_prompt_size = 49152
 dependencies = [
     "build-mika",
     "deploy-mika",


### PR DESCRIPTION
## Summary

- Bump `max_prompt_size` in `skills/bundled/self-dev/skill.toml` from **32,768** to **49,152** (48 KB)
- Emergency unblock: self-dev prompt grew to 33,868 bytes after #626 + #627 and the engine refused to load it (`always_on` skills are rejected when oversized), leaving mika-dev and mika-qa without dev-loop orchestration

## Why this value

- Current prompt: 33,868 bytes → new limit gives ~45% headroom
- 25% below the 64 KB engine ceiling enforced in `crates/mika-agent/src/skills/index.rs`
- Avoids another bump on the next prompt change

## Scope

- Single-line config change — no Rust, no behavioral code
- Plan doc: `docs/plans/2026-04-17-005-fix-bump-self-dev-max-prompt-size-plan.md`
- Compound doc: `docs/solutions/prompt-engineering/2026-04-17-always-on-skill-prompt-size-headroom.md` — captures the recurring-pattern lesson for future always_on skill reviews

## Architectural follow-ups (milestone #12 — Skills loading cleanup)

- #629 — move skill `enabled` state from `.disabled` markers to DB with eviction (removes runtime-filter footgun)
- #630 — hard-skip non-`always_on` overflow symmetrically + split startup log + delete match-time filter (removes silent-empty-prompt footgun)

## Test plan

- [ ] CI passes
- [ ] Post-merge: `make deploy` rebuilds and redeploys
- [ ] Verify both agents load self-dev: `mika skills --agent mika-dev list` and `mika skills --agent mika-qa list` show `self-dev` without the `always_on skill prompt exceeds size limit` ERROR

Closes #628