### PR TITLE
feat(skills): move enabled state from .disabled markers to DB with eviction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - **Grounding rule:** The system prompt prohibits the agent from claiming downstream system state unless a tool result confirms it. Reinforced in `format_callback_framing` and `SilentTrigger::Callback`.
 - **Confirmation before action:** The system prompt instructs the agent to answer informational questions directly without starting multi-step workflows.
 - **Context priority:** current user message > core memory > active skill context > conversation summary > conversation history > search results. See `docs/memory-classification.md`.
-- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v22. See `crates/mika-agent/CLAUDE.md` for schema details.
+- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v24. See `crates/mika-agent/CLAUDE.md` for schema details.
 - **Secrets:** `Settings` has manual `Debug` impl that redacts API key and OTLP auth header. Exec handler executor scrubs all MIKA_* env vars from child processes. MCP child processes use `env_clear()` + allowlist. Git subprocesses scrub MIKA_* vars and set `GIT_TERMINAL_PROMPT=0`.
 - **Labels:** `.github/labels.yml` is the canonical label taxonomy (type, priority, component). All issue-creation paths reference it.
 - **Async DB:** `AsyncDatabase` wraps sync `Database` with dedicated OS thread + `sync_channel(512)` mpsc channel (closure-based dispatch). Clone-able, Send+Sync. `with_db` releases the mutex before calling `send()` to avoid deadlocks.

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -93,6 +93,8 @@ Git-based and local skill distribution via `mika skills install/uninstall/update
 
 **Per-skill LLM override:** DB-only via `skill_overrides` table (schema v20). `[llm]` section no longer supported in `skill.toml` (#504). `resolve_skill_llm_override()` constructs per-skill `LlmProvider`.
 
+**Skill enabled state:** DB-backed via `skill_overrides.enabled` column (schema v24, #629). Tri-state: `NULL` = default (enabled), `0` = disabled, `1` = explicitly enabled. `apply_overrides()` evicts disabled skills from `SkillRegistry.entries` into `disabled: Vec<DisabledSkill>` before applying `always_on`/LLM overrides. `enabled=false` always wins over `always_on=true`. `toggle_skill` agent tool and CLI `mika skills enable/disable` write to DB. Legacy `.disabled` marker files are migrated to DB rows on startup via `migrate_disabled_markers()` (one-shot, idempotent, fail-open). Match-time filter in `matcher.rs` kept as belt-and-suspenders until #630.
+
 **Validation:** `validate_skill()` checks name-in-keywords rejection (#510), markdown validation (#511), required_tools references, context types, and `{{key}}` placeholders. **Startup validation (#530):** `SkillRegistry::validate_loaded()` runs `validate_skill()` on every loaded skill after `apply_overrides()`. Decision matrix: missing handler/broken tools.json → skip skill entirely; deprecated `[llm]` section/name-in-keywords/invalid markdown → load with warning. Results stored in `validated_warnings` for TUI/CLI display. `is_skip_worthy_failure()` classifies Fail diagnostics.
 
 **Required tools enforcement:** Optional `[constraints]` section with `required_tools`. `collect_required_tools()` computes union across keyword-matched skills only. One retry on EndTurn violation.
@@ -175,7 +177,7 @@ All SQLite timestamp columns use ISO 8601 TEXT format (`%Y-%m-%dT%H:%M:%SZ`). Th
 
 ## Schema Version
 
-**Current: v23.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides, tasks (with manual/callback/a2a trigger types and a `type` column distinguishing `issue`/`milestone`/`project`), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
+**Current: v24.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides (with `enabled` column for DB-backed disable state), tasks (with manual/callback/a2a trigger types and a `type` column distinguishing `issue`/`milestone`/`project`), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
 
 Recent migrations:
 - v18->v19: `sessions.task_id` column for reverse session->task lookups. `get_sessions_for_task_tree()`.
@@ -183,5 +185,6 @@ Recent migrations:
 - v20->v21: `llm_calls.prompt_variant` for skill prompt variant recording.
 - v21->v22: `messages.internal` column (`INTEGER NOT NULL DEFAULT 0`) for agent-to-agent message visibility. TUI inbox mode filters internal messages at the DB level. Set by `delegate_task` tool and by `mika ask --task-id` relay sessions (without `--task-complete`). `AgentParams.internal` threads the flag through `run_loop` to all message save paths.
 - v22->v23: `tasks.type` column (`TEXT NOT NULL DEFAULT 'issue' CHECK (type IN ('issue', 'milestone', 'project'))`). Foundational for milestone/project dispatch (mika#595): `create_work_item` accepts an optional `type` parameter; `list_work_items` and `check_work_item` surface it. mika core stays a dumb work-item store — orchestration logic lives in self-dev (mika-skills#149). `NewTask.r#type: Option<String>` defaults to `'issue'` via SQL DEFAULT when `None`. Constants: `TASK_TYPE_ISSUE`/`TASK_TYPE_MILESTONE`/`TASK_TYPE_PROJECT`/`VALID_TASK_TYPES` in `db.rs`.
