### PR TITLE
feat(gateway): dead-letter queue + replay CLI for exhausted webhook retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # Used by `mika dashboard start/stop/status` to reach the running server.
 # MIKA_SERVER_URL=http://localhost:8080
 
+# Optional: mika-gateway URL for CLI webhook DLQ commands (default: http://localhost:3001)
+# Used by `mika webhook list-dead/replay/replay-all` to reach the running gateway.
+# MIKA_GATEWAY_URL=http://localhost:3001
+
 # Optional: Enable embedded dashboard SPA at /dashboard/ (default: false)
 # When enabled, the pre-built React dashboard is served from the binary.
 # Can be toggled at runtime via `mika dashboard start/stop` or the API.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Optional (telemetry — requires `--features telemetry` build):
 
 Optional (CLI -> server communication):
 - `MIKA_SERVER_URL` — mika-server base URL for CLI dashboard commands (default: `http://localhost:8080`)
+- `MIKA_GATEWAY_URL` — mika-gateway base URL for CLI webhook DLQ commands (default: `http://localhost:3001`)
 
 Optional (dashboard): See `dashboard/CLAUDE.md`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "chrono",
  "config",
  "dotenvy",
  "hex",

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -537,6 +537,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 
 \* Set the API key for the active provider. E.g., `MIKA_ANTHROPIC_API_KEY` for Anthropic, `MIKA_GROQ_API_KEY` for Groq. Ollama does not require an API key.
 | `MIKA_SERVER_URL` | No | mika-server URL for dashboard CLI commands (default: `http://localhost:8080`) |
+| `MIKA_GATEWAY_URL` | No | mika-gateway URL for webhook DLQ CLI commands (default: `http://localhost:3001`) |
 | `MIKA_TELEMETRY_ENABLED` | No | Enable OTel trace export (requires `--features telemetry` build) |
 | `MIKA_OTLP_ENDPOINT` | No | OTLP endpoint URL with `/v1/traces` path (required when telemetry enabled) |
 | `MIKA_OTLP_AUTH_HEADER` | No | OTLP auth header value (e.g. Base64-encoded Langfuse credentials) |

--- a/crates/mika-cli/CLAUDE.md
+++ b/crates/mika-cli/CLAUDE.md
@@ -4,7 +4,7 @@ TUI CLI binary (`mika`): ratatui chat interface with clap subcommands.
 
 ## Subcommands
 
-`status`, `memory`, `reminders`, `config`, `setup`, `mcp`, `skills`, `tasks`, `ask`, `doctor`, `dashboard`, `token`, `credential-helper`, `provider`, `model`, `agents`, `teams`.
+`status`, `memory`, `reminders`, `config`, `setup`, `mcp`, `skills`, `tasks`, `ask`, `doctor`, `dashboard`, `token`, `credential-helper`, `provider`, `model`, `agents`, `teams`, `webhook`.
 
 ### Key Commands
 
@@ -44,7 +44,15 @@ Scoped flags: `--agent <name>` (override active agent, most subcommands), `--tea
 
 ## Other `--format text|json` Commands
 
-`agents validate`, `teams list`, `teams status`, `teams validate`, `skills list`, `skills validate`, `status`, `config list`, `memory search`, `provider`, `model`.
+`agents validate`, `teams list`, `teams status`, `teams validate`, `skills list`, `skills validate`, `status`, `config list`, `memory search`, `provider`, `model`, `webhook list-dead`, `webhook replay`, `webhook replay-all`.
+
+## Webhook CLI
+
+`mika webhook list-dead` — list DLQ entries (pending + dead). Optional `--status` filter, `--limit` cap.
+`mika webhook replay <delivery_id>` — replay a single dead entry.
+`mika webhook replay-all` — replay all dead entries.
+
+Requires `MIKA_GATEWAY_URL` (default: `http://localhost:3001`) and `MIKA_INTERNAL_TOKEN` for gateway auth.
 
 ## Skills CLI
 

--- a/crates/mika-cli/src/cli.rs
+++ b/crates/mika-cli/src/cli.rs
@@ -71,6 +71,8 @@ pub enum Commands {
     Provider(ProviderArgs),
     /// List or switch LLM models
     Model(ModelArgs),
+    /// Manage gateway webhook dead-letter queue
+    Webhook(WebhookArgs),
     /// Git credential helper (used by git, not directly by users)
     #[command(name = "credential-helper")]
     CredentialHelper(CredentialHelperArgs),
@@ -99,6 +101,7 @@ impl Commands {
             | Commands::Teams(_)
             | Commands::Dashboard(_)
             | Commands::Token(_)
+            | Commands::Webhook(_)
             | Commands::CredentialHelper(_) => None,
         }
     }
@@ -124,6 +127,7 @@ impl Commands {
             | Commands::Token(_)
             | Commands::Provider(_)
             | Commands::Model(_)
+            | Commands::Webhook(_)
             | Commands::CredentialHelper(_) => None,
         }
     }
@@ -727,4 +731,36 @@ pub fn resolve_model_alias(input: &str) -> String {
         }
     }
     input.to_string()
+}
+
+#[derive(clap::Args)]
+pub struct WebhookArgs {
+    /// Output format: text (default) or json
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: OutputFormat,
+
+    #[command(subcommand)]
+    pub command: WebhookCommand,
+}
+
+#[derive(Subcommand)]
+pub enum WebhookCommand {
+    /// List dead-letter queue entries (pending + dead)
+    #[command(name = "list-dead")]
+    ListDead {
+        /// Filter by status: "pending" or "dead" (omit for both)
+        #[arg(long)]
+        status: Option<String>,
+        /// Maximum entries to return (default 100)
+        #[arg(long)]
+        limit: Option<i64>,
+    },
+    /// Replay a single DLQ entry by delivery ID
+    Replay {
+        /// The delivery ID to replay
+        delivery_id: String,
+    },
+    /// Replay all dead DLQ entries
+    #[command(name = "replay-all")]
+    ReplayAll,
 }

--- a/crates/mika-cli/src/commands/mod.rs
+++ b/crates/mika-cli/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod status;
 pub mod tasks;
 pub mod teams;
 pub mod token;
+pub mod webhook;

