### PR TITLE
feat: raise per-session task creation limit to 25 and make configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,9 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_DISABLE_BUNDLED_SKILLS=false  # WARNING: do not enable in production
 # MIKA_DISABLE_AGENT_PROVISIONING=false  # Prevent dev_mode from overwriting agent files
 
+# Optional: Task engine limits
+# MIKA_MAX_AGENT_TASKS_PER_SESSION=25  # Max agent-created tasks per session (default: 25)
+
 # Optional: Runtime observability (LLM call + tool call recording)
 # MIKA_STORE_LLM_CALLS=true       # Store LLM call metadata in SQLite (default: true)
 # MIKA_STORE_TOOL_CALLS=true      # Store full tool call I/O in SQLite (default: true)

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -65,7 +65,7 @@ Tool trait uses `#[async_trait]` (Send futures). Per-tool timeout override via `
 
 **Phantom retry guard (#579):** `update_task_status` rejects retry-semantic metadata writes (any top-level key containing "retry", case-insensitive) when the task has an active callback child task (`trigger_type="callback"` in `pending` or `in_progress` status). Returns structured JSON error `retry_metadata_rejected_active_dispatch`. Fail-open on `get_child_tasks` DB error — the dispatch readiness guard (#525) is the primary defense against re-dispatch. Non-retry metadata writes are unaffected.
 
-**Idempotent creation:** Deduplicates on `reference_url` (DB partial unique index `idx_tasks_manual_active_ref_url`) and on label (case-insensitive pre-check). Five loop-prevention guards. Max 5 agent-created items per session (user_request exempt).
+**Idempotent creation:** Deduplicates on `reference_url` (DB partial unique index `idx_tasks_manual_active_ref_url`) and on label (case-insensitive pre-check). Five loop-prevention guards. Max 25 agent-created items per session (configurable via `max_agent_tasks_per_session`, user_request exempt).
 
 **Note on renamed scheduled task tools:** The former scheduled-task tools `create_task` and `list_tasks` have been renamed to `create_scheduled_task` (in `create_scheduled_task.rs`) and `list_scheduled_tasks` (in `list_scheduled_tasks.rs`) to avoid name collisions with the task tracking tools above.
 

--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -249,7 +249,7 @@ remaining 9 tools (including task write tools) are added conditionally when `age
 | `get_team_history` | List recent runs for a team with IDs, status, goals, and timestamps. | default (30s) | No |
 | `delete_team` | Delete a team definition and all its data (workspace, config). Irreversible. | default (30s) | No |
 | `update_team` | Update an existing team definition. Only provided fields are changed. | default (30s) | No |
-| `create_task` | Create a trackable task with optional parent, source, and reference_url. Max depth 3, max 5 agent-created per session (user_request exempt). Cannot be used in callback turns. | default (30s) | No |
+| `create_task` | Create a trackable task with optional parent, source, and reference_url. Max depth 3, max 25 agent-created per session (configurable via `max_agent_tasks_per_session`, user_request exempt). Cannot be used in callback turns. | default (30s) | No |
 | `update_task_status` | Update task status with validated transitions. Permitted: pending→any, in_progress→blocked/completed/cancelled, blocked→in_progress/completed/cancelled. Terminal states (completed, cancelled) are final. Logs audit event. | default (30s) | No |
 
 Management tools are NOT registered for team sub-agents or delegated agents,

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1571,6 +1571,9 @@ async fn run_agent_inner(params: &AgentParams<'_>, trace_id: &str) -> Result<Age
         provider_name: provider,
         model_name: model,
         active_skill_paths: &active_skill_paths,
+        max_tasks_per_session: params
+            .settings
+            .map_or(25, |s| s.max_agent_tasks_per_session),
     };
 
     // Auto-adjust max_tokens when thinking is enabled
@@ -2379,6 +2382,9 @@ async fn run_silent_inner(params: &SilentAgentParams<'_>) -> Result<()> {
         provider_name: provider,
         model_name: model,
         active_skill_paths: &[], // Silent mode: no context-redundancy checks needed
+        max_tasks_per_session: params
+            .settings
+            .map_or(25, |s| s.max_agent_tasks_per_session),
     };
 
     let llm_tool_defs: Vec<LlmToolDefinition> =
@@ -2699,6 +2705,9 @@ async fn run_team_agent_inner_impl(params: &TeamAgentParams<'_>) -> Result<Optio
         provider_name: provider,
         model_name: model,
         active_skill_paths: &[], // Team mode: no context-redundancy checks needed
+        max_tasks_per_session: params
+            .settings
+            .map_or(25, |s| s.max_agent_tasks_per_session),
     };
 
     let llm_tool_defs: Vec<LlmToolDefinition> =