+- v23->v24: `skill_overrides.enabled` column (`INTEGER`, nullable tri-state). `NULL` = default (enabled), `0` = disabled, `1` = explicitly enabled. Replaces `.disabled` marker files (#629). `SkillOverride.enabled: Option<bool>`. `set_skill_enabled()` with default-equals-delete (row deleted when all columns are NULL). `apply_overrides()` evicts disabled skills from `SkillRegistry.entries` into `disabled: Vec<DisabledSkill>`. One-shot `migrate_disabled_markers()` converts legacy `.disabled` marker files to DB rows at startup (fail-open on marker removal).
 
 Full migration history: see `docs/runtime-structure.md`.

--- a/crates/mika-agent/docs/runtime-structure.md
+++ b/crates/mika-agent/docs/runtime-structure.md
@@ -141,7 +141,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **failed_sends** — `id INTEGER PK AUTO`, `agent_id FK`, `text TEXT`, `request_id TEXT`, `retry_count INTEGER DEFAULT 0`, `created_at TEXT`
 
-**skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20). Per-agent LLM overrides resolve as: DB > manifest `[llm]` > agent default. Set via `mika skills llm <name> set <provider>/<model>`.
+**skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20), `enabled INTEGER` (v24). Per-agent overrides: LLM overrides resolve as DB > manifest `[llm]` > agent default (`mika skills llm <name> set <provider>/<model>`). Enabled state is tri-state: `NULL`=default (enabled), `0`=disabled, `1`=explicitly enabled. `enabled=false` evicts the skill from `SkillRegistry.entries` during `apply_overrides()`. Replaces `.disabled` marker files (#629). Default-equals-delete: rows where all columns are NULL are pruned.
 
 ### View
 

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -163,6 +163,17 @@ impl AsyncDatabase {
             .await
     }
 
+    pub async fn set_skill_enabled(
+        &self,
+        agent_id: &str,
+        skill_name: &str,
+        enabled: bool,
+    ) -> Result<()> {
+        let (a, s) = (agent_id.to_owned(), skill_name.to_owned());
+        self.with_db(move |db| db.set_skill_enabled(&a, &s, enabled))
+            .await
+    }
+
     pub async fn delete_skill_override(&self, agent_id: &str, skill_name: &str) -> Result<()> {
         let (a, s) = (agent_id.to_owned(), skill_name.to_owned());
         self.with_db(move |db| db.delete_skill_override(&a, &s))

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -22,7 +22,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 23;
+pub const CURRENT_SCHEMA_VERSION: i64 = 24;
 
 /// SQL for the unified_timeline VIEW — cross-subsystem event correlation.
 /// Used in both clean-slate schema creation and incremental migration.
@@ -421,6 +421,9 @@ pub struct SkillOverride {
     pub always_on: Option<bool>,
     pub llm_provider: Option<String>,
     pub llm_model: Option<String>,
+    /// Tri-state: `None` = default (enabled), `Some(false)` = disabled,
+    /// `Some(true)` = explicitly enabled.
+    pub enabled: Option<bool>,
 }
 
 // ===== Observability Types =====
@@ -770,6 +773,10 @@ impl Database {
             self.migrate_v22_to_v23()?;
             info!(version = 23, "database migrated to v23");
         }
+        if (3..=23).contains(&version) {
+            self.migrate_v23_to_v24()?;
+            info!(version = 24, "database migrated to v24");
+        }
         Ok(())
     }
 
@@ -826,7 +833,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (23);
+            INSERT INTO schema_version (version) VALUES (24);
 
             CREATE TABLE agents (
                 id TEXT PRIMARY KEY,
@@ -1106,6 +1113,7 @@ impl Database {
                 always_on    INTEGER,
                 llm_provider TEXT,
                 llm_model    TEXT,
+                enabled      INTEGER,
                 PRIMARY KEY (agent_id, skill_name)
             );
 
@@ -2562,6 +2570,21 @@ impl Database {
         Ok(())
     }
 
+    fn migrate_v23_to_v24(&self) -> Result<()> {
+        info!("migrating database schema v23 → v24 (skill_overrides: enabled column)");
+
+        let has_col = self.column_exists("skill_overrides", "enabled")?;
+
+        let mut sql = String::from("BEGIN IMMEDIATE;\n");
+        if !has_col {
+            sql.push_str("ALTER TABLE skill_overrides ADD COLUMN enabled INTEGER;\n");
+        }
+        sql.push_str("INSERT INTO schema_version (version) VALUES (24);\nCOMMIT;");
+
+        self.conn.execute_batch(&sql)?;
+        Ok(())
+    }
+
     /// Check if a column exists on a table (used for idempotent migrations).
     fn column_exists(&self, table: &'static str, column: &'static str) -> Result<bool> {
         let mut stmt = self
@@ -2627,7 +2650,7 @@ impl Database {
     /// Get all skill overrides for an agent.
     pub fn get_skill_overrides(&self, agent_id: &str) -> Result<Vec<SkillOverride>> {
         let mut stmt = self.conn.prepare(
-            "SELECT skill_name, always_on, llm_provider, llm_model
+            "SELECT skill_name, always_on, llm_provider, llm_model, enabled
              FROM skill_overrides WHERE agent_id = ?1",
         )?;
         let rows = stmt
@@ -2637,6 +2660,7 @@ impl Database {
                     always_on: r.get(1)?,
                     llm_provider: r.get(2)?,
                     llm_model: r.get(3)?,
+                    enabled: r.get(4)?,
                 })
             })?
             .collect::<rusqlite::Result<_>>()?;
@@ -2679,6 +2703,47 @@ impl Database {
         Ok(())
     }
 
+    /// Set (upsert) an enabled override for a skill.
+    ///
+    /// `enabled = false` disables the skill; `enabled = true` explicitly enables it.
+    /// When setting to `true` (the default) and all other override columns are NULL,
+    /// the row is deleted (default-equals-delete).
+    pub fn set_skill_enabled(&self, agent_id: &str, skill_name: &str, enabled: bool) -> Result<()> {
+        let db_val: Option<bool> = if enabled { None } else { Some(false) };
+        self.conn.execute_batch("BEGIN IMMEDIATE;")?;
+        let result: rusqlite::Result<()> = (|| {
+            self.conn.execute(
+                "INSERT INTO skill_overrides (agent_id, skill_name, enabled)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(agent_id, skill_name) DO UPDATE SET enabled = excluded.enabled",
+                params![agent_id, skill_name, db_val],
+            )?;
+            // Default-equals-delete: if all columns are NULL, remove the row.
+            if enabled {
+                self.conn.execute(
+                    "DELETE FROM skill_overrides
+                      WHERE agent_id = ?1 AND skill_name = ?2
+                        AND always_on IS NULL
+                        AND llm_provider IS NULL
+                        AND llm_model IS NULL
+                        AND enabled IS NULL",
+                    params![agent_id, skill_name],
+                )?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT;")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(e.into())
+            }
+        }
+    }
+
     /// Clear the LLM override columns for a skill. If the resulting row has no
     /// remaining override values (all columns NULL), the row is deleted.
     ///
@@ -2698,7 +2763,8 @@ impl Database {
                   WHERE agent_id = ?1 AND skill_name = ?2
                     AND always_on IS NULL
                     AND llm_provider IS NULL
-                    AND llm_model IS NULL",
+                    AND llm_model IS NULL
+                    AND enabled IS NULL",
                 params![agent_id, skill_name],
             )?;
             Ok(())
@@ -8840,6 +8906,95 @@ mod tests {
         let db = db();
         // Should not error
         db.delete_skill_override("mika", "nonexistent").unwrap();
+    }
+
+    #[test]
+    fn test_set_skill_enabled_disable() {
+        let db = db();
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        let ov = overrides.iter().find(|o| o.skill_name == "foo").unwrap();
+        assert_eq!(ov.enabled, Some(false));
+    }
+
+    #[test]
+    fn test_set_skill_enabled_enable_deletes_row() {
+        let db = db();
+        // Disable first
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        assert_eq!(db.get_skill_overrides("mika").unwrap().len(), 1);
+        // Enable (default) — row should be deleted (default-equals-delete)
+        db.set_skill_enabled("mika", "foo", true).unwrap();
+        assert!(db.get_skill_overrides("mika").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_set_skill_enabled_preserves_always_on() {
+        let db = db();
+        // Set always_on first
+        db.set_skill_override("mika", "foo", true).unwrap();
+        // Now disable
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        let ov = overrides.iter().find(|o| o.skill_name == "foo").unwrap();
+        assert_eq!(ov.always_on, Some(true));
+        assert_eq!(ov.enabled, Some(false));
+    }
+
+    #[test]
+    fn test_set_skill_enabled_enable_with_always_on_keeps_row() {
+        let db = db();
+        // Set both always_on and disabled
+        db.set_skill_override("mika", "foo", true).unwrap();
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        // Now enable — row should remain because always_on is non-NULL
+        db.set_skill_enabled("mika", "foo", true).unwrap();
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        let ov = overrides.iter().find(|o| o.skill_name == "foo").unwrap();
+        assert_eq!(ov.always_on, Some(true));
+        assert_eq!(ov.enabled, None); // Cleared to NULL
+    }
+
+    #[test]
+    fn test_set_skill_enabled_preserves_llm_override() {
+        let db = db();
+        db.set_skill_llm_override("mika", "foo", "anthropic", "claude-sonnet-4-6")
+            .unwrap();
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        let ov = overrides.iter().find(|o| o.skill_name == "foo").unwrap();
+        assert_eq!(ov.llm_provider.as_deref(), Some("anthropic"));
+        assert_eq!(ov.enabled, Some(false));
+    }
+
+    #[test]
+    fn test_set_skill_enabled_round_trip() {
+        let db = db();
+        // Disable → enable → state is clean
+        db.set_skill_enabled("mika", "bar", false).unwrap();
+        assert_eq!(db.get_skill_overrides("mika").unwrap().len(), 1);
+        db.set_skill_enabled("mika", "bar", true).unwrap();
+        assert!(db.get_skill_overrides("mika").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_enabled_column_exists_in_skill_overrides() {
+        let db = db();
+        assert!(db.column_exists("skill_overrides", "enabled").unwrap());
+    }
+
+    #[test]
+    fn test_delete_skill_llm_override_with_enabled_keeps_row() {
+        let db = db();
+        db.set_skill_llm_override("mika", "foo", "anthropic", "claude-sonnet-4-6")
+            .unwrap();
+        db.set_skill_enabled("mika", "foo", false).unwrap();
+        // Delete LLM override — row should remain because enabled is non-NULL
+        db.delete_skill_llm_override("mika", "foo").unwrap();
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        let ov = overrides.iter().find(|o| o.skill_name == "foo").unwrap();
+        assert_eq!(ov.llm_provider, None);
+        assert_eq!(ov.enabled, Some(false));
     }
 
     #[test]

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -336,7 +336,14 @@ async fn init_agent(
     startup::seed_bundled_skills_if_needed(agent_home, disable_bundled_skills);
     let async_db = AsyncDatabase::new_with_agent(db, agent_name);
 
-    let mut skill_registry = SkillRegistry::from_dir(&agent_home.join("skills"));
+    let skills_dir = agent_home.join("skills");
+    // Migrate legacy .disabled marker files to DB (one-shot, idempotent).
+    if let Err(e) =
+        crate::skills::migrate_disabled_markers_async(&skills_dir, &async_db, agent_name).await
+    {
+        tracing::warn!(error = %e, "failed to migrate .disabled markers");
+    }
+    let mut skill_registry = SkillRegistry::from_dir(&skills_dir);
     if let Ok(overrides) = async_db.get_skill_overrides(agent_name).await {
         skill_registry.apply_overrides(&overrides);
     }

--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -93,7 +93,9 @@ pub struct SkillEntry {
     pub prompt_snippet: String,
     /// Tools defined in this skill's `tools.json`.
     pub skill_tools: Vec<ResolvedSkillTool>,
-    /// Whether the skill is enabled (no `.disabled` marker file).
+    /// Whether the skill is enabled. Always `true` after scan; disabled state
+    /// is now applied by `SkillRegistry::apply_overrides()` from DB.
+    /// Kept for belt-and-suspenders match-time filter until #630.
     pub enabled: bool,
     /// Whether this entry has a DB override applied (for display purposes).
     pub has_override: bool,
@@ -283,6 +285,15 @@ pub struct SkippedSkill {
     pub name: String,
     /// Human-readable reason for skipping.
     pub reason: String,
+}
+
+/// A skill that was evicted from the registry because it has `enabled = false`
+/// in the `skill_overrides` DB table. Parallels `SkippedSkill` but represents
+/// a user choice rather than an error.
+#[derive(Debug, Clone)]
+pub struct DisabledSkill {
+    /// Skill name from manifest.
+    pub name: String,
 }
 
 /// A loaded skill that has validation warnings (non-fatal issues).
@@ -539,8 +550,9 @@ pub fn scan_skills_dir(skills_dir: &Path) -> ScanResult {
             }
         };
 
-        // Check for .disabled marker file
-        let enabled = !path.join(".disabled").exists();
+        // Enabled state now comes from DB via apply_overrides().
+        // Always set to true here; disabled skills are evicted in apply_overrides().
+        let enabled = true;
 
         // Parse tools.json if present
         let skill_tools = load_tools_json(&path);
@@ -2241,7 +2253,10 @@ mod tests {
     }
 
     #[test]
-    fn test_disabled_skill() {
+    fn test_disabled_marker_ignored_by_scan() {
+        // .disabled marker is no longer read by scan_skills_dir() — enabled
+        // state comes from DB via apply_overrides(). Skills with markers are
+        // still loaded as enabled; migration converts markers to DB rows.
         let tmp = tempfile::tempdir().unwrap();
         let skill_dir = tmp.path().join("web-search");
         fs::create_dir_all(&skill_dir).unwrap();
@@ -2254,12 +2269,13 @@ mod tests {
             "#,
         )
         .unwrap();
-        // Create .disabled marker
+        // Create .disabled marker — should be ignored by scan.
         fs::write(skill_dir.join(".disabled"), "").unwrap();
 
         let scan = scan_skills_dir(tmp.path());
         assert_eq!(scan.entries.len(), 1);
-        assert!(!scan.entries[0].enabled);
+        // Always enabled at scan time; disabled state applied later via DB.
+        assert!(scan.entries[0].enabled);
     }
 
     #[test]

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -11,14 +11,127 @@ pub mod review_filter;
 
 use std::path::Path;
 
-use self::index::{SkillEntry, SkillValidationWarning, SkippedSkill};
-use crate::db::SkillOverride;
+use self::index::{DisabledSkill, SkillEntry, SkillValidationWarning, SkippedSkill};
+use crate::async_db::AsyncDatabase;
+use crate::db::{Database, SkillOverride};
+
+/// Migrate `.disabled` marker files to DB `skill_overrides` rows.
+///
+/// Scans all skill directories under `skills_dir`. For each skill that has a
+/// `.disabled` marker file, writes `enabled = false` to the DB and attempts to
+/// remove the marker. If marker removal fails (e.g., read-only filesystem),
+/// logs a warning and continues (fail-open).
+///
+/// Idempotent: after the first pass, no markers remain (or they're on a
+/// read-only FS and the DB already has the override).
+pub fn migrate_disabled_markers(
+    skills_dir: &Path,
+    db: &Database,
+    agent_id: &str,
+) -> anyhow::Result<()> {
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let marker = path.join(".disabled");
+        if !marker.exists() {
+            continue;
+        }
+
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        // Write DB override.
+        if let Err(e) = db.set_skill_enabled(agent_id, &name, false) {
+            tracing::warn!(
+                skill = %name,
+                error = %e,
+                "failed to migrate .disabled marker to DB"
+            );
+            continue;
+        }
+
+        // Remove the marker file (fail-open).
+        if let Err(e) = std::fs::remove_file(&marker) {
+            tracing::warn!(
+                skill = %name,
+                error = %e,
+                "migrated .disabled to DB but failed to remove marker file"
+            );
+        } else {
+            tracing::info!(skill = %name, "migrated .disabled marker to DB");
+        }
+    }
+    Ok(())
+}
+
+/// Async wrapper for `migrate_disabled_markers`. Collects skill names with
+/// `.disabled` markers from the filesystem, writes DB overrides, and removes
+/// markers. Uses `AsyncDatabase::with_db` for thread-safe DB access.
+pub async fn migrate_disabled_markers_async(
+    skills_dir: &Path,
+    db: &AsyncDatabase,
+    agent_id: &str,
+) -> anyhow::Result<()> {
+    // Phase 1: Collect marker file paths (filesystem work, no DB).
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut to_migrate: Vec<(String, std::path::PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let marker = path.join(".disabled");
+        if !marker.exists() {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            to_migrate.push((name.to_string(), marker));
+        }
+    }
+
+    // Phase 2: Write DB overrides and remove markers.
+    for (name, marker) in to_migrate {
+        let n = name.clone();
+        let a = agent_id.to_owned();
+        if let Err(e) = db.set_skill_enabled(&a, &n, false).await {
+            tracing::warn!(skill = %name, error = %e, "failed to migrate .disabled marker to DB");
+            continue;
+        }
+        if let Err(e) = std::fs::remove_file(&marker) {
+            tracing::warn!(
+                skill = %name,
+                error = %e,
+                "migrated .disabled to DB but failed to remove marker file"
+            );
+        } else {
+            tracing::info!(skill = %name, "migrated .disabled marker to DB");
+        }
+    }
+    Ok(())
+}
 
 /// Registry of discovered skills, built once at startup.
 #[derive(Debug)]
 pub struct SkillRegistry {
     skills: Vec<SkillEntry>,
     skipped: Vec<SkippedSkill>,
+    /// Skills evicted by DB `enabled = false` override.
+    disabled: Vec<DisabledSkill>,
     /// Warnings from post-load semantic validation (`validate_loaded()`).
     /// These skills are still loaded and functional but have non-fatal issues.
     validated_warnings: Vec<SkillValidationWarning>,
@@ -49,6 +162,7 @@ impl SkillRegistry {
         Self {
             skills: result.entries,
             skipped: result.skipped,
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
         }
     }
@@ -58,6 +172,7 @@ impl SkillRegistry {
         Self {
             skills: Vec::new(),
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
         }
     }
@@ -67,6 +182,7 @@ impl SkillRegistry {
         Self {
             skills: Vec::new(),
             skipped,
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
         }
     }
@@ -79,6 +195,16 @@ impl SkillRegistry {
     /// Details of skills that were skipped during scan (name + reason).
     pub fn skipped(&self) -> &[SkippedSkill] {
         &self.skipped
+    }
+
+    /// Skills evicted from the registry by DB `enabled = false` override.
+    pub fn disabled(&self) -> &[DisabledSkill] {
+        &self.disabled
+    }
+
+    /// Number of skills disabled via DB override.
+    pub fn disabled_count(&self) -> usize {
+        self.disabled.len()
     }
 
     /// Validation warnings from `validate_loaded()` — skills that loaded
@@ -213,6 +339,36 @@ impl SkillRegistry {
     /// doesn't match an installed skill name. Does not fail — only emits
     /// `tracing::warn` for each unresolvable dependency.
     pub fn apply_overrides(&mut self, overrides: &[SkillOverride]) {
+        // Phase 0: Evict disabled skills.
+        // Collect disabled skill names first, then evict using retain() + staging vec.
+        // Can't borrow `self.disabled` while `self.skills` is mutably borrowed by retain().
+        let disabled_names: Vec<String> = overrides
+            .iter()
+            .filter(|ov| ov.enabled == Some(false))
+            .map(|ov| ov.skill_name.clone())
+            .collect();
+
+        if !disabled_names.is_empty() {
+            let mut evicted = Vec::new();
+            self.skills.retain(|entry| {
+                let is_disabled = disabled_names
+                    .iter()
+                    .any(|n| entry.manifest.skill.name.eq_ignore_ascii_case(n));
+                if is_disabled {
+                    tracing::info!(
+                        skill = %entry.manifest.skill.name,
+                        "skill disabled via DB override — evicted from registry"
+                    );
+                    evicted.push(DisabledSkill {
+                        name: entry.manifest.skill.name.clone(),
+                    });
+                }
+                !is_disabled
+            });
+            self.disabled.extend(evicted);
+        }
+
+        // Phase 1: Apply remaining overrides (always_on, LLM).
         for ov in overrides {
             let Some(entry) = self
                 .skills
@@ -494,6 +650,7 @@ mod tests {
     fn test_always_on_skills() {
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry("memory", true, true),
@@ -511,6 +668,7 @@ mod tests {
     fn test_always_on_skills_filters_disabled() {
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry("memory", true, true),
@@ -578,6 +736,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![safe_entry, exec_entry, http_entry, prompt_only],
         };
@@ -648,6 +807,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![safe_entry, exec_entry, http_entry, prompt_only],
         };
@@ -705,6 +865,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![included, disabled, not_always_on],
         };
@@ -751,6 +912,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![self_dev, claude_pilot],
         };
@@ -774,6 +936,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![a, b, c],
         };
@@ -799,6 +962,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![a, b, c],
         };
@@ -816,6 +980,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![a, b],
         };
@@ -832,6 +997,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![a, b],
         };
@@ -847,6 +1013,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![a],
         };
@@ -885,6 +1052,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![self_dev, claude_pilot],
         };
@@ -935,6 +1103,7 @@ mod tests {
 
         let registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![safe_with_dep, exec_dep],
         };
@@ -952,6 +1121,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry("web-search", false, true),
@@ -964,6 +1134,7 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         assert!(registry.skills[0].manifest.skill.always_on);
@@ -978,6 +1149,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![make_entry("Web-Search", false, true)],
         };
@@ -987,6 +1159,7 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         assert!(registry.skills[0].manifest.skill.always_on);
@@ -999,6 +1172,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![make_entry("web-search", false, true)],
         };
@@ -1008,6 +1182,7 @@ mod tests {
             always_on: None,
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         assert!(!registry.skills[0].manifest.skill.always_on);
@@ -1020,6 +1195,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![make_entry("web-search", false, true)],
         };
@@ -1029,6 +1205,7 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         // No crash, web-search unchanged
@@ -1041,6 +1218,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry("web-search", false, true),
@@ -1055,6 +1233,7 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         assert_eq!(registry.always_on_skills().len(), 2);
@@ -1064,6 +1243,7 @@ mod tests {
     fn test_apply_overrides_validates_dependencies_silent_on_valid() {
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry_with_deps("self-dev", true, true, &["tmux"]),
@@ -1078,6 +1258,7 @@ mod tests {
     fn test_apply_overrides_validates_dependencies_warns_on_missing() {
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![make_entry_with_deps(
                 "self-dev",
@@ -1094,6 +1275,7 @@ mod tests {
     fn test_apply_overrides_validates_dependencies_case_insensitive() {
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry_with_deps("self-dev", true, true, &["TMUX"]),
@@ -1108,6 +1290,7 @@ mod tests {
     fn test_apply_overrides_validates_dependencies_no_deps_no_warn() {
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![
                 make_entry("web-search", true, true),
@@ -1138,6 +1321,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![entry],
         };
@@ -1148,6 +1332,7 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         // Skill should be removed: always_on + override + empty prompt + oversized file
@@ -1161,6 +1346,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![make_entry("qa-review", false, true)],
         };
@@ -1172,6 +1358,7 @@ mod tests {
             always_on: None,
             llm_provider: Some("anthropic".to_string()),
             llm_model: Some("claude-sonnet-4-6".to_string()),
+            enabled: None,
         }]);
 
         assert!(registry.skills[0].has_override);
@@ -1198,6 +1385,7 @@ mod tests {
         };
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![entry],
         };
@@ -1208,6 +1396,7 @@ mod tests {
             always_on: None,
             llm_provider: None,
             llm_model: Some("deepseek-reasoner".to_string()),
+            enabled: None,
         }]);
 
         assert!(registry.skills[0].has_override);
@@ -1234,6 +1423,7 @@ mod tests {
 
         let mut registry = SkillRegistry {
             skipped: Vec::new(),
+            disabled: Vec::new(),
             validated_warnings: Vec::new(),
             skills: vec![entry],
         };
@@ -1243,11 +1433,257 @@ mod tests {
             always_on: Some(true),
             llm_provider: None,
             llm_model: None,
+            enabled: None,
         }]);
 
         // Should still be present — no prompt file means tool-only, not broken
         assert_eq!(registry.skills.len(), 1);
         assert!(registry.skills[0].manifest.skill.always_on);
+    }
+
+    // -- Eviction tests (#629) --
+
+    #[test]
+    fn test_apply_overrides_evicts_disabled_skill() {
+        let mut registry = SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills: vec![
+                make_entry("web-search", false, true),
+                make_entry("memory", false, true),
+            ],
+        };
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "web-search".to_string(),
+            always_on: None,
+            llm_provider: None,
+            llm_model: None,
+            enabled: Some(false),
+        }]);
+
+        assert_eq!(registry.skills.len(), 1);
+        assert_eq!(registry.skills[0].manifest.skill.name, "memory");
+        assert_eq!(registry.disabled.len(), 1);
+        assert_eq!(registry.disabled[0].name, "web-search");
+    }
+
+    #[test]
+    fn test_apply_overrides_enabled_none_keeps_skill() {
+        let mut registry = SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills: vec![make_entry("web-search", false, true)],
+        };
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "web-search".to_string(),
+            always_on: None,
+            llm_provider: None,
+            llm_model: None,
+            enabled: None,
+        }]);
+
+        assert_eq!(registry.skills.len(), 1);
+        assert!(registry.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_apply_overrides_enabled_true_keeps_skill() {
+        let mut registry = SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills: vec![make_entry("web-search", false, true)],
+        };
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "web-search".to_string(),
+            always_on: None,
+            llm_provider: None,
+            llm_model: None,
+            enabled: Some(true),
+        }]);
+
+        assert_eq!(registry.skills.len(), 1);
+        assert!(registry.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_apply_overrides_disabled_wins_over_always_on() {
+        let mut registry = SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills: vec![make_entry("web-search", true, true)],
+        };
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "web-search".to_string(),
+            always_on: Some(true),
+            llm_provider: None,
+            llm_model: None,
+            enabled: Some(false),
+        }]);
+
+        assert!(registry.skills.is_empty());
+        assert_eq!(registry.disabled.len(), 1);
+    }
+
+    #[test]
+    fn test_apply_overrides_disabled_nonexistent_skill_ignored() {
+        let mut registry = SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills: vec![make_entry("web-search", false, true)],
+        };
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "nonexistent".to_string(),
+            always_on: None,
+            llm_provider: None,
+            llm_model: None,
+            enabled: Some(false),
+        }]);
+
+        assert_eq!(registry.skills.len(), 1);
+        assert!(registry.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_apply_overrides_disabled_not_passed_to_validation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        create_valid_skill(skills_dir, "alpha");
+        create_valid_skill(skills_dir, "beta");
+
+        let mut registry = registry_from_temp(skills_dir);
+        assert_eq!(registry.skills().len(), 2);
+
+        registry.apply_overrides(&[SkillOverride {
+            skill_name: "alpha".to_string(),
+            always_on: None,
+            llm_provider: None,
+            llm_model: None,
+            enabled: Some(false),
+        }]);
+        registry.validate_loaded();
+
+        // alpha evicted before validate_loaded, not in validated_warnings either
+        assert_eq!(registry.skills().len(), 1);
+        assert_eq!(registry.disabled().len(), 1);
+    }
+
+    // -- migrate_disabled_markers tests (#629) --
+
+    #[test]
+    fn test_migrate_disabled_markers_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        let skill_dir = skills_dir.join("foo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join(".disabled"), "").unwrap();
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        migrate_disabled_markers(skills_dir, &db, "mika").unwrap();
+
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].skill_name, "foo");
+        assert_eq!(overrides[0].enabled, Some(false));
+        // Marker file should be removed
+        assert!(!skill_dir.join(".disabled").exists());
+    }
+
+    #[test]
+    fn test_migrate_disabled_markers_no_markers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        let skill_dir = skills_dir.join("foo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        // No .disabled marker
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        migrate_disabled_markers(skills_dir, &db, "mika").unwrap();
+
+        assert!(db.get_skill_overrides("mika").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_migrate_disabled_markers_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        let skill_dir = skills_dir.join("foo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join(".disabled"), "").unwrap();
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        // First run: writes override, removes marker
+        migrate_disabled_markers(skills_dir, &db, "mika").unwrap();
+        // Second run: no markers, no-op
+        migrate_disabled_markers(skills_dir, &db, "mika").unwrap();
+
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        assert_eq!(overrides.len(), 1);
+    }
+
+    #[test]
+    fn test_migrate_disabled_markers_multiple_skills() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        // Two skills with markers, one without
+        let foo = skills_dir.join("foo");
+        let bar = skills_dir.join("bar");
+        let baz = skills_dir.join("baz");
+        std::fs::create_dir_all(&foo).unwrap();
+        std::fs::create_dir_all(&bar).unwrap();
+        std::fs::create_dir_all(&baz).unwrap();
+        std::fs::write(foo.join(".disabled"), "").unwrap();
+        std::fs::write(bar.join(".disabled"), "").unwrap();
+        // baz has no marker
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        migrate_disabled_markers(skills_dir, &db, "mika").unwrap();
+
+        let overrides = db.get_skill_overrides("mika").unwrap();
+        assert_eq!(overrides.len(), 2);
+        assert!(overrides.iter().all(|o| o.enabled == Some(false)));
+        assert!(!foo.join(".disabled").exists());
+        assert!(!bar.join(".disabled").exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_disabled_markers_async_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path();
+        let skill_dir = skills_dir.join("foo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join(".disabled"), "").unwrap();
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        migrate_disabled_markers_async(skills_dir, &async_db, "mika")
+            .await
+            .unwrap();
+
+        let overrides = async_db.get_skill_overrides("mika").await.unwrap();
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].skill_name, "foo");
+        assert_eq!(overrides[0].enabled, Some(false));
+        assert!(!skill_dir.join(".disabled").exists());
+    }
+
+    #[test]
+    fn test_migrate_disabled_markers_nonexistent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills_dir = tmp.path().join("nonexistent");
+
+        let db = crate::db::Database::open_in_memory().unwrap();
+        // Should not error on missing directory
+        migrate_disabled_markers(&skills_dir, &db, "mika").unwrap();
     }
 
     // -- validate_markdown_content tests (#511) --