--- a/crates/mika-cli/src/commands/webhook.rs
+++ b/crates/mika-cli/src/commands/webhook.rs
@@ -1,0 +1,229 @@
+use anyhow::{Context, Result};
+
+use crate::cli::{OutputFormat, WebhookCommand};
+
+/// Run the webhook subcommand.
+pub async fn run(command: WebhookCommand, format: &OutputFormat) -> Result<()> {
+    match command {
+        WebhookCommand::ListDead { status, limit } => list_dead(status, limit, format).await,
+        WebhookCommand::Replay { delivery_id } => replay(&delivery_id, format).await,
+        WebhookCommand::ReplayAll => replay_all(format).await,
+    }
+}
+
+/// Resolve the gateway base URL from env or default.
+fn gateway_url() -> String {
+    if let Ok(url) = std::env::var("MIKA_GATEWAY_URL") {
+        return url;
+    }
+    // Load dotenv so env vars from ~/.mika/.env are available
+    if let Ok(home) = mika_common::home::resolve_home_dir() {
+        mika_common::dotenv::load_dotenv(&home);
+    }
+    std::env::var("MIKA_GATEWAY_URL").unwrap_or_else(|_| "http://localhost:3001".to_string())
+}
+
+/// Read the internal token for gateway auth.
+fn auth_token() -> Result<String> {
+    if let Ok(home) = mika_common::home::resolve_home_dir() {
+        mika_common::dotenv::load_dotenv(&home);
+    }
+    std::env::var("MIKA_INTERNAL_TOKEN")
+        .context("MIKA_INTERNAL_TOKEN is required to communicate with the gateway")
+}
+
+/// Build a reqwest client for gateway API calls.
+fn build_client(token: &str) -> reqwest::Client {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+            .expect("valid header value"),
+    );
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+/// List dead-letter queue entries.
+#[allow(clippy::print_literal)]
+async fn list_dead(
+    status: Option<String>,
+    limit: Option<i64>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let base = gateway_url();
+    let token = auth_token()?;
+    let client = build_client(&token);
+
+    let mut url = format!("{base}/webhook/dlq");
+    let mut params = Vec::new();
+    if let Some(ref s) = status {
+        params.push(format!("status={s}"));
+    }
+    if let Some(l) = limit {
+        params.push(format!("limit={l}"));
+    }
+    if !params.is_empty() {
+        url.push('?');
+        url.push_str(&params.join("&"));
+    }
+
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .context("failed to connect to gateway — is it running?")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "gateway returned HTTP {} for DLQ list",
+            resp.status().as_u16()
+        );
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        OutputFormat::Text => {
+            let deliveries = body["deliveries"].as_array();
+            let count = deliveries.map(|d| d.len()).unwrap_or(0);
+
+            if count == 0 {
+                println!("No DLQ entries found.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<38} {:<16} {:<12} {:<8} {:<20} {}",
+                "DELIVERY ID", "EVENT TYPE", "AGENT", "ATTEMPTS", "CREATED", "LAST ERROR"
+            );
+            println!("{}", "-".repeat(120));
+
+            for entry in deliveries.unwrap() {
+                let id = entry["delivery_id"].as_str().unwrap_or("-");
+                let event = entry["event_type"].as_str().unwrap_or("-");
+                let agent = entry["target_agent"].as_str().unwrap_or("-");
+                let attempts = entry["attempts"].as_i64().unwrap_or(0);
+                let created = entry["created_at"]
+                    .as_str()
+                    .unwrap_or("-")
+                    .chars()
+                    .take(19)
+                    .collect::<String>();
+                let error = entry["last_error"]
+                    .as_str()
+                    .unwrap_or("")
+                    .chars()
+                    .take(40)
+                    .collect::<String>();
+
+                println!(
+                    "{:<38} {:<16} {:<12} {:<8} {:<20} {}",
+                    id, event, agent, attempts, created, error
+                );
+            }
+
+            println!("\n{count} entries total");
+        }
+    }
+
+    Ok(())
+}
+
+/// Replay a single DLQ entry.
+async fn replay(delivery_id: &str, format: &OutputFormat) -> Result<()> {
+    let base = gateway_url();
+    let token = auth_token()?;
+    let client = build_client(&token);
+
+    let url = format!("{base}/webhook/dlq/{delivery_id}/replay");
+    let resp = client
+        .post(&url)
+        .send()
+        .await
+        .context("failed to connect to gateway — is it running?")?;
+
+    if resp.status().as_u16() == 404 {
+        anyhow::bail!("delivery '{delivery_id}' not found in DLQ");
+    }
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "gateway returned HTTP {} for DLQ replay",
+            resp.status().as_u16()
+        );
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        OutputFormat::Text => {
+            let status = body["delivery"]["status"].as_str().unwrap_or("unknown");
+            if status == "delivered" {
+                println!("Replay succeeded — delivery '{delivery_id}' is now 'delivered'.");
+            } else {
+                let error = body["delivery"]["last_error"]
+                    .as_str()
+                    .unwrap_or("unknown error");
+                println!(
+                    "Replay attempted — delivery '{delivery_id}' status: {status} (error: {error})"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Replay all dead DLQ entries.
+async fn replay_all(format: &OutputFormat) -> Result<()> {
+    let base = gateway_url();
+    let token = auth_token()?;
+    let client = build_client(&token);
+
+    let url = format!("{base}/webhook/dlq/replay-all");
+    let resp = client
+        .post(&url)
+        .send()
+        .await
+        .context("failed to connect to gateway — is it running?")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "gateway returned HTTP {} for DLQ replay-all",
+            resp.status().as_u16()
+        );
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        OutputFormat::Text => {
+            let succeeded = body["succeeded"].as_u64().unwrap_or(0);
+            let failed = body["failed"].as_u64().unwrap_or(0);
+            let total = body["total"].as_u64().unwrap_or(0);
+
+            if total == 0 {
+                println!("No dead entries to replay.");
+            } else {
+                println!(
+                    "Replay complete: {succeeded} succeeded, {failed} failed ({total} total)."
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/mika-cli/src/main.rs
+++ b/crates/mika-cli/src/main.rs
@@ -272,6 +272,7 @@ async fn main() -> Result<()> {
         Some(Commands::Dashboard(args)) => commands::dashboard::run(args.command).await,
         Some(Commands::Provider(args)) => commands::provider::run(args, &agent_name).await,
         Some(Commands::Model(args)) => commands::model::run(args, &agent_name).await,
+        Some(Commands::Webhook(args)) => commands::webhook::run(args.command, &args.format).await,
         // Handled by early-exit above — unreachable, but listed for exhaustive match.
         Some(Commands::Token(_) | Commands::CredentialHelper(_)) => unreachable!(),
     }

--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -11,6 +11,9 @@ Telegram and GitHub webhook router with Postgres customer registry. Handles text
 | `/send` | POST | Internal token | Outbound relay with `agent_name` identification |
 | `/health`, `/readyz`, `/livez` | GET | None | Health probes |
 | `/version` | GET | None | Returns `{"version":"<semver>","git_hash":"<short-hash>"}` |
+| `/webhook/dlq` | GET | Internal token | List DLQ entries (pending + dead) |
+| `/webhook/dlq/{delivery_id}/replay` | POST | Internal token | Replay a single DLQ entry |
+| `/webhook/dlq/replay-all` | POST | Internal token | Replay all dead DLQ entries |
 | `/a2a/{customer_id}/{agent_name}` | POST | API key | A2A protocol proxy (2MB limit) |
 | `/a2a/{customer_id}/{agent_name}/agent.json` | GET | None | Agent Card proxy |
 
@@ -29,7 +32,13 @@ The spawned forwarding task retries on HTTP 429/5xx or request timeouts using th
 
 Semaphore lifecycle during retry: the 30-permit `webhook_semaphore` (shared with Telegram) is released during each retry sleep and re-acquired via `try_acquire_owned` before the next attempt. If the semaphore is full on re-acquire, the retry is abandoned with a dedicated ERROR log (`semaphore at capacity during retry`), distinct from the `retry budget exhausted` ERROR emitted when all 6 attempts return a retryable failure.
 
-The delivery LRU cache has no TTL (size-based eviction only). Under extreme webhook volume (>10k deliveries during a single 300s retry sleep), the `X-GitHub-Delivery` entry may be evicted and a GitHub redelivery would bypass gateway dedup. Agent-side idempotency (task unique index on `reference_url`) mitigates double-processing. Events that exhaust retries or are abandoned due to semaphore pressure are dropped with ERROR logs; persistent DLQ + replay CLI is tracked in #590.
+The delivery LRU cache has no TTL (size-based eviction only). Under extreme webhook volume (>10k deliveries during a single 300s retry sleep), the `X-GitHub-Delivery` entry may be evicted and a GitHub redelivery would bypass gateway dedup. Agent-side idempotency (task unique index on `reference_url`) mitigates double-processing.
+
+### Dead-letter queue (#590)
+
+Events that exhaust the retry budget or are abandoned due to semaphore pressure are persisted in the `webhook_deliveries` Postgres table (migration 006) with `status='pending'`. A background tokio task wakes every 30s, selects pending rows past their exponential backoff window (`30s * 2^attempts`, capped at 1h), and re-attempts delivery via the same `forward_to_resolved_route()` path. Route is re-resolved on each worker attempt (container URLs may change). After 10 worker attempts, status transitions to `'dead'`.
+
+The DLQ respects the shared 30-permit webhook semaphore — if all permits are held, the worker skips forwarding for that tick. Manual replay via `POST /webhook/dlq/{id}/replay` and `POST /webhook/dlq/replay-all` follows the same semaphore-gated delivery path. CLI: `mika webhook list-dead`, `mika webhook replay <id>`, `mika webhook replay-all`.
 
 ## Agent Identification & Reply Routing
 
@@ -51,6 +60,7 @@ API keys are SHA-256 hashed and stored in Postgres `a2a_api_keys` table (migrati
 - Migration 003: creates `a2a_api_keys` table
 - Migration 004: creates `github_repos` table (maps `repo_full_name` -> `customer_id` for multi-tenant GitHub webhook routing)
 - Migration 005: adds `agent_mapping JSONB NOT NULL DEFAULT '{}'` to `github_repos` for per-repo agent name overrides (keys are default agent names from `route_event()`, values are customer's replacement names; `apply_agent_mapping()` validates names via `is_valid_agent_name()` and falls back to defaults for invalid values)
+- Migration 006: creates `webhook_deliveries` table for dead-letter queue (delivery_id PK, event_type, target_agent, repo_full_name, payload, request_id, status CHECK IN pending/delivered/dead, attempts, last_attempt_at, last_error). Partial indexes on `(status, last_attempt_at) WHERE status='pending'` and `(created_at DESC) WHERE status='dead'`.
 
 ## build.rs
 

--- a/crates/mika-gateway/Cargo.toml
+++ b/crates/mika-gateway/Cargo.toml
@@ -38,6 +38,7 @@ hmac.workspace = true
 hex.workspace = true
 lru.workspace = true
 rand = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/crates/mika-gateway/migrations/006_webhook_deliveries.sql
+++ b/crates/mika-gateway/migrations/006_webhook_deliveries.sql
@@ -1,0 +1,26 @@
+-- Dead-letter queue for GitHub webhook deliveries that exhausted retries.
+-- Tracks delivery attempts and allows manual/automatic replay.
+CREATE TABLE webhook_deliveries (
+    delivery_id     TEXT PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    target_agent    TEXT NOT NULL,
+    repo_full_name  TEXT,
+    payload         TEXT NOT NULL,
+    request_id      TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'delivered', 'dead')),
+    last_error      TEXT
+);
+
+-- Index for background worker: find pending entries eligible for retry.
+CREATE INDEX idx_webhook_deliveries_pending
+    ON webhook_deliveries (status, last_attempt_at)
+    WHERE status = 'pending';
+
+-- Index for CLI: list dead entries.
+CREATE INDEX idx_webhook_deliveries_dead
+    ON webhook_deliveries (created_at DESC)
+    WHERE status = 'dead';

--- a/crates/mika-gateway/src/dlq.rs
+++ b/crates/mika-gateway/src/dlq.rs
@@ -1,0 +1,478 @@
+//! Dead-letter queue (DLQ) for GitHub webhook deliveries that exhaust retries.
+//!
+//! Provides persistence, background retry, and HTTP endpoints for operator
+//! inspection and manual replay. See issue #590.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::PgPool;
+use tracing::{error, info, warn};
+
+use crate::github::{self, ForwardResult};
+use crate::routes::AppState;
+
+// -- Types --
+
+/// Status of a webhook delivery in the DLQ.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[allow(dead_code)]
+pub(crate) enum DeliveryStatus {
+    Pending,
+    Delivered,
+    Dead,
+}
+
+impl std::fmt::Display for DeliveryStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Delivered => write!(f, "delivered"),
+            Self::Dead => write!(f, "dead"),
+        }
+    }
+}
+
+/// A webhook delivery row from the `webhook_deliveries` table.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+pub(crate) struct WebhookDelivery {
+    pub delivery_id: String,
+    pub event_type: String,
+    pub target_agent: String,
+    pub repo_full_name: Option<String>,
+    pub payload: String,
+    pub request_id: String,
+    pub created_at: DateTime<Utc>,
+    pub attempts: i32,
+    pub last_attempt_at: Option<DateTime<Utc>>,
+    pub status: String,
+    pub last_error: Option<String>,
+}
+
+/// Parameters for inserting a new DLQ entry.
+pub(crate) struct NewDelivery<'a> {
+    pub delivery_id: &'a str,
+    pub event_type: &'a str,
+    pub target_agent: &'a str,
+    pub repo_full_name: Option<&'a str>,
+    pub payload: &'a str,
+    pub request_id: &'a str,
+    pub attempts: i32,
+    pub last_error: &'a str,
+}
+
+// -- Write path --
+
+/// Insert a failed delivery into the DLQ. Fire-and-forget: logs errors but
+/// never propagates them to the caller.
+pub(crate) async fn insert_delivery(pool: &PgPool, delivery: NewDelivery<'_>) {
+    let result = sqlx::query(
+        r#"
+        INSERT INTO webhook_deliveries
+            (delivery_id, event_type, target_agent, repo_full_name, payload, request_id, attempts, last_error, status)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
+        ON CONFLICT (delivery_id) DO NOTHING
+        "#,
+    )
+    .bind(delivery.delivery_id)
+    .bind(delivery.event_type)
+    .bind(delivery.target_agent)
+    .bind(delivery.repo_full_name)
+    .bind(delivery.payload)
+    .bind(delivery.request_id)
+    .bind(delivery.attempts)
+    .bind(delivery.last_error)
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(_) => {
+            info!(
+                delivery_id = delivery.delivery_id,
+                target_agent = delivery.target_agent,
+                attempts = delivery.attempts,
+                "webhook delivery added to DLQ"
+            );
+        }
+        Err(e) => {
+            error!(
+                delivery_id = delivery.delivery_id,
+                error = %e,
+                "failed to insert webhook delivery into DLQ"
+            );
+        }
+    }
+}
+
+// -- Background worker --
+
+/// Maximum number of worker retry attempts before marking a delivery as dead.
+const MAX_WORKER_ATTEMPTS: i32 = 10;
+
+/// How often the worker wakes to check for pending deliveries.
+const WORKER_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Maximum deliveries to process per worker tick.
+const WORKER_BATCH_SIZE: i64 = 50;
+
+/// Run the DLQ background worker. Wakes every 30s, retries pending deliveries
+/// that are past their backoff window, and transitions them to delivered or dead.
+///
+/// This function runs forever — spawn it as a tokio task.
+pub(crate) async fn run_dlq_worker(state: AppState) {
+    info!("DLQ background worker started");
+    loop {
+        tokio::time::sleep(WORKER_INTERVAL).await;
+        if let Err(e) = process_pending_deliveries(&state).await {
+            error!(error = %e, "DLQ worker tick failed");
+        }
+    }
+}
+
+/// Process one batch of pending deliveries. Exposed for testing.
+async fn process_pending_deliveries(state: &AppState) -> anyhow::Result<()> {
+    // Select pending rows whose backoff window has elapsed.
+    // Backoff formula: 30s * 2^attempts (capped at 1 hour).
+    let rows = sqlx::query_as::<_, WebhookDelivery>(
+        r#"
+        SELECT *
+        FROM webhook_deliveries
+        WHERE status = 'pending'
+          AND (
+            last_attempt_at IS NULL
+            OR last_attempt_at < now() - (LEAST(30 * power(2, attempts), 3600) || ' seconds')::interval
+          )
+        ORDER BY created_at ASC
+        LIMIT $1
+        "#,
+    )
+    .bind(WORKER_BATCH_SIZE)
+    .fetch_all(&state.pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        count = rows.len(),
+        "DLQ worker processing pending deliveries"
+    );
+
+    for row in rows {
+        process_single_delivery(state, &row).await;
+    }
+
+    Ok(())
+}
+
+/// Process a single DLQ entry: resolve route, attempt delivery, update status.
+async fn process_single_delivery(state: &AppState, delivery: &WebhookDelivery) {
+    // Respect semaphore backpressure
+    let permit = match state.webhook_semaphore.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            warn!(
+                delivery_id = %delivery.delivery_id,
+                "DLQ worker skipping delivery — semaphore at capacity"
+            );
+            return;
+        }
+    };
+
+    // Re-resolve route (container may have moved since original failure)
+    let route =
+        match github::resolve_github_container_url(state, delivery.repo_full_name.as_deref()).await
+        {
+            Some(r) => r,
+            None => {
+                let error_msg = "route resolution failed (no repo mapping or fallback)";
+                update_delivery_failure(
+                    &state.pool,
+                    &delivery.delivery_id,
+                    delivery.attempts,
+                    error_msg,
+                )
+                .await;
+                return;
+            }
+        };
+
+    // Attempt delivery
+    let result = github::forward_to_resolved_route(
+        state,
+        &route,
+        &delivery.target_agent,
+        &delivery.payload,
+        &delivery.request_id,
+        delivery.repo_full_name.as_deref(),
+    )
+    .await;
+
+    // Release permit after attempt
+    drop(permit);
+
+    match result {
+        ForwardResult::Success => {
+            mark_delivered(&state.pool, &delivery.delivery_id).await;
+            info!(
+                delivery_id = %delivery.delivery_id,
+                target_agent = %delivery.target_agent,
+                "DLQ delivery succeeded"
+            );
+        }
+        ForwardResult::Retryable { reason } | ForwardResult::Permanent { reason } => {
+            update_delivery_failure(
+                &state.pool,
+                &delivery.delivery_id,
+                delivery.attempts,
+                &reason,
+            )
+            .await;
+        }
+    }
+}
+
+/// Mark a delivery as successfully delivered.
+async fn mark_delivered(pool: &PgPool, delivery_id: &str) {
+    if let Err(e) = sqlx::query(
+        "UPDATE webhook_deliveries SET status = 'delivered', last_attempt_at = now() WHERE delivery_id = $1",
+    )
+    .bind(delivery_id)
+    .execute(pool)
+    .await
+    {
+        error!(delivery_id, error = %e, "failed to mark DLQ delivery as delivered");
+    }
+}
+
+/// Increment attempts and record the failure. Transitions to 'dead' if max attempts reached.
+async fn update_delivery_failure(
+    pool: &PgPool,
+    delivery_id: &str,
+    current_attempts: i32,
+    error_msg: &str,
+) {
+    let new_attempts = current_attempts + 1;
+    let new_status = if new_attempts >= MAX_WORKER_ATTEMPTS {
+        "dead"
+    } else {
+        "pending"
+    };
+
+    if new_status == "dead" {
+        warn!(
+            delivery_id,
+            attempts = new_attempts,
+            "DLQ delivery exhausted worker retry budget, marking dead"
+        );
+    }
+
+    if let Err(e) = sqlx::query(
+        r#"
+        UPDATE webhook_deliveries
+        SET attempts = $1, last_attempt_at = now(), last_error = $2, status = $3
+        WHERE delivery_id = $4
+        "#,
+    )
+    .bind(new_attempts)
+    .bind(error_msg)
+    .bind(new_status)
+    .bind(delivery_id)
+    .execute(pool)
+    .await
+    {
+        error!(delivery_id, error = %e, "failed to update DLQ delivery failure");
+    }
+}
+
+// -- Query/Replay (HTTP endpoint helpers) --
+
+/// List deliveries by status. If status is None, returns both pending and dead.
+pub(crate) async fn list_deliveries(
+    pool: &PgPool,
+    status_filter: Option<&str>,
+    limit: i64,
+) -> anyhow::Result<Vec<WebhookDelivery>> {
+    let rows = match status_filter {
+        Some(status) => {
+            sqlx::query_as::<_, WebhookDelivery>(
+                "SELECT * FROM webhook_deliveries WHERE status = $1 ORDER BY created_at DESC LIMIT $2",
+            )
+            .bind(status)
+            .bind(limit)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_as::<_, WebhookDelivery>(
+                "SELECT * FROM webhook_deliveries WHERE status IN ('pending', 'dead') ORDER BY created_at DESC LIMIT $1",
+            )
+            .bind(limit)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+    Ok(rows)
+}
+
+/// Replay a single delivery by ID. Returns the updated delivery or None if not found.
+pub(crate) async fn replay_delivery(
+    state: &AppState,
+    delivery_id: &str,
+) -> anyhow::Result<Option<WebhookDelivery>> {
+    // Fetch the delivery
+    let delivery = sqlx::query_as::<_, WebhookDelivery>(
+        "SELECT * FROM webhook_deliveries WHERE delivery_id = $1",
+    )
+    .bind(delivery_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let delivery = match delivery {
+        Some(d) => d,
+        None => return Ok(None),
+    };
+
+    // Attempt replay
+    replay_single(state, &delivery).await;
+
+    // Return updated row
+    let updated = sqlx::query_as::<_, WebhookDelivery>(
+        "SELECT * FROM webhook_deliveries WHERE delivery_id = $1",
+    )
+    .bind(delivery_id)
+    .fetch_optional(&state.pool)
+    .await?;
+
+    Ok(updated)
+}
+
+/// Replay all dead deliveries. Returns (succeeded, failed) counts.
+pub(crate) async fn replay_all_dead(state: &AppState) -> anyhow::Result<(u32, u32)> {
+    let rows = sqlx::query_as::<_, WebhookDelivery>(
+        "SELECT * FROM webhook_deliveries WHERE status = 'dead' ORDER BY created_at ASC",
+    )
+    .fetch_all(&state.pool)
+    .await?;
+
+    let mut succeeded = 0u32;
+    let mut failed = 0u32;
+
+    for row in &rows {
+        replay_single(state, row).await;
+
+        // Check result
+        let updated = sqlx::query_scalar::<_, String>(
+            "SELECT status FROM webhook_deliveries WHERE delivery_id = $1",
+        )
+        .bind(&row.delivery_id)
+        .fetch_one(&state.pool)
+        .await?;
+
+        if updated == "delivered" {
+            succeeded += 1;
+        } else {
+            failed += 1;
+        }
+    }
+
+    Ok((succeeded, failed))
+}
+
+/// Replay a single delivery entry (shared by replay_delivery and replay_all_dead).
+async fn replay_single(state: &AppState, delivery: &WebhookDelivery) {
+    // Acquire semaphore permit
+    let permit = match state.webhook_semaphore.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            let error_msg = "semaphore at capacity during replay";
+            warn!(
+                delivery_id = %delivery.delivery_id,
+                "DLQ replay skipped — {error_msg}"
+            );
+            update_delivery_failure(
+                &state.pool,
+                &delivery.delivery_id,
+                delivery.attempts,
+                error_msg,
+            )
+            .await;
+            return;
+        }
+    };
+
+    // Re-resolve route
+    let route =
+        match github::resolve_github_container_url(state, delivery.repo_full_name.as_deref()).await
+        {
+            Some(r) => r,
+            None => {
+                let error_msg = "route resolution failed during replay";
+                update_delivery_failure(
+                    &state.pool,
+                    &delivery.delivery_id,
+                    delivery.attempts,
+                    error_msg,
+                )
+                .await;
+                return;
+            }
+        };
+
+    // Attempt delivery
+    let result = github::forward_to_resolved_route(
+        state,
+        &route,
+        &delivery.target_agent,
+        &delivery.payload,
+        &delivery.request_id,
+        delivery.repo_full_name.as_deref(),
+    )
+    .await;
+
+    drop(permit);
+
+    match result {
+        ForwardResult::Success => {
+            mark_delivered(&state.pool, &delivery.delivery_id).await;
+            info!(
+                delivery_id = %delivery.delivery_id,
+                "DLQ replay succeeded"
+            );
+        }
+        ForwardResult::Retryable { reason } | ForwardResult::Permanent { reason } => {
+            update_delivery_failure(
+                &state.pool,
+                &delivery.delivery_id,
+                delivery.attempts,
+                &reason,
+            )
+            .await;
+            warn!(
+                delivery_id = %delivery.delivery_id,
+                reason = %reason,
+                "DLQ replay failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delivery_status_display() {
+        assert_eq!(DeliveryStatus::Pending.to_string(), "pending");
+        assert_eq!(DeliveryStatus::Delivered.to_string(), "delivered");
+        assert_eq!(DeliveryStatus::Dead.to_string(), "dead");
+    }
+
+    #[test]
+    fn max_attempts_threshold() {
+        // Verify the constant matches the issue spec
+        assert_eq!(MAX_WORKER_ATTEMPTS, 10);
+    }
+}

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -286,9 +286,9 @@ pub fn format_event_text(event_type: &str, event: &GitHubWebhookEvent) -> String
 // -- Agent mapping --
 
 /// Result of resolving a GitHub repo to a customer container.
-struct ResolvedRoute {
-    container_url: String,
-    agent_mapping: serde_json::Value,
+pub(crate) struct ResolvedRoute {
+    pub(crate) container_url: String,
+    pub(crate) agent_mapping: serde_json::Value,
 }
 
 /// Validate that an agent name is well-formed: lowercase alphanumeric + hyphens,
@@ -554,11 +554,12 @@ pub(crate) async fn handle_github_webhook(
 
     // 12. Async dispatch with retry — return 200 to GitHub immediately.
     // Retry budget: initial attempt + up to 5 retries with backoff [2s, 5s, 15s, 60s, 300s].
-    // DLQ for events that exhaust retries is tracked in #590.
+    // Events that exhaust retries are persisted in the DLQ (#590).
     let forwarding_state = state.clone();
     let target = target_agent.to_string();
     let repo_name = event.repository.as_ref().and_then(|r| r.full_name.clone());
     let semaphore = state.webhook_semaphore.clone();
+    let event_type_owned = event_type.to_string();
     tokio::spawn(async move {
         deliver_with_retry(
             &forwarding_state,
@@ -566,6 +567,7 @@ pub(crate) async fn handle_github_webhook(
             &text,
             &request_id,
             repo_name.as_deref(),
+            &event_type_owned,
             permit,
             &semaphore,
         )
@@ -578,7 +580,7 @@ pub(crate) async fn handle_github_webhook(
 /// Resolve the container URL and agent mapping for a GitHub webhook event by
 /// looking up the repository's full_name in the `github_repos` table. Falls back
 /// to `agent_base_url` for backward compatibility with single-tenant deployments.
-async fn resolve_github_container_url(
+pub(crate) async fn resolve_github_container_url(
     state: &AppState,
     repo_full_name: Option<&str>,
 ) -> Option<ResolvedRoute> {
@@ -647,7 +649,7 @@ async fn resolve_github_container_url(
 ///
 /// Used by [`deliver_with_retry`] so the route (Postgres lookup + agent mapping)
 /// is resolved exactly once, regardless of how many retries occur.
-async fn forward_to_resolved_route(
+pub(crate) async fn forward_to_resolved_route(
     state: &AppState,
     route: &ResolvedRoute,
     default_agent: &str,
@@ -742,12 +744,14 @@ async fn forward_to_resolved_route(
 /// the same event, the gateway would treat it as new. Agent-side idempotency
 /// (task unique index) prevents duplicate processing. A TTL on the LRU
 /// cache would close this gap but is deferred (see #590 for DLQ).
+#[allow(clippy::too_many_arguments)]
 async fn deliver_with_retry(
     state: &AppState,
     target_agent: &str,
     text: &str,
     request_id: &str,
     repo_full_name: Option<&str>,
+    event_type: &str,
     initial_permit: tokio::sync::OwnedSemaphorePermit,
     semaphore: &Arc<tokio::sync::Semaphore>,
 ) {
@@ -757,6 +761,7 @@ async fn deliver_with_retry(
         text,
         request_id,
         repo_full_name,
+        event_type,
         initial_permit,
         semaphore,
         &RETRY_DELAYS,
@@ -774,6 +779,7 @@ async fn deliver_with_retry_inner(
     text: &str,
     request_id: &str,
     repo_full_name: Option<&str>,
+    event_type: &str,
     initial_permit: tokio::sync::OwnedSemaphorePermit,
     semaphore: &Arc<tokio::sync::Semaphore>,
     retry_delays: &[Duration],
@@ -818,8 +824,22 @@ async fn deliver_with_retry_inner(
                         request_id,
                         attempts_made,
                         last_reason = %last_reason,
-                        "GitHub event delivery abandoned — gateway semaphore at capacity during retry, event dropped"
+                        "GitHub event delivery abandoned — gateway semaphore at capacity during retry, persisting to DLQ"
                     );
+                    crate::dlq::insert_delivery(
+                        &state.pool,
+                        crate::dlq::NewDelivery {
+                            delivery_id: request_id,
+                            event_type,
+                            target_agent,
+                            repo_full_name,
+                            payload: text,
+                            request_id,
+                            attempts: attempts_made as i32,
+                            last_error: &last_reason,
+                        },
+                    )
+                    .await;
                     return;
                 }
             }
@@ -882,14 +902,28 @@ async fn deliver_with_retry_inner(
         }
     }
 
-    // All retries exhausted — every attempt returned Retryable.
+    // All retries exhausted — every attempt returned Retryable. Persist to DLQ.
     error!(
         target_agent,
         request_id,
         total_attempts = attempts_made,
         last_reason = %last_reason,
-        "GitHub event delivery failed — retry budget exhausted, event dropped (DLQ: #590)"
+        "GitHub event delivery failed — retry budget exhausted, persisting to DLQ"
     );
+    crate::dlq::insert_delivery(
+        &state.pool,
+        crate::dlq::NewDelivery {
+            delivery_id: request_id,
+            event_type,
+            target_agent,
+            repo_full_name,
+            payload: text,
+            request_id,
+            attempts: attempts_made as i32,
+            last_error: &last_reason,
+        },
+    )
+    .await;
 }
 
 #[cfg(test)]
@@ -1677,6 +1711,7 @@ mod tests {
             "test event",
             "delivery-1",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )
@@ -1708,6 +1743,7 @@ mod tests {
             "test event",
             "delivery-429",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )
@@ -1736,6 +1772,7 @@ mod tests {
             "test event",
             "delivery-503",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )
@@ -1762,6 +1799,7 @@ mod tests {
             "test event",
             "delivery-400",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )
@@ -1789,6 +1827,7 @@ mod tests {
             "test event",
             "delivery-404",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )
@@ -1839,6 +1878,7 @@ mod tests {
                 "test event",
                 "delivery-exhausted",
                 Some("org/repo"),
+                "issues",
                 permit,
                 &semaphore,
             ),
@@ -1919,6 +1959,7 @@ mod tests {
                 "test event",
                 "delivery-sem",
                 None,
+                "issues",
                 permit,
                 &sem_clone,
                 &TEST_DELAYS_OBSERVE_ONLY,
@@ -1964,6 +2005,7 @@ mod tests {
                 "test event",
                 "delivery-blocked",
                 None,
+                "issues",
                 permit,
                 &sem_clone,
                 &TEST_DELAYS_OBSERVE_AND_ABANDON,
@@ -2021,6 +2063,7 @@ mod tests {
             "test event",
             "delivery-202",
             Some("org/repo"),
+            "issues",
             permit,
             &semaphore,
         )

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -1224,6 +1224,7 @@ mod tests {
         // PgPool::connect_lazy creates a pool that only connects when first used.
         // Our GitHub webhook handler never touches Postgres, so this is safe.
         let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(Duration::from_millis(100))
             .connect_lazy("postgres://fake:fake@localhost/fake")
             .expect("lazy pool");
 
@@ -1332,6 +1333,7 @@ mod tests {
         let telegram =
             TelegramClient::new(http_client.clone(), SecretString::from("fake-bot-token"));
         let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(Duration::from_millis(100))
             .connect_lazy("postgres://fake:fake@localhost/fake")
             .expect("lazy pool");
         let delivery_cache = new_delivery_cache();
@@ -1679,6 +1681,7 @@ mod tests {
         let telegram =
             TelegramClient::new(http_client.clone(), SecretString::from("fake-bot-token"));
         let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(Duration::from_millis(100))
             .connect_lazy("postgres://fake:fake@localhost/fake")
             .expect("lazy pool");
 

--- a/crates/mika-gateway/src/main.rs
+++ b/crates/mika-gateway/src/main.rs
@@ -1,5 +1,6 @@
 mod a2a_auth;
 mod a2a_routes;
+pub(crate) mod dlq;
 pub mod github;
 pub mod openapi;
 mod routes;
@@ -107,6 +108,9 @@ async fn main() -> Result<()> {
         github_webhook_secret: settings.github_webhook_secret.clone(),
         github_delivery_cache: github::new_delivery_cache(),
     };
+
+    // Spawn DLQ background worker (retries pending deliveries every 30s)
+    tokio::spawn(dlq::run_dlq_worker(state.clone()));
 
     let app = build_router(state);
 

--- a/crates/mika-gateway/src/routes.rs
+++ b/crates/mika-gateway/src/routes.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use axum::{
     Json, Router,
-    extract::{Request, State},
+    extract::{Path, Query, Request, State},
     http::{self, HeaderMap, HeaderValue, StatusCode, header},
     middleware::{self, Next},
     response::{IntoResponse, Response},
@@ -152,6 +152,28 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/a2a/{customer_id}/{agent_name}/agent.json",
             get(a2a_routes::handle_a2a_agent_card),
+        )
+        // DLQ endpoints (Bearer token auth, same as /send)
+        .route(
+            "/webhook/dlq",
+            get(handle_dlq_list).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer_token,
+            )),
+        )
+        .route(
+            "/webhook/dlq/{delivery_id}/replay",
+            post(handle_dlq_replay).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer_token,
+            )),
+        )
+        .route(
+            "/webhook/dlq/replay-all",
+            post(handle_dlq_replay_all).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer_token,
+            )),
         )
         // Health probes and version (no auth)
         .route("/health", get(handle_readiness))
@@ -963,6 +985,78 @@ pub(crate) async fn handle_readiness(State(state): State<AppState>) -> StatusCod
     match sqlx::query("SELECT 1").execute(&state.pool).await {
         Ok(_) => StatusCode::OK,
         Err(_) => StatusCode::SERVICE_UNAVAILABLE,
+    }
+}
+
+// -- DLQ endpoints --
+
+/// Query parameters for DLQ list endpoint.
+#[derive(serde::Deserialize)]
+pub(crate) struct DlqListParams {
+    /// Filter by status: "pending", "dead", or omit for both.
+    pub status: Option<String>,
+    /// Max entries to return (default 100).
+    pub limit: Option<i64>,
+}
+
+/// GET /webhook/dlq — List DLQ entries (pending + dead by default).
+pub(crate) async fn handle_dlq_list(
+    State(state): State<AppState>,
+    Query(params): Query<DlqListParams>,
+) -> impl IntoResponse {
+    let limit = params.limit.unwrap_or(100).min(1000);
+    match crate::dlq::list_deliveries(&state.pool, params.status.as_deref(), limit).await {
+        Ok(rows) => Json(serde_json::json!({
+            "deliveries": rows,
+            "count": rows.len(),
+        }))
+        .into_response(),
+        Err(e) => {
+            error!(error = %e, "DLQ list query failed");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// POST /webhook/dlq/{delivery_id}/replay — Replay a single DLQ entry.
+pub(crate) async fn handle_dlq_replay(
+    State(state): State<AppState>,
+    Path(delivery_id): Path<String>,
+) -> impl IntoResponse {
+    match crate::dlq::replay_delivery(&state, &delivery_id).await {
+        Ok(Some(delivery)) => Json(serde_json::json!({
+            "delivery": delivery,
+        }))
+        .into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            error!(delivery_id = %delivery_id, error = %e, "DLQ replay failed");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// Response for the replay-all endpoint.
+#[derive(serde::Serialize)]
+struct ReplayAllResponse {
+    succeeded: u32,
+    failed: u32,
+    total: u32,
+}
+
+/// POST /webhook/dlq/replay-all — Replay all dead DLQ entries.
+pub(crate) async fn handle_dlq_replay_all(State(state): State<AppState>) -> impl IntoResponse {
+    match crate::dlq::replay_all_dead(&state).await {
+        Ok((succeeded, failed)) => Json(ReplayAllResponse {
+            succeeded,
+            failed,
+            total: succeeded + failed,
+        })
+        .into_response(),
+        Err(e) => {
+            error!(error = %e, "DLQ replay-all failed");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -537,6 +537,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 
 \* Set the API key for the active provider. E.g., `MIKA_ANTHROPIC_API_KEY` for Anthropic, `MIKA_GROQ_API_KEY` for Groq. Ollama does not require an API key.
 | `MIKA_SERVER_URL` | No | mika-server URL for dashboard CLI commands (default: `http://localhost:8080`) |
+| `MIKA_GATEWAY_URL` | No | mika-gateway URL for webhook DLQ CLI commands (default: `http://localhost:3001`) |
 | `MIKA_TELEMETRY_ENABLED` | No | Enable OTel trace export (requires `--features telemetry` build) |
 | `MIKA_OTLP_ENDPOINT` | No | OTLP endpoint URL with `/v1/traces` path (required when telemetry enabled) |
 | `MIKA_OTLP_AUTH_HEADER` | No | OTLP auth header value (e.g. Base64-encoded Langfuse credentials) |

--- a/docs/plans/2026-04-20-011-feat-gateway-dead-letter-queue-replay-cli-plan.md
+++ b/docs/plans/2026-04-20-011-feat-gateway-dead-letter-queue-replay-cli-plan.md
@@ -1,0 +1,374 @@
+---
+title: "feat: Gateway dead-letter queue + replay CLI for exhausted webhook retries"
+type: feat
+status: active
+date: 2026-04-20
+issue: 590
+---
+
+# Gateway Dead-Letter Queue + Replay CLI
+
+## Overview
+
+Add a dead-letter queue (DLQ) to the gateway for GitHub webhook events that exhaust their retry budget or are abandoned due to semaphore pressure. A background worker periodically retries pending entries, and new gateway HTTP endpoints + CLI commands allow operators to inspect and manually replay dead entries.
+
+## Problem Frame
+
+Issue #589 added retry-with-backoff to the gateway's inbound webhook delivery. This covers transient failures (short agent downtime, network blips). It does **not** cover pathological cases: agent containers down for 10+ minutes, gateway restart while retries are in-flight, or sustained backpressure exhausting the retry budget. When retries are exhausted, the event is logged as an ERROR and permanently lost. There is no recovery path.
+
+This feature adds persistence for failed deliveries, automatic background retry, and operator tooling for manual intervention.
+
+## Requirements Trace
+
+- R1. Exhausted retries persist the event in a Postgres `webhook_deliveries` table with `status='pending'`
+- R2. Background worker retries pending entries every 30s with exponential backoff per entry
+- R3. After 10 worker attempts, entries transition to `status='dead'`
+- R4. `mika webhook list-dead` shows DLQ entries (dead + pending)
+- R5. `mika webhook replay <delivery_id>` re-delivers a single dead entry
+- R6. `mika webhook replay-all` re-delivers all dead entries
+- R7. Entries survive gateway restart (Postgres-backed)
+- R8. Semaphore-abandoned events are also captured in the DLQ
+
+## Scope Boundaries
+
+- Scope is webhook delivery to agent containers only — not outbound, not Telegram
+- One table, one background task, one CLI subcommand group
+- No web UI, no metrics endpoint, no dashboard integration
+- No generic "reliable delivery framework" abstraction
+
+### Deferred to Separate Tasks
+
+- DLQ for non-webhook channels (Telegram, future channels): separate ticket if needed
+- Web UI for DLQ inspection: separate ticket
+- DLQ metrics/alerting endpoint: separate ticket
+- Cross-gateway HA / replication: out of scope
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-gateway/src/github.rs` — `deliver_with_retry_inner()` (lines 771-893) is the retry loop; `forward_to_resolved_route()` (lines 650-714) handles single delivery attempts; `resolve_github_container_url()` (lines 581-644) does Postgres route lookup
+- `crates/mika-gateway/src/routes.rs` — `AppState` struct with `pool: PgPool`, `webhook_semaphore`, `http_client`, `internal_token`
+- `crates/mika-gateway/src/main.rs` — Server startup, state construction, `shutdown_signal()`
+- `crates/mika-gateway/migrations/` — 5 existing Postgres migrations
+- `crates/mika-cli/src/cli.rs` — `Commands` enum with clap subcommands
+- `crates/mika-cli/src/commands/mod.rs` — 18 existing command modules
+- CLI commands that talk to remote services use `MIKA_SERVER_URL` (dashboard) or direct HTTP calls
+
+### Institutional Learnings
+
+- Gateway uses Postgres (not SQLite) — the issue template mentioned SQLite but the gateway's actual storage is Postgres
+- The `failed_sends` table in the agent container DB is a precedent for persisting delivery failures — this is the symmetric pattern on the gateway side
+- Route resolution is cached per-event in the retry loop — for DLQ replays, route must be re-resolved since container URLs may have changed
+
+## Key Technical Decisions
+
+- **CLI talks to gateway via HTTP, not direct Postgres access**: The CLI runs on user machines; the gateway runs in K8s. New gateway REST endpoints (`GET /webhook/dlq`, `POST /webhook/dlq/{id}/replay`, `POST /webhook/dlq/replay-all`) expose DLQ operations. CLI uses `MIKA_GATEWAY_URL` (new env var) to reach the gateway. This follows the same pattern as the dashboard CLI using `MIKA_SERVER_URL` for the agent server.
+- **Store formatted `text` + metadata, not raw GitHub body**: The DLQ stores the already-formatted message text, target agent, request ID, and repo name — the same values passed to `deliver_with_retry()`. This avoids re-parsing the raw GitHub webhook body on replay and keeps the storage compact. The raw body could be 256KB; the formatted text is typically <1KB.
+- **Replay re-resolves routes**: When replaying, the worker/CLI re-resolves the container URL via `resolve_github_container_url()` rather than caching the original URL. This handles the case where containers moved or were recreated.
+- **Background worker uses the same `forward_to_resolved_route()` path**: The worker calls the same forwarding function as the original retry loop, ensuring consistent behavior and semaphore respect.
+- **DLQ endpoints use internal token auth**: Same Bearer token auth as the `/send` endpoint, since DLQ operations are administrative.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **SQLite vs Postgres?** Postgres — the gateway already has a `PgPool` and all state is in Postgres. The issue mentioned SQLite but was written before the gateway's actual storage was finalized.
+- **How does the CLI access the DLQ?** Via HTTP endpoints on the gateway, not direct DB access. New `MIKA_GATEWAY_URL` env var.
+- **What payload to store?** The formatted text + metadata (target_agent, request_id, repo_full_name, event_type), not the raw GitHub body.
+
+### Deferred to Implementation
+
+- Exact exponential backoff formula for the background worker (likely `min(30s * 2^attempts, 1h)`)
+- Whether `replay-all` should have a batch size limit or rate limiting
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+                    GitHub Webhook
+                         │
+                    ┌────▼────┐
+                    │ handler  │── returns 200 immediately
+                    └────┬────┘
+                         │ tokio::spawn
+                    ┌────▼──────────┐
+                    │ deliver_with  │
+                    │ _retry_inner  │
+                    └───┬───────┬───┘
+                   ok   │       │ exhausted / abandoned
+                        │  ┌────▼──────────────┐
+                        │  │ INSERT INTO        │
+                        │  │ webhook_deliveries │
+                        │  │ status='pending'   │
+                        │  └────────────────────┘
+                        │           │
+                        │  ┌────────▼───────────┐
+                        │  │ Background Worker   │ ← wakes every 30s
+                        │  │ SELECT pending rows │
+                        │  │ forward each        │
+                        │  │ success → delivered  │
+                        │  │ fail → attempts++    │
+                        │  │ attempts≥10 → dead   │
+                        │  └────────────────────┘
+                        │           │
+                    ┌───▼───────────▼──┐
+                    │  CLI (via HTTP)   │
+                    │  list-dead        │
+                    │  replay <id>      │
+                    │  replay-all       │
+                    └──────────────────┘
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Postgres migration + DLQ data types**
+
+**Goal:** Create the `webhook_deliveries` table and Rust types for DLQ rows.
+
+**Requirements:** R1, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `crates/mika-gateway/migrations/006_webhook_deliveries.sql`
+- Create: `crates/mika-gateway/src/dlq.rs`
+- Modify: `crates/mika-gateway/src/main.rs` (add `mod dlq`)
+
+**Approach:**
+- Postgres table with columns: `delivery_id TEXT PRIMARY KEY`, `event_type TEXT NOT NULL`, `target_agent TEXT NOT NULL`, `repo_full_name TEXT`, `payload TEXT NOT NULL` (formatted text), `created_at TIMESTAMPTZ NOT NULL DEFAULT now()`, `attempts INTEGER NOT NULL DEFAULT 0`, `last_attempt_at TIMESTAMPTZ`, `status TEXT NOT NULL DEFAULT 'pending'` (CHECK IN 'pending','delivered','dead'), `last_error TEXT`, `request_id TEXT NOT NULL`
+- Rust struct `WebhookDelivery` with `sqlx::FromRow` derive
+- Status enum type with string serialization
+- Index on `(status, last_attempt_at)` for worker queries
+
+**Patterns to follow:**
+- Existing migrations in `crates/mika-gateway/migrations/` (plain SQL, numbered)
+- `build.rs` already has `cargo::rerun-if-changed=migrations`
+
+**Test scenarios:**
+- Happy path: Migration runs cleanly on an empty database
+- Edge case: Inserting a delivery with all fields populated, verify round-trip via SELECT
+
+**Verification:**
+- `sqlx::migrate!()` compiles without errors
+- Rust types match the table schema
+
+---
+
+- [ ] **Unit 2: DLQ write path — capture exhausted/abandoned deliveries**
+
+**Goal:** When `deliver_with_retry_inner()` exhausts retries or abandons due to semaphore pressure, insert a row into `webhook_deliveries`.
+
+**Requirements:** R1, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs`
+- Modify: `crates/mika-gateway/src/dlq.rs`
+
+**Approach:**
+- Add `pub async fn insert_delivery(pool, delivery)` function in `dlq.rs`
+- At the two terminal failure points in `deliver_with_retry_inner()` (retry budget exhausted, semaphore capacity), call `insert_delivery()` with the event metadata
+- The `delivery_id` comes from the `request_id` parameter (which is the `X-GitHub-Delivery` UUID or a generated UUID)
+- Fire-and-forget insert (log error if DB write fails, don't block the caller)
+- Pass `pool` through to `deliver_with_retry` — `AppState` already carries `pool`
+
+**Patterns to follow:**
+- Existing error logging patterns at the two terminal points in `deliver_with_retry_inner()`
+- The function already has access to `state: &AppState` which contains `pool`
+
+**Test scenarios:**
+- Happy path: Mock a delivery that exhausts all retries, verify row appears in `webhook_deliveries` with `status='pending'` and `attempts` matching retry count
+- Happy path: Mock a delivery abandoned due to semaphore pressure, verify row appears with `status='pending'`
+- Error path: If the DB insert fails, the ERROR log still fires and the function returns normally (no panic)
+- Edge case: Permanent failure (4xx) does NOT insert into DLQ — only retryable exhaustion and semaphore abandonment
+
+**Verification:**
+- The two ERROR log lines in `deliver_with_retry_inner()` are now preceded by DLQ inserts
+- Existing retry tests still pass
+
+---
+
+- [ ] **Unit 3: Background DLQ worker**
+
+**Goal:** A tokio task that periodically retries pending DLQ entries and transitions them to `delivered` or `dead`.
+
+**Requirements:** R2, R3, R7
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `crates/mika-gateway/src/dlq.rs`
+- Modify: `crates/mika-gateway/src/main.rs`
+
+**Approach:**
+- `pub async fn run_dlq_worker(state: AppState)` — infinite loop with `tokio::time::sleep(Duration::from_secs(30))`
+- Each tick: `SELECT * FROM webhook_deliveries WHERE status = 'pending' AND (last_attempt_at IS NULL OR last_attempt_at < now() - interval * backoff(attempts)) ORDER BY created_at ASC LIMIT 50`
+- For each entry: re-resolve route via `resolve_github_container_url()`, call `forward_to_resolved_route()`, update row based on result
+- Success → `status = 'delivered'`
+- Retryable/Permanent failure → `attempts += 1`, `last_attempt_at = now()`, `last_error = reason`
+- `attempts >= 10` → `status = 'dead'`
+- Respect the webhook semaphore (acquire permit before forwarding, release after)
+- Spawn in `main.rs` before `axum::serve()`: `tokio::spawn(dlq::run_dlq_worker(state.clone()))`
+- Worker logs at INFO level on transitions and WARN on failures
+
+**Patterns to follow:**
+- The periodic cleanup in `telegram.rs` (counter-based, different cadence but same spawn pattern)
+- `forward_to_resolved_route()` and `resolve_github_container_url()` from `github.rs`
+
+**Test scenarios:**
+- Happy path: Insert a pending delivery, run one worker tick, verify it gets forwarded and transitions to `delivered`
+- Happy path: Insert a pending delivery with `attempts=9`, fail the forward, verify it transitions to `dead` after the 10th attempt
+- Edge case: No pending deliveries — worker tick completes quickly without errors
+- Edge case: Backoff respected — entry with `last_attempt_at` within its backoff window is skipped
+- Error path: Forward returns `Permanent` — still increments attempts and records error (permanent is a worker failure, not a routing error; the initial routing already resolved)
+- Integration: Worker respects semaphore — if all 30 permits are held, worker skips forwarding for that tick
+
+**Verification:**
+- Worker starts with the gateway and survives across ticks
+- Pending entries are retried, delivered entries are not retried, dead entries are not retried
+
+---
+
+- [ ] **Unit 4: Gateway HTTP endpoints for DLQ operations**
+
+**Goal:** REST endpoints on the gateway for listing, replaying single entries, and replaying all dead entries.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 1, Unit 3
+
+**Files:**
+- Modify: `crates/mika-gateway/src/dlq.rs`
+- Modify: `crates/mika-gateway/src/routes.rs`
+
+**Approach:**
+- `GET /webhook/dlq` — returns JSON array of deliveries with `status IN ('pending', 'dead')`. Optional query params: `?status=dead&limit=50`
+- `POST /webhook/dlq/{delivery_id}/replay` — re-resolves route, forwards, updates status. Returns the delivery row with updated status.
+- `POST /webhook/dlq/replay-all` — selects all `status='dead'` rows, replays each, returns summary (count succeeded, count failed)
+- All endpoints use the same internal token Bearer auth as `/send`
+- Register routes in `build_router()` under the internal auth middleware
+
+**Patterns to follow:**
+- Existing route registration in `routes.rs` `build_router()`
+- Internal token auth middleware already in place for `/send`
+- `utoipa` annotations for OpenAPI docs (optional, other webhook endpoints skip it)
+
+**Test scenarios:**
+- Happy path: `GET /webhook/dlq` returns empty array when no deliveries exist
+- Happy path: `GET /webhook/dlq` returns deliveries filtered by status
+- Happy path: `POST /webhook/dlq/{id}/replay` with valid ID re-delivers and returns updated row
+- Error path: `POST /webhook/dlq/{id}/replay` with non-existent ID returns 404
+- Error path: Unauthenticated request returns 401
+- Happy path: `POST /webhook/dlq/replay-all` replays dead entries and returns summary
+- Edge case: `replay-all` with no dead entries returns success with count=0
+
+**Verification:**
+- Endpoints accessible via curl with correct auth
+- Status transitions reflected in DB after replay
+
+---
+
+- [ ] **Unit 5: CLI `mika webhook` subcommand**
+
+**Goal:** CLI commands that call the gateway HTTP endpoints to list and replay DLQ entries.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Create: `crates/mika-cli/src/commands/webhook.rs`
+- Modify: `crates/mika-cli/src/commands/mod.rs`
+- Modify: `crates/mika-cli/src/cli.rs`
+
+**Approach:**
+- New `Webhook` variant in `Commands` enum with subcommands: `ListDead`, `Replay { delivery_id: String }`, `ReplayAll`
+- `MIKA_GATEWAY_URL` env var (default: `http://localhost:3001`) for gateway base URL
+- `MIKA_INTERNAL_TOKEN` env var for Bearer auth (same token the gateway uses)
+- `list-dead` prints a table: delivery_id, event_type, target_agent, attempts, created_at, last_error (truncated)
+- `replay` and `replay-all` print results and exit codes
+- Support `--format text|json` like other CLI commands
+
+**Patterns to follow:**
+- `crates/mika-cli/src/commands/dashboard.rs` — uses `MIKA_SERVER_URL` for remote API calls
+- `crates/mika-cli/src/commands/tasks.rs` — table output formatting
+- Clap subcommand registration pattern in `cli.rs`
+
+**Test scenarios:**
+- Happy path: `mika webhook list-dead` with gateway running shows table of dead entries
+- Happy path: `mika webhook replay <id>` with valid ID prints success message
+- Error path: Gateway unreachable prints connection error with helpful message
+- Error path: Missing `MIKA_GATEWAY_URL` uses default and warns if connection fails
+- Happy path: `--format json` outputs JSON array/object
+
+**Verification:**
+- `mika webhook --help` shows subcommands
+- Commands execute against a running gateway and display results
+
+---
+
+- [ ] **Unit 6: Tests and documentation**
+
+**Goal:** Integration tests for the DLQ write path and worker, plus documentation updates.
+
+**Requirements:** R1-R8
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs` (add DLQ-related test cases to existing test module)
+- Modify: `crates/mika-gateway/src/dlq.rs` (unit tests for worker logic)
+- Modify: `docs/deployment.md` or relevant docs (mention DLQ, `MIKA_GATEWAY_URL`)
+- Modify: `crates/mika-gateway/CLAUDE.md` (document DLQ architecture)
+- Modify: `crates/mika-cli/CLAUDE.md` (document `webhook` subcommand)
+
+**Approach:**
+- Test the DLQ insert path by extending existing `deliver_with_retry_inner` tests to verify DB writes
+- Test the worker tick function in isolation with a test Postgres instance (if available) or with mock queries
+- Document the new `MIKA_GATEWAY_URL` env var in gateway docs
+- Add DLQ section to gateway CLAUDE.md
+
+**Test scenarios:**
+- Integration: Full flow — deliver_with_retry exhausts budget → row in DB → worker picks up → forward succeeds → status='delivered'
+- Integration: Worker respects backoff — entry just attempted is not re-attempted immediately
+- Edge case: Multiple pending entries processed in created_at order
+- Edge case: Worker handles DB connection failure gracefully (logs, continues next tick)
+
+**Verification:**
+- `cargo test -p mika-gateway` passes with new tests
+- CLAUDE.md files updated with DLQ documentation
+
+## System-Wide Impact
+
+- **Interaction graph:** `handle_github_webhook()` → `deliver_with_retry_inner()` → `dlq::insert_delivery()` (new write path). `dlq::run_dlq_worker()` → `github::resolve_github_container_url()` + `github::forward_to_resolved_route()` (reuse existing functions). Gateway HTTP endpoints → `dlq` module functions.
+- **Error propagation:** DLQ insert failures are logged but never propagate to the webhook handler (fire-and-forget). Worker failures are logged per-entry and don't halt the worker loop.
+- **State lifecycle risks:** Duplicate `delivery_id` entries — handled by PRIMARY KEY constraint (UPSERT or conflict-ignore). Gateway restart mid-worker-tick — pending entries remain in DB, picked up on next tick after restart.
+- **API surface parity:** New gateway endpoints need internal token auth consistent with `/send`. CLI commands need `MIKA_GATEWAY_URL` — a new env var.
+- **Unchanged invariants:** The retry loop's behavior for successful deliveries and permanent failures is unchanged. The LRU dedup cache is unchanged. Semaphore backpressure capacity (30 permits) is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Worker contends with webhook handler for semaphore permits | Worker uses `try_acquire_owned` and skips entries if semaphore is full — same pattern as retry loop |
+| `replay-all` floods agent with many events at once | Process sequentially with semaphore gating; log progress |
+| DLQ table grows unbounded | Add a CRON-like cleanup for delivered entries older than 30 days (deferred — manual cleanup via SQL is acceptable initially) |
+| `forward_to_resolved_route` and `resolve_github_container_url` are currently `pub(crate)` — may need visibility changes for `dlq.rs` | Both are in the same crate, `pub(crate)` is sufficient |
+
+## Documentation / Operational Notes
+
+- New env var: `MIKA_GATEWAY_URL` — base URL for CLI commands that talk to the gateway (default: `http://localhost:3001`)
+- CLI requires `MIKA_INTERNAL_TOKEN` to authenticate with gateway DLQ endpoints
+- Gateway CLAUDE.md needs DLQ section documenting the background worker and endpoints
+- CLI CLAUDE.md needs `webhook` subcommand documentation
+
+## Sources & References
+
+- Related issue: #590 (this feature)
+- Depends on: #589 (retry with backoff — already merged)
+- Related: #583 / PR #586 (engine-side dispatch guards)
+- Precedent: `failed_sends` table in agent container DB (`docs/deployment.md`)
+- Code: `crates/mika-gateway/src/github.rs` — `deliver_with_retry_inner()`, `forward_to_resolved_route()`, `resolve_github_container_url()`

--- a/docs/solutions/infrastructure/gateway-dlq-webhook-delivery-persistence-2026-04-20.md
+++ b/docs/solutions/infrastructure/gateway-dlq-webhook-delivery-persistence-2026-04-20.md
@@ -1,0 +1,90 @@
+---
+title: Gateway dead-letter queue for exhausted webhook retries
+date: 2026-04-20
+category: infrastructure
+module: mika-gateway
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding retry-with-backoff to any delivery pipeline where events must not be lost
+  - Gateway or relay service handles webhook forwarding to downstream containers
+  - Downstream services may be down for extended periods (>5 minutes)
+tags: [dlq, dead-letter-queue, webhook, retry, gateway, postgres, background-worker]
+---
+
+# Gateway Dead-Letter Queue for Exhausted Webhook Retries
+
+## Context
+
+The gateway routes GitHub webhook events to per-customer agent containers. Issue #589 added retry-with-backoff (`[2s, 5s, 15s, 60s, 300s]` with ±25% jitter) for transient failures. However, pathological cases — agent down for 10+ minutes, gateway restart while retries are in-flight, sustained backpressure exhausting the retry budget — result in permanent event loss with only an ERROR log.
+
+This pattern adds persistence at the exhaustion boundary, turning "event dropped" into "event queued for later delivery."
+
+## Guidance
+
+**Architecture:** Single Postgres table (`webhook_deliveries`) stores the formatted delivery payload, metadata, and status. A background tokio task wakes every 30s to retry pending entries with exponential backoff (`30s * 2^attempts`, capped at 1h). After 10 worker attempts, status transitions to `dead`. CLI and HTTP endpoints allow operator inspection and manual replay.
+
+**Key design decisions:**
+
+1. **Store formatted text, not raw webhook body** — The DLQ stores the already-formatted message text (`~1KB`) rather than the raw GitHub body (`~256KB`). This keeps storage compact and avoids re-parsing on replay.
+
+2. **Re-resolve routes on replay** — Container URLs may change between failure and replay (containers moved, recreated). The worker and replay endpoints call `resolve_github_container_url()` fresh rather than caching the original URL.
+
+3. **CLI talks to gateway via HTTP, not direct Postgres** — The CLI runs on user machines; the gateway runs in K8s. New REST endpoints (`GET /webhook/dlq`, `POST .../replay`, `POST .../replay-all`) expose DLQ operations behind the same internal token auth as `/send`.
+
+4. **Fire-and-forget DLQ insert** — The insert into `webhook_deliveries` at the retry exhaustion point logs errors but never propagates them. If the DB write fails, the original ERROR log still fires.
+
+5. **Semaphore respect** — The background worker and replay endpoints use `try_acquire_owned()` on the shared 30-permit webhook semaphore, skipping entries when at capacity rather than blocking.
+
+**Integration points:**
+- Write path: two terminal failure points in `deliver_with_retry_inner()` (retry budget exhausted, semaphore capacity)
+- Worker: spawned in `main.rs` before `axum::serve()`
+- HTTP endpoints: registered in `build_router()` with `require_bearer_token` middleware
+- CLI: `mika webhook list-dead|replay|replay-all` via `MIKA_GATEWAY_URL`
+
+## Why This Matters
+
+Without persistence at the retry exhaustion boundary, events are permanently lost during extended agent downtime or gateway restarts. The DLQ ensures zero-event-loss semantics for the gateway's inbound delivery path with minimal complexity (one table, one background task, one CLI subcommand group).
+
+## When to Apply
+
+- Any delivery pipeline where the retry budget is bounded and events must survive exhaustion
+- When the downstream service has extended downtime windows (maintenance, scaling events)
+- When the gateway process itself may restart with in-flight retries
+
+## Examples
+
+**DLQ insert at retry exhaustion:**
+```rust
+// In deliver_with_retry_inner(), after all retries exhausted:
+crate::dlq::insert_delivery(
+    &state.pool,
+    crate::dlq::NewDelivery {
+        delivery_id: request_id,
+        event_type,
+        target_agent,
+        repo_full_name,
+        payload: text,
+        request_id,
+        attempts: attempts_made as i32,
+        last_error: &last_reason,
+    },
+).await;
+```
+
+**Background worker backoff query:**
+```sql
+SELECT * FROM webhook_deliveries
+WHERE status = 'pending'
+  AND (last_attempt_at IS NULL
+       OR last_attempt_at < now() - (LEAST(30 * power(2, attempts), 3600) || ' seconds')::interval)
+ORDER BY created_at ASC
+LIMIT 50
+```
+
+## Related Issues
+
+- #590 — This feature (dead-letter queue + replay CLI)
+- #589 — Prerequisite (retry with backoff)
+- #583 / PR #586 — Engine-side dispatch guards (symmetric concept on the agent side)


### PR DESCRIPTION
## Summary

- Adds `webhook_deliveries` Postgres table (migration 006) to persist GitHub webhook events that exhaust the retry budget or are abandoned due to semaphore pressure
- Background tokio worker wakes every 30s to retry pending DLQ entries with exponential backoff (30s×2^attempts, capped at 1h); marks dead after 10 attempts
- Gateway HTTP endpoints (`GET /webhook/dlq`, `POST .../replay`, `POST .../replay-all`) with internal token auth
- CLI commands: `mika webhook list-dead|replay|replay-all` with `--format text|json`
- New `MIKA_GATEWAY_URL` env var for CLI → gateway communication (default: `http://localhost:3001`)

## Design decisions

- **Store formatted text, not raw body** — ~1KB vs ~256KB per entry
- **Re-resolve routes on replay** — handles container moves between failure and replay
- **Fire-and-forget insert** — DLQ write never blocks the webhook handler
- **Semaphore respect** — worker and replay use `try_acquire_owned()`, skip when at capacity

Closes #590

## Test plan

- [x] All 144 gateway tests pass (2 ignored long-running tests)
- [x] All 252 CLI tests pass
- [x] Clippy clean, fmt clean, pre-commit hooks pass
- [ ] Manual: trigger exhausted retry (agent down >5 min), verify entry in `webhook_deliveries`
- [ ] Manual: restart agent, verify background worker re-delivers within ~30s
- [ ] Manual: `mika webhook replay <id>` re-delivers and flips to 'delivered'
- [ ] Manual: gateway restart with pending entries — entries persist, worker resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)