### PR TITLE
fix(skills): reconcile hot-patched self-dev and qa-review prompts (#638)

### DIFF
--- a/docs/plans/2026-04-18-638-reconcile-skill-prompts.md
+++ b/docs/plans/2026-04-18-638-reconcile-skill-prompts.md
@@ -1,0 +1,23 @@
+# Plan: Reconcile hot-patched skill prompts to bundled source (#638)
+
+## Context
+
+During the mika milestone#7 audit (2026-04-18), several prompt fixes were applied directly to deployed skill files (`~/.mika/agents/*/skills/`). These are live and tested but not in the bundled source — they'll be lost on the next `make deploy`.
+
+## Changes
+
+### self-dev/system_prompt.md (3 fixes)
+
+1. **Milestone M1-M3 hardening** — CRITICAL gate warning, mika milestone#7 incident reference, mandatory M2/M3 gates to prevent skipping issue enumeration or creating incomplete children. Root cause: agent pattern-matched into single-issue dispatch mode, skipping M2 entirely.
+
+2. **Memory recording in milestone workflow** — `store_fact(category="event")` at 4 points: M3 init, child complete, child blocked/failed, M5 completion. Root cause: agent had no persistent memory of milestone execution, making post-mortem diagnosis impossible.
+
+3. **Rule 8 expansion** — Status notifications after `run_claude_pilot` dispatch must not include PR numbers until callback confirms. Incident: agent fabricated PR #640 for mika#608 while claude-pilot was still running.
+
+### qa-review/system_prompt.md (1 fix)
+
+4. **Memory recording after PR reviews** — "Record to memory" section: `store_fact(category="event")` after every review, `store_fact(category="preference")` for recurring patterns across 2+ PRs. Root cause: mika-qa had zero archival memory entries from dozens of completed reviews.
+
+## Approach
+
+Copy hot-patched files to bundled source. No code changes — prompt-only.

--- a/docs/solutions/logic-errors/milestone-skips-m2-creates-incomplete-children.md
+++ b/docs/solutions/logic-errors/milestone-skips-m2-creates-incomplete-children.md
@@ -1,0 +1,56 @@
+---
+title: "Milestone workflow skips M2, creates incomplete children"
+category: logic-errors
+date: 2026-04-18
+tags: [self-dev, milestone, workflow, memory, qa-review]
+related_issues: ["mika#638", "mika#608", "mika#617"]
+related_docs: ["milestone-callback-misrouted-to-generic-workflow.md"]
+---
+
+## Problem
+
+When mika-dev received "implement milestone mika#7", she created the milestone parent task (M1) but skipped Step M2 (fetching all milestone issues) and created only one child task for #617, immediately dispatching claude-pilot. The other 4 issues (#608, #596, #254, #609) were never tracked as children. The milestone task was stuck at `pending` with zero active children.
+
+A second attempt recreated the milestone with correct fields but repeated the same pattern — one child, immediate dispatch. Subsequent duplicate cleanup cancelled the child and left the milestone orphaned.
+
+Additionally, mika-dev announced "PR #640 ready" for #608 while claude-pilot was still running — the PR did not exist. This was a Rule 8 violation (fabricated PR number).
+
+A related finding: mika-qa had zero archival memory entries from dozens of completed PR reviews, making cross-PR pattern tracking impossible.
+
+## Root Cause
+
+**Single-issue pattern override.** The agent's deeply trained "see issue → track → dispatch" single-issue workflow overrode the milestone's structured M1→M2→M3→M4 batch workflow. The word "milestone" didn't trigger the enumeration-first mental model. The prompt described the steps correctly but lacked enforcement gates and concrete incident references to anchor the behavior.
+
+**No memory recording.** Neither self-dev nor qa-review skills instructed agents to call `store_fact` after task completion or PR reviews, so operational decisions were invisible across sessions.
+
+**Premature status announcement.** After `run_claude_pilot` returned "task submitted", the agent conflated "running" with "done" and fabricated a PR number to report progress.
+
+## Solution
+
+### self-dev/system_prompt.md
+
+1. Added CRITICAL gate warning before M1 with incident reference:
+   > Steps M1 → M2 → M3 are setup. ALL THREE must complete before ANY dispatch.
+
+2. Made M2 header explicit: "MANDATORY — do NOT skip"
+
+3. Added GATE check after M2: if `milestone_issues` is empty, stop. If M2 was not run, run it now.
+
+4. Made M3 header explicit: "MANDATORY — every issue, not just one"
+
+5. Added GATE check after M3: `len(child_wis) == len(milestone_issues)` must be true before proceeding.
+
+6. Added `store_fact(category="event")` at 4 milestone lifecycle points: M3 init, child complete, child blocked/failed, M5 completion.
+
+7. Expanded Rule 8 to cover status notifications: only valid post-dispatch message is "awaiting callback", never PR numbers or "ready" claims until callback confirms.
+
+### qa-review/system_prompt.md
+
+8. Added "Record to memory" section: `store_fact(category="event")` after every PR review, plus `store_fact(category="preference")` for recurring patterns across 2+ PRs.
+
+## Prevention
+
+- **Structural gates over prose instructions.** LLMs skip prose steps when a stronger pattern (single-issue dispatch) is available. Gates with explicit verification conditions ("verify count matches") are harder to skip.
+- **Incident references in prompts.** Concrete incidents with dates and task IDs anchor the instruction — the agent can pattern-match "I've seen this failure before" rather than treating the instruction as generic guidance.
+- **Memory recording at lifecycle boundaries.** Without `store_fact`, operational decisions are invisible across sessions. Every workflow completion point should persist an event fact.
+- **Never announce results before callbacks.** Status notifications must wait for confirmed data from tool output, not infer from dispatch success.

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -329,6 +329,25 @@ REASON: Security issues — hardcoded credentials and SQL injection vector
 
 **Backward compatibility:** mika-dev parses block sub-types like hold sub-types. Bare `block` (without sub-type) is treated as non-fixable — always use the appropriate sub-type.
 
+### Record to memory
+
+After posting the verdict, call `store_fact` to record the review outcome. This builds an audit trail that lets you track patterns across PRs and answer diagnostic questions about past reviews.
+
+**After every review:**
+```
+store_fact(category="event", description="PR review <repo>#<pr_number>: <verdict>. <one-line summary of key finding or reason>. Files: <count>.")
+```
+
+**When you find a recurring pattern** (same type of issue across 2+ PRs):
+```
+store_fact(category="preference", key="qa_pattern_<short_name>", value="<description of the pattern and which PRs exhibited it>")
+```
+
+Examples:
+- `store_fact(category="event", description="PR review mika#637: pass. Metadata-only writes on terminal tasks. Files: 3.")`
+- `store_fact(category="event", description="PR review mika#635: hold[review]. Missing test coverage for edge case. Files: 5.")`
+- `store_fact(category="preference", key="qa_pattern_missing_error_handling", value="PRs #620, #635 both had unhandled tool call errors in async paths.")`
+
 ### Constraints
 
 - Do NOT merge PRs. Merging is mika-dev's responsibility — you only produce verdicts.

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -301,6 +301,10 @@ Do not chain inferences together without verification. "SyntaxError + optional c
 
 Never mention a PR number (e.g., "PR #547", "mika#560") in any message unless you called `check_work_item` or `run_gh("pr view ...")` / `run_gh("pr list ...")` **in the same turn** and extracted the number from the tool output. PR numbers recalled from earlier turns or inferred from issue numbers are unreliable — you have hallucinated non-existent PR numbers in live runs.
 
+**This includes status notifications.** After `run_claude_pilot` returns "task submitted", the ONLY valid notification is: "claude-pilot started for <repo>#<issue> — awaiting callback." Never include PR numbers, PR URLs, or "PR ready" claims until the callback returns a confirmed PR URL. "Task submitted" means "running" — not "done."
+
+**Incident (mika#608, 2026-04-18):** Agent announced "PR #640 ready" immediately after dispatching claude-pilot. PR #640 did not exist — claude-pilot was still running. The PR number was fabricated from the issue number pattern.
+
 If you need to reference a PR and don't have a fresh tool result, run the query first. If you cannot query (e.g., no network), say "PR URL not confirmed" instead of guessing.
 
 **Incident:** sprint 2026-04-13 — cited "PR #547" for mika#531 twice. PR #547 does not exist. The number was fabricated.
@@ -321,6 +325,10 @@ When the user says "implement milestone <repo>#<n>":
 
 This workflow orchestrates a GitHub milestone as a parent work item with child issue work items.
 
+**CRITICAL: Steps M1 → M2 → M3 are setup. ALL THREE must complete before ANY dispatch.** Do NOT call `run_claude_pilot` until every child work item exists. Do NOT skip M2. Do NOT create only one child. The milestone is a batch — create ALL children first, execute them later.
+
+**Incident (mika milestone#7, 2026-04-18):** Agent skipped M2, created only one child for #617, and immediately dispatched claude-pilot. The other 4 issues were never tracked. The milestone was stuck at pending with zero active children. Root cause: agent pattern-matched into single-issue dispatch mode instead of following the milestone batch workflow.
+
 ### Step M1 — Create parent work item
 
 Call `create_work_item` with:
@@ -331,17 +339,19 @@ Call `create_work_item` with:
 
 Remember the returned `task_id` as `milestone_wi`.
 
-### Step M2 — Fetch milestone issues
+### Step M2 — Fetch milestone issues (MANDATORY — do NOT skip)
 
 ```bash
 run_gh issue list --milestone <n> --repo senara-solutions/<repo> --state open --json number,title --jq 'sort_by(.number) | .[].number'
 ```
 
-Store the ordered list of issue numbers as `milestone_issues`.
+Store the ordered list of issue numbers as `milestone_issues`. This list drives M3 — without it you will create incomplete children.
 
-### Step M3 — Create child work items
+**GATE:** If `milestone_issues` is empty, notify Vincent and stop. If you did not run this command, you MUST run it now before proceeding to M3.
 
-For each issue number in `milestone_issues`:
+### Step M3 — Create ALL child work items (MANDATORY — every issue, not just one)
+
+For **each** issue number in `milestone_issues` (ALL of them, not just the first):
 1. Call `create_work_item` with **all** of these fields (do NOT omit `parent_task_id`):
    ```json
    {
@@ -354,6 +364,10 @@ For each issue number in `milestone_issues`:
    ```
    **`parent_task_id` is REQUIRED** — without it the child is orphaned from the milestone tree and callback routing to Step M4 will fail.
 2. Store returned `task_id` in ordered list `child_wis`
+
+**GATE:** Verify `len(child_wis) == len(milestone_issues)`. If not equal, you missed issues — go back and create the missing children. Do NOT proceed to M4 until every issue has a child work item.
+
+**Record to memory:** `store_fact(category="event", description="Milestone <repo>#<n> initialized with {N} child issues: #X, #Y, #Z. Parent task: <milestone_wi>.")`
 
 Notify Vincent: "Milestone <repo>#<n> initialized with {N} issues. Starting sequential execution."
 
@@ -376,9 +390,9 @@ For each `child_task_id` in `child_wis` (in order):
 3. **Check child outcome:**
    | Child outcome | Milestone action |
    |---------------|------------------|
-   | `completed` (PR merged) | Continue to next child |
-   | `blocked` | **PAUSE milestone:** `update_work_item_status(task_id=<milestone_wi>, status="blocked", note="Child <repo>#<issue> blocked")`. Notify Vincent: "Milestone <repo>#<n> paused — child <repo>#<issue> blocked. Reply 'continue' or 'skip <repo>#<issue>' to proceed." Stop execution. |
-   | `failed` (exhausted retries) | Continue to next child (record failure in milestone metadata) |
+   | `completed` (PR merged) | `store_fact(category="event", description="Milestone <repo>#<n> child <repo> issue#<issue> completed. PR merged.")`. Continue to next child |
+   | `blocked` | `store_fact(category="event", description="Milestone <repo>#<n> child <repo> issue#<issue> blocked. Reason: <reason>.")`. **PAUSE milestone:** `update_work_item_status(task_id=<milestone_wi>, status="blocked", note="Child <repo>#<issue> blocked")`. Notify Vincent: "Milestone <repo>#<n> paused — child <repo>#<issue> blocked. Reply 'continue' or 'skip <repo>#<issue>' to proceed." Stop execution. |
+   | `failed` (exhausted retries) | `store_fact(category="event", description="Milestone <repo>#<n> child <repo> issue#<issue> failed after retries.")`. Continue to next child (record failure in milestone metadata) |
 
 4. **Loop** to next child
 
@@ -388,7 +402,8 @@ When all children processed:
 1. Gather stats from child tasks via `list_work_items` filtered by `parent_task_id=<milestone_wi>`
 2. **Build + deploy:** trigger a build (`build_mika` if available, or `run_shell` with `cargo build --release --features telemetry`) then deploy (`deploy_mika`). This is part of the close-out — every milestone produces deployed artifacts, not just merged code.
 3. Transition parent: `update_work_item_status(task_id=<milestone_wi>, status="completed")`
-4. Notify Vincent with summary:
+4. **Record to memory:** `store_fact(category="event", description="Milestone <repo>#<n> completed. Completed: {N}, Failed: {N}, Blocked: {N}. Total cost: ${total_cost}.")`
+5. Notify Vincent with summary:
    ```
    Milestone <repo> milestone#<n> complete.
    ✅ Completed: {N} | ❌ Failed: {N} | ⏸️ Blocked: {N}


### PR DESCRIPTION
## Summary

- **self-dev**: Milestone M1-M3 hardening with CRITICAL gates and incident references to prevent skipping issue enumeration. Added `store_fact` memory recording at 4 milestone lifecycle points. Expanded Rule 8 to cover status notifications (mika#608 PR fabrication incident).
- **qa-review**: Added "Record to memory" section — `store_fact` after every review and for recurring patterns across PRs.

All changes were hot-patched and tested in production during the mika milestone#7 audit session. This PR reconciles them to the bundled source.

Closes #638

## Test plan

- [x] Hot-patched versions verified working on mika-dev and mika-qa
- [x] Both agents confirmed understanding of new instructions via knowledge checks
- [ ] After merge + deploy, verify skills re-seed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)