--- a/crates/mika-agent/src/teams/engine.rs
+++ b/crates/mika-agent/src/teams/engine.rs
@@ -99,7 +99,12 @@ impl TeamEngine {
             let identity = crate::prompt::load_identity(&home_dir);
             db.register_agent(&ta.name, &identity.name, home_dir.to_str().unwrap_or(""))?;
             startup::seed_core_memory_if_empty(&db, &home_dir, &ta.name)?;
-            let mut skills = SkillRegistry::from_dir(&home_dir.join("skills"));
+            let skills_dir = home_dir.join("skills");
+            // Migrate legacy .disabled marker files to DB (one-shot, idempotent).
+            if let Err(e) = crate::skills::migrate_disabled_markers(&skills_dir, &db, &ta.name) {
+                tracing::warn!(agent = %ta.name, error = %e, "failed to migrate .disabled markers");
+            }
+            let mut skills = SkillRegistry::from_dir(&skills_dir);
             if let Ok(overrides) = db.get_skill_overrides(&ta.name) {
                 skills.apply_overrides(&overrides);
             }

--- a/crates/mika-agent/src/tools/toggle_skill.rs
+++ b/crates/mika-agent/src/tools/toggle_skill.rs
@@ -61,8 +61,14 @@ impl Tool for ToggleSkillTool {
             return Ok(ToolOutput::error(e));
         }
 
-        let disabled_marker = skill_dir.join(".disabled");
-        let currently_enabled = !disabled_marker.exists();
+        // Check current enabled state from DB overrides.
+        let agent_id = ctx.db.agent_id();
+        let overrides = ctx.db.get_skill_overrides(agent_id).await?;
+        let current_override = overrides
+            .iter()
+            .find(|o| o.skill_name.eq_ignore_ascii_case(name));
+        // Default is enabled (None or Some(true)).
+        let currently_enabled = current_override.and_then(|o| o.enabled).unwrap_or(true);
 
         if enabled == currently_enabled {
             let state = if enabled { "enabled" } else { "disabled" };
@@ -71,29 +77,19 @@ impl Tool for ToggleSkillTool {
             )));
         }
 
