### PR TITLE
fix(self-dev): sort milestone/project issues ascending by number

### DIFF
--- a/docs/plans/2026-04-17-006-fix-sort-milestone-issues-ascending-plan.md
+++ b/docs/plans/2026-04-17-006-fix-sort-milestone-issues-ascending-plan.md
@@ -1,0 +1,85 @@
+---
+title: "fix: Sort milestone issues ascending in self-dev Step M2"
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Sort milestone issues ascending in self-dev Step M2
+
+## Overview
+
+`gh issue list` returns issues in descending created order by default. The self-dev milestone workflow (Step M2) processes issues in this default order, meaning the newest issue runs first. When child issues have dependency ordering (earlier issues land first, later ones depend on them), this causes dependency breakage. Fix by adding `sort_by(.number)` to the jq filter so issues are processed oldest-first.
+
+## Problem Frame
+
+Caught when milestone #12 was about to be dispatched: #630 depends on #629, but the current ordering would queue #630 first and break it. The root cause is that `gh issue list` returns newest-first by default, and the Step M2 jq filter (`.[].number`) passes through that order without sorting.
+
+The same pattern exists in the Project Workflow (Step P2), where GraphQL returns items in project-board order (non-deterministic). Both should sort ascending by issue number for deterministic, dependency-safe ordering.
+
+## Requirements Trace
+
+- R1. Step M2 must return issues in ascending number order (from issue #632 acceptance criteria)
+- R2. Plan captures reasoning: newest-first is wrong for dependency-ordered work
+- R3. Compound doc surfaces the general pattern: batch work-item fetches should sort deterministically, oldest-first
+
+## Scope Boundaries
+
+- Prompt-only edit to `skills/bundled/self-dev/system_prompt.md`
+- No Rust code changes
+- No test changes (prompt text, not executable code)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/self-dev/system_prompt.md` line 337: Step M2 jq filter `'.[].number'`
+- `skills/bundled/self-dev/system_prompt.md` line 438: Step P2 jq filter (GraphQL, same lack of sorting)
+
+## Key Technical Decisions
+
+- **Sort by `.number` ascending:** Issue numbers are monotonically increasing and match creation order. This is stable, deterministic, and respects natural dependency ordering where earlier issues are prerequisites for later ones.
+- **Also fix Step P2:** The Project Workflow has the same problem — GraphQL returns items in project-board order, which is non-deterministic. Apply the same `sort_by(.number)` pattern for consistency.
+
+## Implementation Units
+
+- [x] **Unit 1: Add sort_by(.number) to Step M2 and Step P2 jq filters**
+
+**Goal:** Ensure milestone and project issue lists are returned in ascending issue number order.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/self-dev/system_prompt.md`
+
+**Approach:**
+- Step M2 (line 337): Change jq filter from `'.[].number'` to `'sort_by(.number) | .[].number'`
+- Step P2 (line 438): The GraphQL jq filter outputs `repo#number` strings. Wrap with a `sort_by` on the numeric suffix: pipe the output through `sort_by(split("#")[1] | tonumber)` or restructure to sort before formatting. The simplest approach: collect into array, sort_by number, then emit.
+
+**Patterns to follow:**
+- jq `sort_by()` is the standard approach for deterministic ordering in gh CLI pipelines
+
+**Test expectation:** none — this is a prompt text edit, not executable code. Verification is by reading the updated command.
+
+**Verification:**
+- The Step M2 command in system_prompt.md includes `sort_by(.number)` before `.[].number`
+- The Step P2 command in system_prompt.md sorts items by issue number ascending
+- Reading the jq filters confirms ascending order output
+
+## System-Wide Impact
+
+- **Interaction graph:** Step M3 (create child work items) and Step M4 (serial execution loop) consume the ordered list from M2/P2. Sorting ascending means dependencies are naturally satisfied as the loop processes items sequentially.
+- **Unchanged invariants:** The Step M2/P2 output format is unchanged (list of issue numbers / repo#number strings). Only the ordering changes.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| jq `sort_by` syntax error in prompt | Simple, well-documented jq operation; verify by reading |
+
+## Sources & References
+
+- Related issue: #632
+- Related incident: #630 depends on #629, milestone #12 would have broken

--- a/docs/solutions/best-practices/2026-04-17-sort-batch-work-items-ascending.md
+++ b/docs/solutions/best-practices/2026-04-17-sort-batch-work-items-ascending.md
@@ -1,0 +1,78 @@
+---
+title: Sort batch work-item fetches ascending by issue number
+date: 2026-04-17
+category: best-practices
+module: self-dev
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Fetching a batch of GitHub issues for sequential processing (milestone or project workflows)
+  - Any workflow step that retrieves work items and processes them in order
+  - Adding new gh CLI or GraphQL queries that list issues for dispatch
+tags:
+  - milestone-workflow
+  - project-workflow
+  - self-dev
+  - issue-ordering
+  - jq
+  - deterministic-ordering
+---
+
+# Sort batch work-item fetches ascending by issue number
+
+## Context
+
+The self-dev skill's milestone workflow (Step M2) and project workflow (Step P2) fetch batches of GitHub issues and process them sequentially. `gh issue list` returns issues in **descending** created order by default (newest first). GitHub's GraphQL ProjectV2 API returns items in project-board order, which is non-deterministic.
+
+When child issues have dependency ordering — earlier issues are prerequisites for later ones — processing newest-first breaks the dependency chain. This was caught when milestone #12 was about to be dispatched: issue #630 depends on #629, but the default ordering would queue #630 first.
+
+## Guidance
+
+Always add explicit ascending sort by issue number when fetching batches of work items for sequential processing.
+
+**Milestone workflow (gh CLI):**
+
+```bash
+# Before — relies on gh's default descending order
+run_gh issue list --milestone <n> --repo senara-solutions/<repo> --state open --json number,title --jq '.[].number'
+
+# After — explicit ascending sort
+run_gh issue list --milestone <n> --repo senara-solutions/<repo> --state open --json number,title --jq 'sort_by(.number) | .[].number'
+```
+
+**Project workflow (GraphQL):**
+
+```bash
+# Before — relies on non-deterministic project-board order
+--jq '.data.organization.projectV2.items.nodes[].content | select(.state == "OPEN") | "\(.repository.name)#\(.number)"'
+
+# After — collect into array, sort, then emit
+--jq '[.data.organization.projectV2.items.nodes[].content | select(.state == "OPEN")] | sort_by(.number) | .[] | "\(.repository.name)#\(.number)"'
+```
+
+## Why This Matters
+
+Issue numbers are monotonically increasing and match creation order. Sorting ascending by number provides:
+
+1. **Dependency safety** — earlier issues (prerequisites) run before later ones that depend on them
+2. **Determinism** — the same milestone always produces the same processing order regardless of API pagination or server-side ordering changes
+3. **Predictability** — operators can reason about execution order by looking at issue numbers
+
+Without explicit sorting, the workflow silently relies on an API default that can change between gh CLI versions or GitHub API updates.
+
+## When to Apply
+
+- Adding any new `gh issue list` or GraphQL query that fetches multiple issues for sequential processing
+- Any batch work-item dispatch step in self-dev, qa-review, or other orchestration skills
+- Whenever the processing order of work items matters for correctness
+
+## Examples
+
+The fix applied to `skills/bundled/self-dev/system_prompt.md` adds `sort_by(.number)` to both the milestone (Step M2) and project (Step P2) jq filters. The output format is unchanged — only the ordering is corrected.
+
+## Related
+
+- GitHub issue: #632
+- Related incident: #630 depends on #629, milestone #12 would have broken with default ordering
+- Related milestone/project workflow: `skills/bundled/self-dev/system_prompt.md` Steps M1–M5, P1–P5

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -334,7 +334,7 @@ Remember the returned `task_id` as `milestone_wi`.
 ### Step M2 — Fetch milestone issues
 
 ```bash
-run_gh issue list --milestone <n> --repo senara-solutions/<repo> --state open --json number,title --jq '.[].number'
+run_gh issue list --milestone <n> --repo senara-solutions/<repo> --state open --json number,title --jq 'sort_by(.number) | .[].number'
 ```
 
 Store the ordered list of issue numbers as `milestone_issues`.
@@ -435,7 +435,7 @@ query {
       }
     }
   }
