### PR TITLE
fix(skills): remove keyword triggers from skill-review to prevent false positives

### DIFF
--- a/crates/mika-agent/src/skills/matcher.rs
+++ b/crates/mika-agent/src/skills/matcher.rs
@@ -357,4 +357,69 @@ mod tests {
             .collect();
         assert_eq!(names, vec!["skill-a"]);
     }
+
+    // --- Keyword false-positive prevention tests (#576) ---
+
+    #[test]
+    fn test_no_keywords_skill_not_matched_by_pr_discussing_it() {
+        // skill-review with empty keywords must NOT match when a PR body
+        // merely discusses skill-review (the feature itself).
+        let skills = vec![make_entry("skill-review", &[], false)];
+        let matched = match_skills(
+            &skills,
+            "[GitHub] PR opened: senara-solutions/mika#576 — skill-review fires on PRs \
+             that discuss skill-review (branch: feat/576/skill-review-fires)",
+        );
+        assert!(
+            matched.is_empty(),
+            "skill-review should not match on PR meta-discussion"
+        );
+    }
+
+    #[test]
+    fn test_no_keywords_skill_not_matched_by_review_skill_phrase() {
+        // Even a message containing "review skill" should not trigger
+        // skill-review when it has no keywords.
+        let skills = vec![make_entry("skill-review", &[], false)];
+        let matched = match_skills(&skills, "the review skill feature is broken");
+        assert!(
+            matched.is_empty(),
+            "skill-review with empty keywords should never keyword-match"
+        );
+    }
+
+    #[test]
+    fn test_no_keywords_skill_not_matched_by_old_keywords() {
+        // Phrases that would have matched the old keywords ("adapt skill",
+        // "generate variant", etc.) must not trigger skill-review.
+        let skills = vec![make_entry("skill-review", &[], false)];
+        for phrase in &[
+            "adapt skill for claude",
+            "generate variant of qa-review",
+            "tune prompt for self-dev",
+            "skill variant needed",
+        ] {
+            let matched = match_skills(&skills, phrase);
+            assert!(
+                matched.is_empty(),
+                "skill-review should not match on '{phrase}' with empty keywords"
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_keywords_skill_loaded_as_dependency() {
+        // skill-review must still load when pulled in as a dependency
+        // of another matched skill — dependency loading is unaffected.
+        let skills = vec![
+            make_entry_with_deps("qa-review", &["review"], true, &["skill-review"]),
+            make_entry("skill-review", &[], false),
+        ];
+        let matched = match_skills(&skills, "review this PR");
+        assert_eq!(matched.len(), 2);
+        assert_eq!(matched[0].entry.manifest.skill.name, "qa-review");
+        assert_eq!(matched[0].reason, MatchReason::Keyword);
+        assert_eq!(matched[1].entry.manifest.skill.name, "skill-review");
+        assert_eq!(matched[1].reason, MatchReason::Dependency);
+    }
 }

--- a/docs/plans/2026-04-20-012-fix-skill-review-keyword-false-positive-plan.md
+++ b/docs/plans/2026-04-20-012-fix-skill-review-keyword-false-positive-plan.md
@@ -1,0 +1,126 @@
+---
+title: "fix: Remove keyword triggers from skill-review to prevent false positive activation"
+type: fix
+status: active
+date: 2026-04-20
+---
+
+# fix: Remove keyword triggers from skill-review to prevent false positive activation
+
+## Overview
+
+Remove all keyword triggers from the `skill-review` skill manifest, making it dependency-only and explicit-invocation-only. This prevents false positive activation when PR titles or bodies contain phrases like "review skill" in meta-discussion rather than as a user intent to invoke the skill.
+
+## Problem Frame
+
+`skill-review` has keywords `["review skill", "adapt skill", "generate variant", "tune prompt", "skill variant"]` in its `skill.toml`. The `match_skills()` function in `matcher.rs` uses pure substring matching (`message_lower.contains(kw)`). When a GitHub webhook delivers a PR event whose body discusses the skill-review feature, phrases like "review skill" trigger keyword matching, loading skill-review's full system prompt and enforcing `required_tools = ["review_skill"]` — even though no one asked for a skill review.
+
+PR #574's `review_filter` only prevents *other* skills from co-activating when skill-review is already matched. It does not prevent skill-review itself from falsely triggering. This is a known class of bug (see `project_keyword_substring_false_positives.md`).
+
+## Requirements Trace
+
+- R1. A PR whose body contains "skill-review" must NOT cause `skill-review` to load during mika-qa's review turn
+- R2. Explicit invocation via dependency loading from another skill must still work
+- R3. Direct user invocation (`review_skill` tool call) must still work — the tool remains registered
+- R4. Unit test covers the false-positive case
+
+## Scope Boundaries
+
+- Only modifying the `skill-review` manifest — no changes to the keyword matching engine itself
+- Not adding skill-review as a dependency to any downstream skill (no current skills need it as a dependency — verified via grep across both `skills/bundled/` and `mika-skills/`)
+- Not addressing the general substring matching problem (tracked separately in memory)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/skill-review/skill.toml` — manifest with keyword triggers to remove
+- `crates/mika-agent/src/skills/matcher.rs` — `match_skills()` with substring matching, existing test suite
+- `crates/mika-agent/src/skills/review_filter.rs` — post-match filter (not affected by this change)
+- `crates/mika-agent/src/skills/mod.rs` — `SkillRegistry::match_message()` entry point
+
+### Institutional Learnings
+
+- `project_keyword_substring_false_positives.md` — documents this exact class of bug with substring matching
+- `docs/solutions/architecture-patterns/review-target-exclusion-filter.md` — documents the existing filter that only handles the inverse problem
+- `docs/solutions/architecture-patterns/conditional-required-tools-enforcement-via-match-reason.md` — confirms constraints (required_tools) only apply to `MatchReason::Keyword` matches, so removing keywords eliminates false constraint enforcement
+
+## Key Technical Decisions
+
+- **Remove keywords entirely (Option 1):** Cleanest fix. skill-review's job is to rewrite other skills' prompts — keyword matching on a meta-skill that operates on skills themselves is inherently dangerous. Any keyword containing "skill" or "review" will false-match on meta-discussion. Dependency-based and direct tool invocation remain available.
+- **No downstream dependency additions needed:** No existing skill declares skill-review as a dependency, and none currently need to. If a future skill needs variant generation, it can add `dependencies = ["skill-review"]` to its own manifest.
+
+## Implementation Units
+
+- [ ] **Unit 1: Remove keywords from skill-review manifest**
+
+**Goal:** Eliminate false positive keyword activation by clearing the keywords list.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/skill-review/skill.toml`
+
+**Approach:**
+- Set `keywords = []` in the `[triggers]` section
+- Keep `always_on = false` — the skill loads only when pulled in as a dependency or when the user directly calls `review_skill`
+- Keep `required_tools = ["review_skill"]` — this constraint only fires for `MatchReason::Keyword`, so with no keywords it never fires, which is correct
+
+**Patterns to follow:**
+- Other dependency-only skills that have `keywords = []` or an empty triggers section
+
+**Test expectation:** none — manifest-only change; behavioral coverage in Unit 2
+
+**Verification:**
+- `skill.toml` has `keywords = []`
+- `cargo build` succeeds (build.rs re-discovers the manifest)
+
+- [ ] **Unit 2: Add unit test for false-positive prevention**
+
+**Goal:** Verify that a message containing "review skill" as meta-discussion does not keyword-match skill-review.
+
+**Requirements:** R1, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/matcher.rs` (test module)
+
+**Approach:**
+- Add a test that creates a skill-review entry with `keywords = []` and verifies it does NOT match a message like `"[GitHub] PR opened: skill-review fires on PRs that discuss skill-review"` or `"the review skill feature is broken"`
+- Also verify it does NOT match via always_on (since `always_on = false`)
+- The test confirms the manifest change achieves the desired behavior at the matcher level
+
+**Patterns to follow:**
+- Existing `test_no_match` test in `matcher.rs` for structure
+- `make_entry()` helper for creating test skill entries
+
+**Test scenarios:**
+- Happy path: skill-review with empty keywords does not match a message containing "review skill" or "skill-review"
+- Happy path: skill-review with empty keywords IS included when pulled in as a dependency of another matched skill
+- Edge case: message that would have matched old keywords ("adapt skill for claude") does not trigger skill-review
+
+**Verification:**
+- `cargo test -p mika-agent -- matcher::tests` passes with new tests
+
+## System-Wide Impact
+
+- **Interaction graph:** No downstream skills depend on skill-review, so removing keywords has no cascade effect. The `review_filter` in `review_filter.rs` only activates when skill-review is keyword-matched — with no keywords, it becomes dormant (correct behavior, no dead code concern since the filter is a safety net).
+- **Error propagation:** No change — `required_tools` enforcement for skill-review becomes unreachable (only fires on `MatchReason::Keyword`), which is the desired outcome.
+- **Unchanged invariants:** The `review_skill` tool itself remains registered and callable. The skill's system prompt and templates remain intact for dependency-based loading.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Future skills may need skill-review via keyword | Any skill needing variant generation can declare `dependencies = ["skill-review"]` — this is the correct activation path for a meta-skill |
+| Direct user invocation harder without keywords | Users can still call `review_skill` tool directly; the tool is always registered. If needed, a future PR can add a CLI command or explicit invocation path |
+
+## Sources & References
+
+- Related issue: #576
+- Related PRs: #573, #574 (review_filter, does not fix this)
+- Memory: `project_keyword_substring_false_positives.md`
+- Solution doc: `docs/solutions/architecture-patterns/review-target-exclusion-filter.md`

--- a/docs/solutions/logic-errors/skill-review-keyword-false-positive-on-pr-discussion-2026-04-20.md
+++ b/docs/solutions/logic-errors/skill-review-keyword-false-positive-on-pr-discussion-2026-04-20.md
@@ -1,0 +1,81 @@
+---
+title: "skill-review fires on PRs that discuss skill-review (keyword false positive)"
+module: skills/matcher, skills/skill-review
+date: 2026-04-20
+problem_type: logic_error
+component: assistant
+severity: high
+symptoms:
+  - "skill-review activates during mika-qa PR review turns when PR title/body mentions 'skill-review'"
+  - "mika-qa calls review_skill tool and writes qa-review variants during a normal PR review"
+  - "required_tools = ['review_skill'] constraint enforced on turns where no skill review was requested"
+root_cause: config_error
+resolution_type: config_change
+tags:
+  - keyword-matching
+  - substring-false-positive
+  - skill-review
+  - webhook
+  - meta-skill
+---
+
+# skill-review fires on PRs that discuss skill-review (keyword false positive)
+
+## Problem
+
+`skill-review` is a keyword-matched skill with keywords `["review skill", "adapt skill", "generate variant", "tune prompt", "skill variant"]`. When a GitHub webhook delivers a PR event whose title or body discusses the skill-review feature (e.g., PRs #573, #574 which fix skill-review itself), the substring matcher in `match_skills()` triggers on phrases like "review skill" appearing in the PR body. This loads skill-review's full system prompt and enforces `required_tools = ["review_skill"]`, causing the agent to run variant generation when it should be doing a normal PR review.
+
+## Symptoms
+
+- `loaded_skills` includes `skill-review` during mika-qa's PR review turn
+- Agent calls `review_skill` tool on `qa-review` unprompted
+- The `required_tools` constraint forces the agent to call `review_skill` even when the turn intent is a normal PR review
+- Confirmed via: `sqlite3 ~/.mika/data/mika.db "SELECT tool_name, skill_name FROM tool_calls WHERE trace_id='<turn-trace>'"`
+
+## What Didn't Work
+
+- **PR #574 (`review_filter`):** Added `apply_review_filter()` to exclude the *reviewed* skill from keyword matching when skill-review is active. This prevents collateral activation of other skills during a review turn, but does NOT prevent skill-review itself from falsely triggering. The filter assumes skill-review was correctly keyword-triggered and cleans up downstream — it cannot prevent the upstream false activation.
+- **Name-in-keywords validation (#510):** `validate_skill()` rejects skills that list their exact name as a keyword. This prevents `"skill-review"` as a keyword but not partial matches like `"review skill"` (the reverse).
+
+## Solution
+
+Remove all keyword triggers from `skill-review`, making it dependency-only and explicit-invocation-only.
+
+**Before** (`skills/bundled/skill-review/skill.toml`):
+```toml
+[triggers]
+keywords = ["review skill", "adapt skill", "generate variant", "tune prompt", "skill variant"]
+```
+
+**After:**
+```toml
+[triggers]
+keywords = []
+```
+
+The `review_skill` tool remains registered and callable. The skill loads only when:
+1. Another skill declares `dependencies = ["skill-review"]` in its `skill.toml`
+2. A user directly invokes the `review_skill` tool
+
+The `required_tools = ["review_skill"]` constraint is intentionally kept but becomes unreachable — it only fires on `MatchReason::Keyword` (#265), and with no keywords it never triggers.
+
+## Why This Works
+
+The root cause is that keyword matching uses pure substring matching (`message_lower.contains(kw)`) in `matcher.rs`. Any keyword containing common words like "skill" or "review" will inevitably false-match on meta-discussion about the skill system itself. For a meta-skill whose entire job is to operate on other skills, keyword-based activation is inherently dangerous — the skill's domain vocabulary overlaps with normal discussion about skills.
+
+Making skill-review dependency-only eliminates the false-positive class entirely. No substring match can trigger it because there are no substrings to match.
+
+## Prevention
+
+1. **Meta-skills should avoid keyword triggers.** Skills that operate on other skills (variant generation, review, analysis) should use dependency-based activation or explicit tool invocation, not keyword matching. Their domain vocabulary inherently overlaps with normal discussion.
+2. **Known pattern:** This is a documented class of bug — see `project_keyword_substring_false_positives.md` in auto memory. The substring matching engine remains unchanged; any future skill with common-word keywords is susceptible.
+3. **Test coverage:** Four unit tests in `matcher.rs` now verify that a skill with empty keywords is not keyword-matched by PR discussion, old keyword phrases, or meta-references — and that dependency loading still works.
+
+## Related
+
+- Issue: [#576](https://github.com/senara-solutions/mika/issues/576)
+- PR #574: review_filter (fixes the collateral activation problem, not the false trigger)
+- PR #513: review-target exclusion filter (same area)
+- Solution doc: `docs/solutions/architecture-patterns/review-target-exclusion-filter.md`
+- Solution doc: `docs/solutions/architecture-patterns/conditional-required-tools-enforcement-via-match-reason.md`
+- Solution doc: `docs/solutions/architecture-patterns/skill-system-quality-validation-enforcement.md`

--- a/skills/bundled/skill-review/skill.toml
+++ b/skills/bundled/skill-review/skill.toml
@@ -8,5 +8,7 @@ timeout_secs = 60
 [triggers]
 keywords = []
 
+# required_tools enforcement only fires on MatchReason::Keyword (#265).
+# With empty keywords, this is a no-op — kept so it activates if keywords are restored.
 [constraints]
 required_tools = ["review_skill"]

--- a/skills/bundled/skill-review/skill.toml
+++ b/skills/bundled/skill-review/skill.toml
@@ -6,7 +6,7 @@ always_on = false
 timeout_secs = 60
 
 [triggers]
-keywords = ["review skill", "adapt skill", "generate variant", "tune prompt", "skill variant"]
+keywords = []
 
 [constraints]
 required_tools = ["review_skill"]


### PR DESCRIPTION
## Summary

- Remove all keyword triggers from `skill-review` manifest (`keywords = []`), making it dependency-only and explicit-invocation-only
- Add 4 unit tests in `matcher.rs` verifying false-positive prevention and dependency loading
- Add clarifying TOML comment explaining the unreachable `required_tools` constraint

Closes #576

## Problem

`skill-review` had keywords `["review skill", "adapt skill", ...]`. The substring matcher in `match_skills()` triggered on PR bodies that discussed the skill-review feature, loading skill-review's system prompt and enforcing `required_tools = ["review_skill"]` — causing mika-qa to run variant generation during normal PR reviews.

## Approach

Option 1 from the issue: remove keywords entirely. A meta-skill whose job is to operate on other skills should not use keyword matching — its domain vocabulary inherently overlaps with normal skill discussion. Dependency loading and direct tool invocation remain available.

## Test plan

- [x] `cargo test -p mika-agent -- matcher::tests` — 23 tests pass (4 new)
- [x] Verify skill-review with empty keywords does NOT match PR meta-discussion
- [x] Verify skill-review with empty keywords does NOT match old keyword phrases
- [x] Verify skill-review still loads as dependency with `MatchReason::Dependency`
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)