-        if enabled {
-            // Remove .disabled marker
-            if let Err(e) = std::fs::remove_file(&disabled_marker) {
-                return Ok(ToolOutput::error(format!(
-                    "Failed to enable skill '{name}': {e}"
-                )));
-            }
-            ctx.skills_dirty.store(true, Ordering::Release);
-            Ok(ToolOutput::success(format!(
-                "Skill '{name}' enabled. Changes take effect immediately on the next turn."
-            )))
-        } else {
-            // Create .disabled marker
-            if let Err(e) = std::fs::write(&disabled_marker, "") {
-                return Ok(ToolOutput::error(format!(
-                    "Failed to disable skill '{name}': {e}"
-                )));
-            }
-            ctx.skills_dirty.store(true, Ordering::Release);
-            Ok(ToolOutput::success(format!(
-                "Skill '{name}' disabled. Changes take effect immediately on the next turn."
-            )))
+        // Write enabled state to DB.
+        if let Err(e) = ctx.db.set_skill_enabled(agent_id, name, enabled).await {
+            return Ok(ToolOutput::error(format!(
+                "Failed to {} skill '{name}': {e}",
+                if enabled { "enable" } else { "disable" }
+            )));
         }
+
+        ctx.skills_dirty.store(true, Ordering::Release);
+        let state = if enabled { "enabled" } else { "disabled" };
+        Ok(ToolOutput::success(format!(
+            "Skill '{name}' {state}. Changes take effect immediately on the next turn."
+        )))
     }
 }
 
