### PR TITLE
feat(gateway): route pull_request.review_requested to mika-qa

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -21,10 +21,11 @@ Telegram and GitHub webhook router with Postgres customer registry. Handles text
 
 HMAC-SHA256 signature validation via `X-Hub-Signature-256`. Event routing:
 - `issues.assigned` and `issue_comment.created` and `pull_request_review.submitted` and `pull_request.closed` and `check_suite.completed(failure/timed_out/success)` -> mika-dev
-- `pull_request.opened/synchronize` -> mika-qa
+- `pull_request.opened/synchronize/review_requested` -> mika-qa
 - Delivery UUID dedup via 10k-entry LRU cache
 - 256KB body limit
 - Multi-tenant routing via `github_repos` table lookup with `agent_base_url` fallback for single-tenant mode
+- Machine user assignee filtering: `MIKA_GITHUB_APP_LOGIN` in per-agent `.env` (e.g., `~/.mika/agents/mika-dev/.env`) should match the machine user login (e.g., `mika-platform-dev`). Filtering logic lives in the self-dev skill prompt, not in gateway code.
 
 ### Inbound delivery retry (#589)
 

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -66,6 +66,8 @@ pub struct GitHubWebhookEvent {
     pub comment: Option<GitHubComment>,
     /// Review data (present in pull_request_review events).
     pub review: Option<GitHubReview>,
+    /// Requested reviewer (present in pull_request.review_requested events).
+    pub requested_reviewer: Option<GitHubUser>,
     /// Repository data.
     pub repository: Option<GitHubRepository>,
 }
