### PR TITLE
feat(agent): auto-create well-known agents (mika-dev, mika-qa) in dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,9 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_LOG_FORMAT=json                  # json (default) or pretty (human-readable, for local dev)
 # MIKA_EMBEDDING_MODEL=text-embedding-3-small
 # MIKA_EMBEDDING_DIMENSIONS=512
+# MIKA_DEV_MODE=false                # Auto-provision mika-dev + mika-qa agents on startup
 # MIKA_DISABLE_BUNDLED_SKILLS=false  # WARNING: do not enable in production
+# MIKA_DISABLE_AGENT_PROVISIONING=false  # Prevent dev_mode from overwriting agent files
 
 # Optional: Runtime observability (LLM call + tool call recording)
 # MIKA_STORE_LLM_CALLS=true       # Store LLM call metadata in SQLite (default: true)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,9 @@ Server mode additionally requires:
 - `MIKA_INTERNAL_TOKEN` — Shared secret for Bearer auth between gateway and agent
 
 Optional (startup behavior):
+- `MIKA_DEV_MODE` — Enable dev mode (default: false). When true, auto-provisions well-known development agents (`mika-dev`, `mika-qa`) on startup with role-specific identity, soul, and skill assignments. mika-dev gets self-dev family skills; mika-qa gets qa-review family skills. Idempotent — existing agents are never overwritten.
 - `MIKA_DISABLE_BUNDLED_SKILLS` — Skip bundled skill re-sync on startup (default: false). WARNING: do not enable in production — prevents security updates to handler scripts.
+- `MIKA_DISABLE_AGENT_PROVISIONING` — Skip well-known agent auto-creation on startup (default: false). When true, prevents `dev_mode` from creating or updating agent identity files, allowing manual edits to persist across restarts/deploys. Same pattern as `MIKA_DISABLE_BUNDLED_SKILLS`.
 
 Optional (runtime observability):
 - `MIKA_STORE_LLM_CALLS` — Store LLM call metadata (model, tokens, latency) in SQLite (default: true)

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -356,6 +356,8 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `server_log_file` | `Option<PathBuf>` | None | `MIKA_SERVER_LOG_FILE` | File path for mika-server log output. Logs go to stdout + file when set. |
 | `dashboard_enabled` | `bool` | `false` | `MIKA_DASHBOARD_ENABLED` | Enable embedded dashboard SPA at `/dashboard/`. When enabled, the pre-built React dashboard is served from the binary via `rust-embed`. Requires `MIKA_DASHBOARD_TOKEN` for token injection. Build the dashboard before compiling: `npm run build --prefix dashboard` (`VITE_BASE_PATH` is set automatically). |
 | `disable_bundled_skills` | `bool` | `false` | `MIKA_DISABLE_BUNDLED_SKILLS` | Skip bundled skill re-sync on startup. Useful for debugging handler scripts. **Do not enable in production** — prevents security updates to handler scripts from propagating. |
+| `dev_mode` | `bool` | `false` | `MIKA_DEV_MODE` | Enable dev mode — auto-provisions well-known development agents (`mika-dev`, `mika-qa`) on startup with role-specific identity, soul, and skill assignments. Idempotent — existing agents are never overwritten. |
+| `disable_agent_provisioning` | `bool` | `false` | `MIKA_DISABLE_AGENT_PROVISIONING` | Skip well-known agent auto-creation on startup. When true, prevents `dev_mode` from creating or updating agent identity files, allowing manual edits to persist across restarts/deploys. |
 | `telemetry_enabled` | `bool` | `false` | `MIKA_TELEMETRY_ENABLED` | Enable OpenTelemetry trace export. Requires `--features telemetry` at build time. When enabled, spans are exported via OTLP HTTP to the configured endpoint. |
 | `otlp_endpoint` | `Option<String>` | None | `MIKA_OTLP_ENDPOINT` | OTLP endpoint URL for trace export — must include `/v1/traces` (e.g. `https://cloud.langfuse.com/api/public/otel/v1/traces` for Langfuse, `http://localhost:4318/v1/traces` for Jaeger). Required when `telemetry_enabled` is true. |
 | `otlp_auth_header` | `Option<SecretString>` | None | `MIKA_OTLP_AUTH_HEADER` | OTLP authorization header value. For Langfuse, pass raw `publicKey:secretKey` (auto-encoded to Base64) or pre-encoded Base64. Sent as `Authorization: Basic <value>`. Zeroized on drop. |
@@ -529,7 +531,9 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |
+| `MIKA_DEV_MODE` | No | Auto-provision mika-dev + mika-qa agents on startup (default: false) |
 | `MIKA_DISABLE_BUNDLED_SKILLS` | No | Skip bundled skill re-sync on startup (default: false) |
+| `MIKA_DISABLE_AGENT_PROVISIONING` | No | Prevent dev_mode from overwriting agent files (default: false) |
 
 \* Set the API key for the active provider. E.g., `MIKA_ANTHROPIC_API_KEY` for Anthropic, `MIKA_GROQ_API_KEY` for Groq. Ollama does not require an API key.
 | `MIKA_SERVER_URL` | No | mika-server URL for dashboard CLI commands (default: `http://localhost:8080`) |
@@ -554,7 +558,9 @@ are required for inter-service communication:
 | `MIKA_DB_PATH` | No | Override database path |
 | `MIKA_LOG_LEVEL` | No | Override log level |
 | `MIKA_LOG_FORMAT` | No | Stdout log format: `json` (default) or `pretty` |
+| `MIKA_DEV_MODE` | No | Auto-provision mika-dev + mika-qa agents on startup (default: false) |
 | `MIKA_DISABLE_BUNDLED_SKILLS` | No | Skip bundled skill re-sync on startup (default: false) |
+| `MIKA_DISABLE_AGENT_PROVISIONING` | No | Prevent dev_mode from overwriting agent files (default: false) |
 | `MIKA_TELEMETRY_ENABLED` | No | Enable OTel trace export (requires `--features telemetry` build) |
 | `MIKA_OTLP_ENDPOINT` | No | OTLP endpoint URL with `/v1/traces` path (required when telemetry enabled) |
 | `MIKA_OTLP_AUTH_HEADER` | No | OTLP auth header value (e.g. Base64-encoded Langfuse credentials) |

--- a/crates/mika-agent/src/lib.rs
+++ b/crates/mika-agent/src/lib.rs
@@ -20,4 +20,5 @@ pub mod test_utils;
 pub mod timestamp;
 pub mod tools;
 pub mod validate;
+pub mod well_known_agents;
 pub mod work_item_metadata;

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -334,6 +334,9 @@ async fn init_agent(
     )?;
     startup::seed_core_memory_if_empty(&db, agent_home, agent_name)?;
     startup::seed_bundled_skills_if_needed(agent_home, disable_bundled_skills);
+    if agent_settings.dev_mode {
+        crate::well_known_agents::seed_well_known_skill_overrides(&db, agent_name);
+    }
     let async_db = AsyncDatabase::new_with_agent(db, agent_name);
 
     let skills_dir = agent_home.join("skills");