@@ -139,17 +135,25 @@ mod tests {
             .unwrap();
         assert!(!result.is_error, "Got: {}", result.content);
         assert!(result.content.contains("disabled"));
-        assert!(tmp.path().join("skills/my-skill/.disabled").exists());
+        // Verify DB state: override should exist with enabled = false.
+        let overrides = ctx.db.get_skill_overrides(ctx.db.agent_id()).await.unwrap();
+        let ov = overrides
+            .iter()
+            .find(|o| o.skill_name == "my-skill")
+            .unwrap();
+        assert_eq!(ov.enabled, Some(false));
     }
 
     #[tokio::test]
     async fn test_enable_disabled_skill() {
         let (tmp, harness) = setup_with_skill("my-skill");
-        // Pre-disable the skill
-        std::fs::write(tmp.path().join("skills/my-skill/.disabled"), "").unwrap();
-
         let ctx = harness.ctx_with_home(tmp.path());
         let tool = ToggleSkillTool;
+        // Pre-disable via DB
+        ctx.db
+            .set_skill_enabled(ctx.db.agent_id(), "my-skill", false)
+            .await
+            .unwrap();
 
         let result = tool
             .execute(
@@ -160,7 +164,9 @@ mod tests {
             .unwrap();
         assert!(!result.is_error, "Got: {}", result.content);
         assert!(result.content.contains("enabled"));
-        assert!(!tmp.path().join("skills/my-skill/.disabled").exists());
+        // Verify DB state: override row should be deleted (default-equals-delete).
+        let overrides = ctx.db.get_skill_overrides(ctx.db.agent_id()).await.unwrap();
+        assert!(overrides.iter().all(|o| o.skill_name != "my-skill"));
     }
 
     #[tokio::test]
@@ -209,5 +215,79 @@ mod tests {
             .unwrap();
         assert!(result.is_error);
         assert!(result.content.contains("path separators"));
+    }
+
+    #[tokio::test]
+    async fn test_disable_with_existing_always_on_preserves_it() {
+        let (tmp, harness) = setup_with_skill("my-skill");
+        let ctx = harness.ctx_with_home(tmp.path());
+        let agent_id = ctx.db.agent_id();
+        // Set always_on override first
+        ctx.db
+            .set_skill_override(agent_id, "my-skill", true)
+            .await
+            .unwrap();
+
+        let tool = ToggleSkillTool;
+        let result = tool
+            .execute(
+                serde_json::json!({"name": "my-skill", "enabled": false}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "Got: {}", result.content);
+        // Both overrides should coexist
+        let overrides = ctx.db.get_skill_overrides(agent_id).await.unwrap();
+        let ov = overrides
+            .iter()
+            .find(|o| o.skill_name == "my-skill")
+            .unwrap();
+        assert_eq!(ov.enabled, Some(false));
+        assert_eq!(ov.always_on, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_already_disabled() {
+        let (tmp, harness) = setup_with_skill("my-skill");
+        let ctx = harness.ctx_with_home(tmp.path());
+        // Pre-disable via DB
+        ctx.db
+            .set_skill_enabled(ctx.db.agent_id(), "my-skill", false)
+            .await
+            .unwrap();
+
+        // Reset shared static before asserting (skills_dirty is a process-wide static)
+        ctx.skills_dirty.store(false, Ordering::Release);
+
+        let tool = ToggleSkillTool;
+        let result = tool
+            .execute(
+                serde_json::json!({"name": "my-skill", "enabled": false}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert!(result.content.contains("already disabled"));
+        // skills_dirty should NOT be set for a no-op
+        assert!(!ctx.skills_dirty.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn test_disable_sets_skills_dirty() {
+        let (tmp, harness) = setup_with_skill("my-skill");
+        let ctx = harness.ctx_with_home(tmp.path());
+        let tool = ToggleSkillTool;
+
+        // Reset shared static before asserting
+        ctx.skills_dirty.store(false, Ordering::Release);
+        tool.execute(
+            serde_json::json!({"name": "my-skill", "enabled": false}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+        assert!(ctx.skills_dirty.load(Ordering::Acquire));
     }
 }

--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -222,7 +222,18 @@ pub async fn run(
         tool_registry.register(tool);
     }
     let tool_registry = Arc::new(tool_registry);
-    let mut skill_registry = SkillRegistry::from_dir(&ctx.home_dir.join("skills"));
+    let skills_dir = ctx.home_dir.join("skills");
+    // Migrate legacy .disabled marker files to DB (one-shot, idempotent).
+    if let Err(e) = mika_agent::skills::migrate_disabled_markers_async(
+        &skills_dir,
+        &ctx.async_db,
+        &ctx.async_db.agent_id,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "failed to migrate .disabled markers");
+    }
+    let mut skill_registry = SkillRegistry::from_dir(&skills_dir);
     if let Ok(overrides) = ctx
         .async_db
         .get_skill_overrides(&ctx.async_db.agent_id)

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -95,7 +95,18 @@ async fn spawn_agent_worker(
         tool_registry.register(tool);
     }
     let tool_registry = Arc::new(tool_registry);
-    let mut skill_registry = SkillRegistry::from_dir(&ctx.home_dir.join("skills"));
+    let skills_dir = ctx.home_dir.join("skills");
+    // Migrate legacy .disabled marker files to DB (one-shot, idempotent).
+    if let Err(e) = mika_agent::skills::migrate_disabled_markers_async(
+        &skills_dir,
+        &ctx.async_db,
+        &ctx.async_db.agent_id,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "failed to migrate .disabled markers");
+    }
+    let mut skill_registry = SkillRegistry::from_dir(&skills_dir);
     if let Ok(overrides) = ctx
         .async_db
         .get_skill_overrides(&ctx.async_db.agent_id)

--- a/crates/mika-cli/src/commands/skills.rs
+++ b/crates/mika-cli/src/commands/skills.rs
@@ -21,11 +21,13 @@ pub async fn run(args: SkillsArgs, agent_name: &str) -> Result<()> {
 
     match args.command {
         None => {
-            let registry = SkillRegistry::from_dir(&skills_dir);
+            let mut registry = SkillRegistry::from_dir(&skills_dir);
+            apply_db_overrides_if_available(&global_home, agent_name, &mut registry);
             list_skills(&registry, &agent_home, &crate::cli::OutputFormat::Text)?;
         }
         Some(SkillsCommand::List { format }) => {
-            let registry = SkillRegistry::from_dir(&skills_dir);
+            let mut registry = SkillRegistry::from_dir(&skills_dir);
+            apply_db_overrides_if_available(&global_home, agent_name, &mut registry);
             list_skills(&registry, &agent_home, &format)?;
         }
         Some(SkillsCommand::Info { name }) => {
@@ -39,10 +41,10 @@ pub async fn run(args: SkillsArgs, agent_name: &str) -> Result<()> {
             test_skill_tool(&skills_dir, &skill, &tool, &input).await?;
         }
         Some(SkillsCommand::Enable { name }) => {
-            toggle_skill(&skills_dir, &name, true)?;
+            toggle_skill(&global_home, &skills_dir, agent_name, &name, true)?;
         }
         Some(SkillsCommand::Disable { name }) => {
-            toggle_skill(&skills_dir, &name, false)?;
+            toggle_skill(&global_home, &skills_dir, agent_name, &name, false)?;
         }
         Some(SkillsCommand::Install { source, name, link }) => {
             // Resolve GitHub token only for git operations (App preferred, PAT fallback)
@@ -243,13 +245,34 @@ async fn resolve_github_token_for_git(global_home: &Path, agent_home: &Path) -> 
     settings.agent_github_token().map(|s| s.to_string())
 }
 
+/// Best-effort: apply DB overrides to the registry so `disabled()` is populated.
+/// If the DB isn't available (first run, missing file), silently skip.
+fn apply_db_overrides_if_available(
+    global_home: &Path,
+    agent_id: &str,
+    registry: &mut SkillRegistry,
+) {
+    let db_path = mika_common::home::container_db_path(global_home);
+    if !db_path.exists() {
+        return;
+    }
+    let Ok(db) = mika_agent::db::Database::open(&db_path) else {
+        return;
+    };
+    let Ok(overrides) = db.get_skill_overrides(agent_id) else {
+        return;
+    };
+    registry.apply_overrides(&overrides);
+}
+
 fn list_skills(
     registry: &SkillRegistry,
     agent_home: &Path,
     format: &crate::cli::OutputFormat,
 ) -> Result<()> {
     let skills = registry.skills();
-    if skills.is_empty() {
+    let disabled = registry.disabled();
+    if skills.is_empty() && disabled.is_empty() {
         match format {
             crate::cli::OutputFormat::Json => println!("[]"),
             crate::cli::OutputFormat::Text => {
@@ -355,6 +378,12 @@ fn list_skills(
                     variants,
                     llm_badge
                 );
+            }
+            if !disabled.is_empty() {
+                println!("\n  Disabled ({}):", disabled.len());
+                for d in disabled {
+                    println!("    {} [disabled]", d.name);
+                }
             }
             println!();
         }
@@ -654,28 +683,52 @@ async fn test_skill_tool(
     Ok(())
 }
 
-fn toggle_skill(skills_dir: &Path, name: &str, enable: bool) -> Result<()> {
+fn toggle_skill(
+    global_home: &Path,
+    skills_dir: &Path,
+    agent_id: &str,
+    name: &str,
+    enable: bool,
+) -> Result<()> {
     let skill_dir = skills_dir.join(name);
     if !skill_dir.is_dir() {
         bail!("Skill '{name}' not found at {}", skill_dir.display());
     }
 
-    let marker = skill_dir.join(".disabled");
-    if enable {
-        if marker.exists() {
-            std::fs::remove_file(&marker)
-                .with_context(|| format!("failed to remove {}", marker.display()))?;
-            println!("\n  Enabled skill '{name}'.\n");
-        } else {
-            println!("\n  Skill '{name}' is already enabled.\n");
-        }
-    } else if !marker.exists() {
-        std::fs::write(&marker, "")
-            .with_context(|| format!("failed to create {}", marker.display()))?;
-        println!("\n  Disabled skill '{name}'.\n");
-    } else {
-        println!("\n  Skill '{name}' is already disabled.\n");
+    let db_path = mika_common::home::container_db_path(global_home);
+    if !db_path.exists() {
+        bail!(
+            "Mika database not found at {}. Run `mika status` to initialize the agent.",
+            db_path.display()
+        );
     }
+    let db = mika_agent::db::Database::open(&db_path)
+        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+
+    // Migrate legacy .disabled markers to DB before reading state.
+    // Without this, `mika skills enable foo` on a skill with a .disabled marker
+    // would no-op (DB shows enabled=NULL=true), then the next server startup
+    // migration would re-disable the skill (#629).
+    if let Err(e) = mika_agent::skills::migrate_disabled_markers(skills_dir, &db, agent_id) {
+        eprintln!("  [WARN] failed to migrate .disabled markers: {e}");
+    }
+
+    // Check current state from DB.
+    let overrides = db.get_skill_overrides(agent_id)?;
+    let current_override = overrides
+        .iter()
+        .find(|o| o.skill_name.eq_ignore_ascii_case(name));
+    let currently_enabled = current_override.and_then(|o| o.enabled).unwrap_or(true);
+
+    if enable == currently_enabled {
+        let state = if enable { "enabled" } else { "disabled" };
+        println!("\n  Skill '{name}' is already {state}.\n");
+        return Ok(());
+    }
+
+    db.set_skill_enabled(agent_id, name, enable)?;
+    let action = if enable { "Enabled" } else { "Disabled" };
+    println!("\n  {action} skill '{name}'.\n");
     Ok(())
 }
 

--- a/docs/plans/2026-04-18-001-feat-skill-enabled-state-db-eviction-plan.md
+++ b/docs/plans/2026-04-18-001-feat-skill-enabled-state-db-eviction-plan.md
@@ -1,0 +1,304 @@
+---
+title: "feat: Move skill enabled state from .disabled marker to DB with eviction"
+type: feat
+status: active
+date: 2026-04-18
+---
+
+# Move skill enabled state from .disabled marker to DB with eviction
+
+## Overview
+
+Move the skill enabled/disabled state from `.disabled` marker files to the `skill_overrides` DB table. Disabled skills are evicted from `SkillRegistry.entries` during `apply_overrides()` instead of being filtered at match time. Existing `.disabled` markers are migrated to DB rows on first startup.
+
+## Problem Frame
+
+`mika skills disable <name>` creates a `.disabled` marker file. The engine reads it during `scan_skills_dir()` and stores `enabled: bool` on `SkillEntry`. But disabled skills still load into `SkillRegistry.entries` — they're only filtered at match time (`matcher.rs:43-46`) and in `always_on_skills()`. This means disabled skills consume memory, their prompts count against budget, the "skills loaded" count conflates disabled and active skills, and `disable` doesn't actually reduce the agent's surface.
+
+## Requirements Trace
+
+- R1. `mika skills disable foo` writes to DB, not filesystem
+- R2. Disabled skills don't appear in `SkillRegistry.entries` or the "skills loaded" count
+- R3. `/skills` CLI output shows disabled skills in a separate section with accurate count
+- R4. Existing `.disabled` markers are migrated on first startup and markers are removed
+- R5. DB override survives agent restart
+- R6. Tests: migration idempotency, eviction, override survival, enable/disable round-trip
+- R7. Match-time filter kept as belt-and-suspenders (removal deferred to #630)
+
+## Scope Boundaries
+
+- Does NOT delete match-time filter in `matcher.rs:43-46` — that's #630
+- Does NOT change overflow behavior, log format, or skill prompt budget
+- Does NOT add cross-process notification for CLI→server skill reload
+
+### Deferred to Separate Tasks
+
+- Match-time filter removal: #630 (P2)
+- Cross-process `skills_dirty` propagation: future iteration
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/db.rs` — `skill_overrides` table (schema v7, extended v20), `SkillOverride` struct (line ~419), `get_skill_overrides()`, `set_skill_override()`, `delete_skill_override()`, default-equals-delete in `delete_skill_llm_override()`
+- `crates/mika-agent/src/skills/mod.rs` — `SkillRegistry` struct, `apply_overrides()`, `skipped()` accessor, `from_dir()`
+- `crates/mika-agent/src/skills/index.rs` — `SkillEntry.enabled` (line ~543: `!path.join(".disabled").exists()`), `scan_skills_dir()`
+- `crates/mika-agent/src/skills/matcher.rs` — match-time filter at lines 43-46
+- `crates/mika-agent/src/tools/toggle_skill.rs` — agent tool, creates/removes `.disabled` marker, sets `skills_dirty`
+- `crates/mika-cli/src/commands/skills.rs` — CLI `toggle_skill()` (line ~657), already opens DB at line 129 for LLM overrides
+- `crates/mika-agent/src/tools/delete_skill.rs` — calls `delete_skill_override()` for full row cleanup
+
+### Institutional Learnings
+
+- **skill-override-persistence-via-db-layer** (docs/solutions/): Documents how `always_on` was moved to `skill_overrides` via post-scan overlay pattern. Original rationale kept `enabled` file-based — this issue intentionally reverses that decision.
+- **skill-llm-override-db-layer** (docs/solutions/): Documents the **migrate_v1 trap** — clean-slate migration must include new columns or fresh DB tests fail.
+- **agent-tool-must-call-validate-loaded** (docs/solutions/): All `SkillRegistry` construction sites must follow `from_dir → apply_overrides → validate_loaded` sequence.
+
+## Key Technical Decisions
+
+- **Tri-state nullable column:** `enabled INTEGER` — `NULL` = default (enabled), `0` = disabled, `1` = explicitly enabled. Follows `always_on` pattern exactly.
+- **Default-equals-delete:** When `enabled` is set back to default (NULL/true) and all other override columns are also NULL, delete the row. Extends existing pattern in `delete_skill_llm_override()`.
+- **Eviction into `disabled` vec:** `apply_overrides()` moves disabled skills from `entries` into a new `disabled: Vec<DisabledSkill>` field using a staging vec (can't borrow `self.disabled` while `self.entries` is mutably borrowed via `retain()`).
+- **`enabled = false` wins over `always_on = true`:** Eviction runs before `always_on` application in `apply_overrides()`, so disabled skills are removed from the registry regardless of other overrides. This is the intuitive behavior — "disabled" means "fully removed from consideration."
+- **Separate `set_skill_enabled()` method:** Parallel to `set_skill_override()` for `always_on`, using same UPSERT pattern. Cleaner than overloading `set_skill_override()`.
+- **CLI DB access already exists:** `skills.rs` line 129 opens the DB for LLM overrides. The enable/disable path reuses this same connection.
+- **Migration fail-open:** If a `.disabled` marker can't be removed (read-only filesystem), log warning and continue. Belt-and-suspenders match-time filter (kept until #630) handles the dual state.
+- **CLI changes require server restart:** Cross-process `skills_dirty` propagation is out of scope. This matches current behavior — CLI `.disabled` file changes also only take effect on next `skills_dirty` trigger or restart.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **CLI DB access:** Already established at `skills.rs:129` for LLM overrides. Same `Database::open()` path reused.
+- **`always_on` vs `enabled` precedence:** `enabled = false` always wins. Eviction in `apply_overrides()` runs before `always_on` application.
+- **Migration error handling:** Fail-open. Write DB row, log warning if marker can't be removed.
+- **Bundled skills:** Have filesystem directories via `seed_bundled_skills()`. `toggle_skill` tool's `skill_dir.exists()` check still valid. No changes needed.
+- **`delete_skill` cleanup:** Already calls `delete_skill_override()` which DELETEs the entire row — naturally covers new `enabled` column.
+
+### Deferred to Implementation
+
+- Exact staging vec pattern in `apply_overrides()` — depends on borrow checker constraints with `self.disabled` and `self.entries`.
+
+## Implementation Units
+
+- [x] **Unit 1: Schema migration v23→v24 and DB methods**
+
+**Goal:** Add `enabled` column to `skill_overrides` and expose DB read/write methods.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs`
+- Modify: `crates/mika-agent/src/async_db.rs`
+- Test: `crates/mika-agent/src/db.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Add `migrate_v23_to_v24()`: `ALTER TABLE skill_overrides ADD COLUMN enabled INTEGER;`
+- **Update `migrate_v1()` clean-slate CREATE TABLE** to include `enabled INTEGER` — this is the documented trap from the LLM override learnings doc
+- Add `enabled: Option<bool>` to `SkillOverride` struct
+- Update `get_skill_overrides()` SELECT to include `enabled` column
+- Add `set_skill_enabled(agent_id, skill_name, enabled: bool)` — UPSERT via `ON CONFLICT DO UPDATE SET enabled = ?3`. If setting to default (enabled=true), check if all other columns are NULL and delete the row (default-equals-delete)
+- Update `delete_skill_llm_override()` default-equals-delete check to include `enabled IS NULL` in the cleanup condition
+- Add async wrappers in `async_db.rs`
+- Bump `CURRENT_SCHEMA_VERSION` to 24
+
+**Patterns to follow:**
+- `set_skill_override()` for UPSERT pattern
+- `delete_skill_llm_override()` for default-equals-delete pattern
+- `migrate_v22_to_v23()` for migration pattern
+
+**Test scenarios:**
+- Happy path: `set_skill_enabled(agent, "foo", false)` creates row with `enabled = 0`, `get_skill_overrides()` returns it with `enabled: Some(false)`
+- Happy path: `set_skill_enabled(agent, "foo", true)` on a row with no other overrides deletes the row (default-equals-delete)
+- Happy path: `set_skill_enabled(agent, "foo", true)` on a row with `always_on = Some(true)` preserves the row with `enabled` set to NULL (not deleted because `always_on` is non-NULL)
+- Edge case: `set_skill_enabled` on a skill with existing LLM override preserves both columns
+- Edge case: migration from v23 to v24 on DB with existing `skill_overrides` rows — `enabled` defaults to NULL
+- Happy path: round-trip — disable then enable returns to clean state
+
+**Verification:**
+- `cargo test -p mika-agent` passes with new migration and DB method tests
+- Fresh in-memory DB (via `migrate_v1`) includes `enabled` column
+
+- [x] **Unit 2: SkillRegistry eviction in `apply_overrides()`**
+
+**Goal:** Evict disabled skills from `entries` into a new `disabled` vec during override application.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/mod.rs`
+- Modify: `crates/mika-agent/src/skills/index.rs` (for `DisabledSkill` type)
+- Test: `crates/mika-agent/src/skills/mod.rs` (inline tests)
+
+**Approach:**
+- Define `DisabledSkill` struct (name, dir, reason) in `index.rs`, parallel to `SkippedSkill`
+- Add `disabled: Vec<DisabledSkill>` field to `SkillRegistry`
+- Add `disabled()` accessor method (parallels `skipped()`)
+- In `apply_overrides()`: before applying `always_on`/LLM overrides, collect names of skills with `enabled == Some(false)` from overrides. Use a staging vec: iterate `entries` with `retain()`, push non-retained to staging vec as `DisabledSkill`, then extend `self.disabled`
+- Update "skills loaded" log in `from_dir()` — this happens before `apply_overrides()`, so the count is pre-eviction. The post-eviction count is logged by callers or visible via `skills().len()`. Consider adding a log line after `apply_overrides()` that reports the disabled count
+- Keep `SkillEntry.enabled` field and `scan_skills_dir()` marker check — they become redundant but serve as belt-and-suspenders until #630
+
+**Patterns to follow:**
+- `skipped()` accessor and `SkippedSkill` struct for the parallel `disabled` pattern
+- Existing `apply_overrides()` match-by-name loop
+
+**Test scenarios:**
+- Happy path: skill with `enabled: Some(false)` override is evicted from `entries` and appears in `disabled()`
+- Happy path: skill with no `enabled` override (NULL) stays in `entries`
+- Happy path: skill with `enabled: Some(true)` stays in `entries`
+- Edge case: skill with both `always_on: Some(true)` and `enabled: Some(false)` — evicted (disabled wins)
+- Edge case: empty overrides list — no eviction, `disabled` is empty
+- Edge case: override for non-existent skill — silently skipped (existing behavior)
+- Integration: `from_dir()` → `apply_overrides()` → `validate_loaded()` — disabled skills not passed to validation
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- `disabled().len()` returns correct count after `apply_overrides()`
+
+- [x] **Unit 3: Agent tool `toggle_skill` writes to DB**
+
+**Goal:** Make the agent tool write `skill_overrides.enabled` instead of `.disabled` marker files.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/toggle_skill.rs`
+- Test: `crates/mika-agent/src/tools/toggle_skill.rs` (inline tests or eval harness)
+
+**Approach:**
+- Replace `.disabled` marker file creation/removal with `ctx.db.set_skill_enabled(agent_id, name, !current_enabled)` call
+- Determine current state from DB (`get_skill_overrides`) rather than filesystem marker
+- Keep `skills_dirty.store(true)` — the reload mechanism still works (rebuilds registry from disk + DB)
+- Remove all `.disabled` marker file I/O from this tool
+
+**Patterns to follow:**
+- `update_skill` tool's DB write pattern for `always_on` overrides
+
+**Test scenarios:**
+- Happy path: disable a skill → DB row created with `enabled = 0`, `skills_dirty` set to true
+- Happy path: enable a previously disabled skill → DB row cleaned up (default-equals-delete), `skills_dirty` set
+- Error path: toggle non-existent skill → error response (existing behavior preserved)
+- Edge case: toggle skill that has existing `always_on` override → `enabled` column updated, `always_on` preserved
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- No references to `.disabled` marker in `toggle_skill.rs`
+
+- [x] **Unit 4: CLI `mika skills enable/disable` writes to DB**
+
+**Goal:** Make CLI enable/disable commands write to DB instead of filesystem.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-cli/src/commands/skills.rs`
+- Test: `crates/mika-cli/src/commands/skills.rs` (inline tests if feasible, otherwise manual verification)
+
+**Approach:**
+- Refactor `toggle_skill()` to accept a `&Database` parameter and call `db.set_skill_enabled()`
+- The DB is already opened at line 129 for LLM overrides — route `Enable`/`Disable` commands through the same DB-opening path
+- For the `list` command: show disabled skills from DB overrides in a separate "[disabled]" section. The CLI already constructs a `SkillRegistry` for listing — after `apply_overrides()`, the `disabled()` accessor provides the data
+- Remove all `.disabled` marker file I/O from the CLI
+
+**Patterns to follow:**
+- Existing `SkillLlmAction` handling at line 132+ for DB-backed CLI operations
+- `skills list` output formatting for the new disabled section
+
+**Test scenarios:**
+- Happy path: `mika skills disable foo` writes DB row, prints confirmation
+- Happy path: `mika skills enable foo` clears DB row, prints confirmation
+- Happy path: `mika skills list` shows disabled skills in separate section with count
+- Error path: disable non-existent skill → error message (preserve existing behavior)
+- Edge case: disable when DB doesn't exist → clear error message (DB path check at line 123)
+
+**Verification:**
+- `cargo build -p mika-cli` succeeds
+- No references to `.disabled` marker in `skills.rs`
+
+- [x] **Unit 5: `.disabled` marker migration**
+
+**Goal:** Migrate existing `.disabled` markers to DB rows on startup and remove the marker files.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/mod.rs` or `crates/mika-agent/src/skills/index.rs`
+- Test: inline tests
+
+**Approach:**
+- Add `migrate_disabled_markers(skills_dir: &Path, db: &Database, agent_id: &str) -> Result<()>` function
+- Iterate skill directories, check for `.disabled` marker, call `db.set_skill_enabled(agent_id, name, false)`, remove marker file
+- On marker removal failure (read-only FS): log warning, continue (fail-open)
+- Call this function at startup BEFORE `scan_skills_dir()` — the migration runs once (idempotent: no markers left after first pass)
+- Hook point: callers of `SkillRegistry::from_dir()` that have DB access. The three startup sites are `chat.rs`, `ask.rs`, and `server/mod.rs`. Also `teams/engine.rs` sync path. Either plumb DB into `from_dir()` or call migration separately before `from_dir()`
+
+**Patterns to follow:**
+- `seed_bundled_skills()` for startup-time filesystem+DB interaction pattern
+
+**Test scenarios:**
+- Happy path: directory with `.disabled` marker → DB row created, marker removed
+- Happy path: directory without `.disabled` marker → no DB write, no error
+- Edge case: idempotency — run twice, second pass is a no-op (no markers left)
+- Edge case: marker file can't be removed → warning logged, DB row still created
+- Edge case: skill directory doesn't exist in DB overrides yet → creates new row
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- After migration, no `.disabled` files remain in test fixtures
+
+- [x] **Unit 6: Remove `.disabled` marker from `scan_skills_dir()`**
+
+**Goal:** Stop reading `.disabled` markers during skill scanning. The enabled state now comes from DB via `apply_overrides()`.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 2, Unit 5
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/index.rs`
+
+**Approach:**
+- Remove `let enabled = !path.join(".disabled").exists();` from `scan_skills_dir()`
+- Set `enabled: true` unconditionally on all scanned skills (the field is still used by the belt-and-suspenders match-time filter until #630, but now always true for scanned skills — the eviction in `apply_overrides()` handles the actual disabling)
+- Keep the `enabled` field on `SkillEntry` — it's still read by `matcher.rs` and `always_on_skills()` until #630
+
+**Test expectation:** Existing `scan_skills_dir` tests that create `.disabled` markers should be updated to verify the field is always `true`.
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- No references to `.disabled` in `scan_skills_dir()`
+
+## System-Wide Impact
+
+- **Interaction graph:** `apply_overrides()` is called from all startup sites (`chat.rs`, `ask.rs`, `server/mod.rs`, `teams/engine.rs`) and from `list_skills` tool. All sites already pass `SkillOverride` data from DB — the new `enabled` field flows automatically via the updated `get_skill_overrides()` SELECT.
+- **Error propagation:** DB write failures in `set_skill_enabled()` propagate as `anyhow::Result` to tool/CLI callers. Migration failures at startup are logged but don't block startup (fail-open on marker removal).
+- **State lifecycle risks:** CLI writes to DB while server is running — server won't see the change until next `skills_dirty` trigger or restart. This matches current `.disabled` file behavior and is documented as a known limitation.
+- **API surface parity:** The `toggle_skill` agent tool and CLI `skills enable/disable` both write to DB — they produce identical state.
+- **Unchanged invariants:** `skills_dirty` reload mechanism, `validate_loaded()` post-processing, `SkippedSkill` tracking, exec handler security, bundled skill seeding — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Clean-slate `migrate_v1` missing new column | Documented trap — Unit 1 explicitly includes updating `migrate_v1` |
+| CLI concurrent write with running server | SQLite WAL mode handles this; CLI uses short-lived connection with busy timeout |
+| `.disabled` markers on read-only filesystem during migration | Fail-open: write DB row, log warning, marker stays (belt-and-suspenders filter handles dual state) |
+| `always_on` + `enabled=false` interaction confusion | Documented: `enabled=false` always wins. Eviction runs first in `apply_overrides()` |
+
+## Sources & References
+
+- Related issue: #629
+- Follow-up: #630 (remove match-time filter)
+- Learnings: `docs/solutions/database-issues/skill-override-persistence-via-db-layer.md`
+- Learnings: `docs/solutions/architecture-patterns/skill-llm-override-db-layer-and-linked-unblock.md`
+- Learnings: `docs/solutions/best-practices/agent-tool-must-call-validate-loaded-on-skill-registry.md`

--- a/docs/runtime-structure.md
+++ b/docs/runtime-structure.md
@@ -141,7 +141,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **failed_sends** — `id INTEGER PK AUTO`, `agent_id FK`, `text TEXT`, `request_id TEXT`, `retry_count INTEGER DEFAULT 0`, `created_at TEXT`
 
-**skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20). Per-agent LLM overrides resolve as: DB > manifest `[llm]` > agent default. Set via `mika skills llm <name> set <provider>/<model>`.
+**skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20), `enabled INTEGER` (v24). Per-agent overrides: LLM overrides resolve as DB > manifest `[llm]` > agent default (`mika skills llm <name> set <provider>/<model>`). Enabled state is tri-state: `NULL`=default (enabled), `0`=disabled, `1`=explicitly enabled. `enabled=false` evicts the skill from `SkillRegistry.entries` during `apply_overrides()`. Replaces `.disabled` marker files (#629). Default-equals-delete: rows where all columns are NULL are pruned.
 
 ### View
 

--- a/docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md
+++ b/docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md
@@ -1,0 +1,201 @@
+---
+title: "Move skill enabled state from filesystem marker to DB with registry eviction"
+category: architecture-patterns
+date: 2026-04-18
+tags: [skills, overrides, migrations, database, registry, eviction, tri-state]
+pr: senara-solutions/mika#629
+issue: senara-solutions/mika#629
+---
+
+# Move skill enabled state from filesystem marker to DB with registry eviction
+
+## Problem
+
+`mika skills disable <name>` wrote a `.disabled` marker file in the skill
+directory. The engine scanned the marker during `scan_skills_dir()` and set
+`SkillEntry.enabled = false`, but disabled skills still loaded into
+`SkillRegistry.entries`. They were only filtered at match time
+(`matcher.rs:43-46`) and in `always_on_skills()`. Consequences:
+
+- Disabled skills consumed memory
+- Their prompts counted against the prompt budget (when `prompt_snippet`
+  was populated)
+- The "skills loaded" log conflated disabled and active skills
+- `disable` didn't actually reduce the agent's surface — it was closer to
+  a hint than a state change
+
+Four logical states existed (Installed, Disabled, Loaded, Skipped); the
+code modeled roughly two.
+
+## Root cause
+
+Two conflations:
+
+1. **State location.** `.disabled` was a filesystem marker co-located with
+   skill source. But `skill_overrides` already existed in SQLite as the
+   "operator overrides" layer for `always_on` and per-skill LLM. Enabled
+   state logically belonged in that same layer.
+2. **State semantics.** "Enabled" was a `bool` on `SkillEntry` — so a
+   disabled skill was an entry with one flag flipped, not an absence.
+   Every downstream consumer had to remember to check the flag.
+
+## Solution
+
+Make "disabled" mean "not in the registry." Move the state to a
+nullable `enabled` column on `skill_overrides`, evict disabled skills out
+of `SkillRegistry.entries` during `apply_overrides()`, and migrate any
+existing `.disabled` markers into DB rows at startup.
+
+### Tri-state nullable column
+
+```sql
+ALTER TABLE skill_overrides ADD COLUMN enabled INTEGER;
+-- NULL = default (enabled), 0 = explicitly disabled, 1 = explicitly enabled
+```
+
+Follows the same shape as `always_on`. `NULL` is the zero-cost default —
+no row needed just to say "this skill is in the normal state."
+
+### Default-equals-delete rule
+
+When every override column on a row becomes `NULL`, delete the row.
+Extends the pattern already used by `delete_skill_llm_override()`.
+`set_skill_enabled(agent, name, true)` on a row where `always_on` and
+all LLM override columns are `NULL` removes the row entirely. Prevents
+`skill_overrides` from accumulating no-op rows as operators toggle skills
+on and off.
+
+### Eviction in `apply_overrides()` (stage-then-extend)
+
+The registry's `entries: Vec<SkillEntry>` can't be mutated with `retain()`
+while simultaneously pushing evicted entries into `self.disabled` — the
+closure can't borrow `self.disabled` while `self.entries` is mutably
+borrowed. Stage into a local vec, then extend:
+
+```rust
+let mut staging: Vec<DisabledSkill> = Vec::new();
+self.entries.retain(|e| {
+    if disabled_names.contains(&e.name) {
+        staging.push(DisabledSkill::from_entry(e, "operator override"));
+        false
+    } else {
+        true
+    }
+});
+self.disabled.extend(staging);
+```
+
+Eviction runs **before** `always_on` and LLM override application, so
+`enabled=false` always wins over `always_on=true` — "disabled" means
+"removed from consideration," not "removed unless forced on."
+
+### One-shot migration of `.disabled` markers
+
+At startup, before `scan_skills_dir()`, walk the skills directory and
+for each `.disabled` marker: write `skill_overrides.enabled = 0`, then
+remove the marker file. Idempotent (no markers left on subsequent runs).
+Fail-open on marker removal — write the DB row, log a warning, continue.
+The belt-and-suspenders match-time filter (kept until the follow-up
+cleanup in #630) handles any dual-state edge.
+
+### Belt-and-suspenders: keep the match-time filter in this PR
+
+Don't delete `matcher.rs:43-46` in the same PR that introduces eviction.
+During rollout, both mechanisms run — if eviction has a bug, the filter
+still hides disabled skills. Filter removal ships separately after the
+eviction path has baked.
+
+## Why it works
+
+- **One source of truth.** `skill_overrides.enabled` is the authoritative
+  state; both the agent tool and CLI write it the same way.
+- **Registry integrity.** After `apply_overrides()`, `entries` contains
+  exactly the active skills. Downstream code (matcher, prompt assembly,
+  logging) sees an accurate count without needing to re-check flags.
+- **Explicit state model.** `SkillRegistry` now exposes `skills()`,
+  `skipped()`, and `disabled()` — the four logical states (Installed,
+  Disabled, Loaded, Skipped) collapse cleanly onto three collections
+  plus filesystem presence.
+- **Zero-cost default.** Tri-state nullable means skills in their normal
+  state occupy zero rows. Operators only pay storage for explicit
+  overrides.
+
+## Traps and guardrails
+
+### The `migrate_v1` clean-slate trap
+
+`migrate_v1` recreates `skill_overrides` from scratch on fresh DBs. A
+new column added via `migrate_vN_to_vN+1` **must also be added to
+`migrate_v1`**. Fresh installs go through `migrate_v1` and skip the
+incremental migration — if `migrate_v1` is stale, fresh DBs miss the
+column and tests on in-memory DBs fail cryptically.
+
+This is the same trap documented in
+`skill-llm-override-db-layer-and-linked-unblock.md`. When adding a
+column to `skill_overrides`, update both migrations in the same commit
+and grep for any other `CREATE TABLE skill_overrides` in the codebase.
+
+### CLI DB access is already solved
+
+The 2026-03-09 skill plan deferred CLI DB writes with the rationale
+"CLI has no DB access." That constraint no longer holds — `skills.rs`
+opens the DB at line 129 for LLM overrides. The enable/disable path
+reuses the same connection. SQLite WAL mode handles concurrent CLI +
+agent readers/writers; use a short busy timeout on the CLI connection.
+
+### Cross-process reload is not in scope
+
+CLI writes to DB while the server is running — the server won't see
+the change until the next `skills_dirty` trigger or restart. This
+matches prior `.disabled` file behavior (the server didn't watch the
+file either) and is documented as a known limitation. Cross-process
+`skills_dirty` propagation is a separate change.
+
+### Bundled vs community skills
+
+Bundled skills (seeded by `seed_bundled_skills()` into
+`~/.mika/agents/<name>/skills/bundled/`) have filesystem directories
+like community skills. The `toggle_skill` tool's `skill_dir.exists()`
+check still applies. No special-casing needed — bundled skills use the
+same DB override path.
+
+## Test coverage (the ones that actually catch bugs)
+
+- Round-trip: disable → enable returns to clean state (row deleted,
+  not just `enabled=NULL`)
+- Precedence: `always_on=true` + `enabled=false` → evicted
+- Preservation: `enabled=false` on a row with LLM override → both
+  columns intact, row not deleted
+- Migration: `.disabled` marker → DB row created, marker removed;
+  second run is a no-op
+- Fresh DB: `migrate_v1` path includes `enabled` column (not just the
+  incremental migration)
+- Eviction count: `disabled().len()` matches the number of
+  `enabled=false` overrides after `apply_overrides()`
+
+## When to reach for this pattern
+
+Reach for this when:
+
+- Operator-controlled state currently lives as a filesystem marker
+  co-located with source (a smell — state and source have different
+  write patterns)
+- Downstream code has to remember to filter a boolean flag on every
+  use (a smell — absence is a cleaner representation than presence
+  with a flag)
+- You already have an overrides table that logically owns this kind
+  of state
+
+Don't reach for this when the filesystem marker is the source of truth
+for a filesystem-scoped concept (`.gitignore`, lock files). Here the
+state was fundamentally about "what this operator wants right now" —
+which is exactly what `skill_overrides` already stored.
+
+## References
+
+- Issue: senara-solutions/mika#629
+- Follow-up (match-time filter removal): senara-solutions/mika#630
+- Plan: `docs/plans/2026-04-18-001-feat-skill-enabled-state-db-eviction-plan.md`
+- Related: `docs/solutions/architecture-patterns/skill-llm-override-db-layer-and-linked-unblock.md`
+- Related: `docs/solutions/database-issues/skill-override-persistence-via-db-layer.md`
+- Related: `docs/solutions/best-practices/agent-tool-must-call-validate-loaded-on-skill-registry.md`


### PR DESCRIPTION
## Summary

- Moves `mika skills disable` from filesystem `.disabled` markers to a new `skill_overrides.enabled INTEGER` column (schema v24, tri-state NULL/0/1).
- Disabled skills are now **evicted** from `SkillRegistry.entries` during `apply_overrides()` — they no longer consume memory, prompt budget, or inflate the "skills loaded" count.
- Existing `.disabled` markers are migrated to DB rows on first startup via a fail-open `migrate_disabled_markers()` pass; markers are then removed.

## What's in the PR

- **Schema v23 → v24:** `skill_overrides.enabled` (nullable tri-state). Clean-slate `migrate_v1` also updated to include the column (the documented `migrate_v1` trap from prior skill-override work).
- **`set_skill_enabled()`** with default-equals-delete: when the row has no overrides left (enabled back to NULL, `always_on` NULL, LLM columns NULL), the row is deleted.
- **Registry eviction** via stage-then-extend in `apply_overrides()` (closure can't borrow `self.disabled` while `self.entries` is being `retain()`-ed). `enabled=false` always wins over `always_on=true`.
- **Agent tool** `toggle_skill` and **CLI** `mika skills enable/disable` both write DB — identical semantics, no filesystem markers.
- **CLI** `mika skills list` now shows disabled skills in a separate `[disabled]` section.
- **Callers updated:** `chat.rs`, `ask.rs`, `server/mod.rs`, `teams/engine.rs` all run `migrate_disabled_markers()` before `scan_skills_dir()`.

## Not in this PR (scope boundary)

- `matcher.rs:43-46` match-time filter removal → belt-and-suspenders during rollout; ships in #630.
- Cross-process `skills_dirty` propagation for CLI writes while the server is running → matches prior `.disabled` file behavior (server didn't watch the file either).

## Test plan

- [x] `cargo test -p mika-agent` — 1690 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bash scripts/verify-pipeline.sh` passes (plan + code + compound doc present)
- [x] New test coverage:
  - Round-trip disable → enable deletes the row (default-equals-delete)
  - `always_on=true` + `enabled=false` → skill evicted
  - `enabled=false` on a row with LLM override preserves both columns
  - `migrate_disabled_markers` idempotency
  - Fresh DB via `migrate_v1` includes `enabled` column

## Artifacts

- Plan: `docs/plans/2026-04-18-001-feat-skill-enabled-state-db-eviction-plan.md`
- Learning: `docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md`

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)