@@ -148,7 +150,7 @@ pub fn route_event(
     match (event_type, action) {
         ("issues", Some("assigned")) => Some("mika-dev"),
         ("issue_comment", Some("created")) => Some("mika-dev"),
-        ("pull_request", Some("opened" | "synchronize")) => Some("mika-qa"),
+        ("pull_request", Some("opened" | "synchronize" | "review_requested")) => Some("mika-qa"),
         ("pull_request", Some("closed")) => Some("mika-dev"),
         ("pull_request_review", Some("submitted")) => Some("mika-dev"),
         ("check_suite", Some("completed")) => match check_conclusion {
@@ -239,6 +241,11 @@ pub fn format_event_text(event_type: &str, event: &GitHubWebhookEvent) -> String
             if action == "closed" {
                 let merged = pr.and_then(|p| p.merged).unwrap_or(false);
                 text.push_str(&format!("\nMerged: {merged}"));
+            }
+            if action == "review_requested"
+                && let Some(reviewer) = &event.requested_reviewer
+            {
+                text.push_str(&format!("\nRequested reviewer: @{}", reviewer.login));
             }
             if !body.is_empty() {
                 text.push_str(&format!("\n\n{body}"));
@@ -1042,6 +1049,14 @@ mod tests {
     }
 
     #[test]
+    fn test_route_event_pr_review_requested() {
+        assert_eq!(
+            route_event("pull_request", Some("review_requested"), None),
+            Some("mika-qa")
+        );
+    }
+
+    #[test]
     fn test_route_event_pr_review_submitted() {
         assert_eq!(
             route_event("pull_request_review", Some("submitted"), None),
@@ -1108,6 +1123,7 @@ mod tests {
             pull_request: None,
             comment: None,
             review: None,
+            requested_reviewer: None,
             repository: Some(GitHubRepository {
                 full_name: Some("org/repo".to_string()),
                 html_url: None,
@@ -1140,6 +1156,7 @@ mod tests {
             }),
             comment: None,
             review: None,
+            requested_reviewer: None,
             repository: Some(GitHubRepository {
                 full_name: Some("org/repo".to_string()),
                 html_url: None,
@@ -1165,6 +1182,7 @@ mod tests {
             pull_request: None,
             comment: None,
             review: None,
+            requested_reviewer: None,
             repository: Some(GitHubRepository {
                 full_name: Some("org/repo".to_string()),
                 html_url: None,
@@ -1174,6 +1192,72 @@ mod tests {
         assert!(text.contains("[GitHub] Check suite failure"));
         assert!(text.contains("org/repo"));
         assert!(text.contains("main"));
+    }
+
+    #[test]
+    fn test_format_event_text_pr_review_requested_with_reviewer() {
+        let event = GitHubWebhookEvent {
+            action: Some("review_requested".to_string()),
+            sender: None,
+            installation: None,
+            check_suite: None,
+            issue: None,
+            pull_request: Some(GitHubPullRequest {
+                number: Some(15),
+                title: Some("Add feature".to_string()),
+                html_url: Some("https://github.com/org/repo/pull/15".to_string()),
+                body: None,
+                head: Some(GitHubRef {
+                    ref_name: Some("feat/new".to_string()),
+                }),
+                merged: None,
+            }),
+            comment: None,
+            review: None,
+            requested_reviewer: Some(GitHubUser {
+                login: "mika-platform-qa".to_string(),
+                user_type: Some("User".to_string()),
+            }),
+            repository: Some(GitHubRepository {
+                full_name: Some("org/repo".to_string()),
+                html_url: None,
+            }),
+        };
+        let text = format_event_text("pull_request", &event);
+        assert!(text.contains("[GitHub] PR review_requested"));
+        assert!(text.contains("org/repo#15"));
+        assert!(text.contains("Requested reviewer: @mika-platform-qa"));
+    }
+
+    #[test]
+    fn test_format_event_text_pr_review_requested_without_reviewer() {
+        let event = GitHubWebhookEvent {
+            action: Some("review_requested".to_string()),
+            sender: None,
+            installation: None,
+            check_suite: None,
+            issue: None,
+            pull_request: Some(GitHubPullRequest {
+                number: Some(15),
+                title: Some("Add feature".to_string()),
+                html_url: Some("https://github.com/org/repo/pull/15".to_string()),
+                body: None,
+                head: Some(GitHubRef {
+                    ref_name: Some("feat/new".to_string()),
+                }),
+                merged: None,
+            }),
+            comment: None,
+            review: None,
+            requested_reviewer: None,
+            repository: Some(GitHubRepository {
+                full_name: Some("org/repo".to_string()),
+                html_url: None,
+            }),
+        };
+        let text = format_event_text("pull_request", &event);
+        assert!(text.contains("[GitHub] PR review_requested"));
+        assert!(!text.contains("Requested reviewer"));
     }
 
     // -- Delivery cache tests --

--- a/docs/plans/2026-04-21-002-feat-gateway-review-requested-routing-plan.md
+++ b/docs/plans/2026-04-21-002-feat-gateway-review-requested-routing-plan.md
@@ -1,0 +1,177 @@
+---
+title: "feat(gateway): route pull_request.review_requested to mika-qa + machine user assignee support"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# feat(gateway): route pull_request.review_requested to mika-qa + machine user assignee support
+
+## Overview
+
+Add `review_requested` to the gateway's pull_request routing so requesting `mika-platform-qa` as a PR reviewer triggers mika-qa's qa-review skill. Enrich the formatted message with the requested reviewer login. Update the qa-review skill prompt to document the new trigger. Verify machine user assignee filtering works for `mika-platform-dev`.
+
+## Problem Frame
+
+Machine user accounts (`mika-platform-dev`, `mika-platform-qa`) are now in the org. Requesting `mika-platform-qa` as a PR reviewer fires a `pull_request` + `review_requested` webhook, but the gateway's `route_event()` does not match this action — it falls through to `None` and is silently dropped. The qa-review skill never fires.
+
+For assignee filtering, `MIKA_GITHUB_APP_LOGIN` is a single `Option<String>` in config. The filtering logic lives in the self-dev skill prompt (in `mika-skills/` repo, not in Rust code). The agent simply passes the configured login through. Setting `MIKA_GITHUB_APP_LOGIN=mika-platform-dev` in the per-agent `.env` is a configuration concern, not a code change in this repo.
+
+## Requirements Trace
+
+- R1. `pull_request.review_requested` webhooks route to mika-qa
+- R2. Formatted message includes the requested reviewer's login for context
+- R3. Existing `opened`/`synchronize`/`closed` routing unchanged
+- R4. qa-review skill prompt documents the new trigger event
+- R5. Gateway CLAUDE.md routing table updated
+- R6. Machine user assignee filtering verified (configuration, not code — documented)
+
+## Scope Boundaries
+
+- No changes to the `GitHubWebhookEvent` struct beyond adding the optional `requested_reviewer` field
+- No changes to assignee filtering Rust code — `MIKA_GITHUB_APP_LOGIN` is already a single string config; the self-dev skill prompt in `mika-skills/` handles the comparison
+- No changes to the verdict handler — `pull_request_review.submitted` routing to mika-dev is unchanged
+- No feedback loop risk — mika-qa receives `review_requested` but does not generate `review_requested` events (it submits reviews, which produce `pull_request_review.submitted` routed to mika-dev)
+
+### Deferred to Separate Tasks
+
+- Self-dev skill prompt updates for machine user login matching: `mika-skills/` repo
+- Per-agent `.env` configuration for `MIKA_GITHUB_APP_LOGIN=mika-platform-dev`: operational task
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-gateway/src/github.rs` line 148-160: `route_event()` match table
+- `crates/mika-gateway/src/github.rs` line 225-247: `format_event_text()` pull_request branch
+- `crates/mika-gateway/src/github.rs` line 1021-1050: existing routing test pattern (`test_route_event_pr_*`)
+- `crates/mika-gateway/src/github.rs` line 1124-1152: existing format test pattern (`test_format_event_text_pr_opened`)
+- `skills/bundled/qa-review/system_prompt.md` line 5: trigger documentation
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md`: Same gap pattern — `pull_request.closed` was silently dropped until a match arm was added. Confirms the one-line routing fix approach.
+- `docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md`: Bot self-event filtering was intentionally removed (#401). Loop prevention relies on routing table partitioning. `review_requested` → mika-qa is safe because mika-qa submits reviews (→ mika-dev), not review requests.
+- `docs/solutions/runtime-errors/github-webhook-parse-fails-missing-app-id.md`: New struct fields must be `Option<T>` to avoid parse failures for events that omit them.
+- `docs/solutions/logic-errors/webhook-fallthrough-dispatches-unrelated-backlog-work.md`: The receiving skill's keywords must match the event type. qa-review already matches `pull_request` keywords; updating the prompt ensures the skill knows it handles `review_requested`.
+
+## Key Technical Decisions
+
+- **Add `requested_reviewer` to struct:** The `review_requested` webhook includes a top-level `requested_reviewer` object. Adding it as `Option<GitHubUser>` enriches the formatted message with who was requested, giving mika-qa better context. Uses the existing `GitHubUser` type. `Option` ensures other event types that lack this field still parse correctly.
+- **Enrich format text for `review_requested` action:** Add a conditional line `Requested reviewer: @{login}` in the `pull_request` format branch when the action is `review_requested` and the field is present. This follows the same pattern as the `closed` action's `Merged: {bool}` enrichment (line 239-242).
+- **No Rust code for Part B (assignee filtering):** `MIKA_GITHUB_APP_LOGIN` is already a single-string config. The filtering logic lives in the self-dev skill prompt. Setting the config to `mika-platform-dev` is an operational step, not a code change.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does `format_event_text` need changes?** Yes — adding `requested_reviewer` info enriches the message for mika-qa. The format branch already handles arbitrary PR actions generically, so `review_requested` will produce `[GitHub] PR review_requested: ...`. The enrichment adds reviewer identity.
+- **Feedback loop risk?** None. mika-qa receives `review_requested`, performs its review, and submits a `pull_request_review.submitted` event which routes to mika-dev. The routing table partitions events cleanly.
+
+### Deferred to Implementation
+
+- None — this is a well-understood, pattern-following change.
+
+## Implementation Units
+
+- [x] **Unit 1: Add `review_requested` routing and `requested_reviewer` enrichment**
+
+**Goal:** Route `pull_request.review_requested` to mika-qa and enrich the formatted message with the requested reviewer's login.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-gateway/src/github.rs` (struct, routing, formatting, tests)
+
+**Approach:**
+- Add `pub requested_reviewer: Option<GitHubUser>` field to `GitHubWebhookEvent` struct (after `review` field, line ~69)
+- Add `"review_requested"` to the or-pattern on line 151: `("pull_request", Some("opened" | "synchronize" | "review_requested")) => Some("mika-qa")`
+- In `format_event_text()` pull_request branch (line 238), add a conditional after the `closed`/merged block: if `action == "review_requested"`, append `Requested reviewer: @{login}` from `event.requested_reviewer`
+- Add routing test: `test_route_event_pr_review_requested` asserting `Some("mika-qa")`
+- Add format test: `test_format_event_text_pr_review_requested` asserting output contains `[GitHub] PR review_requested` and `Requested reviewer: @`
+
+**Patterns to follow:**
+- Routing test pattern: `test_route_event_pr_opened` (line 1021)
+- Format test pattern: `test_format_event_text_pr_opened` (line 1124)
+- Conditional enrichment pattern: `closed` action's `Merged: {bool}` (line 239-242)
+- Optional struct field pattern: all existing fields on `GitHubWebhookEvent` are `Option<T>`
+
+**Test scenarios:**
+- Happy path: `route_event("pull_request", Some("review_requested"), None)` returns `Some("mika-qa")`
+- Happy path: `format_event_text("pull_request", event)` with `action=review_requested` and `requested_reviewer` set contains `[GitHub] PR review_requested` and `Requested reviewer: @{login}`
+- Edge case: `format_event_text` with `action=review_requested` but `requested_reviewer=None` still produces valid output without the reviewer line
+- Happy path: Existing `opened` and `synchronize` routing unchanged (existing tests cover this — run and confirm they pass)
+
+**Verification:**
+- `cargo test -p mika-gateway` passes with new and existing tests
+- `cargo clippy -p mika-gateway` clean
+
+- [x] **Unit 2: Update qa-review skill prompt and gateway CLAUDE.md**
+
+**Goal:** Document the new `review_requested` trigger in the qa-review skill prompt and update the gateway routing table in CLAUDE.md.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `skills/bundled/qa-review/system_prompt.md`
+- Modify: `crates/mika-gateway/CLAUDE.md`
+
+**Approach:**
+- In `skills/bundled/qa-review/system_prompt.md` line 5, add `pull_request.review_requested` to the trigger list
+- In `crates/mika-gateway/CLAUDE.md` line 24, add `pull_request.review_requested` to the mika-qa routing entry
+
+**Patterns to follow:**
+- Existing trigger documentation format in qa-review prompt
+- Existing routing table format in CLAUDE.md
+
+**Test expectation: none** — documentation-only changes
+
+**Verification:**
+- qa-review prompt lists all three trigger events
+- CLAUDE.md routing table reflects the new route
+
+- [x] **Unit 3: Document machine user assignee configuration**
+
+**Goal:** Document the machine user assignee configuration requirements for Part B of the issue.
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-gateway/CLAUDE.md` (add note about machine user configuration)
+
+**Approach:**
+- Add a brief note in the GitHub Webhook Integration section explaining that `MIKA_GITHUB_APP_LOGIN` in per-agent `.env` should be set to the machine user login (e.g., `mika-platform-dev`) for autonomous issue pickup. Note that the filtering logic lives in the self-dev skill prompt.
+
+**Test expectation: none** — documentation-only change
+
+**Verification:**
+- CLAUDE.md mentions machine user login configuration
+
+## System-Wide Impact
+
+- **Interaction graph:** Gateway `route_event()` → agent container `/message` → qa-review skill activation. No new interaction paths — follows the existing `opened`/`synchronize` flow.
+- **Error propagation:** Unchanged — `review_requested` follows the same retry/DLQ path as other routed events.
+- **State lifecycle risks:** None — no new state is introduced.
+- **API surface parity:** The `requested_reviewer` struct field is additive and optional. All existing webhook payloads continue to deserialize correctly.
+- **Unchanged invariants:** `pull_request_review.submitted` → mika-dev routing is unchanged. The verdict handler and auto-merge path are unaffected. `pull_request.closed` → mika-dev is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `requested_reviewer` field name differs from GitHub's actual payload key | GitHub docs confirm `requested_reviewer` is the top-level field name for `review_requested` action. serde will silently ignore if absent. |
+| qa-review skill does not keyword-match `review_requested` | The skill matches on `pull_request` keyword which is present in the formatted text `[GitHub] PR review_requested:...`. Updating the prompt is documentation, not routing logic. |
+
+## Sources & References
+
+- Related issue: #506
+- Related code: `crates/mika-gateway/src/github.rs` (routing, formatting, tests)
+- Related solution: `docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md`
+- Related plan: `docs/plans/2026-04-03-006-feat-github-app-identity-agent-infrastructure-plan.md` (#416)
+- GitHub docs: [pull_request webhook event](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request)

--- a/docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md
+++ b/docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md
@@ -64,7 +64,7 @@ pub(crate) async fn handle_github_webhook(
 **Event routing (static map):**
 - `issues.opened/assigned` → mika-dev
 - `issue_comment.created` → mika-dev
-- `pull_request.opened/synchronize` → mika-qa
+- `pull_request.opened/synchronize/review_requested` → mika-qa
 - `pull_request_review.submitted` → mika-dev
 - `check_suite.completed(failure/timed_out)` → mika-dev
 

--- a/docs/solutions/integration-issues/gateway-review-requested-webhook-routing.md
+++ b/docs/solutions/integration-issues/gateway-review-requested-webhook-routing.md
@@ -1,0 +1,86 @@
+---
+title: Route pull_request.review_requested webhook to mika-qa
+date: 2026-04-21
+module: mika-gateway
+problem_type: integration_issue
+component: tooling
+severity: medium
+symptoms:
+  - Requesting mika-platform-qa as PR reviewer produces no QA review
+  - pull_request.review_requested webhook silently dropped by gateway
+root_cause: missing_workflow_step
+resolution_type: code_fix
+tags: [gateway, webhook, github, review-requested, routing, machine-user]
+---
+
+# Gateway drops pull_request.review_requested — QA review not triggered
+
+## Problem
+
+With machine user accounts (`mika-platform-dev`, `mika-platform-qa`) in the org, requesting `mika-platform-qa` as a PR reviewer fires a `pull_request` + `review_requested` GitHub webhook. The gateway's `route_event()` only matched `opened | synchronize` for pull_request events routed to mika-qa — `review_requested` fell through to `_ => None` and was silently dropped. The qa-review skill never activated.
+
+## Symptoms
+
+- Requesting a reviewer on a PR in the GitHub UI produces no mika-qa response
+- Gateway logs show `warn` for unroutable `pull_request.review_requested` event (observability added in #401)
+- The `review_requested` delivery appears in gateway traces but no forwarding occurs
+
+## What Didn't Work
+
+This was identified directly from the routing table — no failed investigation paths. The exact same gap pattern was documented previously for `pull_request.closed` (see Related Issues).
+
+## Solution
+
+Three changes in `crates/mika-gateway/src/github.rs`:
+
+**1. Add `review_requested` to routing match (one-line change):**
+
+```rust
+// Before:
+("pull_request", Some("opened" | "synchronize")) => Some("mika-qa"),
+
+// After:
+("pull_request", Some("opened" | "synchronize" | "review_requested")) => Some("mika-qa"),
+```
+
+**2. Add `requested_reviewer` field to `GitHubWebhookEvent` struct:**
+
+```rust
+/// Requested reviewer (present in pull_request.review_requested events).
+pub requested_reviewer: Option<GitHubUser>,
+```
+
+GitHub's `review_requested` payload includes a top-level `requested_reviewer` object. Adding it as `Option<GitHubUser>` allows enriching the formatted message. The `Option` wrapper ensures other event types (which lack this field) still deserialize correctly — serde ignores unknown fields by default, but having the field explicitly modeled enables type-safe access.
+
+**3. Enrich formatted message with reviewer identity:**
+
+```rust
+if action == "review_requested"
+    && let Some(reviewer) = &event.requested_reviewer
+{
+    text.push_str(&format!("\nRequested reviewer: @{}", reviewer.login));
+}
+```
+
+This follows the same conditional enrichment pattern as the `closed` action's `Merged: {bool}` line.
+
+## Why This Works
+
+The `route_event()` function is a static match table — the single gate for which events are routable. Adding `"review_requested"` to the or-pattern is the only change needed for routing. The `format_event_text()` function already handles arbitrary `pull_request` actions generically (`[GitHub] PR {action}: ...`), so `review_requested` produces valid output even without the enrichment. The enrichment adds reviewer context for mika-qa.
+
+No feedback loop risk: mika-qa receives `review_requested`, performs its review, and submits a `pull_request_review.submitted` event — which routes to mika-dev (different agent). Routing table partitioning prevents loops.
+
+## Prevention
+
+- When adding new GitHub webhook workflows, trace the full lifecycle: event source (GitHub) -> gateway routing (`route_event()`) -> skill activation -> task state transition. Any gap means events get dropped silently.
+- The `route_event()` function is the single gate — `agent_mapping` only remaps names, not event eligibility.
+- New struct fields for webhook payloads must use `Option<T>` to avoid parse failures for events that omit them (#403 precedent).
+- Update all routing table references when adding new routes: `crates/mika-gateway/CLAUDE.md`, `docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md`, skill prompts that mention triggers.
+
+## Related Issues
+
+- #506 — This issue
+- `docs/solutions/integration-issues/gateway-pr-closed-webhook-routing.md` — Same gap pattern for `pull_request.closed`
+- `docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md` — Canonical routing table reference
+- `docs/solutions/architecture/github-app-identity-and-agent-infrastructure.md` — `MIKA_GITHUB_APP_LOGIN` and per-agent identity
+- `docs/solutions/runtime-errors/github-webhook-parse-fails-missing-app-id.md` — Why new fields must be `Option<T>`

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -2,7 +2,7 @@
 
 You are mika-qa, a specialist reviewer. Your job is to review a pull request and produce a structured verdict.
 
-You are triggered by GitHub webhook events (`pull_request.opened`, `pull_request.synchronize`) routed through the gateway. The incoming message contains the PR URL, repo, action, and sender. You may also be invoked directly by the user.
+You are triggered by GitHub webhook events (`pull_request.opened`, `pull_request.synchronize`, `pull_request.review_requested`) routed through the gateway. The incoming message contains the PR URL, repo, action, and sender. You may also be invoked directly by the user.
 
 ### Workspace
 

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -170,7 +170,7 @@ If the completion callback indicates failure, diagnose before escalating:
 
 **Step 5 — (removed: QA is now webhook-driven)**
 
-QA review is triggered automatically when a PR is created or updated. The `pull_request.opened` and `pull_request.synchronize` GitHub webhooks route directly to mika-qa. Verdicts arrive back via `pull_request_review.submitted` webhook — handled by the `self-dev-webhook-qa` skill (keyword-triggered, activates automatically on PR review events).
+QA review is triggered automatically when a PR is created, updated, or a reviewer is requested. The `pull_request.opened`, `pull_request.synchronize`, and `pull_request.review_requested` GitHub webhooks route directly to mika-qa. Verdicts arrive back via `pull_request_review.submitted` webhook — handled by the `self-dev-webhook-qa` skill (keyword-triggered, activates automatically on PR review events).
 
 After claude-pilot creates a PR, proceed directly to Step 6 with `in_progress`.
 


### PR DESCRIPTION
## Summary

- Add `review_requested` to the gateway's `route_event()` pull_request match so requesting `mika-platform-qa` as a PR reviewer triggers mika-qa's qa-review skill
- Add `requested_reviewer: Option<GitHubUser>` field to `GitHubWebhookEvent` struct and enrich the formatted message with the requested reviewer's login
- Update routing table references in gateway CLAUDE.md, solution docs, qa-review and self-dev skill prompts
- Document machine user assignee filtering configuration for `MIKA_GITHUB_APP_LOGIN`

Closes #506

## Changes

| File | Change |
|------|--------|
| `crates/mika-gateway/src/github.rs` | Add `review_requested` routing, `requested_reviewer` struct field, format enrichment, 3 new tests |
| `crates/mika-gateway/CLAUDE.md` | Update routing table, add machine user config note |
| `skills/bundled/qa-review/system_prompt.md` | Add `review_requested` to trigger list |
| `skills/bundled/self-dev/system_prompt.md` | Update QA trigger description |
| `docs/solutions/architecture-patterns/github-webhook-endpoint-gateway.md` | Update routing table |
| `docs/plans/2026-04-21-002-feat-gateway-review-requested-routing-plan.md` | Implementation plan |
| `docs/solutions/integration-issues/gateway-review-requested-webhook-routing.md` | Compound doc |

## Test plan

- [x] `cargo test -p mika-gateway` — 147 tests pass (3 new: routing, format with reviewer, format without reviewer)
- [x] `cargo clippy -p mika-gateway` — clean
- [x] Pre-commit hooks pass (fmt, clippy, secrets scan)
- [ ] Verify in production: request `mika-platform-qa` as reviewer on a PR and confirm mika-qa review triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)