@@ -525,6 +528,14 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
 
     // Auto-migrate to multi-agent layout if needed
     home::migrate_to_multi_agent(global_home)?;
+
+    // Auto-provision well-known dev agents if dev_mode is enabled
+    if settings.dev_mode {
+        crate::well_known_agents::provision_well_known_agents(
+            global_home,
+            settings.disable_agent_provisioning,
+        );
+    }
 
     // Warn if embedded dashboard is enabled but no assets were compiled in
     if settings.dashboard_enabled && !embedded_dashboard::has_embedded_assets() {

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -270,6 +270,8 @@ pub mod test_helpers {
             server_log_file: None,
             dashboard_enabled: false,
             disable_bundled_skills: false,
+            dev_mode: false,
+            disable_agent_provisioning: false,
             telemetry_enabled: false,
             otlp_endpoint: None,
             otlp_auth_header: None,

--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -1,0 +1,440 @@
+//! Well-known agent provisioning for dev mode.
+//!
+//! When `dev_mode = true` in config, the startup sequence auto-provisions
+//! development agents (`mika-dev`, `mika-qa`) with role-specific identity,
+//! soul, and skill assignments.
+
+use std::path::Path;
+
+use tracing::{info, warn};
+
+use crate::db::Database;
+
+/// Specification for a well-known development agent.
+pub struct WellKnownAgent {
+    /// Agent name (lowercase, hyphenated).
+    pub name: &'static str,
+    /// Display name for identity.toml.
+    pub display_name: &'static str,
+    /// Emoji for identity.toml.
+    pub emoji: &'static str,
+    /// Soul.md content.
+    pub soul: &'static str,
+    /// Bundled skills to disable for this agent.
+    pub disabled_skills: &'static [&'static str],
+}
+
+/// mika-dev agent specification.
+pub static MIKA_DEV: WellKnownAgent = WellKnownAgent {
+    name: "mika-dev",
+    display_name: "Dev",
+    emoji: "🛠",
+    soul: MIKA_DEV_SOUL,
+    disabled_skills: &["qa-review", "qa-review-build-callback", "skill-review"],
+};
+
+/// mika-qa agent specification.
+pub static MIKA_QA: WellKnownAgent = WellKnownAgent {
+    name: "mika-qa",
+    display_name: "QA",
+    emoji: "🔍",
+    soul: MIKA_QA_SOUL,
+    disabled_skills: &[
+        "self-dev",
+        "self-dev-iterate",
+        "self-dev-webhook-qa",
+        "self-dev-webhook-ci",
+        "claude-pilot",
+        "permission-policy",
+        "agents-teams",
+        "address-pr-comments",
+        "resolve-pr-conflicts",
+    ],
+};
+
+/// All well-known agents.
+pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA];
+
+/// Look up a well-known agent by name.
+pub fn find_well_known_agent(name: &str) -> Option<&'static WellKnownAgent> {
+    WELL_KNOWN_AGENTS.iter().find(|a| a.name == name).copied()
+}
+
+/// Provision well-known development agents on the filesystem.
+///
+/// For each well-known agent that doesn't already exist:
+/// 1. Calls `bootstrap_agent()` to create dirs + default files
+/// 2. Overwrites `identity.toml` and `soul.md` with agent-specific content
+///
+/// When `disabled` is true, logs a warning and returns without changes.
+/// This is the filesystem phase — DB skill overrides are set separately
+/// in [`seed_well_known_skill_overrides`] during agent init.
+pub fn provision_well_known_agents(home_dir: &Path, disabled: bool) {
+    if disabled {
+        warn!(
+            "agent provisioning disabled by config \
+             (MIKA_DISABLE_AGENT_PROVISIONING=true) — well-known agents \
+             will not be auto-created or updated"
+        );
+        return;
+    }
+
+    for spec in WELL_KNOWN_AGENTS {
+        if mika_common::agent::agent_exists(home_dir, spec.name) {
+            info!(
+                agent = spec.name,
+                "well-known agent already exists, skipping"
+            );
+            continue;
+        }
+
+        match mika_common::home::bootstrap_agent(home_dir, spec.name) {
+            Ok(()) => {
+                let agent_home = mika_common::agent::agent_dir(home_dir, spec.name);
+
+                // Overwrite identity.toml with agent-specific content
+                let identity_content = format!(
+                    "name = \"{}\"\nemoji = \"{}\"\n",
+                    spec.display_name, spec.emoji
+                );
+                if let Err(e) = std::fs::write(agent_home.join("identity.toml"), &identity_content)
+                {
+                    warn!(
+                        agent = spec.name,
+                        error = %e,
+                        "failed to write identity.toml for well-known agent"
+                    );
+                    continue;
+                }
+
+                // Overwrite soul.md with agent-specific content
+                if let Err(e) = std::fs::write(agent_home.join("soul.md"), spec.soul) {
+                    warn!(
+                        agent = spec.name,
+                        error = %e,
+                        "failed to write soul.md for well-known agent"
+                    );
+                    continue;
+                }
+
+                info!(
+                    agent = spec.name,
+                    display_name = spec.display_name,
+                    "provisioned well-known agent"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    agent = spec.name,
+                    error = %e,
+                    "failed to bootstrap well-known agent"
+                );
+            }
+        }
+    }
+}
+
+/// Seed skill overrides for a well-known agent if none exist yet.
+///
+/// Writes `set_skill_enabled(false)` for each skill in the agent's
+/// `disabled_skills` list. Only runs on first creation — if any
+/// `skill_overrides` rows already exist for this agent, the function
+/// returns early to preserve user customizations.
+pub fn seed_well_known_skill_overrides(db: &Database, agent_name: &str) {
+    let spec = match find_well_known_agent(agent_name) {
+        Some(s) => s,
+        None => return,
+    };
+
+    // Check if any overrides already exist (user has customized)
+    match db.get_skill_overrides(agent_name) {
+        Ok(overrides) if !overrides.is_empty() => {
+            return;
+        }
+        Err(e) => {
+            warn!(
+                agent = agent_name,
+                error = %e,
+                "failed to check skill overrides, skipping well-known seeding"
+            );
+            return;
+        }
+        _ => {}
+    }
+
+    for skill_name in spec.disabled_skills {
+        if let Err(e) = db.set_skill_enabled(agent_name, skill_name, false) {
+            warn!(
+                agent = agent_name,
+                skill = skill_name,
+                error = %e,
+                "failed to disable skill for well-known agent"
+            );
+        }
+    }
+
+    info!(
+        agent = agent_name,
+        disabled_count = spec.disabled_skills.len(),
+        "seeded skill overrides for well-known agent"
+    );
+}
+
+const MIKA_DEV_SOUL: &str = r#"# Mika Dev — Development Agent
+
+## Role
+You are Mika Dev, a senior software development agent. You implement features,
+fix bugs, review code, and manage the development lifecycle autonomously.
+
+## Communication style
+- Be direct and technical
+- Lead with actions taken, then explain reasoning
+- Reference specific files, functions, and line numbers
+- When stuck, state the blocker clearly
+
+## Behaviors
+- Follow existing codebase patterns and conventions
+- Write tests for new behavior
+- Run the full test suite before declaring work done
+- Create focused, well-described PRs
+- Never merge your own PRs without QA review
+"#;
+
+const MIKA_QA_SOUL: &str = r#"# Mika QA — Quality Assurance Agent
+
+## Role
+You are Mika QA, a senior quality assurance agent. You review pull requests,
+verify implementations against requirements, and ensure code quality standards.
+
+## Communication style
+- Be precise about what passes and what doesn't
+- Use structured verdicts (VERDICT: pass/block/hold)
+- Reference specific code locations when flagging issues
+- Separate blocking issues from suggestions
+
+## Behaviors
+- Review PRs for correctness, test coverage, and adherence to conventions
+- Verify that CI checks pass before approving
+- Check that PR descriptions accurately reflect the changes
+- Never approve your own team's work without independent verification
+- Flag security, performance, and maintainability concerns
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_find_well_known_agent_found() {
+        assert!(find_well_known_agent("mika-dev").is_some());
+        assert_eq!(find_well_known_agent("mika-dev").unwrap().name, "mika-dev");
+        assert!(find_well_known_agent("mika-qa").is_some());
+        assert_eq!(find_well_known_agent("mika-qa").unwrap().name, "mika-qa");
+    }
+
+    #[test]
+    fn test_find_well_known_agent_not_found() {
+        assert!(find_well_known_agent("mika").is_none());
+        assert!(find_well_known_agent("custom-agent").is_none());
+        assert!(find_well_known_agent("").is_none());
+    }
+
+    #[test]
+    fn test_provision_creates_both_agents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Create the agents directory
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        provision_well_known_agents(home, false);
+
+        // Both agents should exist
+        assert!(mika_common::agent::agent_exists(home, "mika-dev"));
+        assert!(mika_common::agent::agent_exists(home, "mika-qa"));
+    }
+
+    #[test]
+    fn test_provision_correct_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        provision_well_known_agents(home, false);
+
+        let dev_identity = fs::read_to_string(
+            mika_common::agent::agent_dir(home, "mika-dev").join("identity.toml"),
+        )
+        .unwrap();
+        assert!(dev_identity.contains("name = \"Dev\""));
+        assert!(dev_identity.contains("emoji = \"🛠\""));
+
+        let qa_identity = fs::read_to_string(
+            mika_common::agent::agent_dir(home, "mika-qa").join("identity.toml"),
+        )
+        .unwrap();
+        assert!(qa_identity.contains("name = \"QA\""));
+        assert!(qa_identity.contains("emoji = \"🔍\""));
+    }
+
+    #[test]
+    fn test_provision_correct_soul() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        provision_well_known_agents(home, false);
+
+        let dev_soul =
+            fs::read_to_string(mika_common::agent::agent_dir(home, "mika-dev").join("soul.md"))
+                .unwrap();
+        assert!(dev_soul.contains("Mika Dev"));
+        assert!(dev_soul.contains("Development Agent"));
+
+        let qa_soul =
+            fs::read_to_string(mika_common::agent::agent_dir(home, "mika-qa").join("soul.md"))
+                .unwrap();
+        assert!(qa_soul.contains("Mika QA"));
+        assert!(qa_soul.contains("Quality Assurance"));
+    }
+
+    #[test]
+    fn test_provision_skips_existing_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        // Create mika-dev with custom soul
+        mika_common::home::bootstrap_agent(home, "mika-dev").unwrap();
+        let dev_home = mika_common::agent::agent_dir(home, "mika-dev");
+        fs::write(dev_home.join("soul.md"), "custom soul content").unwrap();
+
+        provision_well_known_agents(home, false);
+
+        // mika-dev should keep custom soul
+        let dev_soul = fs::read_to_string(dev_home.join("soul.md")).unwrap();
+        assert_eq!(dev_soul, "custom soul content");
+
+        // mika-qa should be created fresh
+        assert!(mika_common::agent::agent_exists(home, "mika-qa"));
+    }
+
+    #[test]
+    fn test_provision_partial_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        // Only mika-dev exists
+        mika_common::home::bootstrap_agent(home, "mika-dev").unwrap();
+        assert!(!mika_common::agent::agent_exists(home, "mika-qa"));
+
+        provision_well_known_agents(home, false);
+
+        // mika-qa should now exist
+        assert!(mika_common::agent::agent_exists(home, "mika-qa"));
+    }
+
+    #[test]
+    fn test_provision_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        provision_well_known_agents(home, true);
+
+        // No agents should be created
+        assert!(!mika_common::agent::agent_exists(home, "mika-dev"));
+        assert!(!mika_common::agent::agent_exists(home, "mika-qa"));
+    }
+
+    #[test]
+    fn test_seed_skill_overrides_mika_dev() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.register_agent("mika-dev", "Dev", "/tmp/mika-dev")
+            .unwrap();
+
+        seed_well_known_skill_overrides(&db, "mika-dev");
+
+        let overrides = db.get_skill_overrides("mika-dev").unwrap();
+        assert_eq!(overrides.len(), MIKA_DEV.disabled_skills.len());
+        for ovr in &overrides {
+            assert_eq!(ovr.enabled, Some(false));
+            assert!(
+                MIKA_DEV.disabled_skills.contains(&ovr.skill_name.as_str()),
+                "unexpected override: {}",
+                ovr.skill_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_seed_skill_overrides_mika_qa() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.register_agent("mika-qa", "QA", "/tmp/mika-qa").unwrap();
+
+        seed_well_known_skill_overrides(&db, "mika-qa");
+
+        let overrides = db.get_skill_overrides("mika-qa").unwrap();
+        assert_eq!(overrides.len(), MIKA_QA.disabled_skills.len());
+        for ovr in &overrides {
+            assert_eq!(ovr.enabled, Some(false));
+            assert!(
+                MIKA_QA.disabled_skills.contains(&ovr.skill_name.as_str()),
+                "unexpected override: {}",
+                ovr.skill_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_seed_skill_overrides_skips_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.register_agent("mika-dev", "Dev", "/tmp/mika-dev")
+            .unwrap();
+
+        // Set a custom override first
+        db.set_skill_enabled("mika-dev", "some-custom-skill", false)
+            .unwrap();
+
+        // Now seed — should not add anything since overrides exist
+        seed_well_known_skill_overrides(&db, "mika-dev");
+
+        let overrides = db.get_skill_overrides("mika-dev").unwrap();
+        // Should only have the one custom override, not the well-known ones
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].skill_name, "some-custom-skill");
+    }
+
+    #[test]
+    fn test_seed_skill_overrides_non_well_known() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.register_agent("custom-agent", "Custom", "/tmp/custom")
+            .unwrap();
+
+        seed_well_known_skill_overrides(&db, "custom-agent");
+
+        let overrides = db.get_skill_overrides("custom-agent").unwrap();
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn test_well_known_agent_specs() {
+        // Verify the skill lists don't overlap
+        for dev_skill in MIKA_DEV.disabled_skills {
+            assert!(
+                !MIKA_QA.disabled_skills.contains(dev_skill),
+                "skill '{}' is disabled for both mika-dev and mika-qa",
+                dev_skill
+            );
+        }
+    }
+}

