### PR TITLE
fix(agent): handle chat_id == 0 as structured NoChannel outcome (#650)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -139,9 +139,11 @@ Background tasks (heartbeat, reminders) where text output is NOT delivered. Agen
 
 ## MessageSender Trait
 
-`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Returns `Result<SendOutcome>` where `SendOutcome` is `Delivered` (gateway 2xx) or `Failed { reason }` (non-2xx after retry, saved to `failed_sends`). `Err` is reserved for infrastructure failures (chat_id resolution, DB errors). Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender` (one retry after 2s, error classification: connection/timeout/HTTP status with body snippet). Team engine agents intentionally have `message_sender: None`.
+`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Returns `Result<SendOutcome>` where `SendOutcome` is `Delivered` (gateway 2xx), `Failed { reason }` (non-2xx after retry, saved to `failed_sends`), or `NoChannel` (`chat_id == 0` sentinel — no reply channel available, e.g. GitHub webhook sessions). `Err` is reserved for infrastructure failures (chat_id resolution, DB errors). Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender` (one retry after 2s, error classification: connection/timeout/HTTP status with body snippet). Team engine agents intentionally have `message_sender: None`.
 
-**Callsite handling policy:** The `send_message` tool surfaces `Failed` as `ToolOutput::error` so the LLM knows delivery failed. The task-engine dispatcher absorbs `Failed` with a warning (fire-and-forget for scheduled sends). Server handlers and notification paths (verdict, CI success) log warnings on `Failed` but continue. The `failed_sends` flush path increments retry count on `Failed`.
+**`NoChannel` sentinel (#650):** `GatewayMessageSender::send()` detects `chat_id == 0` after `resolve_chat_id()` and returns `Ok(NoChannel)` before the HTTP POST — no retry, no `failed_sends` entry. `chat_id == 0` is the documented sentinel for sessions without a Telegram reply channel (GitHub webhooks, non-Telegram channels). The agent should use channel-appropriate tools (e.g., `run_gh`) instead of `send_message`.
+
+**Callsite handling policy:** The `send_message` tool surfaces `Failed` as `ToolOutput::error` so the LLM knows delivery failed; `NoChannel` returns `ToolOutput::success` with redirect guidance (prevents LLM retry loops). The task-engine dispatcher absorbs `Failed` and `NoChannel` with a warning (fire-and-forget for scheduled sends). Server handlers and notification paths (verdict, CI success) log warnings on `Failed` and `NoChannel` but continue. The `failed_sends` flush path increments retry count on `Failed`; deletes entries on `NoChannel` (permanent condition).
 
 ## Conversation Compaction & Rewind
 

--- a/crates/mika-agent/src/messaging.rs
+++ b/crates/mika-agent/src/messaging.rs
@@ -17,6 +17,12 @@ pub enum SendOutcome {
         /// Human-readable reason including HTTP status or network error classification.
         reason: String,
     },
+    /// No reply channel available for this session. `chat_id == 0` is the
+    /// documented sentinel for GitHub webhook and other non-Telegram channels
+    /// where the agent should use channel-appropriate tools (e.g., `run_gh`)
+    /// instead of `send_message`. This is a permanent session condition, not a
+    /// transient error — callers should not retry or save to `failed_sends`.
+    NoChannel,
 }
 
 /// Trait for sending outbound messages to the user.
@@ -134,6 +140,17 @@ impl GatewayMessageSender {
 impl MessageSender for GatewayMessageSender {
     async fn send(&self, text: &str) -> Result<SendOutcome> {
         let chat_id = self.resolve_chat_id().await?;
+
+        // chat_id == 0 is the documented sentinel for "no reply channel" (GitHub
+        // webhooks, non-Telegram sessions). Short-circuit before the HTTP POST —
+        // no retry, no failed_sends entry, since this is a permanent condition.
+        if chat_id == 0 {
+            warn!(
+                agent_name = ?self.agent_name,
+                "send() called with chat_id=0 — no reply channel available"
+            );
+            return Ok(SendOutcome::NoChannel);
+        }
 
         tracing::debug!(
             agent_name = ?self.agent_name,
@@ -278,9 +295,10 @@ mod tests {
         );
     }
 
-    /// Verifies that a poisoned chat_id ("0") in the DB is parsed as 0,
-    /// which the gateway would reject. Defense-in-depth: resolve_chat_id
-    /// returns the raw value — validation happens at the gateway /send boundary.
+    /// Verifies that a poisoned chat_id ("0") in the DB is parsed as 0.
+    /// `resolve_chat_id()` returns the raw value — the `send()` method
+    /// catches `chat_id == 0` and returns `SendOutcome::NoChannel` before
+    /// the HTTP POST (#650).
     #[tokio::test]
     async fn test_resolve_chat_id_poisoned_zero_in_db() {
         let harness = TestHarness::new();
@@ -303,7 +321,86 @@ mod tests {
         let chat_id = sender.resolve_chat_id().await.unwrap();
         assert_eq!(
             chat_id, 0,
-            "poisoned value returns 0 — gateway rejects at /send"
+            "poisoned value returns 0 — send() catches this as NoChannel"
+        );
+    }
+
+    /// chat_id == 0 via explicit override returns NoChannel without HTTP POST (#650).
+    #[tokio::test]
+    async fn test_send_chat_id_zero_explicit_returns_no_channel() {
+        let harness = TestHarness::with_agent("test-agent");
+        let sender = GatewayMessageSender::new(
+            "http://localhost:9999".to_string(),
+            SecretString::from("test-token"),
+            harness.db.clone(),
+            reqwest::Client::new(),
+            None,
+            Some("test-agent".to_string()),
+            Some(0), // explicit chat_id override of 0
+        );
+
+        let outcome = sender.send("hello").await.unwrap();
+        assert_eq!(
+            outcome,
+            SendOutcome::NoChannel,
+            "chat_id=0 should return NoChannel, not attempt HTTP POST"
+        );
+    }
+
+    /// chat_id == 0 from DB (poisoned value) returns NoChannel via send() (#650).
+    #[tokio::test]
+    async fn test_send_chat_id_zero_from_db_returns_no_channel() {
+        let harness = TestHarness::new();
+        harness
+            .db
+            .set_customer_config("chat_id", "0")
+            .await
+            .unwrap();
+
+        let sender = GatewayMessageSender::new(
+            "http://localhost:9999".to_string(),
+            SecretString::from("test-token"),
+            harness.db.clone(),
+            reqwest::Client::new(),
+            None,
+            Some("mika".to_string()),
+            None, // no explicit override — falls back to DB
+        );
+
+        let outcome = sender.send("hello").await.unwrap();
+        assert_eq!(
+            outcome,
+            SendOutcome::NoChannel,
+            "poisoned chat_id=0 from DB should return NoChannel"
+        );
+    }
+
+    /// resolve_chat_id() returning Err (no chat_id configured) still propagates
+    /// as Err, not NoChannel.
+    #[tokio::test]
+    async fn test_send_no_chat_id_configured_returns_err() {
+        let harness = TestHarness::with_agent("no-chat-agent");
+        let sender = GatewayMessageSender::new(
+            "http://localhost:9999".to_string(),
+            SecretString::from("test-token"),
+            harness.db.clone(),
+            reqwest::Client::new(),
+            None,
+            Some("no-chat-agent".to_string()),
+            None, // no explicit override, no DB entry
+        );
+
+        let result = sender.send("hello").await;
+        assert!(
+            result.is_err(),
+            "missing chat_id should return Err, not NoChannel"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("chat_id not configured"),
+            "error should mention chat_id not configured"
         );
     }
 }

--- a/crates/mika-agent/src/server/ci_success_handler.rs
+++ b/crates/mika-agent/src/server/ci_success_handler.rs
@@ -312,6 +312,11 @@ pub async fn try_handle_ci_success(
                     Ok(crate::messaging::SendOutcome::Failed { reason }) => {
                         warn!(reason = %reason, "CI success merge notification delivery failed");
                     }
+                    Ok(crate::messaging::SendOutcome::NoChannel) => {
+                        warn!(
+                            "CI success merge notification skipped — no reply channel (chat_id=0)"
+                        );
+                    }
                     Err(e) => {
                         warn!(error = %e, "Failed to send CI success merge notification");
                     }

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -847,6 +847,9 @@ async fn run_agent_for_message(
                     Ok(crate::messaging::SendOutcome::Failed { reason }) => {
                         warn!(reason = %reason, "response delivery failed, saved to failed_sends");
                     }
+                    Ok(crate::messaging::SendOutcome::NoChannel) => {
+                        warn!("response delivery skipped — no reply channel (chat_id=0)");
+                    }
                     Err(e) => {
                         error!(error = %e, "failed to send response");
                     }
@@ -857,6 +860,9 @@ async fn run_agent_for_message(
                     Ok(crate::messaging::SendOutcome::Delivered) => {}
                     Ok(crate::messaging::SendOutcome::Failed { reason }) => {
                         warn!(reason = %reason, "fallback response delivery failed, saved to failed_sends");
+                    }
+                    Ok(crate::messaging::SendOutcome::NoChannel) => {
+                        warn!("fallback response delivery skipped — no reply channel (chat_id=0)");
                     }
                     Err(e) => {
                         error!(error = %e, "failed to send fallback response");
@@ -910,6 +916,15 @@ async fn flush_failed_sends(state: &AppState, agent_state: &AgentState) {
             Ok(crate::messaging::SendOutcome::Failed { reason }) => {
                 warn!(id = send.id, reason = %reason, "failed send flush: delivery failed again");
                 let _ = agent_state.db.increment_failed_send_retry(send.id).await;
+            }
+            Ok(crate::messaging::SendOutcome::NoChannel) => {
+                // Permanent condition — delete the entry instead of retrying.
+                // These entries were created before the NoChannel check existed.
+                let _ = agent_state.db.delete_failed_send(send.id).await;
+                warn!(
+                    id = send.id,
+                    "failed send flush: no reply channel (chat_id=0), deleting entry"
+                );
             }
             Err(e) => {
                 warn!(id = send.id, error = %e, "failed send flush: sender error");

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -308,6 +308,9 @@ async fn handle_pass_verdict(
                             Ok(crate::messaging::SendOutcome::Failed { reason }) => {
                                 warn!(reason = %reason, "Merge notification delivery failed");
                             }
+                            Ok(crate::messaging::SendOutcome::NoChannel) => {
+                                warn!("Merge notification skipped — no reply channel (chat_id=0)");
+                            }
                             Err(e) => {
                                 warn!(error = %e, "Failed to send merge notification");
                             }

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -149,6 +149,9 @@ impl TaskDispatcher {
                 crate::messaging::SendOutcome::Failed { reason } => {
                     warn!(task_id = %task.id, reason = %reason, "send_message task: delivery failed");
                 }
+                crate::messaging::SendOutcome::NoChannel => {
+                    warn!(task_id = %task.id, "send_message task: no reply channel (chat_id=0)");
+                }
             }
         } else {
             debug!(task_id = %task.id, "send_message: no sender configured, dropping message");

--- a/crates/mika-agent/src/tools/send_message.rs
+++ b/crates/mika-agent/src/tools/send_message.rs
@@ -75,6 +75,20 @@ impl Tool for SendMessageTool {
                             "Message delivery failed: {reason}"
                         )))
                     }
+                    // Intentionally returns success, not error. chat_id == 0 is a
+                    // permanent session condition (GitHub webhook / non-Telegram
+                    // channel), not a transient failure. Using ToolOutput::error
+                    // would cause Claude to retry in a loop. The message tells the
+                    // LLM to use channel-appropriate tools instead.
+                    Ok(SendOutcome::NoChannel) => {
+                        warn!("send_message: no reply channel (chat_id=0)");
+                        Ok(ToolOutput::success(
+                            "No reply channel for this session (chat_id is zero). \
+                             The user cannot receive messages via send_message. \
+                             Use channel-appropriate tools (e.g., run_gh for GitHub) \
+                             to deliver your response.",
+                        ))
+                    }
                     Err(e) => {
                         warn!(error = %e, "send_message: sender error");
                         Ok(ToolOutput::error(format!("Message delivery error: {e}")))
@@ -339,6 +353,57 @@ mod tests {
         assert!(
             result.content.contains("chat_id not configured"),
             "expected error details: {}",
+            result.content
+        );
+    }
+
+    /// NoChannel outcome returns success (not error) with actionable text (#650).
+    #[tokio::test]
+    async fn test_send_message_no_channel() {
+        let harness = TestHarness::new();
+        let mock = Arc::new(MockSender::with_outcome(SendOutcome::NoChannel));
+        let skills_dirty = std::sync::atomic::AtomicBool::new(false);
+        let pr_review_posted = std::sync::atomic::AtomicBool::new(false);
+        let ctx = crate::tools::ToolContext {
+            db: &harness.db,
+            session_id: "test-session",
+            trace_id: "00000000000000000000000000000000",
+            home_dir: std::path::Path::new("/tmp"),
+            global_home_dir: None,
+            core_memory_edit_count: &harness.counter,
+            is_onboarding: false,
+            message_sender: Some(mock.clone()),
+            embedding_client: None,
+            brave_api_key: None,
+            github_token: None,
+            skills_dirty: &skills_dirty,
+            is_reflection: false,
+            is_task_context: false,
+            is_callback_turn: false,
+            provider_name: "anthropic",
+            model_name: "claude-sonnet-4-6",
+            active_skill_paths: &[],
+            max_tasks_per_session: 25,
+            pr_review_posted: &pr_review_posted,
+        };
+        let tool = SendMessageTool;
+
+        let result = tool
+            .execute(serde_json::json!({"text": "Hello!"}), &ctx)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "NoChannel should return success (not error) to avoid LLM retry loops"
+        );
+        assert!(
+            result.content.contains("No reply channel"),
+            "expected 'No reply channel' in output: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("run_gh"),
+            "expected tool redirect hint in output: {}",
             result.content
         );
     }

--- a/crates/mika-agent/tests/eval/test_tool_calling.rs
+++ b/crates/mika-agent/tests/eval/test_tool_calling.rs
@@ -359,3 +359,40 @@ async fn test_send_message_gateway_success_records_success() {
     );
     assert_tool_output_contains(&trace, "send_message", 0, "Message sent.");
 }
+
+#[tokio::test]
+async fn test_send_message_no_channel_returns_success_with_redirect() {
+    // LLM calls send_message, sender returns NoChannel (chat_id=0) ->
+    // tool_call should record success=true with actionable redirect text (#650).
+    let sender = Arc::new(EvalMockSender {
+        outcome: SendOutcome::NoChannel,
+    });
+
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response("send_message", json!({"text": "Build complete"})),
+            text_response("I see there's no reply channel. I'll use run_gh instead."),
+        ])
+        .message_sender(sender)
+        .build()
+        .await
+        .unwrap();
+
+    let trace = harness.run("Notify about the build").await.unwrap();
+
+    assert_tools_include(&trace, &["send_message"]);
+
+    let send_calls = trace.calls_for_tool("send_message");
+    assert_eq!(
+        send_calls.len(),
+        1,
+        "expected exactly one send_message call"
+    );
+    // NoChannel is a success (not error) to prevent LLM retry loops
+    assert!(
+        send_calls[0].success,
+        "expected success=true for NoChannel outcome, got success=false"
+    );
+    assert_tool_output_contains(&trace, "send_message", 0, "No reply channel");
+    assert_tool_output_contains(&trace, "send_message", 0, "run_gh");
+}

--- a/crates/mika-gateway/src/routes.rs
+++ b/crates/mika-gateway/src/routes.rs
@@ -824,6 +824,11 @@ pub(crate) async fn handle_send(
     // Validate chat_id is a usable Telegram identifier (positive for private chats,
     // negative for groups/channels — but never zero, which is an invalid sentinel).
     if payload.chat_id == 0 {
+        tracing::warn!(
+            agent_name = ?payload.agent_name,
+            request_id = ?payload.request_id,
+            "chat_id=0 POST received at /send — agent should use NoChannel path"
+        );
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": "chat_id must be non-zero"})),

--- a/docs/plans/2026-04-20-009-fix-send-message-chat-id-zero-plan.md
+++ b/docs/plans/2026-04-20-009-fix-send-message-chat-id-zero-plan.md
@@ -1,0 +1,229 @@
+---
+title: "fix: Handle chat_id == 0 in send_message as structured NoChannel outcome"
+type: fix
+status: active
+date: 2026-04-20
+---
+
+# fix: Handle chat_id == 0 in send_message as structured NoChannel outcome
+
+## Overview
+
+`send_message` invoked with `chat_id == 0` (a documented sentinel for "no reply channel") propagates the gateway's 400 error as a generic failure. The agent retries uselessly, pollutes `failed_sends`, and the LLM sees an opaque error instead of an actionable signal to pivot to channel-appropriate tools (e.g., `run_gh`). The fix adds a `SendOutcome::NoChannel` variant detected before the HTTP POST, returns a clear tool output, and adds gateway observability.
+
+## Problem Frame
+
+`chat_id == 0` is the GitHub webhook design's sentinel meaning "this session has no Telegram reply channel." The gateway correctly rejects it with 400. But the agent-side `GatewayMessageSender::send()` doesn't recognize this as a permanent, expected condition — it retries (wasting 2s), saves to `failed_sends` (futile), and returns `SendOutcome::Failed` which the tool surfaces as `ToolOutput::error`. The LLM sees "Message delivery failed: gateway /send returned 400: chat_id must be non-zero" — an infrastructure error message, not a redirect to the right tool.
+
+10 occurrences in 24 hours across callbacks, heartbeats, and CLI sessions confirm this is a steady-state defect, not a one-off.
+
+## Requirements Trace
+
+- R1. `send_message` with `chat_id == 0` returns a structured "no reply channel" result to the LLM (not a gateway 400 propagation)
+- R2. Tool output tells the LLM what to use instead (e.g., `run_gh` for GitHub channels)
+- R3. No retry attempt and no `failed_sends` entry for `chat_id == 0` (permanent condition)
+- R4. Gateway adds observability for `chat_id == 0` POST arrivals (defense-in-depth logging)
+- R5. Unit test: `send_message` with `chat_id == 0` → typed `Ok(NoChannel)`, not `Err` or `Failed`
+- R6. Eval harness integration test covering the flow
+- R7. All existing `SendOutcome` match sites compile and handle the new variant
+
+## Scope Boundaries
+
+- No changes to the `MessageSender` trait signature (still returns `Result<SendOutcome>`)
+- No channel field plumbed into `ToolContext` — the tool output is actionable without naming the channel (the LLM already knows channel context from the system prompt)
+- No per-channel `MessageSender` trait selection (explicitly deferred per issue #650)
+- No changes to how `chat_id` flows from gateway to agent in `/message` handler
+- No schema migration needed
+
+### Deferred to Separate Tasks
+
+- Per-channel `MessageSender` trait selection (long-term, out of scope per issue description)
+- `resolve_chat_id()` rejecting `0` from DB (defense-in-depth improvement, but the `send()` check catches it first and is the correct architectural layer for the fix)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/messaging.rs` — `SendOutcome` enum (line 10-20), `GatewayMessageSender::send()` (line 134-175), `resolve_chat_id()` (line 78-89)
+- `crates/mika-agent/src/tools/send_message.rs` — tool handler matching on `SendOutcome` (line 64-98), `None` sender pattern at line 90-96 (returns `ToolOutput::success` with warning — the closest precedent for NoChannel)
+- `crates/mika-agent/src/server/handlers.rs` — failed_sends flush (line 846-858), end-of-turn notification (line 906-910)
+- `crates/mika-agent/src/server/verdict_handler.rs` — verdict notification (line 307-308)
+- `crates/mika-agent/src/server/ci_success_handler.rs` — CI notification (line 311-312)
+- `crates/mika-agent/src/task_engine/dispatcher.rs` — fire-and-forget task dispatch (line 145-149)
+- `crates/mika-gateway/src/routes.rs` — existing `chat_id == 0` guard (line 826-831)
+- Test at `messaging.rs:281` — `test_resolve_chat_id_poisoned_zero_in_db` documents current pass-through behavior
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/send-message-tool-false-success-on-gateway-error.md` — Documents the `SendOutcome` enum introduction. All callsites must handle new variants.
+- `docs/solutions/integration-issues/github-webhook-poisons-telegram-chat-id.md` — Documents the `chat_id == 0` sentinel and the gateway's 400 validation. The fix here is the agent-side companion.
+- `docs/solutions/integration-issues/multi-agent-telegram-delivery-and-reply-routing.md` — Documents `resolve_chat_id()` mechanism and delegate chat_id override flow.
+
+## Key Technical Decisions
+
+- **Check in `GatewayMessageSender::send()`, not in the tool handler:** The `send()` method is the single choke point called by the tool, task engine dispatcher, verdict/CI handlers, and failed_sends flush. Checking here catches all callers uniformly, avoiding scattered duplicate checks. The tool handler only needs to match the new `NoChannel` variant.
+
+- **New `SendOutcome::NoChannel` variant (not a separate pre-check method):** Adding a variant to the existing enum is clean for the type system and forces exhaustive handling at every match site (Rust compiler enforces this). The alternative — a `can_deliver()` pre-check — would be optional to call and easy to forget.
+
+- **`ToolOutput::success` for NoChannel (not `ToolOutput::error`):** Following the existing "no sender" precedent at line 90 of `send_message.rs`. `chat_id == 0` is a permanent session condition, not a transient error. Using `is_error: true` would cause the LLM to retry in a loop. The success-with-warning pattern gives the LLM a clear signal without triggering retry behavior.
+
+- **Skip `failed_sends` for NoChannel:** `chat_id == 0` is a permanent condition — saving to `failed_sends` creates futile retry entries that will fail again on flush. The `send()` method returns `Ok(NoChannel)` before reaching the retry/save logic.
+
+- **Message persistence ordering unchanged:** The `send_message` tool persists to conversation history at line 60 before calling the sender. Changing this ordering is a separate concern. The message was "said" by the agent even if it couldn't be delivered — keeping it in history is consistent with the `SendOutcome::Failed` behavior where the message is also persisted.
+
+## Implementation Units
+
+- [x] **Unit 1: Add `SendOutcome::NoChannel` variant and detect in `GatewayMessageSender::send()`**
+
+**Goal:** Add the typed variant and short-circuit before HTTP POST when `chat_id == 0`.
+
+**Requirements:** R1, R3, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/messaging.rs`
+- Test: `crates/mika-agent/src/messaging.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Add `NoChannel` variant to `SendOutcome` enum with a doc comment explaining the sentinel
+- In `GatewayMessageSender::send()`, after `resolve_chat_id()` returns `Ok(id)`, check `if id == 0` and return `Ok(SendOutcome::NoChannel)` immediately — before the payload construction, HTTP POST, retry, and `failed_sends` write
+- This naturally satisfies R3 (no retry, no failed_sends) because the early return skips all downstream logic
+- Update `test_resolve_chat_id_poisoned_zero_in_db` — the test currently documents pass-through behavior; update the comment to note that `send()` now catches this before the HTTP POST
+- Add a new test: construct `GatewayMessageSender` with explicit `chat_id: Some(0)`, call `send()`, assert `Ok(SendOutcome::NoChannel)`
+
+**Patterns to follow:**
+- Existing `SendOutcome::Delivered` and `SendOutcome::Failed` variant style
+- The existing `resolve_chat_id()` error early-return pattern at line 136
+
+**Test scenarios:**
+- Happy path: `GatewayMessageSender::send()` with `chat_id == 0` (explicit override `Some(0)`) returns `Ok(SendOutcome::NoChannel)` without making any HTTP request
+- Happy path: `GatewayMessageSender::send()` with `chat_id == 0` from DB lookup (poisoned "0" in `customer_config`) returns `Ok(SendOutcome::NoChannel)`
+- Edge case: `GatewayMessageSender::send()` with valid non-zero `chat_id` still returns `Delivered` (regression guard — use a mock HTTP server or accept that this is covered by existing tests)
+- Edge case: `resolve_chat_id()` returning `Err` (no chat_id configured) still propagates as `Err` (not `NoChannel`)
+
+**Verification:**
+- `cargo test -p mika-agent messaging` passes with new and updated tests
+- `cargo check -p mika-agent` confirms all `SendOutcome` match sites report exhaustiveness errors (will be fixed in Unit 2)
+
+---
+
+- [x] **Unit 2: Handle `SendOutcome::NoChannel` at all match sites**
+
+**Goal:** Update every `SendOutcome` match arm across the codebase so the project compiles and each callsite handles `NoChannel` appropriately.
+
+**Requirements:** R2, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/tools/send_message.rs`
+- Modify: `crates/mika-agent/src/server/handlers.rs`
+- Modify: `crates/mika-agent/src/server/verdict_handler.rs`
+- Modify: `crates/mika-agent/src/server/ci_success_handler.rs`
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs`
+- Test: `crates/mika-agent/src/tools/send_message.rs` (inline tests)
+
+**Approach:**
+- **`send_message` tool** (primary — R2): Add `Ok(SendOutcome::NoChannel)` arm returning `ToolOutput::success(...)` with actionable text: "No reply channel for this session (chat_id is zero). The user cannot receive messages via send_message. Use channel-appropriate tools (e.g., run_gh for GitHub) to deliver your response." Follow the existing `None` sender pattern (success, not error)
+- **`handlers.rs` failed_sends flush** (~3 match sites): Add `Ok(SendOutcome::NoChannel)` arm with `warn!` log and continue (same as `Failed` but with distinct log message noting permanent condition)
+- **`verdict_handler.rs`** and **`ci_success_handler.rs`**: Add `Ok(SendOutcome::NoChannel)` arm with `warn!` log — notifications that can't be delivered are logged but don't block the verdict/CI flow
+- **`task_engine/dispatcher.rs`**: Add `Ok(SendOutcome::NoChannel)` arm with `warn!` log — fire-and-forget semantics, same as `Failed`
+- **Test mock `MockSender`** in `send_message.rs` and `dispatcher.rs` and `engine.rs`: Add `NoChannel` to any mock implementations that construct `SendOutcome`
+
+**Patterns to follow:**
+- The `None` sender arm in `send_message.rs` (line 90-96) for the tool output text style
+- The existing `Failed` arm handling at each callsite for the non-tool match sites
+
+**Test scenarios:**
+- Happy path: `send_message` tool with `MockSender` returning `SendOutcome::NoChannel` → `ToolOutput` with `is_error: false` and output containing "No reply channel"
+- Happy path: `send_message` tool with `MockSender` returning `SendOutcome::Delivered` still works (regression)
+- Error path: `send_message` tool with `MockSender` returning `SendOutcome::Failed` still returns `ToolOutput::error` (regression)
+
+**Verification:**
+- `cargo build -p mika-agent` compiles cleanly (no unhandled enum variants)
+- `cargo test -p mika-agent` passes with new test
+
+---
+
+- [x] **Unit 3: Add gateway observability for `chat_id == 0` arrivals**
+
+**Goal:** Add a structured `warn!` log at the gateway's existing `chat_id == 0` guard so defense-in-depth violations are visible in dashboards.
+
+**Requirements:** R4
+
+**Dependencies:** None (can be done in parallel with Units 1-2)
+
+**Files:**
+- Modify: `crates/mika-gateway/src/routes.rs`
+
+**Approach:**
+- At the existing `chat_id == 0` check (line 826), add a `warn!` with structured fields (`agent_name`, `request_id`) before returning 400. This makes the event searchable in log aggregation without changing the response.
+- Use `tracing::warn!` consistent with gateway logging patterns
+
+**Patterns to follow:**
+- Existing `tracing::warn!` usage in `routes.rs` for validation failures
+- Structured field style: `warn!(agent_name = ?payload.agent_name, "chat_id == 0 POST received")`
+
+**Test scenarios:**
+- Test expectation: none — this is a log-only addition to an existing validation guard. The existing gateway tests for chat_id validation cover the 400 response behavior. Log output verification would require a tracing subscriber test harness which is disproportionate for a single `warn!` line.
+
+**Verification:**
+- `cargo build -p mika-gateway` compiles cleanly
+- Manual: POST to `/send` with `chat_id: 0` produces structured warn log
+
+---
+
+- [x] **Unit 4: Eval harness integration test**
+
+**Goal:** End-to-end test using `EvalHarness` that verifies the full agent loop handles `send_message` with `NoChannel` correctly.
+
+**Requirements:** R6
+
+**Dependencies:** Units 1, 2
+
+**Files:**
+- Modify: `crates/mika-agent/tests/eval/test_tool_calling.rs`
+- Test: `crates/mika-agent/tests/eval/test_tool_calling.rs`
+
+**Approach:**
+- Create a `MockNoChannelSender` (or reuse `MockSender` with configurable outcome) that returns `Ok(SendOutcome::NoChannel)` on `send()`
+- Build `EvalHarness` with `.message_sender(Arc::new(sender))` and mock LLM responses that include a `send_message` tool call
+- Assert: tool output contains "No reply channel" text, `is_error` is false, and the LLM receives the actionable message
+- Use `assert_tool_output_contains` helper from the eval assertions module
+
+**Patterns to follow:**
+- Existing eval tests in `test_tool_calling.rs` for `send_message`
+- `EvalHarness::builder().responses(...).message_sender(...).build()` pattern
+
+**Test scenarios:**
+- Integration: LLM calls `send_message` with text → sender returns `NoChannel` → tool output is success with "No reply channel" message → agent continues (does not error out or retry)
+- Integration: Verify the tool call appears in `trace.tool_calls` with expected output
+
+**Verification:**
+- `cargo test -p mika-agent --test eval` passes including the new test
+- The test exercises the full `run_agent()` path through `send_message` tool → `MockSender` → `NoChannel` → tool output
+
+## System-Wide Impact
+
+- **Interaction graph:** `SendOutcome` is matched in 7 production sites across 5 files. The Rust compiler's exhaustive match enforcement ensures no site is missed. The `MessageSender` trait signature is unchanged — all `impl MessageSender` blocks are unaffected.
+- **Error propagation:** `NoChannel` is an `Ok` variant, not an `Err`. It flows through the same success path as `Delivered` and `Failed`. The `send_message` tool returns `ToolOutput::success` (not error), consistent with the "no sender" precedent.
+- **State lifecycle risks:** No schema changes. `failed_sends` table is not written for `NoChannel` (correct — permanent condition). Conversation history is still written (message was "said" by the agent).
+- **API surface parity:** The gateway `/send` endpoint response is unchanged. The agent's tool output changes from an error to a success with different text — this is visible to the LLM but not to external APIs.
+- **Unchanged invariants:** `MessageSender` trait, `ToolContext` struct, `resolve_chat_id()` return type, gateway `/send` response format, `failed_sends` flush logic (just adds a new match arm).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Exhaustive match enforcement may reveal match sites in untested code paths | Rust compiler catches all sites at build time; each site follows the same pattern as its `Failed` arm |
+| LLM may still attempt `send_message` repeatedly despite success result | The "no sender" precedent at line 90 has been stable — LLMs respect `ToolOutput::success` with explanatory text. The text explicitly names an alternative tool. |
+| Task engine reminders with `action_type='send_message'` will silently log and continue | This is the correct behavior — same as transient `Failed`. The reminder was for a session that has no reply channel; there's no better fallback without per-channel sender selection (deferred). |
+
+## Sources & References
+
+- Related issue: #650
+- Related fixes: #580 (GitHub webhook chat_id poisoning), #524 (verdict handler), #571 (CI success handler)
+- Documented solution: `docs/solutions/logic-errors/send-message-tool-false-success-on-gateway-error.md`
+- Documented solution: `docs/solutions/integration-issues/github-webhook-poisons-telegram-chat-id.md`
+- Documented anti-pattern rules: `docs/solutions/channels/multi-agent-telegram-delivery-and-reply-routing.md`

--- a/docs/solutions/logic-errors/send-message-chat-id-zero-no-channel-sentinel.md
+++ b/docs/solutions/logic-errors/send-message-chat-id-zero-no-channel-sentinel.md
@@ -1,0 +1,98 @@
+---
+title: send_message propagates gateway 400 instead of structured NoChannel for chat_id == 0
+date: 2026-04-20
+category: logic-errors
+module: crates/mika-agent/src/messaging.rs
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "gateway /send returned 400 Bad Request: chat_id must be non-zero"
+  - "send_message tool returns ToolOutput::error with opaque gateway error on GitHub webhook sessions"
+  - "LLM sees infrastructure failure instead of actionable redirect to channel-appropriate tools"
+  - "2-second retry delay wasted on permanent condition, failed_sends table polluted with undeliverable entries"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - send-message
+  - chat-id
+  - no-channel
+  - gateway-400
+  - github-webhook
+  - sentinel-value
+  - send-outcome
+---
+
+# send_message propagates gateway 400 instead of structured NoChannel for chat_id == 0
+
+## Problem
+
+`send_message` invoked with `chat_id == 0` (the documented sentinel for "no reply channel" on GitHub webhook sessions) triggered a gateway 400 error that propagated back to the LLM as a generic delivery failure. 10 occurrences in 24 hours across callbacks, heartbeats, and CLI sessions — notifications silently lost.
+
+## Symptoms
+
+- `send_message` tool returns `ToolOutput::error("Message delivery failed: gateway /send returned 400 Bad Request: {\"error\":\"chat_id must be non-zero\"}")`
+- Agent retries uselessly (2-second sleep), saves to `failed_sends` (futile for permanent condition)
+- LLM sees opaque infrastructure error, cannot pivot to `run_gh` or other channel-appropriate tools
+- `failed_sends` flush re-attempts delivery on every subsequent message, accumulating futile retries
+
+## What Didn't Work
+
+- The gateway's 400 response for `chat_id == 0` was correct validation — the bug was agent-side, not gateway-side. The gateway should continue rejecting `chat_id == 0` as defense-in-depth.
+- Silent drop was explicitly rejected: documented anti-pattern in `docs/solutions/channels/multi-agent-telegram-delivery-and-reply-routing.md`. Drops hide defects and kill observability.
+- Re-routing at the gateway (sending to an alternate channel) couples gateway delivery logic to channel semantics — violates the "gateway is a dumb delivery layer" principle.
+
+## Solution
+
+Added `SendOutcome::NoChannel` variant to the existing `SendOutcome` enum, detected in `GatewayMessageSender::send()` before the HTTP POST:
+
+```rust
+// In SendOutcome enum (messaging.rs)
+pub enum SendOutcome {
+    Delivered,
+    Failed { reason: String },
+    NoChannel,  // chat_id == 0 sentinel — permanent, no retry
+}
+
+// In GatewayMessageSender::send() — after resolve_chat_id(), before HTTP POST
+if chat_id == 0 {
+    warn!(agent_name = ?self.agent_name, "send() called with chat_id=0");
+    return Ok(SendOutcome::NoChannel);
+}
+```
+
+**Key design decisions:**
+
+1. **Check in `send()`, not the tool handler** — single choke point catches all 7 callers (tool, task engine, verdict/CI handlers, failed_sends flush).
+
+2. **`ToolOutput::success` (not error)** — follows the existing "no sender" precedent. `chat_id == 0` is permanent; `ToolOutput::error` would cause LLM retry loops. Tool output: "No reply channel for this session (chat_id is zero). Use channel-appropriate tools (e.g., run_gh for GitHub) to deliver your response."
+
+3. **No retry, no `failed_sends`** — early return before HTTP POST, retry, and DB write. The `failed_sends` flush path deletes NoChannel entries (cleaning up pre-fix entries).
+
+All 7 `SendOutcome` match sites updated. Rust exhaustive matching enforces coverage at compile time.
+
+## Why This Works
+
+`chat_id == 0` is the documented sentinel from the GitHub webhook design (#580) meaning "this session has no Telegram reply channel." The gateway correctly rejects it — but the agent-side `GatewayMessageSender::send()` didn't recognize it as an expected, permanent condition. It treated the 400 as a transient failure: retried, saved to `failed_sends`, and returned `SendOutcome::Failed`.
+
+The fix intercepts at the correct architectural layer — after `resolve_chat_id()` returns the value but before any network call — and returns a typed outcome that each caller handles appropriately:
+- Tool handler: success with redirect text (LLM can pivot to `run_gh`)
+- Task engine dispatcher: log and continue (fire-and-forget)
+- Verdict/CI handlers: log and continue (merge proceeds, notification skipped)
+- Failed_sends flush: delete entry (permanent condition, not retryable)
+
+## Prevention
+
+- **New `SendOutcome` variants require exhaustive handling.** Rust's match enforcement guarantees all callers are updated at compile time. Grep for `SendOutcome` match sites when extending the enum.
+- **Sentinel values (0, -1) should be caught at the sender layer, not the gateway.** The gateway's 400 is defense-in-depth; the agent-side check is the primary guard.
+- **Permanent conditions return `ToolOutput::success` with explanation, not `ToolOutput::error`.** The "no sender" pattern at `send_message.rs:90` established this convention — errors trigger LLM retries on permanent conditions.
+- **7 callsites for `SendOutcome`** across 5 files as of #650: `send_message.rs`, `handlers.rs` (3 sites), `verdict_handler.rs`, `ci_success_handler.rs`, `dispatcher.rs`. Check all when modifying the enum.
+
+## Related Issues
+
+- #650 — This fix
+- #580 — GitHub webhook chat_id poisoning (gateway-side defense-in-depth)
+- #581 — `SendOutcome` enum introduction (false success on gateway error)
+- `docs/solutions/logic-errors/send-message-tool-false-success-on-gateway-error.md` — Companion: introduced the `SendOutcome` enum
+- `docs/solutions/integration-issues/github-webhook-poisons-telegram-chat-id.md` — Companion: gateway-side chat_id == 0 validation
+- `docs/solutions/integration-issues/multi-agent-telegram-delivery-and-reply-routing.md` — Anti-pattern rules ("Treat None as deliberate", "failed_sends silently dropped")


### PR DESCRIPTION
## Summary

- Add `SendOutcome::NoChannel` variant to handle `chat_id == 0` (GitHub webhook sentinel for "no reply channel") as a structured outcome instead of propagating gateway 400 errors
- `GatewayMessageSender::send()` detects `chat_id == 0` before HTTP POST — no retry, no `failed_sends` entry
- `send_message` tool returns `ToolOutput::success` with actionable redirect text (not error, prevents LLM retry loops)
- All 7 `SendOutcome` match sites updated across 5 files (Rust exhaustive matching enforces coverage)
- Gateway adds `warn!` log on `chat_id == 0` POST arrivals for observability
- 6 new tests: 4 unit (messaging.rs), 1 unit (send_message.rs), 1 eval harness integration

## Test plan

- [x] `cargo test -p mika-agent` — 1905 tests pass, 0 failures
- [x] `cargo test -p mika-agent --test eval -- test_send_message` — 3 eval tests pass (including new NoChannel test)
- [x] `cargo clippy -p mika-agent -p mika-gateway` — clean
- [x] Pre-commit hooks pass (fmt, clippy, no-secrets)
- [ ] CI passes

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)