--- a/crates/mika-agent/src/server/investigate.rs
+++ b/crates/mika-agent/src/server/investigate.rs
@@ -765,6 +765,7 @@ async fn run_investigation(
         provider_name: llm.provider_name(),
         model_name: llm.model_name(),
         active_skill_paths: &[],
+        max_tasks_per_session: 25,
     };
 
     let mut text_sent = false;

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -52,6 +52,7 @@ pub mod test_helpers {
             provider_name: "anthropic",
             model_name: "claude-sonnet-4-6",
             active_skill_paths: &[],
+            max_tasks_per_session: 25,
         }
     }
 
@@ -123,6 +124,7 @@ pub mod test_helpers {
                 provider_name: "anthropic",
                 model_name: "claude-sonnet-4-6",
                 active_skill_paths: &[],
+                max_tasks_per_session: 25,
             }
         }
 
@@ -148,6 +150,7 @@ pub mod test_helpers {
                 provider_name: "anthropic",
                 model_name: "claude-sonnet-4-6",
                 active_skill_paths: &[],
+                max_tasks_per_session: 25,
             }
         }
         /// Create a ToolContext with custom home and global home directories.
@@ -177,6 +180,7 @@ pub mod test_helpers {
                 provider_name: "anthropic",
                 model_name: "claude-sonnet-4-6",
                 active_skill_paths: &[],
+                max_tasks_per_session: 25,
             }
         }
     }
