### PR TITLE
feat: add calibration rules for issue number verification and UUID hygiene

### DIFF
--- a/docs/plans/2026-04-20-010-feat-calibration-rule-verify-issue-number-plan.md
+++ b/docs/plans/2026-04-20-010-feat-calibration-rule-verify-issue-number-plan.md
@@ -1,0 +1,40 @@
+# Plan: Add calibration rules for issue number verification and task UUID hygiene
+
+**Issue:** mika#684
+**Date:** 2026-04-20
+**Type:** Enhancement (prompt change only)
+
+## Problem
+
+Two fabrication patterns observed on 2026-04-20:
+1. mika-dev said "mika#675 complete" when she meant mika#682 — confused related issue numbers from memory
+2. mika-dev tried `check_task` with a memorized UUID that had drifted — the real task ID was different
+
+Both are the same class: trusting memorized references instead of verifying against live data.
+
+## Solution
+
+Add two new calibration rules to `skills/bundled/self-dev/system_prompt.md`:
+
+### Rule 10 — Verify issue numbers before completion claims
+
+Never cite an issue number from memory when reporting completion. Cross-reference against the active task's label or `check_task` output. Related issues with similar numbers (e.g., #675 vs #682) are a known confusion source.
+
+**Incident:** 2026-04-20 — reported "mika#675 complete" when the completed issue was mika#682.
+
+### Rule 11 — Never memorize task UUIDs
+
+Never store task UUIDs in core memory. Store the issue reference (e.g. mika#677). Look up the UUID fresh from `list_tasks` every time you need it. UUIDs drift across sessions and compaction.
+
+**Incident:** 2026-04-20 — `check_task` failed with wrong UUID. Engine dedup guard prevented duplicate task creation.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `skills/bundled/self-dev/system_prompt.md` | Add Rule 10 and Rule 11 after Rule 9 in Calibration Rules section |
+
+## Risks
+
+- None — prompt-only change, no code impact
+- Rules are additive (new numbered rules after existing Rule 9)

--- a/docs/solutions/684-calibration-rules-verify-issue-number-uuid-hygiene.md
+++ b/docs/solutions/684-calibration-rules-verify-issue-number-uuid-hygiene.md
@@ -1,0 +1,51 @@
+---
+module: skills/bundled/self-dev
+tags: [calibration-rules, fabrication, prompt-engineering, issue-numbers, uuid]
+problem_type: prompt-enforcement
+date: 2026-04-20
+issue: 684
+---
+
+# Calibration Rules: Verify Issue Numbers and UUID Hygiene
+
+## Problem
+
+Two fabrication patterns observed in the same session (2026-04-20):
+
+1. **Wrong issue number in completion claim:** Agent said "mika#675 complete" when the completed issue was mika#682. Similar numbers confused the agent when relying on memory.
+
+2. **Stale task UUID:** Agent tried `check_task` with a memorized UUID that had drifted — first 8 chars correct, remaining suffix fabricated. The engine's dedup guard caught the mismatch.
+
+Both are the same failure class: trusting memorized references instead of verifying against live tool output.
+
+## Root Cause
+
+LLM agents are prone to "memory fabrication" — recalling approximate values that look plausible but are incorrect. This is especially dangerous for:
+- Issue numbers that differ by small amounts (#675 vs #682)
+- UUIDs where the prefix is memorable but the full 36-char value drifts
+
+## Solution
+
+Added two calibration rules to `skills/bundled/self-dev/system_prompt.md`:
+
+**Rule 10 — Verify issue numbers before completion claims**
+- Never cite issue numbers from memory in completion messages
+- Must call `list_tasks` + `check_task` and extract `reference_url`/`label` to confirm
+- Cross-references Rule 8 (PR numbers) and Rule 11 (UUID lookup)
+
+**Rule 11 — Never memorize task UUIDs**
+- Store human-readable issue references (e.g., `mika#677`) in core memory, never UUIDs
+- Look up UUIDs fresh from `list_tasks` filtered by `reference_url` every time
+- UUIDs drift across sessions and compaction
+
+## Pattern
+
+This follows the established calibration rule pattern:
+1. Observe a specific failure in production
+2. Document the incident with exact details (date, wrong value, correct value)
+3. Add a numbered rule with clear verification steps
+4. Cross-reference related rules to form a coherent verification discipline
+
+## Key Insight
+
+Calibration rules work best when they prescribe a **verification action** (call tool X, check field Y) rather than just saying "don't do Z." The agent needs a concrete alternative behavior, not just a prohibition.

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -333,6 +333,22 @@ The engine enforces a hard limit of one `run_claude_pilot` dispatch per turn and
 
 **Incident:** mika#583 on 2026-04-15 — `pull_request_review.submitted` webhook arrived, no webhook-specific skill activated. Agent followed generic Workflow, scanned backlog via `list_tasks`, dispatched claude-pilot on unrelated issues #571 and #572.
 
+### Rule 10 — Verify issue numbers before completion claims
+
+Never cite an issue number from memory when reporting completion. Cross-reference against the active task's label or `check_task` output before including any issue number in a completion claim, status notification, or close-out message. Related issues with similar numbers (e.g., #675 vs #682) are a known confusion source — the wrong number can cause incorrect task transitions and confuse Vincent.
+
+**Required verification:** Before any message containing "{repo}#{number} complete" or similar, call `check_task(task_id)` and extract the `reference_url` or `label` to confirm the issue number. If the number in your draft message does not match the tool output, use the tool output.
+
+**Incident:** 2026-04-20 — reported "mika#675 complete" when the completed issue was mika#682. The agent relied on a memorized issue number instead of checking the active task.
+
+### Rule 11 — Never memorize task UUIDs
+
+Never store task UUIDs in core memory. UUIDs drift across sessions and compaction — a UUID that was correct 3 turns ago may have the right prefix but a fabricated suffix now.
+
+**Instead:** Store the human-readable issue reference (e.g., `mika#677`) in core memory. Look up the UUID fresh from `list_tasks` every time you need it. Filter by `reference_url` to find the correct task.
+
+**Incident:** 2026-04-20 — `check_task` failed with UUID `12e27a78-08dd-43d7-833a-9f9c6c4215cc` but the real task ID was `12e27a78-155c-40e0-8af2-ca74a3021553`. The first 8 characters matched but the rest was fabricated from stale memory. The engine's dedup guard caught it on `create_task`, but the lookup failed silently.
+
 ---
 
 ## Milestone Workflow

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -337,7 +337,7 @@ The engine enforces a hard limit of one `run_claude_pilot` dispatch per turn and
 
 Never cite an issue number from memory when reporting completion. Cross-reference against the active task's label or `check_task` output before including any issue number in a completion claim, status notification, or close-out message. Related issues with similar numbers (e.g., #675 vs #682) are a known confusion source — the wrong number can cause incorrect task transitions and confuse Vincent.
 
-**Required verification:** Before any message containing "{repo}#{number} complete" or similar, call `check_task(task_id)` and extract the `reference_url` or `label` to confirm the issue number. If the number in your draft message does not match the tool output, use the tool output.
+**Required verification:** Before any message containing "{repo}#{number} complete" or similar, look up the task via `list_tasks` (see Rule 11), then call `check_task(task_id)` with the fresh UUID and extract the `reference_url` or `label` to confirm the issue number. If the number in your draft message does not match the tool output, use the tool output. This complements Rule 8 (PR numbers) — Rule 8 covers PR number fabrication; this rule covers issue number confusion in completion claims.
 
 **Incident:** 2026-04-20 — reported "mika#675 complete" when the completed issue was mika#682. The agent relied on a memorized issue number instead of checking the active task.
 


### PR DESCRIPTION
## Summary

- Add **Rule 10** (verify issue numbers before completion claims) to self-dev calibration rules — prevents citing wrong issue numbers from memory
- Add **Rule 11** (never memorize task UUIDs) — prevents stale UUID drift across sessions and compaction
- Both rules prescribe concrete verification actions (call `list_tasks` + `check_task`) rather than just prohibitions

Closes #684

## Test plan

- [ ] Verify `cargo build -p mika-agent` succeeds (bundled skill discovery)
- [ ] Review prompt text for clarity and consistency with existing Rules 4–9
- [ ] Post-merge: remove corresponding entries from mika-dev's fact store (stored UUIDs, issue number preferences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)