-}' --jq '.data.organization.projectV2.items.nodes[].content | select(.state == "OPEN") | "\(.repository.name)#\(.number)"'
+}' --jq '[.data.organization.projectV2.items.nodes[].content | select(.state == "OPEN")] | sort_by(.number) | .[] | "\(.repository.name)#\(.number)"'
 ```
 
 Store ordered list of `repo#issue` references as `project_issues`.


### PR DESCRIPTION
## Summary

- Add `sort_by(.number)` to the Step M2 (milestone) and Step P2 (project) jq filters in `skills/bundled/self-dev/system_prompt.md`
- `gh issue list` returns newest-first by default, breaking dependency ordering when child issues depend on earlier ones
- Also fixes Step P2's GraphQL query which returned items in non-deterministic project-board order

Caught when milestone #12 was about to be dispatched: #630 depends on #629, but the default ordering would queue #630 first.

## Changes

**Step M2 (milestone workflow):**
```diff
- --jq '.[].number'
+ --jq 'sort_by(.number) | .[].number'
```

**Step P2 (project workflow):**
```diff
- --jq '...nodes[].content | select(.state == "OPEN") | ...'
+ --jq '[...nodes[].content | select(.state == "OPEN")] | sort_by(.number) | .[] | ...'
```

## Test plan

- [x] Verified both jq filters produce ascending output with test data
- [x] No Rust code changes — prompt-only edit
- [x] Compound doc captures the general pattern for future reference

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>