--- a/crates/mika-agent/tests/eval/harness.rs
+++ b/crates/mika-agent/tests/eval/harness.rs
@@ -294,6 +294,8 @@ fn dummy_settings() -> Settings {
         server_log_file: None,
         dashboard_enabled: false,
         disable_bundled_skills: false,
+        dev_mode: false,
+        disable_agent_provisioning: false,
         telemetry_enabled: false,
         otlp_endpoint: None,
         otlp_auth_header: None,

--- a/crates/mika-cli/src/init.rs
+++ b/crates/mika-cli/src/init.rs
@@ -66,6 +66,9 @@ fn init_base_for_agent(agent_name: &str) -> Result<(Settings, AsyncDatabase, Pat
     )?;
     startup::seed_core_memory_if_empty(&db, &agent_home, agent_name)?;
     startup::seed_bundled_skills_if_needed(&agent_home, settings.disable_bundled_skills);
+    if settings.dev_mode {
+        mika_agent::well_known_agents::seed_well_known_skill_overrides(&db, agent_name);
+    }
     let async_db = AsyncDatabase::new_with_agent(db, agent_name);
 
     Ok((settings, async_db, agent_home, global_home))
@@ -138,9 +141,22 @@ fn ensure_initialized_for_agent(
     // In multi-agent layout, check the specific agent's home
     if home::is_multi_agent_layout(global_home) {
         if !agent_home.join("config.toml").exists() {
-            anyhow::bail!(
-                "Agent '{agent_name}' not found. Create it with `mika agents create {agent_name}`."
-            );
+            // Auto-provision well-known agents if dev_mode is enabled
+            if mika_agent::well_known_agents::find_well_known_agent(agent_name).is_some()
+                && let Ok(global_settings) = Settings::load(global_home)
+                && global_settings.dev_mode
+            {
+                mika_agent::well_known_agents::provision_well_known_agents(
+                    global_home,
+                    global_settings.disable_agent_provisioning,
+                );
+            }
+            // Re-check after provisioning attempt
+            if !agent_home.join("config.toml").exists() {
+                anyhow::bail!(
+                    "Agent '{agent_name}' not found. Create it with `mika agents create {agent_name}`."
+                );
+            }
         }
     } else if !home::is_initialized(global_home) {
         anyhow::bail!(

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -668,6 +668,18 @@ pub struct Settings {
     #[serde(default)]
     pub disable_bundled_skills: bool,
 
+    /// Enable dev mode — auto-provisions well-known development agents
+    /// (mika-dev, mika-qa) with role-specific identity and skill assignments
+    /// on startup (default: false)
+    #[serde(default)]
+    pub dev_mode: bool,
+
+    /// Disable agent provisioning on startup (default: false).
+    /// When true, prevents auto-creation and file overwrites for well-known agents,
+    /// allowing manual edits to persist across restarts/deploys.
+    #[serde(default)]
+    pub disable_agent_provisioning: bool,
+
     /// Enable OpenTelemetry trace export (default: false, requires "telemetry" feature)
     #[serde(default)]
     pub telemetry_enabled: bool,
@@ -1132,6 +1144,11 @@ impl std::fmt::Debug for Settings {
             .field("server_log_file", &self.server_log_file)
             .field("dashboard_enabled", &self.dashboard_enabled)
             .field("disable_bundled_skills", &self.disable_bundled_skills)
+            .field("dev_mode", &self.dev_mode)
+            .field(
+                "disable_agent_provisioning",
+                &self.disable_agent_provisioning,
+            )
             .field("telemetry_enabled", &self.telemetry_enabled)
             .field("otlp_endpoint", &self.otlp_endpoint)
             .field(
@@ -1294,6 +1311,45 @@ mod tests {
         assert!(settings.disable_bundled_skills);
 
         unsafe { std::env::remove_var("MIKA_DISABLE_BUNDLED_SKILLS") };
+    }
+
+    #[test]
+    #[serial]
+    fn test_dev_mode_from_env() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_DEV_MODE", "true") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+        assert!(settings.dev_mode);
+
+        unsafe { std::env::remove_var("MIKA_DEV_MODE") };
+    }
+
+    #[test]
+    #[serial]
+    fn test_disable_agent_provisioning_from_env() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_DISABLE_AGENT_PROVISIONING", "true") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+        assert!(settings.disable_agent_provisioning);
+
+        unsafe { std::env::remove_var("MIKA_DISABLE_AGENT_PROVISIONING") };
+    }
+
+    #[test]
+    #[serial]
+    fn test_dev_mode_defaults_false() {
+        clean_env();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+        assert!(!settings.dev_mode);
+        assert!(!settings.disable_agent_provisioning);
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,8 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `server_log_file` | `Option<PathBuf>` | None | `MIKA_SERVER_LOG_FILE` | File path for mika-server log output. Logs go to stdout + file when set. |
 | `dashboard_enabled` | `bool` | `false` | `MIKA_DASHBOARD_ENABLED` | Enable embedded dashboard SPA at `/dashboard/`. When enabled, the pre-built React dashboard is served from the binary via `rust-embed`. Requires `MIKA_DASHBOARD_TOKEN` for token injection. Build the dashboard before compiling: `npm run build --prefix dashboard` (`VITE_BASE_PATH` is set automatically). |
 | `disable_bundled_skills` | `bool` | `false` | `MIKA_DISABLE_BUNDLED_SKILLS` | Skip bundled skill re-sync on startup. Useful for debugging handler scripts. **Do not enable in production** — prevents security updates to handler scripts from propagating. |
+| `dev_mode` | `bool` | `false` | `MIKA_DEV_MODE` | Enable dev mode — auto-provisions well-known development agents (`mika-dev`, `mika-qa`) on startup with role-specific identity, soul, and skill assignments. Idempotent — existing agents are never overwritten. |
+| `disable_agent_provisioning` | `bool` | `false` | `MIKA_DISABLE_AGENT_PROVISIONING` | Skip well-known agent auto-creation on startup. When true, prevents `dev_mode` from creating or updating agent identity files, allowing manual edits to persist across restarts/deploys. |
 | `telemetry_enabled` | `bool` | `false` | `MIKA_TELEMETRY_ENABLED` | Enable OpenTelemetry trace export. Requires `--features telemetry` at build time. When enabled, spans are exported via OTLP HTTP to the configured endpoint. |
 | `otlp_endpoint` | `Option<String>` | None | `MIKA_OTLP_ENDPOINT` | OTLP endpoint URL for trace export — must include `/v1/traces` (e.g. `https://cloud.langfuse.com/api/public/otel/v1/traces` for Langfuse, `http://localhost:4318/v1/traces` for Jaeger). Required when `telemetry_enabled` is true. |
 | `otlp_auth_header` | `Option<SecretString>` | None | `MIKA_OTLP_AUTH_HEADER` | OTLP authorization header value. For Langfuse, pass raw `publicKey:secretKey` (auto-encoded to Base64) or pre-encoded Base64. Sent as `Authorization: Basic <value>`. Zeroized on drop. |
@@ -529,7 +531,9 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |
+| `MIKA_DEV_MODE` | No | Auto-provision mika-dev + mika-qa agents on startup (default: false) |
 | `MIKA_DISABLE_BUNDLED_SKILLS` | No | Skip bundled skill re-sync on startup (default: false) |
+| `MIKA_DISABLE_AGENT_PROVISIONING` | No | Prevent dev_mode from overwriting agent files (default: false) |
 
 \* Set the API key for the active provider. E.g., `MIKA_ANTHROPIC_API_KEY` for Anthropic, `MIKA_GROQ_API_KEY` for Groq. Ollama does not require an API key.
 | `MIKA_SERVER_URL` | No | mika-server URL for dashboard CLI commands (default: `http://localhost:8080`) |
@@ -554,7 +558,9 @@ are required for inter-service communication:
 | `MIKA_DB_PATH` | No | Override database path |
 | `MIKA_LOG_LEVEL` | No | Override log level |
 | `MIKA_LOG_FORMAT` | No | Stdout log format: `json` (default) or `pretty` |
+| `MIKA_DEV_MODE` | No | Auto-provision mika-dev + mika-qa agents on startup (default: false) |
 | `MIKA_DISABLE_BUNDLED_SKILLS` | No | Skip bundled skill re-sync on startup (default: false) |
+| `MIKA_DISABLE_AGENT_PROVISIONING` | No | Prevent dev_mode from overwriting agent files (default: false) |
 | `MIKA_TELEMETRY_ENABLED` | No | Enable OTel trace export (requires `--features telemetry` build) |
 | `MIKA_OTLP_ENDPOINT` | No | OTLP endpoint URL with `/v1/traces` path (required when telemetry enabled) |
 | `MIKA_OTLP_AUTH_HEADER` | No | OTLP auth header value (e.g. Base64-encoded Langfuse credentials) |

--- a/docs/plans/2026-04-18-005-feat-auto-create-well-known-agents-plan.md
+++ b/docs/plans/2026-04-18-005-feat-auto-create-well-known-agents-plan.md
@@ -1,0 +1,337 @@
+---
+title: "feat: Auto-create well-known agents (mika-dev, mika-qa) at setup time"
+type: feat
+status: active
+date: 2026-04-18
+issue: 254
+---
+
+# feat: Auto-create well-known agents (mika-dev, mika-qa) at setup time
+
+## Overview
+
+When `dev_mode = true` in config, the startup sequence auto-provisions two well-known development agents (`mika-dev`, `mika-qa`) with role-specific identity, soul, and skill assignments. A companion `disable_agent_provisioning` flag prevents file overwrites on restart, allowing manual customization to persist.
+
+## Problem Frame
+
+The autonomous dev loop requires `mika-dev` and `mika-qa` agents with specific configurations: identity files (soul.md), skill assignments, env vars, core memory. Currently these must be manually created and configured. Missing agents cause silent degradation. Wrong skill assignments cause active interference (qa-review's run_gh allowlist blocked mika-dev's `gh pr create` in issue #602).
+
+## Requirements Trace
+
+- R1. `dev_mode = true` in config.toml triggers auto-provisioning of mika-dev and mika-qa on startup
+- R2. `MIKA_DISABLE_AGENT_PROVISIONING=1` prevents agent file overwrites on restart/deploy
+- R3. mika-dev gets self-dev family skills; qa-review family skills disabled
+- R4. mika-qa gets qa-review family skills; self-dev family skills disabled
+- R5. First-time setup with `dev_mode = true` produces a fully functional autonomous loop without manual agent creation
+- R6. Existing manually-configured agents are never overwritten
+
+## Scope Boundaries
+
+- No changes to the skill seeding mechanism itself — `seed_bundled_skills()` continues to write ALL bundled skills to ALL agents. Role-specific filtering is done via `skill_overrides` DB table (disable unwanted skills per agent)
+- No new manifest file format — uses existing DB-backed `skill_overrides` for skill assignment
+- No agent deletion when `dev_mode` goes from true to false — agents persist, just stop being re-provisioned
+- No core memory seeding beyond the default `user.md` mechanism — soul.md and identity are file-based
+- Soul content for well-known agents is minimal/placeholder — operators customize via soul.md files
+
+### Deferred to Separate Tasks
+
+- Per-agent `.env` templates for GitHub App credentials: separate concern, documented in provisioning output
+- `mika setup --mode dev` interactive wizard: future enhancement once provisioning is proven
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-common/src/home.rs` — `bootstrap_agent()`, `write_default_if_missing()`, `bootstrap()`
+- `crates/mika-common/src/config.rs` — `Settings` struct, `disable_bundled_skills: bool` pattern
+- `crates/mika-agent/src/startup.rs` — `seed_bundled_skills_if_needed()`, `seed_core_memory_if_empty()`
+- `crates/mika-agent/src/server/mod.rs` — `run_server()` (line 518), `init_agent()` (line 307)
+- `crates/mika-cli/src/init.rs` — `init_base_for_agent()`, `ensure_initialized_for_agent()`
+- `crates/mika-agent/src/tools/create_agent.rs` — `CreateAgentTool::execute()` pattern for custom identity/soul after bootstrap
+- `crates/mika-agent/src/db.rs` — `set_skill_enabled()`, `SkillOverride`, `get_skill_overrides()`
+
+### Institutional Learnings
+
+- **TOML injection (P1):** Config file writes MUST use typed structs + serde, never `format!()` (from `docs/solutions/ux-improvements/cli-agent-team-creation-wizard.md`). However, `create_agent.rs` already uses `format!()` for identity.toml — follow the existing tool pattern for consistency, then fix both in a follow-up
+- **Skill overrides are the source of truth for per-agent skill config:** `seed_bundled_skills()` overwrites skill files on every startup (security updates). User preferences survive via `skill_overrides` DB table
+- **soul.md is required:** Validation checks for its existence. Auto-created agents must include one
+- **CLI vs server execution models:** Both paths need provisioning. Server iterates all agents; CLI targets a single named agent
+- **Startup sequence order:** provision agents → seed bundled skills → scan skills dir → apply overrides → validate
+
+## Key Technical Decisions
+
+- **DB overrides, not a new manifest file:** Per-agent skill assignments use the existing `skill_overrides` table with `set_skill_enabled()`. No new file format or mechanism — keeps the system simple and consistent with how skill enable/disable already works
+- **First-creation-only overrides:** Skill overrides are written to DB only when the agent is first created (not on every startup). This means user manual `mika skills enable/disable` changes persist across restarts. Trade-off: no "reset to defaults" without deleting the agent
+- **Provisioning in `startup.rs`, not `home.rs`:** The provisioning function belongs in `mika-agent::startup` because it needs the `Database` to write skill overrides. `home.rs` (in `mika-common`) has no DB dependency. The file-system bootstrapping still delegates to `home::bootstrap_agent()`
+- **`dev_mode` as a Settings field:** Follows the exact `disable_bundled_skills` pattern — settable via config.toml or `MIKA_DEV_MODE=true` env var
+- **Provisioning runs before `list_agents()`:** In `run_server()`, provisioning must happen after `Settings::load()` (to read `dev_mode`) and before `list_agents()` (so newly created agents are discovered). In the CLI path, `ensure_initialized_for_agent()` is extended to auto-create well-known agents when requested
+- **Soul content as embedded constants:** Well-known agent souls are defined as `const` strings in the provisioning module (same pattern as `DEFAULT_SOUL` in `home.rs`). Operators customize by editing the files after first creation
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to insert provisioning in server startup?** After `migrate_to_multi_agent()` (line 527) and before `list_agents()` (line 586) in `run_server()`. This ensures agents exist on disk before discovery
+- **DB not available during provisioning?** Skill overrides are written inside `init_agent()` (which opens the DB), not during the file-system provisioning step. Two-phase: (1) create files, (2) set DB overrides during init
+- **What if mika-dev exists but mika-qa doesn't?** Provisioning checks each agent independently via `agent_exists()`. Partial state is handled naturally
+
+### Deferred to Implementation
+
+- Exact soul.md prose for mika-dev and mika-qa — will be minimal placeholders that operators customize
+- Whether `create_agent.rs` identity.toml format!() should be fixed in this PR or a follow-up
+
+## Output Structure
+
+```
+crates/mika-agent/src/
+  well_known_agents.rs          # NEW — agent specs + provisioning logic
+  startup.rs                    # MODIFY — add provision_well_known_agents_if_needed()
+
+crates/mika-common/src/
+  config.rs                     # MODIFY — add dev_mode + disable_agent_provisioning fields
+
+crates/mika-agent/src/server/
+  mod.rs                        # MODIFY — call provisioning before list_agents()
+
+crates/mika-cli/src/
+  init.rs                       # MODIFY — auto-create well-known agents in CLI path
+```
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+Startup (server):
+  Settings::load()           → reads dev_mode, disable_agent_provisioning
+  migrate_to_multi_agent()
+  provision_well_known_agents_if_needed(global_home, dev_mode, disabled)
+    for each well-known agent spec:
+      if agent_exists() → skip (log)
+      bootstrap_agent()                    → creates dirs + default files
+      overwrite identity.toml              → agent-specific name/emoji
+      overwrite soul.md                    → agent-specific soul
+  list_agents()              → discovers all agents including newly created
+  for each agent:
+    init_agent()
+      seed_bundled_skills()  → writes ALL skills to disk (as before)
+      seed_well_known_skill_overrides(db, agent_name)
+        if agent is well-known AND no overrides exist yet:
+          set_skill_enabled(disabled=true) for unwanted skills
+      apply_overrides()      → evicts disabled skills from registry
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add `dev_mode` and `disable_agent_provisioning` to Settings**
+
+**Goal:** Add two new boolean config fields following the `disable_bundled_skills` pattern.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-common/src/config.rs`
+- Test: `crates/mika-common/src/config.rs` (inline tests)
+
+**Approach:**
+- Add `dev_mode: bool` with `#[serde(default)]` (defaults to false)
+- Add `disable_agent_provisioning: bool` with `#[serde(default)]` (defaults to false)
+- Add both to the manual `Debug` impl (no redaction needed — not secrets)
+- Both are settable via config.toml or `MIKA_DEV_MODE` / `MIKA_DISABLE_AGENT_PROVISIONING` env vars (automatic via config-rs `MIKA_` prefix)
+
+**Patterns to follow:**
+- `disable_bundled_skills: bool` field and its test `test_disable_bundled_skills_from_env`
+
+**Test scenarios:**
+- Happy path: `MIKA_DEV_MODE=true` env var → `settings.dev_mode == true`
+- Happy path: `MIKA_DISABLE_AGENT_PROVISIONING=true` env var → `settings.disable_agent_provisioning == true`
+- Happy path: Both default to false when unset
+- Happy path: Config.toml `dev_mode = true` → field is true
+
+**Verification:**
+- `cargo test -p mika-common` passes with new fields and tests
+
+---
+
+- [x] **Unit 2: Create `well_known_agents` module with agent specs and provisioning**
+
+**Goal:** Define the well-known agent specifications (name, display name, emoji, soul, skill assignments) and the filesystem provisioning function.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `crates/mika-agent/src/well_known_agents.rs`
+- Modify: `crates/mika-agent/src/lib.rs` (add `pub mod well_known_agents;`)
+- Test: `crates/mika-agent/src/well_known_agents.rs` (inline tests)
+
+**Approach:**
+- Define a `WellKnownAgent` struct with: `name`, `display_name`, `emoji`, `soul` (all `&'static str`), and `disabled_skills: &'static [&'static str]` (skills to disable for this agent)
+- Define two static specs: `MIKA_DEV` and `MIKA_QA`
+- `MIKA_DEV.disabled_skills`: qa-review, qa-review-build-callback, skill-review
+- `MIKA_QA.disabled_skills`: self-dev, self-dev-iterate, self-dev-webhook-qa, self-dev-webhook-ci, claude-pilot, permission-policy, agents-teams, address-pr-comments, resolve-pr-conflicts
+- Shared skills (both get): build-mika, deploy-mika, self-check
+- `WELL_KNOWN_AGENTS: &[WellKnownAgent]` static slice for iteration
+- `provision_well_known_agents(home_dir, disabled)` function:
+  - If `disabled`: log warning and return (same pattern as `seed_bundled_skills_if_needed`)
+  - For each spec: check `agent_exists()`, skip if yes (log info), otherwise call `bootstrap_agent()`, then overwrite `identity.toml` and `soul.md` with agent-specific content
+- `is_well_known_agent(name) -> Option<&WellKnownAgent>` helper for lookup
+- `seed_well_known_skill_overrides(db, agent_name)` function:
+  - If agent is not well-known, return early
+  - If agent already has any `skill_overrides` rows, return early (user has customized)
+  - Otherwise, write `set_skill_enabled(agent_name, skill, Some(false))` for each skill in `disabled_skills`
+
+**Patterns to follow:**
+- `seed_bundled_skills_if_needed()` in `startup.rs` for the guard pattern
+- `CreateAgentTool::execute()` in `tools/create_agent.rs` for the bootstrap + overwrite pattern
+- `DEFAULT_SOUL`, `DEFAULT_IDENTITY` constants in `home.rs` for content constants
+
+**Test scenarios:**
+- Happy path: `provision_well_known_agents()` creates both agents when they don't exist
+- Happy path: Created agents have correct identity.toml content (name, emoji)
+- Happy path: Created agents have correct soul.md content
+- Edge case: Agent already exists → skipped, files not overwritten
+- Edge case: One agent exists, other doesn't → only missing one created
+- Edge case: `disabled = true` → no agents created, warning logged
+- Happy path: `is_well_known_agent("mika-dev")` returns the spec
+- Edge case: `is_well_known_agent("mika")` returns None
+- Happy path: `seed_well_known_skill_overrides()` writes correct disabled skills for mika-dev
+- Happy path: `seed_well_known_skill_overrides()` writes correct disabled skills for mika-qa
+- Edge case: Agent already has skill overrides → no changes written
+- Edge case: Non-well-known agent → no changes written
+
+**Verification:**
+- `cargo test -p mika-agent` passes with new module and tests
+
+---
+
+- [x] **Unit 3: Integrate provisioning into server startup**
+
+**Goal:** Call `provision_well_known_agents()` in `run_server()` before agent discovery, and `seed_well_known_skill_overrides()` inside `init_agent()` after DB is available.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/mod.rs`
+- Test: `crates/mika-agent/src/server/mod.rs` (or integration test if needed)
+
+**Approach:**
+- In `run_server()`, after `migrate_to_multi_agent()` (line 527) and before `list_agents()` (line 586):
+  ```
+  if settings.dev_mode {
+      well_known_agents::provision_well_known_agents(
+          global_home,
+          settings.disable_agent_provisioning,
+      );
+  }
+  ```
+- In `init_agent()`, after `seed_bundled_skills_if_needed()` (line 336) and before skill registry construction:
+  - Open a sync DB handle (already available as `db` at that point)
+  - Call `well_known_agents::seed_well_known_skill_overrides(&db, agent_name)`
+- Log at info level when provisioning creates agents or sets overrides
+
+**Patterns to follow:**
+- The `disable_bundled_skills` guard in `init_agent()` (line 336)
+- The `dashboard_enabled` check pattern (line 530)
+
+**Test scenarios:**
+- Integration: Server startup with `dev_mode = true` creates both agents and initializes them
+- Integration: Server startup with `dev_mode = false` does not create well-known agents
+- Integration: `disable_agent_provisioning = true` prevents file creation even when `dev_mode = true`
+
+**Verification:**
+- `cargo build` succeeds
+- Server startup with `dev_mode = true` logs agent creation
+
+---
+
+- [x] **Unit 4: Integrate provisioning into CLI startup**
+
+**Goal:** Auto-create well-known agents in the CLI path when `dev_mode` is enabled and the requested agent is a well-known name.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-cli/src/init.rs`
+
+**Approach:**
+- In `ensure_initialized_for_agent()`, before the "Agent not found" error:
+  - Load global settings to check `dev_mode`
+  - If `dev_mode == true` and `is_well_known_agent(agent_name).is_some()` and agent doesn't exist:
+    - Call `provision_well_known_agents()` (provisions all well-known agents, idempotent)
+    - Continue to the next check (agent should now exist)
+- In `init_base_for_agent()`, after DB is opened and `seed_bundled_skills_if_needed()`:
+  - Call `seed_well_known_skill_overrides(&db, agent_name)` (same as server path)
+- The CLI error message remains for non-well-known agents that don't exist
+
+**Patterns to follow:**
+- `ensure_initialized_for_agent()` guard pattern
+- `init_base_for_agent()` initialization sequence
+
+**Test scenarios:**
+- Happy path: `mika chat --agent mika-dev` with `dev_mode = true` auto-creates the agent
+- Edge case: `mika chat --agent mika-dev` with `dev_mode = false` still errors ("Agent not found")
+- Edge case: `mika chat --agent custom-agent` with `dev_mode = true` still errors for non-well-known agents
+
+**Verification:**
+- `cargo build` succeeds
+- CLI startup with well-known agent name and `dev_mode = true` works without pre-creating the agent
+
+---
+
+- [x] **Unit 5: Update documentation and env var references**
+
+**Goal:** Document the new config flags and provisioning behavior.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `CLAUDE.md` (root) — add `MIKA_DEV_MODE` and `MIKA_DISABLE_AGENT_PROVISIONING` to env vars section
+- Modify: `.env.example` — add the new env vars with comments
+
+**Approach:**
+- Add `MIKA_DEV_MODE` to the optional startup behavior section in CLAUDE.md
+- Add `MIKA_DISABLE_AGENT_PROVISIONING` alongside `MIKA_DISABLE_BUNDLED_SKILLS`
+- Document the behavior: what agents are created, what skills each gets, idempotency
+
+**Patterns to follow:**
+- `MIKA_DISABLE_BUNDLED_SKILLS` documentation pattern in CLAUDE.md
+
+**Test expectation:** none — documentation-only changes
+
+**Verification:**
+- Documentation accurately describes the provisioning behavior and env vars
+
+## System-Wide Impact
+
+- **Interaction graph:** Provisioning runs before `list_agents()` in server, before `ensure_initialized_for_agent()` in CLI. Skill overrides are set inside `init_agent()` / `init_base_for_agent()` after DB open but before `SkillRegistry::from_dir()` + `apply_overrides()`
+- **Error propagation:** Provisioning failures (filesystem errors) should log warnings but not crash the server — other agents should still initialize. Individual agent provisioning failures are non-fatal
+- **State lifecycle risks:** Two-phase design (files first, DB overrides during init) means a crash between file creation and DB init would leave an agent with all skills enabled. Next startup would detect existing overrides and skip — but if the DB was never written to, overrides would be applied on that next init. This is safe because `seed_well_known_skill_overrides` checks for existing overrides, not for agent age
+- **API surface parity:** No API changes. Dashboard discovers agents via `list_agents()` which will naturally include provisioned agents
+- **Unchanged invariants:** `seed_bundled_skills()` continues to write ALL skills to ALL agents. The per-agent filtering happens entirely in the DB override layer. This preserves the security-update propagation guarantee
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Identity.toml uses `format!()` (TOML injection risk from learning) | Well-known agent names are hardcoded constants, not user input. No injection vector. Follow-up to fix both this and `create_agent.rs` |
+| Skill overrides written only on first creation — no reset path | Document `mika skills enable/disable` for manual adjustment. Agent deletion + re-creation as escape hatch |
+| Dev_mode flag checked on every startup but provisioning is idempotent | `agent_exists()` check is cheap (stat call). No performance concern |
+
+## Sources & References
+
+- Related issue: #254
+- Related issues mentioned: #601 (bundling migration), #602 (skill interference), #620 (re-seed disabled skills)
+- Existing pattern: `seed_bundled_skills_if_needed()` in `crates/mika-agent/src/startup.rs`
+- Existing pattern: `CreateAgentTool::execute()` in `crates/mika-agent/src/tools/create_agent.rs`
+- Learning: `docs/solutions/ux-improvements/cli-agent-team-creation-wizard.md` (TOML injection)
+- Learning: `docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md` (override flow)

--- a/docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md
+++ b/docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md
@@ -1,0 +1,104 @@
+---
+title: Well-known agent provisioning via dev_mode flag
+date: 2026-04-18
+category: architecture-patterns
+module: startup, config, skills
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Adding new well-known agents to the platform
+  - Extending agent provisioning with new skill assignments
+  - Debugging why a well-known agent has wrong skills enabled
+tags:
+  - agent-provisioning
+  - dev-mode
+  - skill-overrides
+  - well-known-agents
+  - startup-sequence
+---
+
+# Well-known agent provisioning via dev_mode flag
+
+## Context
+
+The autonomous dev loop requires `mika-dev` and `mika-qa` agents with specific configurations: identity files (soul.md), skill assignments, and per-agent env vars. Previously these had to be created manually. Missing agents caused silent degradation. Wrong skill assignments caused active interference (qa-review's run_gh allowlist blocked mika-dev's `gh pr create`).
+
+The provisioning system follows a two-phase design to work within the existing startup sequence where filesystem operations happen before the DB is available.
+
+## Guidance
+
+### Two-phase provisioning
+
+**Phase 1 (filesystem):** `provision_well_known_agents()` runs after `migrate_to_multi_agent()` but before `list_agents()` in server startup. For each well-known agent spec, it checks `agent_exists()`, calls `bootstrap_agent()` to create the directory structure, then overwrites `identity.toml` and `soul.md` with agent-specific content.
+
+**Phase 2 (DB overrides):** `seed_well_known_skill_overrides()` runs inside `init_agent()` after the DB is opened and `seed_bundled_skills_if_needed()` has written all skill files. It writes `set_skill_enabled(false)` for skills the agent should not have. Both phases are gated on `settings.dev_mode`.
+
+### Key design decisions
+
+1. **DB overrides, not file filtering:** All bundled skills are still written to all agents by `seed_bundled_skills()` (preserving security update propagation). Per-agent filtering uses the existing `skill_overrides` DB table.
+
+2. **First-creation-only overrides:** Skill overrides are written only when no `skill_overrides` rows exist for the agent. This preserves user customizations via `mika skills enable/disable` across restarts.
+
+3. **`disable_agent_provisioning` env var:** Follows the `MIKA_DISABLE_BUNDLED_SKILLS` pattern. When true, prevents file creation/overwrite even when `dev_mode = true`. Allows manual edits to soul.md and identity.toml to persist across deploys.
+
+4. **Gate `seed_well_known_skill_overrides` on `dev_mode`:** The skill override seeding must be gated on `dev_mode` at the call site, not just inside the function. Without this gate, a user who manually names an agent "mika-dev" outside dev mode would have skills silently disabled.
+
+### Adding a new well-known agent
+
+1. Add a `WellKnownAgent` static spec in `crates/mika-agent/src/well_known_agents.rs` with name, display_name, emoji, soul content, and `disabled_skills` list
+2. Add a reference to `WELL_KNOWN_AGENTS` static slice
+3. The agent is automatically provisioned on next startup with `dev_mode = true`
+
+### Agent spec structure
+
+```rust
+pub static MIKA_DEV: WellKnownAgent = WellKnownAgent {
+    name: "mika-dev",
+    display_name: "Dev",
+    emoji: "...",
+    soul: MIKA_DEV_SOUL,
+    disabled_skills: &["qa-review", "qa-review-build-callback", "skill-review"],
+};
+```
+
+## Why This Matters
+
+Without automated provisioning, every fresh install or new developer requires manual agent creation with exact skill assignments. Getting it wrong causes silent degradation (missing agents) or active interference (wrong skills enabled). The two-phase design respects the startup sequence constraints: filesystem provisioning must happen before `list_agents()` discovers agents, but DB operations can only happen after `init_agent()` opens the database.
+
+The `dev_mode` gate is important: provisioning is opt-in and only affects development environments. Production deployments without `dev_mode` are unaffected.
+
+## When to Apply
+
+- When adding new well-known agents to the platform
+- When modifying skill assignments for existing well-known agents
+- When debugging startup sequence issues related to agent provisioning
+- When understanding why `seed_bundled_skills()` writes ALL skills to ALL agents (by design)
+
+## Examples
+
+**Startup sequence with `dev_mode = true`:**
+```
+Settings::load()                    -> reads dev_mode
+migrate_to_multi_agent()
+provision_well_known_agents()       -> creates agent dirs + identity/soul files
+list_agents()                       -> discovers all agents including new ones
+for each agent:
+  init_agent()
+    seed_bundled_skills()           -> writes ALL skills to ALL agents
+    seed_well_known_skill_overrides -> disables unwanted skills via DB
+    apply_overrides()               -> evicts disabled skills from registry
+```
+
+**Key files:**
+- `crates/mika-agent/src/well_known_agents.rs` -- agent specs + provisioning logic
+- `crates/mika-common/src/config.rs` -- `dev_mode` and `disable_agent_provisioning` fields
+- `crates/mika-agent/src/server/mod.rs` -- server startup integration
+- `crates/mika-cli/src/init.rs` -- CLI startup integration
+
+## Related
+
+- Issue #254 -- original feature request
+- Issue #602 -- skill interference incident that motivated per-agent skill filtering
+- `docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md` -- how skill overrides work
+- `docs/solutions/architecture-patterns/per-agent-dotenv-config-injection.md` -- per-agent config loading


### PR DESCRIPTION
## Summary

Closes #254

When `dev_mode = true` in config, startup auto-provisions two well-known development agents (`mika-dev`, `mika-qa`) with role-specific identity, soul, and skill assignments.

- **`MIKA_DEV_MODE`** — enables auto-provisioning of well-known agents on startup
- **`MIKA_DISABLE_AGENT_PROVISIONING`** — prevents file overwrites, allowing manual edits to persist
- **Two-phase design**: filesystem provisioning before `list_agents()`, DB skill overrides during `init_agent()`
- **mika-dev** gets self-dev family skills; qa-review family disabled
- **mika-qa** gets qa-review family skills; self-dev family disabled
- Idempotent — existing agents never overwritten
- Both server and CLI startup paths supported

## Changes

| File | Change |
|------|--------|
| `crates/mika-agent/src/well_known_agents.rs` | **NEW** — agent specs, provisioning function, skill override seeding |
| `crates/mika-common/src/config.rs` | Add `dev_mode` and `disable_agent_provisioning` fields |
| `crates/mika-agent/src/server/mod.rs` | Call provisioning in `run_server()` and `init_agent()` |
| `crates/mika-cli/src/init.rs` | Auto-create well-known agents in CLI path |
| `docs/configuration.md` | Document new config fields and env vars |
| `CLAUDE.md`, `.env.example` | Document new env vars |

## Test plan

- [x] 13 new unit tests covering provisioning, identity/soul correctness, skip-existing, disabled mode, skill overrides
- [x] 3 new config tests for env var loading
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test -p mika-common -p mika-agent` passes (1988 tests)
- [x] Pre-commit hooks pass (fmt, clippy, secrets scan)
- [ ] Manual: set `MIKA_DEV_MODE=true`, start `mika-server`, verify mika-dev and mika-qa agents created
- [ ] Manual: verify `mika skills list --agent mika-dev` shows qa-review disabled
- [ ] Manual: verify `mika skills list --agent mika-qa` shows self-dev disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)