@@ -279,6 +283,7 @@ pub mod test_helpers {
             telemetry_enabled: false,
             otlp_endpoint: None,
             otlp_auth_header: None,
+            max_agent_tasks_per_session: 25,
             store_llm_calls: true,
             store_tool_calls: true,
             log_llm_bodies: false,

--- a/crates/mika-agent/src/tools/create_task.rs
+++ b/crates/mika-agent/src/tools/create_task.rs
@@ -28,9 +28,6 @@ fn format_dedup_response(existing: &Task) -> String {
     response
 }
 
-/// Maximum agent-created tasks per session (Guard 5).
-const MAX_TASKS_PER_SESSION: i64 = 5;
-
 const VALID_SOURCES: &[&str] = &["user_request", "github_issue", "team_run", "self_dev"];
 
 pub struct CreateTaskTool;
@@ -48,7 +45,7 @@ impl Tool for CreateTaskTool {
                 Tasks can be linked to external references (GitHub issues, URLs) \
                 and progressed through status stages. Use for significant tasks like \
                 feature implementation, research projects, or items waiting on external input. \
-                Cannot be used during callback turns. Max 5 agent-created tasks per session. \
+                Cannot be used during callback turns. Max 25 agent-created tasks per session (configurable). \
                 Max nesting depth of 3. Set 'type' to 'milestone' or 'project' to mark a parent \
                 container that aggregates child 'issue' tasks via parent_task_id."
                 .to_string(),
@@ -227,9 +224,10 @@ impl Tool for CreateTaskTool {
         // Guard 5: Cap agent-created tasks per session
         if source != Some("user_request") {
             let count = ctx.db.count_session_tasks(ctx.session_id).await?;
-            if count >= MAX_TASKS_PER_SESSION {
+            let limit = ctx.max_tasks_per_session;
+            if count >= limit {
                 return Ok(ToolOutput::error(format!(
-                    "Maximum of {MAX_TASKS_PER_SESSION} agent-created tasks per session reached."
+                    "Maximum of {limit} agent-created tasks per session reached."
                 )));
             }
         }
@@ -476,12 +474,14 @@ mod tests {
     #[tokio::test]
     async fn test_create_task_session_cap() {
         let harness = TestHarness::new();
-        let ctx = harness.ctx();
+        let mut ctx = harness.ctx();
+        // Use a small limit for test speed
+        ctx.max_tasks_per_session = 5;
         let tool = CreateTaskTool;
 
-        // Create MAX_TASKS_PER_SESSION items
+        // Create 5 items (the configured limit)
         let mut item_ids = Vec::new();
-        for i in 0..MAX_TASKS_PER_SESSION {
+        for i in 0..5 {
             let result = tool
                 .execute(serde_json::json!({"label": format!("Item {i}")}), &ctx)
                 .await
@@ -504,7 +504,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_error);
-        assert!(result.content.contains("Maximum"));
+        assert!(result.content.contains("Maximum of 5"));
 
         // Complete one item — should free up a slot
         ctx.db
@@ -527,11 +527,13 @@ mod tests {
     #[tokio::test]
     async fn test_create_task_session_cap_excludes_user_request() {
         let harness = TestHarness::new();
-        let ctx = harness.ctx();
+        let mut ctx = harness.ctx();
+        // Use a small limit for test speed
+        ctx.max_tasks_per_session = 5;
         let tool = CreateTaskTool;
 
-        // Create MAX items with source != user_request
-        for i in 0..MAX_TASKS_PER_SESSION {
+        // Create 5 items with source != user_request (at the limit)
+        for i in 0..5 {
             tool.execute(
                 serde_json::json!({"label": format!("Agent item {i}")}),
                 &ctx,
@@ -551,6 +553,36 @@ mod tests {
         assert!(
             !result.is_error,
             "user_request should bypass cap: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_task_session_cap_configurable() {
+        let harness = TestHarness::new();
+        let mut ctx = harness.ctx();
+        // Configure a custom limit of 3
+        ctx.max_tasks_per_session = 3;
+        let tool = CreateTaskTool;
+
+        // Create 3 items (at the custom limit)
+        for i in 0..3 {
+            let result = tool
+                .execute(serde_json::json!({"label": format!("Item {i}")}), &ctx)
+                .await
+                .unwrap();
+            assert!(!result.is_error, "item {i} failed: {}", result.content);
+        }
+
+        // 4th should be rejected at limit 3
+        let result = tool
+            .execute(serde_json::json!({"label": "Over custom limit"}), &ctx)
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(
+            result.content.contains("Maximum of 3"),
+            "error should reflect custom limit: {}",
             result.content
         );
     }
@@ -951,7 +983,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_task_dedup_skips_session_counter() {
         let harness = TestHarness::new();
-        let ctx = harness.ctx();
+        let mut ctx = harness.ctx();
+        ctx.max_tasks_per_session = 5;
         let tool = CreateTaskTool;
 
         // Create 4 unique items (leaves 1 slot)

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -120,6 +120,8 @@ pub struct ToolContext<'a> {
     /// Used by read tools (e.g., `read_agent_file`) to detect redundant fetches.
     /// Empty in silent mode and tests by default.
     pub active_skill_paths: &'a [SkillPathInfo],
+    /// Maximum agent-created tasks per session (configurable, default 25).
+    pub max_tasks_per_session: i64,
 }
 
 /// A tool that the agent can invoke via Claude's tool_use.

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -198,6 +198,7 @@ mod tests {
             provider_name: "anthropic",
             model_name: "claude-sonnet-4-6",
             active_skill_paths: &[],
+            max_tasks_per_session: 25,
         };
         let tool = SendMessageTool;
 
@@ -265,6 +266,7 @@ mod tests {
             provider_name: "anthropic",
             model_name: "claude-sonnet-4-6",
             active_skill_paths: &[],
+            max_tasks_per_session: 25,
         };
         let tool = SendMessageTool;
 
@@ -314,6 +316,7 @@ mod tests {
             provider_name: "anthropic",
             model_name: "claude-sonnet-4-6",
             active_skill_paths: &[],
+            max_tasks_per_session: 25,
         };
         let tool = SendMessageTool;
 
@@ -360,6 +363,7 @@ mod tests {
             provider_name: "anthropic",
             model_name: "claude-sonnet-4-6",
             active_skill_paths: &[],
+            max_tasks_per_session: 25,
         };
         let tool = SendMessageTool;
 

--- a/crates/mika-agent/tests/eval/harness.rs
+++ b/crates/mika-agent/tests/eval/harness.rs
@@ -299,6 +299,7 @@ fn dummy_settings() -> Settings {
         telemetry_enabled: false,
         otlp_endpoint: None,
         otlp_auth_header: None,
+        max_agent_tasks_per_session: 25,
         store_llm_calls: true,
         store_tool_calls: true,
         log_llm_bodies: false,

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -286,6 +286,14 @@ pub static CONFIG_KEYS: &[ConfigKeyInfo] = &[
         secret: false,
         description: "Enable embedded dashboard SPA at /dashboard/ (default: false)",
     },
+    // -- Task engine --
+    ConfigKeyInfo {
+        key: "max_agent_tasks_per_session",
+        backend: ConfigBackend::File,
+        env_var: Some("MIKA_MAX_AGENT_TASKS_PER_SESSION"),
+        secret: false,
+        description: "Maximum agent-created tasks per session (default: 25)",
+    },
     // -- Observability --
     ConfigKeyInfo {
         key: "store_llm_calls",
@@ -511,6 +519,8 @@ pub fn get_effective_value(key: &str, settings: &Settings) -> Option<String> {
             .map(|_| "[SET]".to_string()),
         "home_dir" => Some(settings.home_dir.display().to_string()),
         "db_path" => Some(settings.db_path.display().to_string()),
+        // Task engine
+        "max_agent_tasks_per_session" => Some(settings.max_agent_tasks_per_session.to_string()),
         // Observability
         "store_llm_calls" => Some(settings.store_llm_calls.to_string()),
         "store_tool_calls" => Some(settings.store_tool_calls.to_string()),
@@ -719,6 +729,11 @@ pub struct Settings {
     #[serde(default)]
     pub otlp_auth_header: Option<SecretString>,
 
+    /// Maximum agent-created tasks per session (default: 25).
+    /// Guards against runaway task creation while allowing legitimate bulk operations.
+    #[serde(default = "default_max_agent_tasks_per_session")]
+    pub max_agent_tasks_per_session: i64,
+
     /// Store LLM call metadata (model, tokens, latency) in SQLite (default: true)
     #[serde(default = "default_true")]
     pub store_llm_calls: bool,
@@ -746,6 +761,10 @@ fn default_llm_provider() -> ProviderKind {
 
 fn default_max_tokens() -> u32 {
     4096
+}
+
+fn default_max_agent_tasks_per_session() -> i64 {
+    25
 }
 
 fn default_db_path() -> PathBuf {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,7 +249,7 @@ remaining 9 tools (including task write tools) are added conditionally when `age
 | `get_team_history` | List recent runs for a team with IDs, status, goals, and timestamps. | default (30s) | No |
 | `delete_team` | Delete a team definition and all its data (workspace, config). Irreversible. | default (30s) | No |
 | `update_team` | Update an existing team definition. Only provided fields are changed. | default (30s) | No |
-| `create_task` | Create a trackable task with optional parent, source, and reference_url. Max depth 3, max 5 agent-created per session (user_request exempt). Cannot be used in callback turns. | default (30s) | No |
+| `create_task` | Create a trackable task with optional parent, source, and reference_url. Max depth 3, max 25 agent-created per session (configurable via `max_agent_tasks_per_session`, user_request exempt). Cannot be used in callback turns. | default (30s) | No |
 | `update_task_status` | Update task status with validated transitions. Permitted: pending→any, in_progress→blocked/completed/cancelled, blocked→in_progress/completed/cancelled. Terminal states (completed, cancelled) are final. Logs audit event. | default (30s) | No |
 
 Management tools are NOT registered for team sub-agents or delegated agents,

--- a/docs/plans/677-raise-per-session-task-limit.md
+++ b/docs/plans/677-raise-per-session-task-limit.md
@@ -1,0 +1,52 @@
+# Plan: Raise per-session task creation limit (#677)
+
+## Problem
+
+The task engine limits agent-created tasks to 5 per session (Guard 5 in `create_task.rs`). Milestone dispatch with 7+ issues hits this limit, forcing workarounds that add complexity. The guard exists to catch runaway loops, not to limit legitimate bulk creation.
+
+## Solution
+
+1. Raise default from 5 to 25
+2. Make configurable via `max_agent_tasks_per_session` in agent config (config.toml / env var)
+
+## Implementation Steps
+
+### Step 1: Add config key to mika-common
+
+- **File:** `crates/mika-common/src/config.rs`
+- Add `ConfigKeyInfo` entry for `max_agent_tasks_per_session` (backend: `File`, env: `MIKA_MAX_AGENT_TASKS_PER_SESSION`)
+- Add field `pub max_agent_tasks_per_session: i64` to `Settings` struct with `#[serde(default = "default_max_agent_tasks_per_session")]` defaulting to 25
+
+### Step 2: Thread through ToolContext
+
+- **File:** `crates/mika-agent/src/tools/mod.rs`
+- Add `pub max_tasks_per_session: i64` field to `ToolContext`
+
+### Step 3: Set field at all ToolContext construction sites
+
+- **File:** `crates/mika-agent/src/agent.rs` — 3 construction sites (conversation, silent, team)
+- Source from `params.settings.map_or(25, |s| s.max_agent_tasks_per_session)`
+- **File:** `crates/mika-agent/src/test_utils.rs` — test helper uses default 25
+
+### Step 4: Use configurable limit in create_task
+
+- **File:** `crates/mika-agent/src/tools/create_task.rs`
+- Remove `const MAX_TASKS_PER_SESSION: i64 = 5;`
+- Replace usage with `ctx.max_tasks_per_session`
+
+### Step 5: Update tests
+
+- Update existing test in `create_task.rs` that validates the limit (line ~1161)
+- Add test verifying custom limit is respected
+
+### Step 6: Update documentation
+
+- `docs/architecture.md` — update "Max 5 agent-created items per session" references
+- `.env.example` — add `MIKA_MAX_AGENT_TASKS_PER_SESSION`
+
+## Design Decisions
+
+- **Field on ToolContext (not re-reading config per call):** Follows existing pattern (brave_api_key, github_token are resolved once and threaded). Avoids per-tool-call config lookups.
+- **i64 type:** Matches `count_session_tasks()` return type.
+- **Default 25:** Covers largest milestone (18 tickets = 19 tasks) with margin, still catches runaway loops.
+- **File backend (config.toml):** Per-agent configurable without env vars. Env var override available for container deployments.

--- a/docs/solutions/677-configurable-task-session-limit.md
+++ b/docs/solutions/677-configurable-task-session-limit.md
@@ -1,0 +1,33 @@
+---
+module: mika-agent/tools/create_task
+tags: [task-engine, configuration, guard, limits]
+problem_type: enhancement
+---
+
+# Configurable per-session task creation limit
+
+## Problem
+
+Guard 5 in `create_task` hardcoded a limit of 5 agent-created tasks per session. Milestone dispatch with 7+ child issues hit this ceiling, forcing complex workarounds (deferring task creation to subsequent callbacks).
+
+## Solution
+
+Made the limit configurable via `max_agent_tasks_per_session` (config.toml or `MIKA_MAX_AGENT_TASKS_PER_SESSION` env var), defaulting to 25.
+
+## Threading pattern
+
+The limit flows: `Settings.max_agent_tasks_per_session` -> `ToolContext.max_tasks_per_session` -> used by `create_task` Guard 5. This follows the existing pattern where values are resolved once at ToolContext construction (like `brave_api_key`, `github_token`).
+
+At all 3 ToolContext construction sites (conversation, silent, team) in `agent.rs`:
+```rust
+max_tasks_per_session: params.settings.map_or(25, |s| s.max_agent_tasks_per_session),
+```
+
+The `map_or(25, ...)` fallback covers cases where `settings` is `None` (test contexts, investigation panel).
+
+## Key decisions
+
+- **Field on ToolContext, not per-call config read:** Follows the established pattern. Avoids DB/file reads during tool execution.
+- **Default 25 (not unbounded):** Covers the largest foreseeable milestone (18 tickets = 19 tasks with parent) while still catching runaway loops.
+- **File backend:** Per-agent configurable via `config.toml` without env vars, with env var override for container deployments.
+- **Tests use small limits (3-5):** Avoids 25-iteration test loops while still exercising the guard logic.


### PR DESCRIPTION
## Summary

- Raises the per-session agent task creation limit from 5 to 25 (default)
- Makes it configurable via `max_agent_tasks_per_session` in config.toml or `MIKA_MAX_AGENT_TASKS_PER_SESSION` env var
- Threads the config value through `Settings` → `ToolContext` → Guard 5 in `create_task`

Closes #677

## Changes

- **mika-common/config.rs**: New `ConfigKeyInfo` entry + `Settings` field with serde default
- **mika-agent/tools/mod.rs**: New `max_tasks_per_session` field on `ToolContext`
- **mika-agent/agent.rs**: Thread setting at all 3 ToolContext construction sites
- **mika-agent/tools/create_task.rs**: Use `ctx.max_tasks_per_session` instead of hardcoded const
- **Tests**: Updated to use explicit small limits for speed + new configurability test
- **Docs**: Updated architecture.md, CLAUDE.md, .env.example

## Test plan

- [x] All 1813 mika-agent lib tests pass
- [x] All 286 mika-common tests pass
- [x] `test_create_task_session_cap` — verifies limit enforcement
- [x] `test_create_task_session_cap_excludes_user_request` — user_request bypasses cap
- [x] `test_create_task_session_cap_configurable` — custom limit of 3 works correctly
- [x] `test_create_task_dedup_skips_session_counter` — dedup hits don't consume quota
- [x] Clippy clean, fmt clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)