### PR TITLE
feat(skills): variant management tooling (CLI + server API + dashboard)

### DIFF
--- a/crates/mika-agent/src/a2a_card.rs
+++ b/crates/mika-agent/src/a2a_card.rs
@@ -89,6 +89,7 @@ mod tests {
             llm: Default::default(),
             constraints: Default::default(),
             context: std::collections::HashMap::new(),
+            variants: Default::default(),
         };
         let toml_str = toml::to_string(&manifest).unwrap();
         std::fs::write(skill_dir.join("skill.toml"), toml_str).unwrap();

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -3714,6 +3714,7 @@ mod tests {
                     required_tools: required_tools.iter().map(|s| s.to_string()).collect(),
                 },
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from(format!("/skills/{name}")),
             keywords_lower: vec![name.to_lowercase()],

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -12,6 +12,7 @@ pub mod openapi;
 pub mod rewind;
 pub mod state;
 pub mod types;
+pub mod variants;
 pub(crate) mod verdict;
 pub mod verdict_handler;
 pub mod webhook_queue;
@@ -190,6 +191,34 @@ fn build_router(state: AppState) -> Router {
             post(embedded_dashboard::handle_disable),
         )
         .route("/dashboard/status", get(embedded_dashboard::handle_status))
+        // Variant management endpoints (read-only)
+        .route("/skills/variants", get(variants::handle_variants_summary))
+        .route(
+            "/skills/{skill}/variants",
+            get(variants::handle_skill_variants),
+        )
+        // Static route MUST come before {provider}/{model} wildcard
+        .route(
+            "/skills/{skill}/variants/reflect",
+            get(variants::handle_variant_reflect),
+        )
+        .route(
+            "/skills/{skill}/variants/{provider}/{model}",
+            get(variants::handle_variant_detail),
+        )
+        .route(
+            "/skills/{skill}/variants/{provider}/{model}/diff",
+            get(variants::handle_variant_diff),
+        )
+        // Variant mutation endpoints (still dashboard-auth for validate, promote needs internal)
+        .route(
+            "/skills/{skill}/variants/{provider}/{model}/validate",
+            post(variants::handle_variant_validate),
+        )
+        .route(
+            "/skills/{skill}/variants/{provider}/{model}/promote",
+            post(variants::handle_variant_promote),
+        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             auth::require_dashboard_or_internal_token,

--- a/crates/mika-agent/src/server/variants.rs
+++ b/crates/mika-agent/src/server/variants.rs
@@ -1,0 +1,347 @@
+//! HTTP handlers for variant management endpoints.
+
+use std::collections::HashSet;
+use std::sync::atomic::Ordering;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::skills::variants;
+
+use super::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Find a skill directory by name from the first agent's skill registry.
+fn find_skill_dir(
+    state: &AppState,
+    skill_name: &str,
+) -> Result<
+    (std::path::PathBuf, crate::skills::manifest::SkillManifest),
+    (StatusCode, Json<serde_json::Value>),
+> {
+    let agent_state = state.agents.values().next().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "no agents configured"})),
+        )
+    })?;
+
+    let registry = agent_state.skills.lock().unwrap().clone();
+    let entry = registry
+        .skills()
+        .iter()
+        .find(|s| s.manifest.skill.name.eq_ignore_ascii_case(skill_name))
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("skill '{skill_name}' not found")})),
+            )
+        })?;
+
+    Ok((entry.dir.clone(), entry.manifest.clone()))
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/skills/variants — cross-skill summary
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variants_summary(State(state): State<AppState>) -> impl IntoResponse {
+    let agent_state = match state.agents.values().next() {
+        Some(a) => a,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "no agents configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let registry = agent_state.skills.lock().unwrap().clone();
+    let mut all_variants = Vec::new();
+
+    for entry in registry.skills() {
+        let mut skill_variants = variants::scan_all_variants(&entry.dir, &entry.manifest);
+        all_variants.append(&mut skill_variants);
+    }
+
+    let summaries = variants::summarize_variants(&all_variants);
+    Json(summaries).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/skills/{skill}/variants — per-skill list
+// ---------------------------------------------------------------------------
+
+pub async fn handle_skill_variants(
+    State(state): State<AppState>,
+    Path(skill_name): Path<String>,
+) -> impl IntoResponse {
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    let all_variants = variants::scan_all_variants(&skill_dir, &manifest);
+    Json(all_variants).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/skills/{skill}/variants/reflect — audit report
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variant_reflect(
+    State(state): State<AppState>,
+    Path(skill_name): Path<String>,
+) -> impl IntoResponse {
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    match variants::reflect_skill(&skill_dir, &manifest) {
+        Ok(report) => Json(report).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("{e}")})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/skills/{skill}/variants/{provider}/{model} — content + metadata
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variant_detail(
+    State(state): State<AppState>,
+    Path((skill_name, provider, model)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    let all_variants = variants::scan_all_variants(&skill_dir, &manifest);
+    let key = format!("{provider}/{model}");
+
+    // Find the runtime-resolved variant (hand-authored > generated > experimental)
+    let variant = all_variants.iter().find(|v| {
+        let vkey = format!("{}/{}", v.provider, v.model);
+        vkey == key
+    });
+
+    match variant {
+        Some(v) => {
+            let content = std::fs::read_to_string(&v.file_path).unwrap_or_default();
+            Json(json!({
+                "metadata": v,
+                "content": content,
+            }))
+            .into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("variant '{key}' not found")})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/skills/{skill}/variants/{provider}/{model}/diff
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variant_diff(
+    State(state): State<AppState>,
+    Path((skill_name, provider, model)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    let base_path = skill_dir.join("system_prompt.md");
+    let base_content = match std::fs::read_to_string(&base_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("cannot read base prompt: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let sanitized = crate::skills::index::sanitize_model_dir_name(&model);
+    // Try hand-authored > generated > experimental
+    let variant_path = {
+        let hand = skill_dir
+            .join(&provider)
+            .join(&sanitized)
+            .join("system_prompt.md");
+        if hand.exists() {
+            hand
+        } else {
+            let generated = skill_dir
+                .join("generated")
+                .join(&provider)
+                .join(&sanitized)
+                .join("system_prompt.md");
+            if generated.exists() {
+                generated
+            } else {
+                skill_dir
+                    .join("experimental")
+                    .join(&provider)
+                    .join(&sanitized)
+                    .join("system_prompt.md")
+            }
+        }
+    };
+
+    if !variant_path.exists() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": format!("variant '{provider}/{model}' not found")})),
+        )
+            .into_response();
+    }
+
+    let variant_content = match std::fs::read_to_string(&variant_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("cannot read variant: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let report = variants::diff_variant(&base_content, &variant_content);
+    let _ = manifest; // silence unused
+    Json(report).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/skills/{skill}/variants/{provider}/{model}/validate
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variant_validate(
+    State(state): State<AppState>,
+    Path((skill_name, provider, model)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    let sanitized = crate::skills::index::sanitize_model_dir_name(&model);
+    let all_variants = variants::scan_all_variants(&skill_dir, &manifest);
+    let key = format!("{provider}/{sanitized}");
+
+    let variant = all_variants.iter().find(|v| {
+        let vkey = format!("{}/{}", v.provider, v.model);
+        vkey == key
+    });
+
+    let variant = match variant {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": format!("variant '{provider}/{model}' not found")})),
+            )
+                .into_response();
+        }
+    };
+
+    let content = match std::fs::read_to_string(&variant.file_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("cannot read variant: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let base_content = std::fs::read_to_string(skill_dir.join("system_prompt.md")).ok();
+    let tool_names = HashSet::new();
+
+    let results =
+        variants::validate_variant(&content, base_content.as_deref(), &manifest, &tool_names);
+    let passed = !variants::has_failures(&results);
+
+    Json(json!({
+        "skill": skill_name,
+        "provider": provider,
+        "model": model,
+        "passed": passed,
+        "results": results,
+    }))
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/skills/{skill}/variants/{provider}/{model}/promote
+// ---------------------------------------------------------------------------
+
+pub async fn handle_variant_promote(
+    State(state): State<AppState>,
+    Path((skill_name, provider, model)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let agent_state = match state.agents.values().next() {
+        Some(a) => a.clone(),
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "no agents configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let (skill_dir, manifest) = match find_skill_dir(&state, &skill_name) {
+        Ok(v) => v,
+        Err(e) => return e.into_response(),
+    };
+
+    let base_content = std::fs::read_to_string(skill_dir.join("system_prompt.md")).ok();
+    let tool_names = HashSet::new();
+
+    match variants::promote_variant(
+        &skill_dir,
+        &manifest,
+        &provider,
+        &model,
+        base_content.as_deref(),
+        &tool_names,
+    ) {
+        Ok(result) => {
+            // Signal that the skill registry needs a refresh
+            agent_state.skills_dirty.store(true, Ordering::Relaxed);
+
+            Json(json!({
+                "promoted": true,
+                "source": result.source_path.display().to_string(),
+                "target": result.target_path.display().to_string(),
+                "warnings": result.warnings,
+            }))
+            .into_response()
+        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": format!("{e}")})),
+        )
+            .into_response(),
+    }
+}

--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -1401,6 +1401,12 @@ fn scan_provider_variants(skill_dir: &Path, manifest: &SkillManifest) -> Variant
             None => continue,
         };
 
+        // Skip reserved directory names (defense-in-depth — these also fail
+        // ProviderKind parse, but an explicit check prevents future regressions).
+        if super::variants::RESERVED_VARIANT_DIRS.contains(&subdir_name.as_str()) {
+            continue;
+        }
+
         // Only recognize subdirs that match a known ProviderKind
         if subdir_name.parse::<ProviderKind>().is_err() {
             continue;
@@ -2855,6 +2861,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -2894,6 +2901,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -2929,6 +2937,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -2964,6 +2973,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3664,6 +3674,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3715,6 +3726,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3758,6 +3770,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3813,6 +3826,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3874,6 +3888,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -3932,6 +3947,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -4582,6 +4598,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -4619,6 +4636,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -4663,6 +4681,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -4703,6 +4722,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],
@@ -4749,6 +4769,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from("/skills/test"),
             keywords_lower: vec![],

--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -248,7 +248,7 @@ impl SkillEntry {
 /// Sanitize a model name for use as a directory name.
 /// Replaces '/' with '--' to avoid filesystem path conflicts.
 /// Applied at both scan time (directory discovery) and resolution time (lookup).
-pub(crate) fn sanitize_model_dir_name(model: &str) -> String {
+pub fn sanitize_model_dir_name(model: &str) -> String {
     model.replace('/', "--")
 }
 

--- a/crates/mika-agent/src/skills/manifest.rs
+++ b/crates/mika-agent/src/skills/manifest.rs
@@ -39,6 +39,11 @@ pub struct SkillManifest {
     /// in the system prompt. The engine pre-fetches the data before the LLM turn.
     #[serde(default)]
     pub context: std::collections::HashMap<String, ContextRequirement>,
+    /// Optional variant management configuration.
+    /// Declares which providers have variants, size limits, and required sections
+    /// for the validation gate. Backward-compatible — absent section defaults to empty.
+    #[serde(default)]
+    pub variants: VariantsConfig,
 }
 
 /// Per-skill LLM provider and model preferences.
@@ -192,6 +197,33 @@ pub struct ProviderSkillFields {
     pub timeout_secs: Option<u64>,
     #[serde(default)]
     pub max_prompt_size: Option<u64>,
+}
+
+/// Optional variant management configuration from `[variants]` in `skill.toml`.
+///
+/// Controls the validation gate and variant metadata. All fields are optional
+/// with backward-compatible defaults (existing skill.toml files parse without changes).
+///
+/// Example:
+/// ```toml
+/// [variants]
+/// required_sections = ["Tools", "Constraints"]
+/// max_prompt_size = 32768
+/// ```
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct VariantsConfig {
+    /// Providers that have (or are expected to have) variants for this skill.
+    /// Informational only — does not restrict variant creation.
+    #[serde(default)]
+    pub providers: Option<Vec<String>>,
+    /// Per-variant max prompt size override (bytes). If set, overrides
+    /// `skill.max_prompt_size` for the validation gate.
+    #[serde(default)]
+    pub max_prompt_size: Option<u64>,
+    /// Markdown section headings required in every variant prompt.
+    /// The validation gate checks that each heading appears as `# Heading` or `## Heading`.
+    #[serde(default)]
+    pub required_sections: Option<Vec<String>>,
 }
 
 /// A tool definition loaded from a skill's `tools.json`.

--- a/crates/mika-agent/src/skills/matcher.rs
+++ b/crates/mika-agent/src/skills/matcher.rs
@@ -117,6 +117,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from(format!("/skills/{name}")),
             keywords_lower: keywords.iter().map(|s| s.to_lowercase()).collect(),

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -8,6 +8,7 @@ pub mod manifest;
 pub mod marketplace;
 pub mod matcher;
 pub mod review_filter;
+pub mod variants;
 
 use std::path::Path;
 
@@ -719,6 +720,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from(format!("/skills/{name}")),
             keywords_lower: vec![],

--- a/crates/mika-agent/src/skills/review_filter.rs
+++ b/crates/mika-agent/src/skills/review_filter.rs
@@ -100,6 +100,7 @@ mod tests {
                 llm: Default::default(),
                 constraints: Default::default(),
                 context: std::collections::HashMap::new(),
+                variants: Default::default(),
             },
             dir: PathBuf::from(format!("/skills/{name}")),
             keywords_lower: keywords.iter().map(|s| s.to_lowercase()).collect(),

--- a/crates/mika-agent/src/skills/variants.rs
+++ b/crates/mika-agent/src/skills/variants.rs
@@ -413,7 +413,9 @@ pub fn validate_variant(
             .filter(|section| {
                 !content.lines().any(|line| {
                     let trimmed = line.trim_start();
-                    (trimmed.starts_with("# ") || trimmed.starts_with("## "))
+                    // Match any heading level (#, ##, ###, etc.)
+                    trimmed.starts_with('#')
+                        && trimmed.trim_start_matches('#').starts_with(' ')
                         && trimmed
                             .trim_start_matches('#')
                             .trim()
@@ -615,13 +617,13 @@ pub fn diff_variant(base_content: &str, variant_content: &str) -> DiffReport {
     }
 }
 
-/// Extract markdown headings (# or ##) from content.
+/// Extract markdown headings (any level) from content.
 fn extract_headings(content: &str) -> Vec<String> {
     content
         .lines()
         .filter(|line| {
             let t = line.trim_start();
-            t.starts_with("# ") || t.starts_with("## ")
+            t.starts_with('#') && t.trim_start_matches('#').starts_with(' ')
         })
         .map(|line| line.trim_start().trim_start_matches('#').trim().to_string())
         .collect()
@@ -634,13 +636,31 @@ fn is_whitespace_only_diff(a: &str, b: &str) -> bool {
     normalize(a) == normalize(b)
 }
 
-/// Count added and removed lines between two sets of lines.
+/// Count added and removed lines using frequency maps (handles duplicate lines correctly).
 fn count_diff_lines(base: &[&str], variant: &[&str]) -> (usize, usize) {
-    let base_set: HashSet<&str> = base.iter().copied().collect();
-    let variant_set: HashSet<&str> = variant.iter().copied().collect();
+    let mut base_freq: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for line in base {
+        *base_freq.entry(line).or_insert(0) += 1;
+    }
+    let mut variant_freq: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for line in variant {
+        *variant_freq.entry(line).or_insert(0) += 1;
+    }
 
-    let removed = base.iter().filter(|l| !variant_set.contains(**l)).count();
-    let added = variant.iter().filter(|l| !base_set.contains(**l)).count();
+    let mut removed = 0;
+    for (line, &count) in &base_freq {
+        let var_count = variant_freq.get(line).copied().unwrap_or(0);
+        if count > var_count {
+            removed += count - var_count;
+        }
+    }
+    let mut added = 0;
+    for (line, &count) in &variant_freq {
+        let base_count = base_freq.get(line).copied().unwrap_or(0);
+        if count > base_count {
+            added += count - base_count;
+        }
+    }
 
     (added, removed)
 }
@@ -1021,7 +1041,7 @@ fn timestamp_parts(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
         30,
         31,
     ];
-    let mut month = 0u64;
+    let mut month = 12u64; // Default to December; overwritten if days < month boundary
     for (i, &md) in month_days.iter().enumerate() {
         if days < md {
             month = i as u64 + 1;

--- a/crates/mika-agent/src/skills/variants.rs
+++ b/crates/mika-agent/src/skills/variants.rs
@@ -1,0 +1,1823 @@
+//! Skill variant management: scanning, validation, diffing, reflection, and promotion.
+//!
+//! This module provides the shared data model and operations for managing
+//! per-provider/per-model prompt variants across skills. It is consumed by
+//! both CLI commands and HTTP API handlers.
+//!
+//! Design principle: **pure computation, no DB access**. All data comes from
+//! `SkillEntry` fields and filesystem reads.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+use mika_common::llm::ProviderKind;
+use serde::Serialize;
+use tracing::warn;
+
+use super::index::{
+    DiagnosticLevel, MAX_PROMPT_SIZE_CEILING, MAX_PROMPT_SNIPPET_SIZE, SkillDiagnostic,
+    sanitize_model_dir_name,
+};
+use super::manifest::SkillManifest;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Directory names reserved by the engine. These are never treated as provider
+/// names during variant scanning, even if a `ProviderKind` with the same name
+/// were to be added in the future (defense-in-depth).
+pub const RESERVED_VARIANT_DIRS: &[&str] = &["generated", "experimental"];
+
+/// Minimum ratio of variant size to base prompt size.
+/// Variants smaller than 50% of the base are likely truncated or corrupt.
+const MIN_VARIANT_RATIO: f64 = 0.5;
+
+// ---------------------------------------------------------------------------
+// Variant source types
+// ---------------------------------------------------------------------------
+
+/// Source tier of a variant prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VariantSource {
+    /// Hand-authored model variant under `<provider>/<model>/`.
+    HandAuthored,
+    /// Auto-generated variant under `generated/<provider>/<model>/`.
+    Generated,
+    /// Experimental variant under `experimental/<provider>/<model>/`.
+    Experimental,
+}
+
+impl std::fmt::Display for VariantSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HandAuthored => write!(f, "hand-authored"),
+            Self::Generated => write!(f, "generated"),
+            Self::Experimental => write!(f, "experimental"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variant metadata
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single variant prompt file.
+#[derive(Debug, Clone, Serialize)]
+pub struct VariantMetadata {
+    /// Skill name (for cross-skill reports).
+    pub skill_name: String,
+    /// Provider name (e.g. "anthropic").
+    pub provider: String,
+    /// Model directory name (sanitized, e.g. "claude-sonnet-4-6").
+    pub model: String,
+    /// Which tier this variant belongs to.
+    pub source: VariantSource,
+    /// Absolute path to the `system_prompt.md` file.
+    #[serde(skip)]
+    pub file_path: PathBuf,
+    /// File size in bytes.
+    pub size_bytes: u64,
+    /// Line count.
+    pub line_count: usize,
+    /// Last modified timestamp (ISO 8601).
+    pub last_modified: Option<String>,
+    /// Whether this variant is stale relative to the base prompt.
+    /// `None` if staleness cannot be determined (e.g. base missing).
+    pub stale: Option<bool>,
+}
+
+/// Cross-skill summary of variant counts.
+#[derive(Debug, Clone, Serialize)]
+pub struct VariantSummary {
+    pub skill_name: String,
+    pub total: usize,
+    pub hand_authored: usize,
+    pub generated: usize,
+    pub experimental: usize,
+    pub stale_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+/// Scan a skill directory for ALL variant prompts (hand-authored, generated, experimental).
+///
+/// This is the management-surface scanner — it discovers variants across all three
+/// tiers for listing, diffing, and reflection. Unlike `scan_provider_variants()`
+/// (which loads prompts into memory for runtime resolution), this returns metadata
+/// without loading prompt content.
+pub fn scan_all_variants(skill_dir: &Path, manifest: &SkillManifest) -> Vec<VariantMetadata> {
+    let skill_name = &manifest.skill.name;
+    let base_mtime = base_prompt_mtime(skill_dir);
+
+    let mut variants = Vec::new();
+
+    // 1. Hand-authored: <skill>/<provider>/<model>/system_prompt.md
+    scan_tier(
+        skill_dir,
+        skill_name,
+        VariantSource::HandAuthored,
+        base_mtime,
+        &mut variants,
+    );
+
+    // 2. Generated: <skill>/generated/<provider>/<model>/system_prompt.md
+    let generated_root = skill_dir.join("generated");
+    scan_tier(
+        &generated_root,
+        skill_name,
+        VariantSource::Generated,
+        base_mtime,
+        &mut variants,
+    );
+
+    // 3. Experimental: <skill>/experimental/<provider>/<model>/system_prompt.md
+    let experimental_root = skill_dir.join("experimental");
+    scan_tier(
+        &experimental_root,
+        skill_name,
+        VariantSource::Experimental,
+        base_mtime,
+        &mut variants,
+    );
+
+    variants
+}
+
+/// Scan a single tier (provider/model tree) for variant prompts.
+fn scan_tier(
+    root: &Path,
+    skill_name: &str,
+    source: VariantSource,
+    base_mtime: Option<SystemTime>,
+    out: &mut Vec<VariantMetadata>,
+) {
+    let provider_dirs = match std::fs::read_dir(root) {
+        Ok(rd) => rd,
+        Err(_) => return,
+    };
+
+    for provider_entry in provider_dirs.flatten() {
+        let provider_path = provider_entry.path();
+        if !provider_path.is_dir() {
+            continue;
+        }
+        // Defense-in-depth: skip symlinks
+        if std::fs::symlink_metadata(&provider_path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(true)
+        {
+            continue;
+        }
+
+        let provider_name = match provider_path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('.') => n.to_string(),
+            _ => continue,
+        };
+
+        // Skip reserved directory names
+        if RESERVED_VARIANT_DIRS.contains(&provider_name.as_str()) {
+            continue;
+        }
+
+        // Only recognize known providers
+        if provider_name.parse::<ProviderKind>().is_err() {
+            continue;
+        }
+
+        let model_dirs = match std::fs::read_dir(&provider_path) {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+
+        for model_entry in model_dirs.flatten() {
+            let model_path = model_entry.path();
+            if !model_path.is_dir() {
+                continue;
+            }
+            // Defense-in-depth: skip symlinks
+            if std::fs::symlink_metadata(&model_path)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(true)
+            {
+                continue;
+            }
+
+            let model_name = match model_path.file_name().and_then(|n| n.to_str()) {
+                Some(n) if !n.starts_with('.') => n.to_string(),
+                _ => continue,
+            };
+
+            let prompt_path = model_path.join("system_prompt.md");
+            if !prompt_path.exists() {
+                continue;
+            }
+
+            let file_meta = match std::fs::metadata(&prompt_path) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            let variant_mtime = file_meta.modified().ok();
+            let stale = match (base_mtime, variant_mtime) {
+                (Some(base), Some(variant)) => Some(variant < base),
+                _ => None,
+            };
+
+            let line_count = std::fs::read_to_string(&prompt_path)
+                .map(|c| c.lines().count())
+                .unwrap_or(0);
+
+            out.push(VariantMetadata {
+                skill_name: skill_name.to_string(),
+                provider: provider_name.clone(),
+                model: model_name,
+                source,
+                file_path: prompt_path,
+                size_bytes: file_meta.len(),
+                line_count,
+                last_modified: variant_mtime.map(format_system_time),
+                stale,
+            });
+        }
+    }
+}
+
+/// Build a cross-skill summary from variant metadata.
+pub fn summarize_variants(variants: &[VariantMetadata]) -> Vec<VariantSummary> {
+    let mut by_skill: std::collections::HashMap<String, VariantSummary> =
+        std::collections::HashMap::new();
+
+    for v in variants {
+        let entry = by_skill
+            .entry(v.skill_name.clone())
+            .or_insert_with(|| VariantSummary {
+                skill_name: v.skill_name.clone(),
+                total: 0,
+                hand_authored: 0,
+                generated: 0,
+                experimental: 0,
+                stale_count: 0,
+            });
+        entry.total += 1;
+        match v.source {
+            VariantSource::HandAuthored => entry.hand_authored += 1,
+            VariantSource::Generated => entry.generated += 1,
+            VariantSource::Experimental => entry.experimental += 1,
+        }
+        if v.stale == Some(true) {
+            entry.stale_count += 1;
+        }
+    }
+
+    let mut summaries: Vec<_> = by_skill.into_values().collect();
+    summaries.sort_by(|a, b| a.skill_name.cmp(&b.skill_name));
+    summaries
+}
+
+// ---------------------------------------------------------------------------
+// Validation gate (4 rules)
+// ---------------------------------------------------------------------------
+
+/// Which validation rule produced a finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationRule {
+    SizeLimit,
+    RequiredSections,
+    MarkdownWellFormedness,
+    ToolReferenceLint,
+}
+
+impl std::fmt::Display for ValidationRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SizeLimit => write!(f, "size_limit"),
+            Self::RequiredSections => write!(f, "required_sections"),
+            Self::MarkdownWellFormedness => write!(f, "markdown_well_formedness"),
+            Self::ToolReferenceLint => write!(f, "tool_reference_lint"),
+        }
+    }
+}
+
+/// A single validation finding.
+#[derive(Debug, Clone, Serialize)]
+pub struct ValidationResult {
+    pub rule: ValidationRule,
+    pub passed: bool,
+    pub message: String,
+    pub level: DiagnosticLevel,
+}
+
+impl ValidationResult {
+    fn ok(rule: ValidationRule, msg: impl Into<String>) -> Self {
+        Self {
+            rule,
+            passed: true,
+            message: msg.into(),
+            level: DiagnosticLevel::Ok,
+        }
+    }
+    fn warn(rule: ValidationRule, msg: impl Into<String>) -> Self {
+        Self {
+            rule,
+            passed: true, // warnings don't block promotion
+            message: msg.into(),
+            level: DiagnosticLevel::Warn,
+        }
+    }
+    fn fail(rule: ValidationRule, msg: impl Into<String>) -> Self {
+        Self {
+            rule,
+            passed: false,
+            message: msg.into(),
+            level: DiagnosticLevel::Fail,
+        }
+    }
+}
+
+/// Run the 4-rule validation gate on variant content.
+///
+/// `base_content` is the base `system_prompt.md` content (for ratio check).
+/// `tool_names` is the set of known tool names (for reference lint).
+/// `manifest` provides size limits and required sections.
+pub fn validate_variant(
+    content: &str,
+    base_content: Option<&str>,
+    manifest: &SkillManifest,
+    tool_names: &HashSet<String>,
+) -> Vec<ValidationResult> {
+    let mut results = Vec::with_capacity(4);
+
+    // Rule 1: Size limit
+    let max_size = manifest
+        .skill
+        .max_prompt_size
+        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
+        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+    let content_bytes = content.len() as u64;
+
+    if content_bytes > max_size {
+        results.push(ValidationResult::fail(
+            ValidationRule::SizeLimit,
+            format!(
+                "variant is {} bytes, exceeds limit of {} bytes",
+                content_bytes, max_size
+            ),
+        ));
+    } else if let Some(base) = base_content {
+        let min_size = ((base.len() as f64) * MIN_VARIANT_RATIO).ceil() as u64;
+        if content_bytes < min_size {
+            results.push(ValidationResult::fail(
+                ValidationRule::SizeLimit,
+                format!(
+                    "variant is {} bytes, below {} minimum ({}% of base {} bytes)",
+                    content_bytes,
+                    min_size,
+                    (MIN_VARIANT_RATIO * 100.0) as u32,
+                    base.len()
+                ),
+            ));
+        } else {
+            results.push(ValidationResult::ok(
+                ValidationRule::SizeLimit,
+                format!("variant is {} bytes (within limits)", content_bytes),
+            ));
+        }
+    } else {
+        results.push(ValidationResult::ok(
+            ValidationRule::SizeLimit,
+            format!("variant is {} bytes (within limits)", content_bytes),
+        ));
+    }
+
+    // Rule 2: Required sections
+    let required_sections = manifest
+        .variants
+        .required_sections
+        .as_deref()
+        .unwrap_or(&[]);
+    if required_sections.is_empty() {
+        results.push(ValidationResult::ok(
+            ValidationRule::RequiredSections,
+            "no required sections configured".to_string(),
+        ));
+    } else {
+        let missing: Vec<&str> = required_sections
+            .iter()
+            .filter(|section| {
+                !content.lines().any(|line| {
+                    let trimmed = line.trim_start();
+                    (trimmed.starts_with("# ") || trimmed.starts_with("## "))
+                        && trimmed
+                            .trim_start_matches('#')
+                            .trim()
+                            .eq_ignore_ascii_case(section)
+                })
+            })
+            .map(|s| s.as_str())
+            .collect();
+
+        if missing.is_empty() {
+            results.push(ValidationResult::ok(
+                ValidationRule::RequiredSections,
+                "all required sections present".to_string(),
+            ));
+        } else {
+            results.push(ValidationResult::fail(
+                ValidationRule::RequiredSections,
+                format!("missing required sections: {}", missing.join(", ")),
+            ));
+        }
+    }
+
+    // Rule 3: Markdown well-formedness
+    match super::validate_markdown_content(content) {
+        Ok(()) => {
+            results.push(ValidationResult::ok(
+                ValidationRule::MarkdownWellFormedness,
+                "markdown is well-formed".to_string(),
+            ));
+        }
+        Err(reason) => {
+            results.push(ValidationResult::fail(
+                ValidationRule::MarkdownWellFormedness,
+                format!("markdown issue: {reason}"),
+            ));
+        }
+    }
+
+    // Rule 4: Tool reference lint (warn-only)
+    if tool_names.is_empty() {
+        results.push(ValidationResult::ok(
+            ValidationRule::ToolReferenceLint,
+            "no tool names to lint against".to_string(),
+        ));
+    } else {
+        let mut unknown_refs = Vec::new();
+        for line in content.lines() {
+            // Check for backtick-quoted tool references like `tool_name`
+            for cap in line.split('`').enumerate() {
+                // Odd indices are inside backticks
+                if cap.0 % 2 == 1 {
+                    let word = cap.1.trim();
+                    if !word.is_empty()
+                        && !word.contains(' ')
+                        && word.chars().all(|c| c.is_alphanumeric() || c == '_')
+                        && !tool_names.contains(word)
+                        && looks_like_tool_name(word)
+                    {
+                        unknown_refs.push(word.to_string());
+                    }
+                }
+            }
+        }
+        unknown_refs.sort();
+        unknown_refs.dedup();
+
+        if unknown_refs.is_empty() {
+            results.push(ValidationResult::ok(
+                ValidationRule::ToolReferenceLint,
+                "no unrecognized tool references found".to_string(),
+            ));
+        } else {
+            results.push(ValidationResult::warn(
+                ValidationRule::ToolReferenceLint,
+                format!(
+                    "unrecognized tool references (may be false positives): {}",
+                    unknown_refs.join(", ")
+                ),
+            ));
+        }
+    }
+
+    results
+}
+
+/// Heuristic: does this identifier look like a tool name?
+/// Tool names typically use snake_case and are not common English words.
+fn looks_like_tool_name(word: &str) -> bool {
+    word.contains('_') && word.len() >= 3
+}
+
+/// Check if any validation results have failures (not warnings).
+pub fn has_failures(results: &[ValidationResult]) -> bool {
+    results.iter().any(|r| !r.passed)
+}
+
+/// Convert validation results to `SkillDiagnostic` for consistent CLI output.
+pub fn to_diagnostics(results: &[ValidationResult]) -> Vec<SkillDiagnostic> {
+    results
+        .iter()
+        .map(|r| match r.level {
+            DiagnosticLevel::Ok => SkillDiagnostic::ok(&r.message),
+            DiagnosticLevel::Warn => SkillDiagnostic::warn(&r.message),
+            DiagnosticLevel::Fail => SkillDiagnostic::fail(&r.message),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Diff and reflection
+// ---------------------------------------------------------------------------
+
+/// Classification of changes between a variant and its base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffClassification {
+    /// Only whitespace or formatting differences.
+    Cosmetic,
+    /// Text content changes without structural heading changes.
+    Content,
+    /// Heading additions or removals indicating structural change.
+    Structural,
+    /// No differences.
+    Identical,
+}
+
+impl std::fmt::Display for DiffClassification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cosmetic => write!(f, "cosmetic"),
+            Self::Content => write!(f, "content"),
+            Self::Structural => write!(f, "structural"),
+            Self::Identical => write!(f, "identical"),
+        }
+    }
+}
+
+/// Report from diffing a variant against its base prompt.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffReport {
+    pub classification: DiffClassification,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub missing_base_sections: Vec<String>,
+    /// Unified diff text for display.
+    pub unified_diff: String,
+}
+
+/// Compute a diff between base and variant content.
+pub fn diff_variant(base_content: &str, variant_content: &str) -> DiffReport {
+    if base_content == variant_content {
+        return DiffReport {
+            classification: DiffClassification::Identical,
+            added_lines: 0,
+            removed_lines: 0,
+            missing_base_sections: vec![],
+            unified_diff: String::new(),
+        };
+    }
+
+    // Simple line-by-line diff
+    let base_lines: Vec<&str> = base_content.lines().collect();
+    let variant_lines: Vec<&str> = variant_content.lines().collect();
+
+    // Count added/removed lines using LCS-based approach
+    let (added, removed) = count_diff_lines(&base_lines, &variant_lines);
+
+    // Build unified diff output
+    let unified_diff = build_unified_diff(&base_lines, &variant_lines);
+
+    // Check for heading changes (structural)
+    let base_headings = extract_headings(base_content);
+    let variant_headings = extract_headings(variant_content);
+
+    let missing_base_sections: Vec<String> = base_headings
+        .iter()
+        .filter(|h| !variant_headings.contains(h))
+        .cloned()
+        .collect();
+
+    let has_heading_changes =
+        !missing_base_sections.is_empty() || base_headings.len() != variant_headings.len();
+
+    // Classify
+    let classification = if has_heading_changes {
+        DiffClassification::Structural
+    } else if is_whitespace_only_diff(base_content, variant_content) {
+        DiffClassification::Cosmetic
+    } else {
+        DiffClassification::Content
+    };
+
+    DiffReport {
+        classification,
+        added_lines: added,
+        removed_lines: removed,
+        missing_base_sections,
+        unified_diff,
+    }
+}
+
+/// Extract markdown headings (# or ##) from content.
+fn extract_headings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter(|line| {
+            let t = line.trim_start();
+            t.starts_with("# ") || t.starts_with("## ")
+        })
+        .map(|line| line.trim_start().trim_start_matches('#').trim().to_string())
+        .collect()
+}
+
+/// Check if differences are whitespace-only.
+fn is_whitespace_only_diff(a: &str, b: &str) -> bool {
+    let normalize =
+        |s: &str| -> String { s.lines().map(|l| l.trim()).collect::<Vec<_>>().join("\n") };
+    normalize(a) == normalize(b)
+}
+
+/// Count added and removed lines between two sets of lines.
+fn count_diff_lines(base: &[&str], variant: &[&str]) -> (usize, usize) {
+    let base_set: HashSet<&str> = base.iter().copied().collect();
+    let variant_set: HashSet<&str> = variant.iter().copied().collect();
+
+    let removed = base.iter().filter(|l| !variant_set.contains(**l)).count();
+    let added = variant.iter().filter(|l| !base_set.contains(**l)).count();
+
+    (added, removed)
+}
+
+/// Build a simple unified diff string.
+fn build_unified_diff(base: &[&str], variant: &[&str]) -> String {
+    let mut out = String::new();
+    out.push_str("--- base/system_prompt.md\n");
+    out.push_str("+++ variant/system_prompt.md\n");
+
+    // Simple approach: show context around changes
+    let base_set: HashSet<&str> = base.iter().copied().collect();
+    let variant_set: HashSet<&str> = variant.iter().copied().collect();
+
+    // Show removed lines
+    for line in base {
+        if !variant_set.contains(*line) {
+            out.push('-');
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    // Show added lines
+    for line in variant {
+        if !base_set.contains(*line) {
+            out.push('+');
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Reflection
+// ---------------------------------------------------------------------------
+
+/// Recommended action for a variant after a base edit.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendedAction {
+    /// Variant is up to date, no action needed.
+    UpToDate,
+    /// Variant should be re-reviewed after base changes.
+    ReReview,
+    /// Variant should be regenerated (significant structural drift).
+    ConsiderRegenerate,
+}
+
+impl std::fmt::Display for RecommendedAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UpToDate => write!(f, "Variant is up to date"),
+            Self::ReReview => write!(f, "Re-review variant after base changes"),
+            Self::ConsiderRegenerate => write!(f, "Consider regenerating variant"),
+        }
+    }
+}
+
+/// Per-variant impact assessment in a reflection report.
+#[derive(Debug, Clone, Serialize)]
+pub struct VariantImpact {
+    pub metadata: VariantMetadata,
+    pub diff_summary: DiffSummary,
+    pub recommendation: RecommendedAction,
+}
+
+/// Compact diff summary for reflection reports.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffSummary {
+    pub classification: DiffClassification,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub missing_sections: Vec<String>,
+}
+
+/// Reflection report for a skill after a base prompt edit.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReflectionReport {
+    pub skill_name: String,
+    pub base_path: PathBuf,
+    pub base_last_modified: Option<String>,
+    pub impacts: Vec<VariantImpact>,
+}
+
+/// Generate a reflection report for a skill.
+///
+/// Reads the base prompt and all production variants (generated + hand-authored),
+/// computes diffs, and produces per-variant impact assessments with recommendations.
+/// Pure computation — never writes any files.
+pub fn reflect_skill(skill_dir: &Path, manifest: &SkillManifest) -> Result<ReflectionReport> {
+    let base_path = skill_dir.join("system_prompt.md");
+    let base_content = std::fs::read_to_string(&base_path)
+        .with_context(|| format!("cannot read base prompt: {}", base_path.display()))?;
+
+    let base_mtime = std::fs::metadata(&base_path)
+        .ok()
+        .and_then(|m| m.modified().ok());
+
+    let all_variants = scan_all_variants(skill_dir, manifest);
+
+    // Reflect on production variants only (hand-authored + generated)
+    let production_variants: Vec<_> = all_variants
+        .into_iter()
+        .filter(|v| v.source != VariantSource::Experimental)
+        .collect();
+
+    let mut impacts = Vec::new();
+
+    for variant in production_variants {
+        let variant_content = match std::fs::read_to_string(&variant.file_path) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    path = %variant.file_path.display(),
+                    error = %e,
+                    "cannot read variant for reflection"
+                );
+                continue;
+            }
+        };
+
+        let diff = diff_variant(&base_content, &variant_content);
+
+        let recommendation = match diff.classification {
+            DiffClassification::Identical => RecommendedAction::UpToDate,
+            DiffClassification::Cosmetic => RecommendedAction::UpToDate,
+            DiffClassification::Content => {
+                if variant.stale == Some(true) {
+                    RecommendedAction::ReReview
+                } else {
+                    RecommendedAction::UpToDate
+                }
+            }
+            DiffClassification::Structural => {
+                if !diff.missing_base_sections.is_empty() {
+                    RecommendedAction::ConsiderRegenerate
+                } else {
+                    RecommendedAction::ReReview
+                }
+            }
+        };
+
+        impacts.push(VariantImpact {
+            metadata: variant,
+            diff_summary: DiffSummary {
+                classification: diff.classification,
+                added_lines: diff.added_lines,
+                removed_lines: diff.removed_lines,
+                missing_sections: diff.missing_base_sections,
+            },
+            recommendation,
+        });
+    }
+
+    Ok(ReflectionReport {
+        skill_name: manifest.skill.name.clone(),
+        base_path,
+        base_last_modified: base_mtime.map(format_system_time),
+        impacts,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Promote
+// ---------------------------------------------------------------------------
+
+/// Result of a successful variant promotion.
+#[derive(Debug, Clone, Serialize)]
+pub struct PromoteResult {
+    pub source_path: PathBuf,
+    pub target_path: PathBuf,
+    pub warnings: Vec<String>,
+}
+
+/// Promote an experimental variant to generated.
+///
+/// Steps:
+/// 1. Verify experimental source exists
+/// 2. Check for hand-authored variant shadow
+/// 3. Validate content (4-rule gate)
+/// 4. Copy to generated/
+/// 5. Clean up experimental source (expected files only)
+pub fn promote_variant(
+    skill_dir: &Path,
+    manifest: &SkillManifest,
+    provider: &str,
+    model: &str,
+    base_content: Option<&str>,
+    tool_names: &HashSet<String>,
+) -> Result<PromoteResult> {
+    let sanitized_model = sanitize_model_dir_name(model);
+    let mut warnings = Vec::new();
+
+    // Check for symlinked skill directory
+    if let Ok(meta) = std::fs::symlink_metadata(skill_dir)
+        && meta.file_type().is_symlink()
+    {
+        warnings.push(format!(
+            "skill directory is a symlink (--link mode) — writes will affect the shared source at {}",
+            std::fs::read_link(skill_dir).unwrap_or_else(|_| skill_dir.to_path_buf()).display()
+        ));
+    }
+
+    // 1. Verify experimental source
+    let experimental_dir = skill_dir
+        .join("experimental")
+        .join(provider)
+        .join(&sanitized_model);
+    let source_prompt = experimental_dir.join("system_prompt.md");
+
+    if !source_prompt.exists() {
+        bail!(
+            "experimental variant not found: {}",
+            source_prompt.display()
+        );
+    }
+
+    // 2. Check for hand-authored variant shadow
+    let hand_authored_prompt = skill_dir
+        .join(provider)
+        .join(&sanitized_model)
+        .join("system_prompt.md");
+    if hand_authored_prompt.exists() {
+        bail!(
+            "hand-authored variant exists at {} and would shadow the promoted variant at runtime. \
+             Remove the hand-authored variant first.",
+            hand_authored_prompt.display()
+        );
+    }
+
+    // 3. Validate content
+    let content = std::fs::read_to_string(&source_prompt).with_context(|| {
+        format!(
+            "cannot read experimental variant: {}",
+            source_prompt.display()
+        )
+    })?;
+
+    let validation = validate_variant(&content, base_content, manifest, tool_names);
+    if has_failures(&validation) {
+        let violations: Vec<String> = validation
+            .iter()
+            .filter(|r| !r.passed)
+            .map(|r| format!("{}: {}", r.rule, r.message))
+            .collect();
+        bail!(
+            "experimental variant failed validation:\n  {}",
+            violations.join("\n  ")
+        );
+    }
+
+    // 4. Copy to generated
+    let target_dir = skill_dir
+        .join("generated")
+        .join(provider)
+        .join(&sanitized_model);
+    std::fs::create_dir_all(&target_dir)
+        .with_context(|| format!("cannot create target directory: {}", target_dir.display()))?;
+
+    let target_prompt = target_dir.join("system_prompt.md");
+    std::fs::copy(&source_prompt, &target_prompt).with_context(|| {
+        format!(
+            "cannot copy variant from {} to {}",
+            source_prompt.display(),
+            target_prompt.display()
+        )
+    })?;
+
+    // Also copy skill.toml override if present
+    let source_toml = experimental_dir.join("skill.toml");
+    if source_toml.exists() {
+        let target_toml = target_dir.join("skill.toml");
+        std::fs::copy(&source_toml, &target_toml).with_context(|| {
+            format!(
+                "cannot copy skill.toml from {} to {}",
+                source_toml.display(),
+                target_toml.display()
+            )
+        })?;
+    }
+
+    // 5. Clean up experimental source (expected files only)
+    for expected_file in &["system_prompt.md", "skill.toml"] {
+        let file = experimental_dir.join(expected_file);
+        if file.exists()
+            && let Err(e) = std::fs::remove_file(&file)
+        {
+            warnings.push(format!(
+                "cannot remove experimental file {}: {e}",
+                file.display()
+            ));
+        }
+    }
+
+    // Check for unexpected files before removing directories
+    if let Ok(remaining) = std::fs::read_dir(&experimental_dir) {
+        let unexpected: Vec<_> = remaining.flatten().collect();
+        if !unexpected.is_empty() {
+            warnings.push(format!(
+                "experimental directory {} contains {} unexpected file(s), not removing directory",
+                experimental_dir.display(),
+                unexpected.len()
+            ));
+        } else {
+            // Remove model directory if empty
+            let _ = std::fs::remove_dir(&experimental_dir);
+            // Remove provider directory if empty
+            let provider_dir = skill_dir.join("experimental").join(provider);
+            let _ = std::fs::remove_dir(&provider_dir);
+            // Remove experimental root if empty
+            let experimental_root = skill_dir.join("experimental");
+            let _ = std::fs::remove_dir(&experimental_root);
+        }
+    }
+
+    Ok(PromoteResult {
+        source_path: source_prompt,
+        target_path: target_prompt,
+        warnings,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Get the base prompt's mtime.
+fn base_prompt_mtime(skill_dir: &Path) -> Option<SystemTime> {
+    let base_path = skill_dir.join("system_prompt.md");
+    std::fs::metadata(&base_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+}
+
+/// Format a `SystemTime` as ISO 8601 UTC.
+fn format_system_time(t: SystemTime) -> String {
+    let dur = t.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default();
+    let secs = dur.as_secs();
+    // Simple UTC formatting
+    let (year, month, day, hour, min, sec) = timestamp_parts(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+/// Break Unix timestamp into date/time components.
+fn timestamp_parts(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = secs % 60;
+    let min = (secs / 60) % 60;
+    let hour = (secs / 3600) % 24;
+
+    // Days since epoch
+    let mut days = secs / 86400;
+    let mut year = 1970u64;
+
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let leap = is_leap(year);
+    let month_days = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut month = 0u64;
+    for (i, &md) in month_days.iter().enumerate() {
+        if days < md {
+            month = i as u64 + 1;
+            break;
+        }
+        days -= md;
+    }
+    let day = days + 1;
+
+    (year, month, day, hour, min, sec)
+}
+
+fn is_leap(year: u64) -> bool {
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::manifest::{Constraints, LlmOverride, SkillInfo, Triggers, VariantsConfig};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn make_manifest(name: &str) -> SkillManifest {
+        SkillManifest {
+            skill: SkillInfo {
+                name: name.to_string(),
+                description: "Test skill".to_string(),
+                version: "0.1.0".to_string(),
+                always_on: false,
+                timeout_secs: 30,
+                dependencies: vec![],
+                max_prompt_size: None,
+            },
+            triggers: Triggers::default(),
+            llm: LlmOverride::default(),
+            constraints: Constraints::default(),
+            context: Default::default(),
+            variants: VariantsConfig::default(),
+        }
+    }
+
+    fn write_file(dir: &Path, content: &str) {
+        if let Some(parent) = dir.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(dir).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn create_skill_dir(tmp: &TempDir) -> PathBuf {
+        let skill_dir = tmp.path().join("test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        write_file(
+            &skill_dir.join("system_prompt.md"),
+            "# Test Skill\n\n## Tools\n\nUse `search_memory` to find facts.\n\n## Constraints\n\nBe concise.\n",
+        );
+        write_file(
+            &skill_dir.join("skill.toml"),
+            "[skill]\nname = \"test-skill\"\ndescription = \"Test\"\nversion = \"0.1.0\"\n",
+        );
+        skill_dir
+    }
+
+    // -- Scanning tests --
+
+    #[test]
+    fn test_scan_empty_skill_dir() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        assert!(variants.is_empty(), "no variant dirs → empty list");
+    }
+
+    #[test]
+    fn test_scan_all_three_tiers() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Hand-authored
+        write_file(
+            &skill_dir
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Hand authored variant\n",
+        );
+
+        // Generated
+        write_file(
+            &skill_dir
+                .join("generated")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Generated variant\n",
+        );
+
+        // Experimental
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("openai")
+                .join("gpt-4o")
+                .join("system_prompt.md"),
+            "# Experimental variant\n",
+        );
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        assert_eq!(variants.len(), 3, "should find all three tiers");
+
+        let hand = variants
+            .iter()
+            .find(|v| v.source == VariantSource::HandAuthored);
+        assert!(hand.is_some(), "should find hand-authored");
+        assert_eq!(hand.unwrap().provider, "anthropic");
+
+        let generated = variants
+            .iter()
+            .find(|v| v.source == VariantSource::Generated);
+        assert!(generated.is_some(), "should find generated");
+
+        let exp = variants
+            .iter()
+            .find(|v| v.source == VariantSource::Experimental);
+        assert!(exp.is_some(), "should find experimental");
+        assert_eq!(exp.unwrap().provider, "openai");
+    }
+
+    #[test]
+    fn test_scan_skips_unknown_provider() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Unknown provider
+        write_file(
+            &skill_dir
+                .join("unknown-provider")
+                .join("some-model")
+                .join("system_prompt.md"),
+            "# Unknown\n",
+        );
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        assert!(variants.is_empty(), "unknown provider should be skipped");
+    }
+
+    #[test]
+    fn test_scan_skips_dotfiles() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Dotdir
+        write_file(
+            &skill_dir
+                .join(".hidden")
+                .join("model")
+                .join("system_prompt.md"),
+            "# Hidden\n",
+        );
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        assert!(variants.is_empty(), "dotdirs should be skipped");
+    }
+
+    #[test]
+    fn test_staleness_detection() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Create variant BEFORE touching base (so variant is older)
+        write_file(
+            &skill_dir
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Old variant\n",
+        );
+
+        // Small delay and touch the base
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        write_file(
+            &skill_dir.join("system_prompt.md"),
+            "# Updated base\n\n## Tools\n\nNew content.\n",
+        );
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0].stale, Some(true), "variant should be stale");
+    }
+
+    #[test]
+    fn test_scan_skips_reserved_dirs_in_hand_authored() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // The `generated` and `experimental` directories under the skill root
+        // should NOT be treated as provider directories in the hand-authored tier
+        write_file(
+            &skill_dir
+                .join("generated")
+                .join("anthropic")
+                .join("model")
+                .join("system_prompt.md"),
+            "# This is generated, not hand-authored\n",
+        );
+
+        let variants = scan_all_variants(&skill_dir, &manifest);
+        // Should find the variant only as Generated, not as HandAuthored
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0].source, VariantSource::Generated);
+    }
+
+    // -- Summary tests --
+
+    #[test]
+    fn test_summarize_variants() {
+        let variants = vec![
+            VariantMetadata {
+                skill_name: "skill-a".to_string(),
+                provider: "anthropic".to_string(),
+                model: "claude-sonnet-4-6".to_string(),
+                source: VariantSource::HandAuthored,
+                file_path: PathBuf::new(),
+                size_bytes: 100,
+                line_count: 10,
+                last_modified: None,
+                stale: Some(true),
+            },
+            VariantMetadata {
+                skill_name: "skill-a".to_string(),
+                provider: "openai".to_string(),
+                model: "gpt-4o".to_string(),
+                source: VariantSource::Generated,
+                file_path: PathBuf::new(),
+                size_bytes: 200,
+                line_count: 20,
+                last_modified: None,
+                stale: Some(false),
+            },
+            VariantMetadata {
+                skill_name: "skill-b".to_string(),
+                provider: "anthropic".to_string(),
+                model: "claude-sonnet-4-6".to_string(),
+                source: VariantSource::Experimental,
+                file_path: PathBuf::new(),
+                size_bytes: 150,
+                line_count: 15,
+                last_modified: None,
+                stale: None,
+            },
+        ];
+
+        let summaries = summarize_variants(&variants);
+        assert_eq!(summaries.len(), 2);
+
+        let a = summaries
+            .iter()
+            .find(|s| s.skill_name == "skill-a")
+            .unwrap();
+        assert_eq!(a.total, 2);
+        assert_eq!(a.hand_authored, 1);
+        assert_eq!(a.generated, 1);
+        assert_eq!(a.stale_count, 1);
+
+        let b = summaries
+            .iter()
+            .find(|s| s.skill_name == "skill-b")
+            .unwrap();
+        assert_eq!(b.total, 1);
+        assert_eq!(b.experimental, 1);
+    }
+
+    // -- Validation tests --
+
+    #[test]
+    fn test_validate_variant_all_pass() {
+        let manifest = make_manifest("test");
+        let content = "# Test\n\nSome content here.\n";
+        let base = "# Base\n\nBase content here.\n";
+        let tools = HashSet::new();
+
+        let results = validate_variant(content, Some(base), &manifest, &tools);
+        assert!(results.iter().all(|r| r.passed), "all should pass");
+    }
+
+    #[test]
+    fn test_validate_variant_size_exceeds_limit() {
+        let mut manifest = make_manifest("test");
+        manifest.skill.max_prompt_size = Some(10); // Very small limit
+        let content = "# Test\n\nThis is definitely more than 10 bytes.\n";
+        let tools = HashSet::new();
+
+        let results = validate_variant(content, None, &manifest, &tools);
+        let size_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::SizeLimit)
+            .unwrap();
+        assert!(!size_result.passed, "should fail size limit");
+    }
+
+    #[test]
+    fn test_validate_variant_below_min_ratio() {
+        let manifest = make_manifest("test");
+        let base = "x".repeat(1000);
+        let content = "tiny"; // Way below 50% of base
+        let tools = HashSet::new();
+
+        let results = validate_variant(content, Some(&base), &manifest, &tools);
+        let size_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::SizeLimit)
+            .unwrap();
+        assert!(!size_result.passed, "should fail min ratio check");
+    }
+
+    #[test]
+    fn test_validate_variant_no_required_sections() {
+        let manifest = make_manifest("test");
+        let content = "# Test\n\nContent.\n";
+        let tools = HashSet::new();
+
+        let results = validate_variant(content, None, &manifest, &tools);
+        let section_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::RequiredSections)
+            .unwrap();
+        assert!(
+            section_result.passed,
+            "should pass when no sections required"
+        );
+    }
+
+    #[test]
+    fn test_validate_variant_missing_required_section() {
+        let mut manifest = make_manifest("test");
+        manifest.variants.required_sections = Some(vec!["Tools".to_string(), "Setup".to_string()]);
+        let content = "# Test\n\n## Tools\n\nSome tools.\n";
+        let tools = HashSet::new();
+
+        let results = validate_variant(content, None, &manifest, &tools);
+        let section_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::RequiredSections)
+            .unwrap();
+        assert!(
+            !section_result.passed,
+            "should fail when 'Setup' is missing"
+        );
+        assert!(
+            section_result.message.contains("Setup"),
+            "should list missing section"
+        );
+    }
+
+    #[test]
+    fn test_validate_variant_markdown_wellformedness() {
+        let manifest = make_manifest("test");
+        let tools = HashSet::new();
+
+        // Unclosed fence
+        let content = "# Test\n\n```rust\nfn main() {}\n";
+        let results = validate_variant(content, None, &manifest, &tools);
+        let md_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::MarkdownWellFormedness)
+            .unwrap();
+        assert!(!md_result.passed, "unclosed fence should fail");
+
+        // Null bytes
+        let content = "# Test\n\nHello\0world\n";
+        let results = validate_variant(content, None, &manifest, &tools);
+        let md_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::MarkdownWellFormedness)
+            .unwrap();
+        assert!(!md_result.passed, "null bytes should fail");
+    }
+
+    #[test]
+    fn test_validate_variant_tool_reference_lint() {
+        let manifest = make_manifest("test");
+        let mut tools = HashSet::new();
+        tools.insert("search_memory".to_string());
+        tools.insert("store_fact".to_string());
+
+        // Reference to known tool - pass
+        let content = "# Test\n\nUse `search_memory` for lookups.\n";
+        let results = validate_variant(content, None, &manifest, &tools);
+        let lint_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::ToolReferenceLint)
+            .unwrap();
+        assert!(lint_result.passed, "known tool should pass");
+        assert_eq!(lint_result.level, DiagnosticLevel::Ok);
+
+        // Reference to unknown tool - warn (still passes)
+        let content = "# Test\n\nUse `unknown_tool` for something.\n";
+        let results = validate_variant(content, None, &manifest, &tools);
+        let lint_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::ToolReferenceLint)
+            .unwrap();
+        assert!(lint_result.passed, "unknown tool should still pass (warn)");
+        assert_eq!(
+            lint_result.level,
+            DiagnosticLevel::Warn,
+            "should be a warning"
+        );
+    }
+
+    #[test]
+    fn test_validate_variant_empty_tools() {
+        let manifest = make_manifest("test");
+        let tools = HashSet::new();
+
+        let content = "# Test\n\nUse `some_tool` for something.\n";
+        let results = validate_variant(content, None, &manifest, &tools);
+        let lint_result = results
+            .iter()
+            .find(|r| r.rule == ValidationRule::ToolReferenceLint)
+            .unwrap();
+        assert!(lint_result.passed, "empty tools should pass trivially");
+    }
+
+    // -- Diff tests --
+
+    #[test]
+    fn test_diff_identical() {
+        let content = "# Test\n\nSame content.\n";
+        let report = diff_variant(content, content);
+        assert_eq!(report.classification, DiffClassification::Identical);
+        assert_eq!(report.added_lines, 0);
+        assert_eq!(report.removed_lines, 0);
+    }
+
+    #[test]
+    fn test_diff_content_changes() {
+        let base = "# Test\n\nOld content.\n";
+        let variant = "# Test\n\nNew content.\n";
+        let report = diff_variant(base, variant);
+        assert_eq!(report.classification, DiffClassification::Content);
+        assert!(report.added_lines > 0 || report.removed_lines > 0);
+    }
+
+    #[test]
+    fn test_diff_structural_missing_section() {
+        let base = "# Test\n\n## Tools\n\nTools here.\n\n## Constraints\n\nConstraints here.\n";
+        let variant = "# Test\n\n## Tools\n\nTools here.\n";
+        let report = diff_variant(base, variant);
+        assert_eq!(report.classification, DiffClassification::Structural);
+        assert!(
+            report
+                .missing_base_sections
+                .contains(&"Constraints".to_string())
+        );
+    }
+
+    #[test]
+    fn test_diff_cosmetic_whitespace() {
+        let base = "# Test\n\nContent here.\n";
+        let variant = "# Test\n\n  Content here.  \n";
+        let report = diff_variant(base, variant);
+        assert_eq!(report.classification, DiffClassification::Cosmetic);
+    }
+
+    // -- Reflection tests --
+
+    #[test]
+    fn test_reflect_no_variants() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        let report = reflect_skill(&skill_dir, &manifest).unwrap();
+        assert!(report.impacts.is_empty());
+    }
+
+    #[test]
+    fn test_reflect_with_stale_variant() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Create variant first (older)
+        write_file(
+            &skill_dir
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Old variant\n\nOld content.\n",
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Touch base (newer)
+        write_file(
+            &skill_dir.join("system_prompt.md"),
+            "# Test Skill\n\n## Tools\n\nUpdated tools.\n\n## New Section\n\nNew content.\n",
+        );
+
+        let report = reflect_skill(&skill_dir, &manifest).unwrap();
+        assert_eq!(report.impacts.len(), 1);
+
+        let impact = &report.impacts[0];
+        assert_eq!(impact.metadata.stale, Some(true));
+    }
+
+    #[test]
+    fn test_reflect_excludes_experimental() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Experimental variant should NOT appear in reflection
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Experimental\n",
+        );
+
+        let report = reflect_skill(&skill_dir, &manifest).unwrap();
+        assert!(
+            report.impacts.is_empty(),
+            "experimental variants excluded from reflection"
+        );
+    }
+
+    // -- Promote tests --
+
+    #[test]
+    fn test_promote_success() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        let content = "# Promoted Variant\n\n## Tools\n\nUse tools wisely.\n\n## Constraints\n\nBe concise and precise in responses.\n";
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            content,
+        );
+
+        let base = std::fs::read_to_string(skill_dir.join("system_prompt.md")).unwrap();
+        let tools = HashSet::new();
+
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            Some(&base),
+            &tools,
+        )
+        .unwrap();
+
+        // Target should exist
+        assert!(result.target_path.exists());
+        let target_content = std::fs::read_to_string(&result.target_path).unwrap();
+        assert_eq!(target_content, content);
+
+        // Source should be gone
+        assert!(!result.source_path.exists());
+    }
+
+    #[test]
+    fn test_promote_with_skill_toml() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Variant\n\n## Tools\n\nUse search tools.\n\n## Constraints\n\nBe precise in all responses.\n",
+        );
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("skill.toml"),
+            "[skill]\ntimeout_secs = 60\n",
+        );
+
+        let base = std::fs::read_to_string(skill_dir.join("system_prompt.md")).unwrap();
+        let tools = HashSet::new();
+
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            Some(&base),
+            &tools,
+        )
+        .unwrap();
+
+        // Both files should be in generated
+        assert!(result.target_path.exists());
+        assert!(
+            skill_dir
+                .join("generated/anthropic/claude-sonnet-4-6/skill.toml")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn test_promote_missing_source() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+        let tools = HashSet::new();
+
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            None,
+            &tools,
+        );
+        assert!(result.is_err(), "missing source should error");
+        assert!(
+            result.unwrap_err().to_string().contains("not found"),
+            "error should mention not found"
+        );
+    }
+
+    #[test]
+    fn test_promote_blocked_by_hand_authored() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Create both experimental and hand-authored
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Experimental Variant\n\n## Tools\n\nUse search tools.\n\n## Constraints\n\nBe precise in responses.\n",
+        );
+        write_file(
+            &skill_dir
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Hand Authored Variant\n\n## Tools\n\nHand authored tools.\n\n## Constraints\n\nHand authored constraints.\n",
+        );
+
+        let tools = HashSet::new();
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            None,
+            &tools,
+        );
+        assert!(result.is_err(), "should be blocked by hand-authored");
+        assert!(
+            result.unwrap_err().to_string().contains("hand-authored"),
+            "error should mention hand-authored"
+        );
+
+        // Verify no filesystem changes occurred
+        assert!(
+            skill_dir
+                .join("experimental/anthropic/claude-sonnet-4-6/system_prompt.md")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn test_promote_blocked_by_validation() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let mut manifest = make_manifest("test-skill");
+        manifest.skill.max_prompt_size = Some(10); // Very small limit
+
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# This variant is definitely too large for the 10 byte limit.\n",
+        );
+
+        let tools = HashSet::new();
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            None,
+            &tools,
+        );
+        assert!(result.is_err(), "should be blocked by validation");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("failed validation")
+        );
+
+        // Source should still exist
+        assert!(
+            skill_dir
+                .join("experimental/anthropic/claude-sonnet-4-6/system_prompt.md")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn test_promote_overwrites_existing_generated() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = create_skill_dir(&tmp);
+        let manifest = make_manifest("test-skill");
+
+        // Existing generated variant
+        write_file(
+            &skill_dir
+                .join("generated")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            "# Old generated\n",
+        );
+
+        // New experimental
+        let new_content = "# New Promoted Variant\n\n## Tools\n\nUse tools wisely.\n\n## Constraints\n\nBe concise and precise.\n";
+        write_file(
+            &skill_dir
+                .join("experimental")
+                .join("anthropic")
+                .join("claude-sonnet-4-6")
+                .join("system_prompt.md"),
+            new_content,
+        );
+
+        let base = std::fs::read_to_string(skill_dir.join("system_prompt.md")).unwrap();
+        let tools = HashSet::new();
+
+        let result = promote_variant(
+            &skill_dir,
+            &manifest,
+            "anthropic",
+            "claude-sonnet-4-6",
+            Some(&base),
+            &tools,
+        )
+        .unwrap();
+        let target_content = std::fs::read_to_string(&result.target_path).unwrap();
+        assert_eq!(target_content, new_content, "should overwrite");
+    }
+
+    // -- has_failures tests --
+
+    #[test]
+    fn test_has_failures_with_no_failures() {
+        let results = vec![
+            ValidationResult::ok(ValidationRule::SizeLimit, "ok"),
+            ValidationResult::warn(ValidationRule::ToolReferenceLint, "warn"),
+        ];
+        assert!(!has_failures(&results), "warnings are not failures");
+    }
+
+    #[test]
+    fn test_has_failures_with_failure() {
+        let results = vec![
+            ValidationResult::ok(ValidationRule::SizeLimit, "ok"),
+            ValidationResult::fail(ValidationRule::MarkdownWellFormedness, "bad"),
+        ];
+        assert!(has_failures(&results), "should detect failure");
+    }
+}

--- a/crates/mika-agent/src/tools/create_skill.rs
+++ b/crates/mika-agent/src/tools/create_skill.rs
@@ -278,6 +278,7 @@ impl Tool for CreateSkillTool {
             llm: Default::default(),
             constraints: Default::default(),
             context: std::collections::HashMap::new(),
+            variants: Default::default(),
         };
 
         let skill_toml = match toml::to_string_pretty(&manifest) {

--- a/crates/mika-agent/tests/eval/test_required_tools_gate.rs
+++ b/crates/mika-agent/tests/eval/test_required_tools_gate.rs
@@ -137,6 +137,7 @@ fn make_skill_with_required_tools(
                 required_tools: required_tools.iter().map(|s| s.to_string()).collect(),
             },
             context: HashMap::new(),
+            variants: Default::default(),
         },
         dir: PathBuf::from(format!("/skills/{name}")),
         keywords_lower: keywords.iter().map(|s| s.to_lowercase()).collect(),

--- a/crates/mika-cli/src/cli.rs
+++ b/crates/mika-cli/src/cli.rs
@@ -442,6 +442,11 @@ pub enum SkillsCommand {
         #[command(subcommand)]
         action: SkillLlmAction,
     },
+    /// Manage per-provider/per-model prompt variants
+    Variants {
+        #[command(subcommand)]
+        action: SkillVariantsAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -455,6 +460,67 @@ pub enum SkillLlmAction {
     Reset,
     /// Show the effective LLM provider/model and its source
     Show,
+}
+
+#[derive(Subcommand)]
+pub enum SkillVariantsAction {
+    /// List all variants for a skill
+    List {
+        /// Skill name
+        name: String,
+        /// Output format: text (default) or json
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Show cross-skill variant summary
+    Status {
+        /// Output format: text (default) or json
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Show diff between variant and base prompt
+    Diff {
+        /// Skill name
+        name: String,
+        /// Variant specifier: provider/model (e.g. anthropic/claude-sonnet-4-6)
+        variant: String,
+        /// Variant source filter: hand-authored, generated, or experimental
+        #[arg(long)]
+        source: Option<String>,
+        /// Output format: text (default) or json
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Reflect on variant impact after base prompt edit
+    Reflect {
+        /// Skill name
+        name: String,
+        /// Output format: text (default) or json
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Validate variant prompts against the 4-rule gate
+    Validate {
+        /// Skill name (omit to validate all)
+        name: Option<String>,
+        /// Output format: text (default) or json
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Promote an experimental variant to generated (after validation)
+    Promote {
+        /// Skill name
+        name: String,
+        /// Variant specifier: provider/model (e.g. anthropic/claude-sonnet-4-6)
+        variant: String,
+    },
+    /// Print the command to regenerate a variant (prepare-only in v1)
+    Regen {
+        /// Skill name
+        name: String,
+        /// Variant specifier: provider/model (e.g. anthropic/claude-sonnet-4-6)
+        variant: String,
+    },
 }
 
 #[derive(clap::Args)]

--- a/crates/mika-cli/src/commands/mod.rs
+++ b/crates/mika-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod provider;
 pub mod reminders;
 pub mod setup;
 pub mod skills;
+pub mod skills_variants;
 pub mod status;
 pub mod tasks;
 pub mod teams;

--- a/crates/mika-cli/src/commands/skills.rs
+++ b/crates/mika-cli/src/commands/skills.rs
@@ -12,6 +12,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 use crate::cli::{SkillLlmAction, SkillsArgs, SkillsCommand};
+use crate::commands::skills_variants;
 
 pub async fn run(args: SkillsArgs, agent_name: &str) -> Result<()> {
     let global_home = home::resolve_home_dir()?;
@@ -77,6 +78,9 @@ pub async fn run(args: SkillsArgs, agent_name: &str) -> Result<()> {
         }
         Some(SkillsCommand::Llm { name, action }) => {
             run_skill_llm(&global_home, &skills_dir, agent_name, &name, action)?;
+        }
+        Some(SkillsCommand::Variants { action }) => {
+            skills_variants::run(action, &skills_dir)?;
         }
     }
     Ok(())

--- a/crates/mika-cli/src/commands/skills_variants.rs
+++ b/crates/mika-cli/src/commands/skills_variants.rs
@@ -1,0 +1,472 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use mika_agent::skills::index::sanitize_model_dir_name;
+use mika_agent::skills::manifest::SkillManifest;
+use mika_agent::skills::variants;
+
+use crate::cli::{OutputFormat, SkillVariantsAction};
+
+/// Parse a `provider/model` specifier, splitting on the first `/`.
+fn parse_variant_spec(spec: &str) -> Result<(&str, &str)> {
+    let (provider, model) = spec.split_once('/').ok_or_else(|| {
+        anyhow::anyhow!(
+            "Expected `provider/model`, got '{spec}'. Example: anthropic/claude-sonnet-4-6"
+        )
+    })?;
+    if provider.is_empty() || model.is_empty() {
+        bail!("Both provider and model are required (got '{spec}').");
+    }
+    Ok((provider, model))
+}
+
+/// Load a skill manifest from a skill directory.
+fn load_manifest(skill_dir: &Path) -> Result<SkillManifest> {
+    let manifest_path = skill_dir.join("skill.toml");
+    if !manifest_path.exists() {
+        bail!("skill.toml not found in {}", skill_dir.display());
+    }
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let manifest: SkillManifest = toml::from_str(&content)?;
+    Ok(manifest)
+}
+
+pub fn run(action: SkillVariantsAction, skills_dir: &Path) -> Result<()> {
+    match action {
+        SkillVariantsAction::List { name, format } => run_list(skills_dir, &name, &format),
+        SkillVariantsAction::Status { format } => run_status(skills_dir, &format),
+        SkillVariantsAction::Diff {
+            name,
+            variant,
+            source,
+            format,
+        } => run_diff(skills_dir, &name, &variant, source.as_deref(), &format),
+        SkillVariantsAction::Reflect { name, format } => run_reflect(skills_dir, &name, &format),
+        SkillVariantsAction::Validate { name, format } => {
+            run_validate(skills_dir, name.as_deref(), &format)
+        }
+        SkillVariantsAction::Promote { name, variant } => run_promote(skills_dir, &name, &variant),
+        SkillVariantsAction::Regen { name, variant } => run_regen(&name, &variant),
+    }
+}
+
+fn run_list(skills_dir: &Path, name: &str, format: &OutputFormat) -> Result<()> {
+    let skill_dir = skills_dir.join(name);
+    if !skill_dir.is_dir() {
+        bail!("Skill '{name}' not found at {}", skill_dir.display());
+    }
+    let manifest = load_manifest(&skill_dir)?;
+    let all_variants = variants::scan_all_variants(&skill_dir, &manifest);
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&all_variants)?);
+        }
+        OutputFormat::Text => {
+            if all_variants.is_empty() {
+                println!("\n  No variants found for skill '{name}'.\n");
+                return Ok(());
+            }
+            println!(
+                "\n  Variants for '{name}' ({} total):\n",
+                all_variants.len()
+            );
+            println!(
+                "  {:15} {:25} {:12} {:>8} {:>6} {:10} LAST MODIFIED",
+                "PROVIDER", "MODEL", "SOURCE", "SIZE", "LINES", "STALE"
+            );
+            for v in &all_variants {
+                let stale_str = match v.stale {
+                    Some(true) => "yes",
+                    Some(false) => "no",
+                    None => "?",
+                };
+                let modified = v.last_modified.as_deref().unwrap_or("-");
+                println!(
+                    "  {:15} {:25} {:12} {:>7}B {:>5} {:10} {}",
+                    v.provider,
+                    v.model,
+                    v.source.to_string(),
+                    v.size_bytes,
+                    v.line_count,
+                    stale_str,
+                    modified
+                );
+            }
+            println!();
+        }
+    }
+    Ok(())
+}
+
+fn run_status(skills_dir: &Path, format: &OutputFormat) -> Result<()> {
+    if !skills_dir.is_dir() {
+        match format {
+            OutputFormat::Json => println!("[]"),
+            OutputFormat::Text => {
+                println!("\n  No skills directory found.\n");
+            }
+        }
+        return Ok(());
+    }
+
+    let mut all_variants = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(skills_dir) {
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Ok(manifest) = load_manifest(&path) {
+                let mut skill_variants = variants::scan_all_variants(&path, &manifest);
+                all_variants.append(&mut skill_variants);
+            }
+        }
+    }
+
+    let summaries = variants::summarize_variants(&all_variants);
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&summaries)?);
+        }
+        OutputFormat::Text => {
+            if summaries.is_empty() {
+                println!("\n  No variants found across any skills.\n");
+                return Ok(());
+            }
+            println!(
+                "\n  Variant status ({} skills with variants):\n",
+                summaries.len()
+            );
+            println!(
+                "  {:25} {:>6} {:>6} {:>6} {:>8} {:>6}",
+                "SKILL", "TOTAL", "HAND", "GEN", "EXPER.", "STALE"
+            );
+            for s in &summaries {
+                println!(
+                    "  {:25} {:>6} {:>6} {:>6} {:>8} {:>6}",
+                    s.skill_name,
+                    s.total,
+                    s.hand_authored,
+                    s.generated,
+                    s.experimental,
+                    s.stale_count
+                );
+            }
+            println!();
+        }
+    }
+    Ok(())
+}
+
+fn run_diff(
+    skills_dir: &Path,
+    name: &str,
+    variant_spec: &str,
+    source_filter: Option<&str>,
+    format: &OutputFormat,
+) -> Result<()> {
+    let skill_dir = skills_dir.join(name);
+    if !skill_dir.is_dir() {
+        bail!("Skill '{name}' not found at {}", skill_dir.display());
+    }
+    let manifest = load_manifest(&skill_dir)?;
+
+    let (provider, model) = parse_variant_spec(variant_spec)?;
+    let sanitized_model = sanitize_model_dir_name(model);
+
+    // Read base content
+    let base_path = skill_dir.join("system_prompt.md");
+    let base_content = std::fs::read_to_string(&base_path)
+        .map_err(|e| anyhow::anyhow!("Cannot read base prompt: {e}"))?;
+
+    // Find the variant to diff
+    let variant_path = match source_filter {
+        Some("experimental") => skill_dir
+            .join("experimental")
+            .join(provider)
+            .join(&sanitized_model)
+            .join("system_prompt.md"),
+        Some("generated") => skill_dir
+            .join("generated")
+            .join(provider)
+            .join(&sanitized_model)
+            .join("system_prompt.md"),
+        Some("hand-authored") => skill_dir
+            .join(provider)
+            .join(&sanitized_model)
+            .join("system_prompt.md"),
+        None => {
+            // Default: runtime-resolved (hand-authored > generated)
+            let hand = skill_dir
+                .join(provider)
+                .join(&sanitized_model)
+                .join("system_prompt.md");
+            if hand.exists() {
+                hand
+            } else {
+                let generated = skill_dir
+                    .join("generated")
+                    .join(provider)
+                    .join(&sanitized_model)
+                    .join("system_prompt.md");
+                if generated.exists() {
+                    generated
+                } else {
+                    // Try experimental as last resort
+                    skill_dir
+                        .join("experimental")
+                        .join(provider)
+                        .join(&sanitized_model)
+                        .join("system_prompt.md")
+                }
+            }
+        }
+        Some(other) => bail!(
+            "Invalid --source '{other}'. Must be one of: hand-authored, generated, experimental"
+        ),
+    };
+
+    if !variant_path.exists() {
+        bail!("Variant not found at {}", variant_path.display());
+    }
+
+    let variant_content = std::fs::read_to_string(&variant_path)?;
+    let report = variants::diff_variant(&base_content, &variant_content);
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        OutputFormat::Text => {
+            println!("\n  Diff: {name} {provider}/{model}");
+            println!("  Classification: {}", report.classification);
+            println!("  Lines: +{} -{}", report.added_lines, report.removed_lines);
+            if !report.missing_base_sections.is_empty() {
+                println!(
+                    "  Missing base sections: {}",
+                    report.missing_base_sections.join(", ")
+                );
+            }
+            if !report.unified_diff.is_empty() {
+                println!();
+                print!("{}", report.unified_diff);
+            }
+            println!();
+            let _ = &manifest; // silence unused warning
+        }
+    }
+    Ok(())
+}
+
+fn run_reflect(skills_dir: &Path, name: &str, format: &OutputFormat) -> Result<()> {
+    let skill_dir = skills_dir.join(name);
+    if !skill_dir.is_dir() {
+        bail!("Skill '{name}' not found at {}", skill_dir.display());
+    }
+    let manifest = load_manifest(&skill_dir)?;
+    let report = variants::reflect_skill(&skill_dir, &manifest)?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        OutputFormat::Text => {
+            println!("\n  Reflection report for '{name}':");
+            println!(
+                "  Base last modified: {}",
+                report.base_last_modified.as_deref().unwrap_or("unknown")
+            );
+            if report.impacts.is_empty() {
+                println!("  No production variants found.\n");
+                return Ok(());
+            }
+            println!("  {} variant(s) analyzed:\n", report.impacts.len());
+            for impact in &report.impacts {
+                let v = &impact.metadata;
+                let stale = match v.stale {
+                    Some(true) => " [STALE]",
+                    _ => "",
+                };
+                println!("    {}/{} ({}){}", v.provider, v.model, v.source, stale);
+                println!(
+                    "      Classification: {}, +{} -{} lines",
+                    impact.diff_summary.classification,
+                    impact.diff_summary.added_lines,
+                    impact.diff_summary.removed_lines
+                );
+                if !impact.diff_summary.missing_sections.is_empty() {
+                    println!(
+                        "      Missing sections: {}",
+                        impact.diff_summary.missing_sections.join(", ")
+                    );
+                }
+                println!("      Recommendation: {}", impact.recommendation);
+            }
+            println!();
+        }
+    }
+    Ok(())
+}
+
+fn run_validate(skills_dir: &Path, name: Option<&str>, format: &OutputFormat) -> Result<()> {
+    let dirs: Vec<(String, std::path::PathBuf)> = match name {
+        Some(n) => {
+            let skill_dir = skills_dir.join(n);
+            if !skill_dir.is_dir() {
+                bail!("Skill '{n}' not found at {}", skill_dir.display());
+            }
+            vec![(n.to_string(), skill_dir)]
+        }
+        None => {
+            let mut found = Vec::new();
+            if let Ok(rd) = std::fs::read_dir(skills_dir) {
+                for entry in rd.flatten() {
+                    let path = entry.path();
+                    if path.is_dir()
+                        && let Some(dir_name) = path.file_name().and_then(|n| n.to_str())
+                    {
+                        found.push((dir_name.to_string(), path));
+                    }
+                }
+            }
+            found.sort_by(|a, b| a.0.cmp(&b.0));
+            found
+        }
+    };
+
+    // CLI doesn't have the full tool registry, pass empty set
+    let tool_names = HashSet::new();
+    let mut all_json: Vec<serde_json::Value> = Vec::new();
+
+    if matches!(format, OutputFormat::Text) {
+        println!();
+    }
+
+    for (skill_name, skill_dir) in &dirs {
+        let manifest = match load_manifest(skill_dir) {
+            Ok(m) => m,
+            Err(e) => {
+                match format {
+                    OutputFormat::Text => {
+                        println!("  {skill_name}/");
+                        println!("    [FAIL] Cannot load manifest: {e}");
+                    }
+                    OutputFormat::Json => {
+                        all_json.push(serde_json::json!({
+                            "skill": skill_name,
+                            "error": format!("{e}"),
+                        }));
+                    }
+                }
+                continue;
+            }
+        };
+
+        let all_variants = variants::scan_all_variants(skill_dir, &manifest);
+        if all_variants.is_empty() {
+            continue;
+        }
+
+        let base_content = std::fs::read_to_string(skill_dir.join("system_prompt.md")).ok();
+
+        if matches!(format, OutputFormat::Text) {
+            println!("  {skill_name}/");
+        }
+
+        for v in &all_variants {
+            let content = match std::fs::read_to_string(&v.file_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let results = variants::validate_variant(
+                &content,
+                base_content.as_deref(),
+                &manifest,
+                &tool_names,
+            );
+            let diags = variants::to_diagnostics(&results);
+
+            match format {
+                OutputFormat::Text => {
+                    println!("    {}/{} ({}):", v.provider, v.model, v.source);
+                    for d in &diags {
+                        println!("      {} {}", d.tag(), d.message);
+                    }
+                }
+                OutputFormat::Json => {
+                    let rule_results: Vec<serde_json::Value> = results
+                        .iter()
+                        .map(|r| {
+                            serde_json::json!({
+                                "rule": r.rule,
+                                "passed": r.passed,
+                                "message": r.message,
+                                "level": r.level,
+                            })
+                        })
+                        .collect();
+                    all_json.push(serde_json::json!({
+                        "skill": skill_name,
+                        "provider": v.provider,
+                        "model": v.model,
+                        "source": v.source,
+                        "results": rule_results,
+                    }));
+                }
+            }
+        }
+    }
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&all_json)?);
+        }
+        OutputFormat::Text => println!(),
+    }
+
+    Ok(())
+}
+
+fn run_promote(skills_dir: &Path, name: &str, variant_spec: &str) -> Result<()> {
+    let skill_dir = skills_dir.join(name);
+    if !skill_dir.is_dir() {
+        bail!("Skill '{name}' not found at {}", skill_dir.display());
+    }
+    let manifest = load_manifest(&skill_dir)?;
+
+    let (provider, model) = parse_variant_spec(variant_spec)?;
+
+    let base_content = std::fs::read_to_string(skill_dir.join("system_prompt.md")).ok();
+    let tool_names = HashSet::new();
+
+    let result = variants::promote_variant(
+        &skill_dir,
+        &manifest,
+        provider,
+        model,
+        base_content.as_deref(),
+        &tool_names,
+    )?;
+
+    println!("\n  Promoted variant:");
+    println!("    From: {}", result.source_path.display());
+    println!("    To:   {}", result.target_path.display());
+    for w in &result.warnings {
+        println!("    [WARN] {w}");
+    }
+    println!();
+    Ok(())
+}
+
+fn run_regen(name: &str, variant_spec: &str) -> Result<()> {
+    let (provider, model) = parse_variant_spec(variant_spec)?;
+
+    println!("\n  To regenerate the variant for '{name}' targeting {provider}/{model}, run:\n");
+    println!(
+        "    mika ask --enable-skill skill-review \"review and generate variant for {name} targeting {provider}/{model}\"\n"
+    );
+    Ok(())
+}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -17,6 +17,7 @@ import DevRuns from './pages/DevRuns.tsx'
 import DevRunDetail from './pages/DevRunDetail.tsx'
 import TeamRuns from './pages/TeamRuns.tsx'
 import TeamRunDetail from './pages/TeamRunDetail.tsx'
+import SkillVariants from './pages/SkillVariants.tsx'
 import NotFound from './pages/NotFound.tsx'
 
 export default function App() {
@@ -40,6 +41,7 @@ export default function App() {
         <Route path="dev-runs/:taskId" element={<DevRunDetail />} />
         <Route path="team-runs" element={<TeamRuns />} />
         <Route path="team-runs/:runId" element={<TeamRunDetail />} />
+        <Route path="skill-variants" element={<SkillVariants />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/dashboard/src/api/variants.ts
+++ b/dashboard/src/api/variants.ts
@@ -1,0 +1,151 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch, TOKEN, API_BASE } from './client'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VariantSummary {
+  skill_name: string
+  total: number
+  hand_authored: number
+  generated: number
+  experimental: number
+  stale_count: number
+}
+
+export interface VariantMetadata {
+  skill_name: string
+  provider: string
+  model: string
+  source: 'hand_authored' | 'generated' | 'experimental'
+  size_bytes: number
+  line_count: number
+  last_modified: string | null
+  stale: boolean | null
+}
+
+export interface DiffReport {
+  classification: 'cosmetic' | 'content' | 'structural' | 'identical'
+  added_lines: number
+  removed_lines: number
+  missing_base_sections: string[]
+  unified_diff: string
+}
+
+export interface ValidationResult {
+  rule: string
+  passed: boolean
+  message: string
+  level: 'ok' | 'warn' | 'fail'
+}
+
+export interface ValidationResponse {
+  skill: string
+  provider: string
+  model: string
+  passed: boolean
+  results: ValidationResult[]
+}
+
+export interface VariantImpact {
+  metadata: VariantMetadata
+  diff_summary: {
+    classification: string
+    added_lines: number
+    removed_lines: number
+    missing_sections: string[]
+  }
+  recommendation: string
+}
+
+export interface ReflectionReport {
+  skill_name: string
+  base_last_modified: string | null
+  impacts: VariantImpact[]
+}
+
+export interface PromoteResponse {
+  promoted: boolean
+  source: string
+  target: string
+  warnings: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+export function useVariantsSummary() {
+  return useQuery<VariantSummary[]>({
+    queryKey: ['variants-summary'],
+    queryFn: () => apiFetch<VariantSummary[]>('/skills/variants'),
+  })
+}
+
+export function useSkillVariants(skillName: string | null) {
+  return useQuery<VariantMetadata[]>({
+    queryKey: ['skill-variants', skillName],
+    queryFn: () => apiFetch<VariantMetadata[]>(`/skills/${skillName}/variants`),
+    enabled: !!skillName,
+  })
+}
+
+export function useVariantDiff(skillName: string, provider: string, model: string, enabled: boolean) {
+  return useQuery<DiffReport>({
+    queryKey: ['variant-diff', skillName, provider, model],
+    queryFn: () => apiFetch<DiffReport>(`/skills/${skillName}/variants/${provider}/${model}/diff`),
+    enabled,
+  })
+}
+
+export function useVariantReflect(skillName: string | null, enabled: boolean) {
+  return useQuery<ReflectionReport>({
+    queryKey: ['variant-reflect', skillName],
+    queryFn: () => apiFetch<ReflectionReport>(`/skills/${skillName}/variants/reflect`),
+    enabled: !!skillName && enabled,
+  })
+}
+
+export function useValidateVariant() {
+  return useMutation<ValidationResponse, Error, { skill: string; provider: string; model: string }>({
+    mutationFn: async ({ skill, provider, model }) => {
+      const url = `${API_BASE}/skills/${skill}/variants/${provider}/${model}/validate`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+        },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+  })
+}
+
+export function usePromoteVariant() {
+  const queryClient = useQueryClient()
+  return useMutation<PromoteResponse, Error, { skill: string; provider: string; model: string }>({
+    mutationFn: async ({ skill, provider, model }) => {
+      const url = `${API_BASE}/skills/${skill}/variants/${provider}/${model}/promote`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+        },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['skill-variants', variables.skill] })
+      queryClient.invalidateQueries({ queryKey: ['variants-summary'] })
+    },
+  })
+}

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router'
-import { Activity, Bot, MessageSquare, Search, CheckSquare, Hammer, Users, Brain, Wrench } from 'lucide-react'
+import { Activity, Bot, MessageSquare, Search, CheckSquare, Hammer, Users, Brain, Wrench, Layers } from 'lucide-react'
 
 const navItems = [
   { to: '/', label: 'Event Timeline', icon: Activity },
@@ -11,6 +11,7 @@ const navItems = [
   { to: '/tool-calls', label: 'Tool Calls', icon: Wrench },
   { to: '/dev-runs', label: 'Dev Runs', icon: Hammer },
   { to: '/team-runs', label: 'Team Runs', icon: Users },
+  { to: '/skill-variants', label: 'Skill Variants', icon: Layers },
 ]
 
 export default function Sidebar() {

--- a/dashboard/src/components/VariantDiffViewer.tsx
+++ b/dashboard/src/components/VariantDiffViewer.tsx
@@ -1,0 +1,68 @@
+import { X } from 'lucide-react'
+import type { DiffReport } from '../api/variants'
+
+interface Props {
+  report: DiffReport
+  skillName: string
+  provider: string
+  model: string
+  onClose: () => void
+}
+
+const classColors: Record<string, string> = {
+  identical: 'text-green-400',
+  cosmetic: 'text-blue-400',
+  content: 'text-yellow-400',
+  structural: 'text-red-400',
+}
+
+export default function VariantDiffViewer({ report, skillName, provider, model, onClose }: Props) {
+  const lines = report.unified_diff.split('\n')
+
+  return (
+    <div className="border border-white/[0.08] rounded-lg bg-bg-card mt-4">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/[0.05]">
+        <div className="flex items-center gap-3">
+          <h3 className="text-heading text-sm font-medium">
+            Diff: {skillName} &mdash; {provider}/{model}
+          </h3>
+          <span className={`text-xs font-medium ${classColors[report.classification] ?? 'text-muted'}`}>
+            {report.classification}
+          </span>
+          <span className="text-xs text-muted">
+            +{report.added_lines} -{report.removed_lines}
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-muted hover:text-heading transition-colors p-1 rounded hover:bg-white/[0.05]"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {report.missing_base_sections.length > 0 && (
+        <div className="px-4 py-2 text-xs text-yellow-400 bg-yellow-400/5 border-b border-white/[0.05]">
+          Missing base sections: {report.missing_base_sections.join(', ')}
+        </div>
+      )}
+
+      <div className="overflow-x-auto max-h-96">
+        <pre className="text-xs font-mono p-4 leading-relaxed">
+          {lines.map((line, i) => {
+            let color = 'text-muted'
+            if (line.startsWith('+')) color = 'text-green-400'
+            else if (line.startsWith('-')) color = 'text-red-400'
+            else if (line.startsWith('@@')) color = 'text-blue-400'
+
+            return (
+              <div key={i} className={color}>
+                {line || '\u00A0'}
+              </div>
+            )
+          })}
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/pages/SkillVariants.tsx
+++ b/dashboard/src/pages/SkillVariants.tsx
@@ -1,0 +1,321 @@
+import { useState } from 'react'
+import { AlertTriangle, FileSearch, Shield, ArrowUpCircle, RefreshCw } from 'lucide-react'
+import {
+  useVariantsSummary,
+  useSkillVariants,
+  useVariantDiff,
+  useVariantReflect,
+  useValidateVariant,
+  usePromoteVariant,
+} from '../api/variants'
+import type { VariantMetadata, ValidationResponse } from '../api/variants'
+import VariantDiffViewer from '../components/VariantDiffViewer'
+
+const sourceColors: Record<string, string> = {
+  hand_authored: 'text-blue-400',
+  generated: 'text-green-400',
+  experimental: 'text-yellow-400',
+}
+
+const sourceLabels: Record<string, string> = {
+  hand_authored: 'hand-authored',
+  generated: 'generated',
+  experimental: 'experimental',
+}
+
+export default function SkillVariants() {
+  const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
+  const [diffTarget, setDiffTarget] = useState<{ provider: string; model: string } | null>(null)
+  const [showReflect, setShowReflect] = useState(false)
+  const [validationResult, setValidationResult] = useState<Record<string, ValidationResponse>>({})
+  const [confirmPromote, setConfirmPromote] = useState<{ provider: string; model: string } | null>(null)
+
+  const { data: summaries, isLoading: summaryLoading } = useVariantsSummary()
+  const { data: variants } = useSkillVariants(selectedSkill)
+  const { data: diffReport } = useVariantDiff(
+    selectedSkill ?? '',
+    diffTarget?.provider ?? '',
+    diffTarget?.model ?? '',
+    !!selectedSkill && !!diffTarget
+  )
+  const { data: reflectReport } = useVariantReflect(selectedSkill, showReflect)
+  const validateMutation = useValidateVariant()
+  const promoteMutation = usePromoteVariant()
+
+  const hasStaleVariants = variants?.some(v => v.stale === true) ?? false
+
+  const handleValidate = async (v: VariantMetadata) => {
+    const key = `${v.provider}/${v.model}`
+    try {
+      const result = await validateMutation.mutateAsync({
+        skill: selectedSkill!,
+        provider: v.provider,
+        model: v.model,
+      })
+      setValidationResult(prev => ({ ...prev, [key]: result }))
+    } catch {
+      // Error handled by mutation state
+    }
+  }
+
+  const handlePromote = async (provider: string, model: string) => {
+    try {
+      await promoteMutation.mutateAsync({
+        skill: selectedSkill!,
+        provider,
+        model,
+      })
+      setConfirmPromote(null)
+    } catch {
+      // Error handled by mutation state
+    }
+  }
+
+  return (
+    <div className="flex h-full">
+      {/* Left panel: skill list */}
+      <div className="w-64 shrink-0 border-r border-white/[0.05] overflow-y-auto">
+        <div className="p-4 border-b border-white/[0.05]">
+          <h2 className="text-heading text-sm font-medium">Skills with Variants</h2>
+        </div>
+        {summaryLoading ? (
+          <div className="p-4 text-muted text-sm">Loading...</div>
+        ) : !summaries || summaries.length === 0 ? (
+          <div className="p-4 text-muted text-sm">No variants found</div>
+        ) : (
+          <div className="p-2">
+            {summaries.map(s => (
+              <button
+                key={s.skill_name}
+                onClick={() => {
+                  setSelectedSkill(s.skill_name)
+                  setDiffTarget(null)
+                  setShowReflect(false)
+                  setValidationResult({})
+                }}
+                className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                  selectedSkill === s.skill_name
+                    ? 'bg-accent/10 text-accent-light'
+                    : 'text-muted hover:text-heading hover:bg-white/[0.03]'
+                }`}
+              >
+                <div className="font-medium">{s.skill_name}</div>
+                <div className="flex gap-2 mt-1 text-xs">
+                  <span>{s.total} total</span>
+                  {s.stale_count > 0 && (
+                    <span className="text-yellow-400">{s.stale_count} stale</span>
+                  )}
+                  {s.experimental > 0 && (
+                    <span className="text-yellow-400">{s.experimental} exp</span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Right panel: variant table */}
+      <div className="flex-1 overflow-y-auto">
+        {!selectedSkill ? (
+          <div className="flex items-center justify-center h-full text-muted text-sm">
+            Select a skill to view its variants
+          </div>
+        ) : (
+          <div className="p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-heading text-lg font-medium">{selectedSkill}</h2>
+              <button
+                onClick={() => setShowReflect(!showReflect)}
+                className="flex items-center gap-2 px-3 py-1.5 text-xs rounded-lg border border-white/[0.1] text-muted hover:text-heading hover:bg-white/[0.03] transition-colors"
+              >
+                <RefreshCw size={14} />
+                {showReflect ? 'Hide Reflect' : 'Reflect'}
+              </button>
+            </div>
+
+            {/* Stale warning banner */}
+            {hasStaleVariants && (
+              <div className="flex items-center gap-2 px-4 py-2.5 mb-4 rounded-lg bg-yellow-400/5 border border-yellow-400/20 text-yellow-400 text-sm">
+                <AlertTriangle size={16} />
+                Base prompt was modified after some variants. Consider re-reviewing stale variants.
+              </div>
+            )}
+
+            {/* Variant table */}
+            {!variants || variants.length === 0 ? (
+              <div className="text-muted text-sm">No variants for this skill.</div>
+            ) : (
+              <div className="border border-white/[0.08] rounded-lg overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-white/[0.05] bg-white/[0.02]">
+                      <th className="text-left px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Provider</th>
+                      <th className="text-left px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Model</th>
+                      <th className="text-left px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Source</th>
+                      <th className="text-right px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Size</th>
+                      <th className="text-right px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Lines</th>
+                      <th className="text-center px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Stale</th>
+                      <th className="text-right px-4 py-2.5 text-muted font-medium text-xs uppercase tracking-wider">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {variants.map(v => {
+                      const key = `${v.provider}/${v.model}`
+                      const vResult = validationResult[key]
+                      return (
+                        <tr key={`${v.source}-${key}`} className="border-b border-white/[0.03] hover:bg-white/[0.02]">
+                          <td className="px-4 py-2.5 text-heading">{v.provider}</td>
+                          <td className="px-4 py-2.5 text-heading font-mono text-xs">{v.model}</td>
+                          <td className="px-4 py-2.5">
+                            <span className={`text-xs font-medium ${sourceColors[v.source] ?? 'text-muted'}`}>
+                              {sourceLabels[v.source] ?? v.source}
+                            </span>
+                          </td>
+                          <td className="px-4 py-2.5 text-right text-muted">{v.size_bytes}B</td>
+                          <td className="px-4 py-2.5 text-right text-muted">{v.line_count}</td>
+                          <td className="px-4 py-2.5 text-center">
+                            {v.stale === true ? (
+                              <span className="text-yellow-400 text-xs">yes</span>
+                            ) : v.stale === false ? (
+                              <span className="text-green-400 text-xs">no</span>
+                            ) : (
+                              <span className="text-muted text-xs">-</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2.5 text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <button
+                                onClick={() => setDiffTarget({ provider: v.provider, model: v.model })}
+                                title="View diff"
+                                className="p-1 text-muted hover:text-heading transition-colors"
+                              >
+                                <FileSearch size={14} />
+                              </button>
+                              <button
+                                onClick={() => handleValidate(v)}
+                                title="Validate"
+                                className="p-1 text-muted hover:text-heading transition-colors"
+                              >
+                                <Shield size={14} />
+                              </button>
+                              {v.source === 'experimental' && (
+                                <button
+                                  onClick={() => setConfirmPromote({ provider: v.provider, model: v.model })}
+                                  title="Promote to generated"
+                                  className="p-1 text-muted hover:text-green-400 transition-colors"
+                                >
+                                  <ArrowUpCircle size={14} />
+                                </button>
+                              )}
+                            </div>
+                            {vResult && (
+                              <div className="mt-1 text-xs text-left">
+                                {vResult.results.map((r, i) => (
+                                  <div key={i} className={
+                                    r.level === 'ok' ? 'text-green-400' :
+                                    r.level === 'warn' ? 'text-yellow-400' : 'text-red-400'
+                                  }>
+                                    [{r.level.toUpperCase()}] {r.message}
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {/* Diff viewer */}
+            {diffTarget && diffReport && (
+              <VariantDiffViewer
+                report={diffReport}
+                skillName={selectedSkill}
+                provider={diffTarget.provider}
+                model={diffTarget.model}
+                onClose={() => setDiffTarget(null)}
+              />
+            )}
+
+            {/* Reflection report */}
+            {showReflect && reflectReport && (
+              <div className="mt-4 border border-white/[0.08] rounded-lg bg-bg-card p-4">
+                <h3 className="text-heading text-sm font-medium mb-3">Reflection Report</h3>
+                <div className="text-xs text-muted mb-3">
+                  Base last modified: {reflectReport.base_last_modified ?? 'unknown'}
+                </div>
+                {reflectReport.impacts.length === 0 ? (
+                  <div className="text-muted text-sm">No production variants to reflect on.</div>
+                ) : (
+                  <div className="space-y-3">
+                    {reflectReport.impacts.map((impact, i) => (
+                      <div key={i} className="border border-white/[0.05] rounded-lg p-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-heading text-sm">
+                            {impact.metadata.provider}/{impact.metadata.model}
+                          </span>
+                          <span className={`text-xs ${sourceColors[impact.metadata.source] ?? 'text-muted'}`}>
+                            {sourceLabels[impact.metadata.source] ?? impact.metadata.source}
+                          </span>
+                          {impact.metadata.stale === true && (
+                            <span className="text-yellow-400 text-xs">[STALE]</span>
+                          )}
+                        </div>
+                        <div className="mt-1 text-xs text-muted">
+                          {impact.diff_summary.classification} &mdash; +{impact.diff_summary.added_lines} -{impact.diff_summary.removed_lines} lines
+                        </div>
+                        {impact.diff_summary.missing_sections.length > 0 && (
+                          <div className="mt-1 text-xs text-yellow-400">
+                            Missing: {impact.diff_summary.missing_sections.join(', ')}
+                          </div>
+                        )}
+                        <div className="mt-1 text-xs text-accent-light">{impact.recommendation}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Promote confirmation modal */}
+            {confirmPromote && (
+              <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+                <div className="bg-bg-card border border-white/[0.1] rounded-xl p-6 max-w-md w-full mx-4">
+                  <h3 className="text-heading font-medium mb-2">Promote Variant</h3>
+                  <p className="text-muted text-sm mb-4">
+                    Promote <span className="text-heading">{confirmPromote.provider}/{confirmPromote.model}</span> from
+                    experimental to generated? This will run validation first.
+                  </p>
+                  {promoteMutation.isError && (
+                    <div className="text-red-400 text-sm mb-4 p-2 bg-red-400/5 rounded">
+                      {promoteMutation.error.message}
+                    </div>
+                  )}
+                  <div className="flex justify-end gap-3">
+                    <button
+                      onClick={() => { setConfirmPromote(null); promoteMutation.reset() }}
+                      className="px-4 py-2 text-sm text-muted hover:text-heading transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => handlePromote(confirmPromote.provider, confirmPromote.model)}
+                      disabled={promoteMutation.isPending}
+                      className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-500 transition-colors disabled:opacity-50"
+                    >
+                      {promoteMutation.isPending ? 'Promoting...' : 'Promote'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/docs/plans/2026-04-21-003-feat-skill-variant-management-tooling-plan.md
+++ b/docs/plans/2026-04-21-003-feat-skill-variant-management-tooling-plan.md
@@ -1,0 +1,580 @@
+---
+title: "feat: Skill variant management tooling (CLI + server API + dashboard)"
+type: feat
+status: active
+date: 2026-04-21
+deepened: 2026-04-21
+---
+
+# feat: Skill variant management tooling (CLI + server API + dashboard)
+
+## Overview
+
+Add a management layer for per-provider/per-model prompt variants across skills. This introduces a `mika skills variants <op>` CLI subcommand family, matching `/api/v1/skills/variants/*` HTTP endpoints, and a new dashboard "Skills > Variants" page. A new `experimental/` directory tier provides isolated variant authoring that is excluded from runtime resolution, with a `promote` gate to move experimental variants into production `generated/` after validation.
+
+## Problem Frame
+
+The Sprint 2026-04-11 hot-patch chain deleted all 4 existing variants because the minimax self-dev variant silently carried an outdated unconditional `{"action":"allow"}` directive that had been fixed in the base but never propagated. No tooling exists to detect drift, validate integrity, observe staleness, or gate promotion from experimental to production. Before variants can be safely reintroduced, the platform needs management tooling across all three surfaces (CLI, API, dashboard).
+
+## Requirements Trace
+
+- R1. Shared Rust module (`variants.rs`) with variant metadata struct, 4-rule validation gate, reflection report builder
+- R2. `experimental/` directory convention excluded from runtime resolution
+- R3. `skill.toml` `[variants]` section parsing (optional, backward-compatible)
+- R4. CLI `mika skills variants` subcommands: list, status, diff, reflect, validate, promote, regen
+- R5. All CLI subcommands support `--format text|json`
+- R6. HTTP API endpoints for all variant operations (dashboard auth for reads, internal auth for writes)
+- R7. Dashboard "Skills > Variants" page with skill list, variant table, diff viewer, reflect/validate/promote actions
+- R8. Unit tests for validation rules, integration tests for reflect/promote, runtime resolver tests
+
+## Scope Boundaries
+
+- No auto-propagation, auto-fix, or auto-delete of variants (warn-don't-cascade principle)
+- `regen` is prepare-only in v1 (prints command string, does not spawn claude-pilot)
+- Dashboard `Regen` button is hidden in v1
+- No DB-backed variant registry -- filesystem-only
+- No semantic similarity, imperative density, or unconditional-directive detection (deferred to v2)
+- No CI workflow integration (deferred to mika-skills repo follow-up issue)
+
+### Deferred to Separate Tasks
+
+- CI integration for variant validation on PRs: separate mika-skills issue after this lands
+- `regen` end-to-end command (spawn claude-pilot): v2
+- Operational panel ("Variant usage this week"): v2
+- Composite risk scoring: v2
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/skills/index.rs` -- `SkillEntry`, `resolve_prompt()`, `scan_provider_variants()`, `scan_generated_variants()`, `sanitize_model_dir_name()`, `PromptVariantSource`, `ResolvedPrompt`
+- `crates/mika-agent/src/skills/manifest.rs` -- `SkillManifest`, `SkillInfo`, `ProviderSkillOverride`
+- `crates/mika-agent/src/skills/mod.rs` -- `SkillRegistry`, `validate_markdown_content()`, `SkillDiagnostic`, `DiagnosticLevel`
+- `crates/mika-cli/src/cli.rs` -- `SkillsCommand` enum, `OutputFormat`, `SkillLlmAction` subcommand pattern
+- `crates/mika-cli/src/commands/skills.rs` -- CLI dispatch pattern with path resolution
+- `crates/mika-agent/src/server/mod.rs` -- `build_router()`, dashboard route registration pattern
+- `crates/mika-agent/src/server/dashboard.rs` -- handler pattern with `State(state)`, `Json` responses
+- `dashboard/src/pages/` -- page component pattern (Tasks.tsx reference)
+- `dashboard/src/api/` -- API client module pattern with TanStack Query hooks
+
+### Institutional Learnings
+
+- Provider dirs must match `ProviderKind::config_prefix()` values; model dirs use `sanitize_model_dir_name()` (slash-to-`--`)
+- `generated/` is a separate namespace; hand-authored always wins at resolution time
+- Reuse `OutputFormat` enum for `--format text|json` -- never create a new one
+- Reuse `SkillDiagnostic` with `ok()`/`warn()`/`fail()` constructors for validation output
+- Canonicalize paths when comparing for `--link` mode correctness
+- Dashboard pages follow the 4-layer pattern: DB getter -> async wrapper -> handler -> route
+- Context validation is bidirectional: placeholders vs `[context]` declarations across all variants
+- `collect_skill_files` in `build_support/bundled_skills_discover.rs` does NOT recurse into variant dirs -- bundled skill variants require filesystem path at runtime
+
+## Key Technical Decisions
+
+- **Staleness detection uses `mtime` comparison**: Variant file mtime vs base `system_prompt.md` mtime. Simple, filesystem-native, imperfect after git operations (documented limitation). Git-based staleness deferred to v2.
+- **`experimental/` is a reserved directory name**: Added to a `RESERVED_VARIANT_DIRS` constant alongside `generated` in `index.rs`. Explicit skip in `scan_provider_variants` prevents future refactors from accidentally resolving experimental variants.
+- **`diff` defaults to runtime-resolved variant**: When a provider/model has both hand-authored and generated variants, `diff` targets the one that would win at resolution time. `--source experimental|generated|hand-authored` flag for explicit selection.
+- **`promote` blocks when hand-authored variant exists at target**: Returns a clear error explaining the hand-authored variant would shadow the promoted one. No `--force` in v1 -- remove the hand-authored variant manually first.
+- **`promote` warns but proceeds for symlinked skills**: Follows the existing `write_skill_variant` pattern -- warn and write through.
+- **Required section headings for validation**: Configurable per-skill via optional `[variants] required_sections` in `skill.toml`, with a sensible default empty list. Skills without the section pass this rule trivially.
+- **`regen` prints a `mika ask` invocation**: `mika ask --enable-skill skill-review "review and generate variant for <skill> targeting <provider>/<model>"` -- matches how variant generation works today via `review_skill`.
+- **Validation on experimental variants**: `validate` runs on all variants by default but `promote` is the actual gate. Experimental variants can be validated explicitly for early feedback without blocking authoring.
+- **Variant module is pure computation**: `variants.rs` contains no DB access. All data comes from `SkillEntry` fields and filesystem reads. This keeps it testable and avoids coupling to `AsyncDatabase`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **What constitutes "stale"?**: `mtime` comparison of variant vs base `system_prompt.md`. Documented limitation for git-normalized timestamps.
+- **Should `promote` detect hand-authored shadowing?**: Yes, block with clear error message.
+- **Which variant does `diff` target by default?**: Runtime-resolved (hand-authored > generated). `--source` flag for explicit selection.
+- **What are "required section headings"?**: Configurable per-skill via `[variants]` in `skill.toml`. Empty default (all pass).
+- **What command does `regen` print?**: `mika ask --enable-skill skill-review "..."` invocation string.
+
+### Deferred to Implementation
+
+- Exact diff classification algorithm (pure-wording / semantic / structural) -- will depend on available diff library
+- Token counting method for variant size metrics -- may use simple whitespace-split estimation or tiktoken if available
+- Dashboard layout fine-tuning -- exact column widths, responsive breakpoints
+
+## Output Structure
+
+```
+crates/mika-agent/src/skills/
+  variants.rs                          # NEW: shared variant management module
+
+crates/mika-cli/src/commands/
+  skills.rs                            # MODIFY: add Variants match arm
+  skills_variants.rs                   # NEW: variant subcommand handlers
+
+crates/mika-agent/src/server/
+  mod.rs                               # MODIFY: add variant routes
+  variants.rs                          # NEW: HTTP handler functions
+
+dashboard/src/
+  api/variants.ts                      # NEW: API client + hooks
+  pages/SkillVariants.tsx              # NEW: main variants page
+  components/VariantDiffViewer.tsx      # NEW: side-by-side diff component
+```
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+graph TD
+    subgraph "Shared Module (variants.rs)"
+        VM[VariantMetadata] --> VG[ValidationGate<br/>4 rules]
+        VM --> RR[ReflectionReport]
+        VM --> DD[DiffReport]
+        SC[scan_all_variants] --> VM
+    end
+
+    subgraph "CLI"
+        CLI[mika skills variants] --> SC
+        CLI --> VG
+        CLI --> RR
+        CLI --> DD
+        CLI --> PM[promote_variant]
+    end
+
+    subgraph "HTTP API"
+        API[/api/v1/skills/variants/] --> SC
+        API --> VG
+        API --> RR
+        API --> DD
+        API --> PM
+    end
+
+    subgraph "Dashboard"
+        UI[SkillVariants page] --> API
+    end
+
+    subgraph "Runtime (existing)"
+        RP[resolve_prompt] -.->|skips experimental/| VM
+    end
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Variant metadata and scanning (`variants.rs`)**
+
+**Goal:** Create the shared variant management module with data types and filesystem scanning.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Create: `crates/mika-agent/src/skills/variants.rs`
+- Modify: `crates/mika-agent/src/skills/mod.rs` (add `pub mod variants;`)
+- Test: `crates/mika-agent/src/skills/variants.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Define `VariantMetadata` struct: skill name, provider, model, source type (hand-authored/generated/experimental), file path, size bytes, line count, last modified timestamp, staleness flag vs base
+- Define `VariantSource` enum: `HandAuthored`, `Generated`, `Experimental`
+- Define `RESERVED_VARIANT_DIRS: &[&str] = &["generated", "experimental"]` constant
+- `scan_all_variants(skill_dir, manifest) -> Vec<VariantMetadata>` walks the skill directory for all three source types. Reuses `sanitize_model_dir_name` and `ProviderKind` gating from `index.rs`
+- `scan_experimental_variants(skill_dir, manifest) -> HashMap<String, String>` mirrors `scan_generated_variants` for the `experimental/` directory
+- `compute_staleness(base_mtime, variant_mtime) -> bool` simple mtime comparison
+- `VariantSummary` struct for cross-skill aggregation: total, stale, experimental counts per skill
+
+**Patterns to follow:**
+- `scan_generated_variants()` in `index.rs` for directory walking pattern
+- `ProviderKind` gating on subdirectory names
+- Symlink defense-in-depth from `scan_generated_variants`
+
+**Test scenarios:**
+- Happy path: scan a skill dir with hand-authored, generated, and experimental variants -> correct `VariantMetadata` for each
+- Happy path: scan a skill dir with only a base prompt -> empty variant list
+- Edge case: provider dir name not matching `ProviderKind` -> skipped
+- Edge case: dotfile/dotdir in variant tree -> skipped
+- Edge case: symlinked variant directory -> skipped (defense-in-depth)
+- Edge case: model name with slashes -> correctly sanitized key
+- Happy path: staleness flag set when variant mtime < base mtime
+- Edge case: missing base `system_prompt.md` -> variants still listed, staleness marked as unknown
+
+**Verification:**
+- `cargo test -p mika-agent` passes with all variant scanning tests green
+- Module compiles and is accessible from `crate::skills::variants`
+
+---
+
+- [x] **Unit 2: Validation gate (4 rules)**
+
+**Goal:** Implement the 4-rule validation gate for variant prompts.
+
+**Requirements:** R1, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/variants.rs`
+- Test: `crates/mika-agent/src/skills/variants.rs` (inline tests)
+
+**Approach:**
+- Define `ValidationRule` enum: `SizeLimit`, `RequiredSections`, `MarkdownWellFormedness`, `ToolReferenceLint`
+- Define `ValidationResult` struct: rule, passed, message, severity (using `DiagnosticLevel`)
+- `validate_variant(content, manifest, tool_names) -> Vec<ValidationResult>`:
+  1. **Size limit**: check content bytes against `manifest.skill.max_prompt_size` (or default `MAX_PROMPT_SNIPPET_SIZE`). Also check `MIN_VARIANT_RATIO` (0.5) against base prompt size.
+  2. **Required sections**: parse `[variants] required_sections` from manifest. Check that each listed heading exists in content (markdown `## Heading` or `# Heading` match).
+  3. **Markdown well-formedness**: reuse existing `validate_markdown_content()` checks (null bytes, control chars, unclosed code fences).
+  4. **Tool reference lint**: scan for `tool_name(` or `` `tool_name` `` patterns in content, cross-reference against provided `tool_names` set. Warn (not fail) on unrecognized references -- false positives are expected.
+- Rule 4 accepts tool names as a parameter (caller-provided, not self-resolved) so the module stays pure
+
+**Patterns to follow:**
+- `validate_markdown_content()` in `skills/mod.rs` for existing markdown checks
+- `SkillDiagnostic::warn()`/`SkillDiagnostic::fail()` for severity classification
+
+**Test scenarios:**
+- Happy path: valid variant within size limit, all required sections present, well-formed markdown -> all pass
+- Error path: variant exceeds size limit -> SizeLimit fails with byte count details
+- Error path: variant below MIN_VARIANT_RATIO of base -> SizeLimit fails
+- Edge case: no required sections configured -> RequiredSections passes trivially
+- Error path: missing required section heading -> RequiredSections fails listing missing headings
+- Error path: unclosed code fence -> MarkdownWellFormedness fails
+- Error path: null bytes in content -> MarkdownWellFormedness fails
+- Happy path: tool reference matching known tool -> ToolReferenceLint passes
+- Edge case: tool reference not matching any known tool -> ToolReferenceLint warns (not fails)
+- Edge case: empty tool_names set -> ToolReferenceLint passes (nothing to lint against)
+
+**Verification:**
+- All validation rule tests pass
+- Validation output uses `SkillDiagnostic` formatting consistently
+
+---
+
+- [x] **Unit 3: Diff and reflection reports**
+
+**Goal:** Implement variant-vs-base diffing with classification and the reflection report builder.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/variants.rs`
+- Test: `crates/mika-agent/src/skills/variants.rs` (inline tests)
+
+**Approach:**
+- `diff_variant(base_content, variant_content) -> DiffReport`: line-by-line diff using the `similar` crate (already a dependency or add if not). Classify changes: structural (heading additions/removals), content (body text changes), cosmetic (whitespace only). Report missing sections from base.
+- `DiffReport` struct: added lines, removed lines, classification, missing sections list
+- `reflect_skill(skill_dir, manifest) -> ReflectionReport`: reads base prompt, iterates all production variants (`generated/` + hand-authored), computes diff against base for each, builds per-variant impact summary with recommended next actions. Pure computation, no writes.
+- `ReflectionReport` struct: base path, base last modified, list of `VariantImpact` (variant metadata + diff summary + staleness + recommended actions)
+- Recommended actions are string constants: "Re-review variant", "Variant is up to date", "Consider regenerating"
+
+**Patterns to follow:**
+- `similar` crate TextDiff for unified diff output
+- Structured report output suitable for both text and JSON serialization
+
+**Test scenarios:**
+- Happy path: base and variant with known diffs -> correct classification and line counts
+- Happy path: identical base and variant -> "no changes" report
+- Edge case: variant has extra sections not in base -> classified as structural addition
+- Edge case: base has sections missing from variant -> listed in missing sections
+- Happy path: reflect with 2 variants, one stale one fresh -> correct staleness flags and different recommendations
+- Edge case: reflect with no variants -> empty impact list, clean report
+- Integration: create temp dir with base + variant, edit base, verify reflect reports drift
+
+**Verification:**
+- Diff reports correctly classify change types
+- Reflection reports never write to the filesystem
+
+---
+
+- [x] **Unit 4: `skill.toml` `[variants]` section and `experimental/` directory convention**
+
+**Goal:** Add `[variants]` section parsing to `SkillManifest` and exclude `experimental/` from runtime resolution.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/manifest.rs`
+- Modify: `crates/mika-agent/src/skills/index.rs`
+- Test: `crates/mika-agent/src/skills/manifest.rs` (inline tests), `crates/mika-agent/src/skills/index.rs` (inline tests)
+
+**Approach:**
+- Add `VariantsConfig` struct: `providers: Option<Vec<String>>`, `max_prompt_size: Option<u64>`, `required_sections: Option<Vec<String>>`
+- Add `#[serde(default)] pub variants: VariantsConfig` to `SkillManifest`
+- Add `RESERVED_VARIANT_DIRS` constant in `index.rs`
+- Add explicit skip for `"experimental"` in `scan_provider_variants()` -- before `ProviderKind` parse, check against reserved names
+- `scan_generated_variants` already only walks `generated/`, so no change needed there
+- The `experimental` name does not parse as `ProviderKind`, providing implicit defense. The explicit check is defense-in-depth.
+
+**Patterns to follow:**
+- `#[serde(default)]` on `SkillManifest` fields for backward compatibility
+- `ProviderKind::from_str()` gating in `scan_provider_variants`
+
+**Test scenarios:**
+- Happy path: skill.toml with `[variants]` section parses correctly
+- Happy path: skill.toml without `[variants]` section -> default empty config
+- Happy path: skill.toml with `[variants] required_sections = ["Tools", "Constraints"]` -> parsed correctly
+- Edge case: `[variants] providers = []` -> empty vec, not None
+- Integration: `resolve_prompt` with experimental variant present -> returns base or generated, never experimental
+- Integration: `scan_provider_variants` with `experimental/` directory present -> not included in results
+
+**Verification:**
+- Existing skill.toml files continue to parse without changes
+- Experimental variants are never loaded into `model_prompts` or `generated_model_prompts`
+
+---
+
+- [x] **Unit 5: Promote operation**
+
+**Goal:** Implement the `promote` operation that moves an experimental variant to generated after validation.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1, Unit 2, Unit 4
+
+**Files:**
+- Modify: `crates/mika-agent/src/skills/variants.rs`
+- Test: `crates/mika-agent/src/skills/variants.rs` (inline tests)
+
+**Approach:**
+- `promote_variant(skill_dir, manifest, provider, model, tool_names) -> Result<PromoteResult>`:
+  1. Resolve source path: `experimental/{provider}/{sanitized_model}/system_prompt.md`
+  2. Verify source exists, bail if not
+  3. Check for hand-authored variant at `{provider}/{sanitized_model}/system_prompt.md` -- if exists, return error explaining shadowing
+  4. Run `validate_variant` on source content -- if any rule fails, return error with violations
+  5. Create target directory `generated/{provider}/{sanitized_model}/` if needed
+  6. Copy content to target (not move -- copy then delete for atomicity)
+  7. Also copy `skill.toml` override if it exists in experimental source
+  8. Delete only expected files (`system_prompt.md`, `skill.toml`) from experimental source, then `remove_dir` on the model and provider directories if empty. Do NOT use `remove_dir_all` -- unexpected files should be preserved with a warning.
+  9. Return `PromoteResult` with source/target paths
+- Detect symlinked skill directory (`symlink_metadata`), warn but proceed (matching `write_skill_variant` pattern)
+
+**Patterns to follow:**
+- `write_skill_variant` in `builtin_handlers.rs` for symlink-aware writes
+- `std::fs::create_dir_all` for target directory creation
+
+**Test scenarios:**
+- Happy path: promote experimental variant -> file copied to generated, experimental deleted
+- Happy path: promote with skill.toml override in experimental -> both files copied
+- Error path: experimental source does not exist -> clear error
+- Error path: hand-authored variant exists at target -> error explaining shadowing
+- Error path: validation fails (e.g., oversized) -> error with violation details, no file changes
+- Edge case: target generated directory already has a variant -> overwritten (re-promotion)
+- Edge case: symlinked skill dir -> warning emitted, promotion proceeds
+- Integration: promote then scan -> variant appears in generated, not in experimental
+
+**Verification:**
+- Filesystem state correct after promotion
+- No writes occur when validation fails or hand-authored variant exists
+
+---
+
+- [x] **Unit 6: CLI subcommands**
+
+**Goal:** Add `mika skills variants <op>` subcommand family with all 7 operations.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Modify: `crates/mika-cli/src/cli.rs` (add `Variants` to `SkillsCommand`)
+- Create: `crates/mika-cli/src/commands/skills_variants.rs`
+- Modify: `crates/mika-cli/src/commands/skills.rs` (add `Variants` match arm)
+- Modify: `crates/mika-cli/src/commands/mod.rs` (add `pub mod skills_variants;`)
+- Test: `crates/mika-cli/src/commands/skills_variants.rs` (inline tests where applicable)
+
+**Approach:**
+- Define `SkillVariantsAction` enum (Subcommand derive):
+  - `List { name: String, format: OutputFormat }`
+  - `Status { format: OutputFormat }`
+  - `Diff { name: String, variant: String, source: Option<VariantSourceFilter>, format: OutputFormat }`
+  - `Reflect { name: String, format: OutputFormat }`
+  - `Validate { name: Option<String>, format: OutputFormat }`
+  - `Promote { name: String, variant: String }`
+  - `Regen { name: String, variant: String }`
+- Add `Variants { #[command(subcommand)] action: SkillVariantsAction }` to `SkillsCommand`
+- `variant` argument uses `provider/model` format (parsed with split on first `/`). Model names with internal slashes (e.g., OpenRouter's `anthropic/claude-sonnet-4`) should be passed as-is -- the CLI applies `sanitize_model_dir_name()` internally. Example: `mika skills variants diff self-dev "anthropic/anthropic/claude-sonnet-4"` splits as provider=`anthropic`, model=`anthropic/claude-sonnet-4`.
+- Each subcommand handler resolves skill paths, constructs `SkillRegistry`, calls into `variants.rs` functions
+- Text output uses tabular formatting for list/status, unified diff for diff, diagnostic badges for validate
+- JSON output uses `serde_json::to_string_pretty`
+
+**Patterns to follow:**
+- `SkillLlmAction` pattern for nested subcommands
+- `OutputFormat` reuse with `#[arg(long, value_enum, default_value = "text")]`
+- `run()` dispatch pattern in `skills.rs`
+- `SkillDiagnostic` `[OK]`/`[WARN]`/`[FAIL]` formatting for validate output
+
+**Test scenarios:**
+- Happy path: `mika skills variants list self-dev --format json` -> valid JSON array of variant metadata
+- Happy path: `mika skills variants status` -> summary table with counts
+- Happy path: `mika skills variants validate self-dev` -> diagnostic output with per-rule results
+- Edge case: `mika skills variants list nonexistent` -> clear "skill not found" error
+- Edge case: `mika skills variants diff self-dev anthropic/claude-sonnet-4-6 --source experimental` -> targets experimental variant specifically
+- Happy path: `mika skills variants regen self-dev anthropic/claude-sonnet-4-6` -> prints `mika ask` command string
+
+**Verification:**
+- All subcommands compile and dispatch correctly
+- `--format json` produces valid JSON for all operations
+- `--format text` produces human-readable output
+
+---
+
+- [x] **Unit 7: HTTP API endpoints**
+
+**Goal:** Add variant management REST endpoints to mika-server.
+
+**Requirements:** R6
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `crates/mika-agent/src/server/variants.rs`
+- Modify: `crates/mika-agent/src/server/mod.rs` (add routes + `pub mod variants;`)
+- Test: `crates/mika-agent/src/server/variants.rs` (inline tests)
+
+**Approach:**
+- Handlers follow existing dashboard pattern: `State(state): State<AppState>`, return `impl IntoResponse`
+- Lock `state.skills`, clone `Arc<SkillRegistry>`, release lock immediately
+- GET endpoints use dashboard auth layer; POST promote uses internal auth layer
+- Endpoints:
+  - `GET /api/v1/skills/variants` -> `handle_variants_summary`: cross-skill summary
+  - `GET /api/v1/skills/{skill}/variants` -> `handle_skill_variants`: per-skill list
+  - `GET /api/v1/skills/{skill}/variants/{provider}/{model}` -> `handle_variant_detail`: content + metadata
+  - `GET /api/v1/skills/{skill}/variants/{provider}/{model}/diff` -> `handle_variant_diff`: diff payload
+  - `GET /api/v1/skills/{skill}/variants/reflect` -> `handle_variant_reflect`: audit report
+  - `POST /api/v1/skills/{skill}/variants/{provider}/{model}/validate` -> `handle_variant_validate`: run gate
+  - `POST /api/v1/skills/{skill}/variants/{provider}/{model}/promote` -> `handle_variant_promote`: promote
+- Path parameters: `skill` by name, `provider`/`model` as path segments
+- Variant operations need filesystem access to the skill directory -- resolve via `SkillEntry.dir` from the cloned `SkillRegistry` (NOT `home_dir + "skills/{name}/"` which breaks for `--link` mode symlinked skills)
+
+**Patterns to follow:**
+- `dashboard.rs` handler pattern with `State`, `Path`, `Query` extractors
+- `internal_error()` helper for error responses
+- Auth layer separation in `build_router()`
+- **Route ordering:** Static `/reflect` route MUST be registered before `/{provider}/{model}` wildcard routes to avoid being swallowed by Axum's path parameter matching
+
+**Test scenarios:**
+- Happy path: GET /api/v1/skills/variants -> JSON summary with variant counts per skill
+- Happy path: GET /api/v1/skills/self-dev/variants -> JSON array of variant metadata
+- Happy path: GET /api/v1/skills/self-dev/variants/anthropic/claude-sonnet-4-6/diff -> JSON diff report
+- Error path: GET /api/v1/skills/nonexistent/variants -> 404
+- Error path: POST promote with dashboard token only -> 401/403
+- Happy path: POST validate -> JSON with pass/fail per rule
+
+**Verification:**
+- Routes registered correctly in `build_router`
+- Auth layers applied correctly (GET = dashboard, POST promote = internal)
+- Response JSON matches what the dashboard will consume
+
+---
+
+- [x] **Unit 8: Dashboard "Skills > Variants" page**
+
+**Goal:** Add the dashboard page for variant management with skill list, variant table, diff viewer, and actions.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 7
+
+**Files:**
+- Create: `dashboard/src/api/variants.ts`
+- Create: `dashboard/src/pages/SkillVariants.tsx`
+- Create: `dashboard/src/components/VariantDiffViewer.tsx`
+- Modify: `dashboard/src/App.tsx` (add route)
+- Modify: `dashboard/src/components/Sidebar.tsx` (add nav item)
+- Test: manual verification via screenshot
+
+**Approach:**
+- API client module with interfaces matching server response shapes and TanStack Query hooks
+- Main page layout: left panel with skill list (clickable, shows badges for variant/stale/experimental counts), right panel with variant table for selected skill
+- Variant table columns: provider, model, source type, size (bytes/lines), staleness indicator, validation status, last modified
+- Base-edit amber banner at top of variant table when any variant's mtime is older than base mtime
+- "Diff" button per variant row -> opens `VariantDiffViewer` (side-by-side using `<pre>` blocks with color-coded additions/deletions)
+- "Reflect" button -> fetches and inlines the reflection report below the variant table
+- "Validate" button per variant row -> calls POST validate, shows inline results
+- "Promote" button per experimental variant row -> confirmation modal, calls POST promote (hidden when no internal token available)
+- "Regen" button hidden in v1
+- Use `lucide-react` icons for actions, Tailwind CSS v4 for styling
+- Responsive: single-column on narrow screens
+
+**Patterns to follow:**
+- `Tasks.tsx` for list page structure with filters
+- `LlmCallDetail.tsx` for detail panel layout
+- `dashboard/src/api/tasks.ts` for API module structure
+- Sidebar `navItems` array for navigation entry
+
+**Test scenarios:**
+- Test expectation: none -- dashboard pages are verified via manual screenshot review. The API module type contracts are validated implicitly by TypeScript compilation.
+
+**Verification:**
+- Page renders correctly with mock/real data
+- Navigation link appears in sidebar
+- All action buttons wire to correct API endpoints
+- TypeScript compiles without errors
+
+---
+
+- [x] **Unit 9: Integration tests**
+
+**Goal:** Add integration tests covering the end-to-end variant management flows.
+
+**Requirements:** R8
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `crates/mika-agent/tests/variant_management.rs` (or inline in `variants.rs`)
+- Test: self
+
+**Approach:**
+- Create temp directories with realistic skill structures (base + variants in all three locations)
+- Test reflect flow: create base + variant, modify base, verify reflect reports drift and recommendations
+- Test promote flow: create experimental variant, run promote, verify it appears in generated and is removed from experimental
+- Test promote failure: create experimental + hand-authored at same key, verify promote is blocked
+- Test runtime resolver: verify `resolve_prompt` skips experimental variants at all fallback steps
+
+**Patterns to follow:**
+- `tempfile::TempDir` for isolated test directories
+- Existing `#[cfg(test)]` patterns in `index.rs` for skill scanning tests
+
+**Test scenarios:**
+- Integration: base edit -> reflect -> all variants reported with staleness and recommendations
+- Integration: experimental variant -> validate (pass) -> promote -> appears in generated
+- Integration: experimental variant -> validate (fail) -> promote blocked -> no filesystem change
+- Integration: promote with hand-authored shadow -> blocked with clear error
+- Integration: full scan -> resolve_prompt for provider/model with experimental variant -> experimental never returned
+- Edge case: promote on empty experimental dir -> clear error
+
+**Verification:**
+- All integration tests pass
+- Tests are deterministic (no mtime races -- use explicit file timestamps where needed)
+
+## System-Wide Impact
+
+- **Interaction graph:** `variants.rs` is consumed by CLI commands and HTTP handlers. Both surfaces call into the same functions. `SkillEntry` gains no new fields in v1 -- variant scanning for management uses its own `scan_all_variants` independent of the startup-time `scan_provider_variants`.
+- **Error propagation:** Validation errors are structured (`Vec<ValidationResult>`) and propagated as-is to CLI/HTTP callers. `promote` errors are `anyhow::Result` with descriptive messages.
+- **State lifecycle risks:** `promote` is the only write operation. Copy-then-delete ordering prevents data loss on partial failure. The `SkillRegistry` in memory is NOT updated after promote -- the caller must reload (CLI exits, server would need a registry refresh mechanism or a note that the next restart picks it up).
+- **Post-promote registry refresh:** The server's existing `skills_dirty: Arc<AtomicBool>` on `AgentState` can signal that the registry needs a rescan after promote. Set it to `true` after a successful promote so the next message handler reloads. CLI exits after promote so no refresh needed.
+- **API surface parity:** All 7 operations available via CLI, 7 via HTTP API, read operations + promote/validate actions via dashboard. `regen` is CLI-only (prints a command string).
+- **Unchanged invariants:** `resolve_prompt()` fallback chain is unchanged. `scan_provider_variants()` and `scan_generated_variants()` behavior for existing variants is unchanged. `SkillEntry` struct fields are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `mtime` staleness is unreliable after git clone/checkout | Document limitation; staleness is advisory, not blocking. Git-based staleness deferred to v2. |
+| Tool reference lint has high false-positive potential | Rule 4 warns but never fails -- users see tool references flagged but promotion is not blocked by stale tool references alone |
+| `promote` write on symlinked skill affects shared source | Follow existing `write_skill_variant` pattern: warn and proceed. Document that linked skills share variant state. |
+| Dashboard page adds bundle size | Lazy-load the SkillVariants page via React.lazy + Suspense |
+| `similar` crate dependency (if not already present) | Well-maintained, widely-used Rust diff library. Small dependency footprint. |
+
+## Documentation / Operational Notes
+
+- Update `docs/skills.md` to document the `experimental/` directory convention and the `[variants]` section in `skill.toml`
+- Update `crates/mika-cli/CLAUDE.md` to list the new `mika skills variants` subcommands
+- Update `crates/mika-agent/CLAUDE.md` to mention the `variants.rs` module in the Skills System section
+- Update `docs/openapi/mika-server.yaml` with the new variant endpoints
+
+## Sources & References
+
+- Related issues: #541
+- Related code: `crates/mika-agent/src/skills/index.rs` (variant resolution), `crates/mika-agent/src/skills/builtin_handlers.rs` (`review_skill`, `write_skill_variant`)
+- Institutional learnings: `docs/solutions/architecture-patterns/per-provider-skill-variant-directories.md`, `docs/solutions/architecture-patterns/harden-write-skill-variant-no-path-input.md`, `docs/solutions/architecture-patterns/cli-format-json-nine-commands.md`
+- Related commits: `mika-skills@15bcc45` (variant deletion that motivated this ticket)

--- a/docs/solutions/541-skill-variant-management-tooling.md
+++ b/docs/solutions/541-skill-variant-management-tooling.md
@@ -1,0 +1,58 @@
+---
+module: mika-agent/skills, mika-cli, mika-agent/server, dashboard
+tags: [skills, variants, validation, management, cli, dashboard]
+problem_type: feature
+issue: "#541"
+---
+
+# Skill Variant Management Tooling
+
+## Problem
+
+Per-provider/per-model prompt variants are a first-class skill extension mechanism, but no tooling existed to detect drift, validate integrity, observe staleness, or gate promotion. The Sprint 2026-04-11 hot-patch chain deleted all 4 existing variants because a minimax self-dev variant silently carried an outdated unconditional `{"action":"allow"}` directive — the base had been fixed but the variant was never updated.
+
+## Solution
+
+Added a comprehensive variant management layer across all three surfaces:
+
+### Shared Module (`crates/mika-agent/src/skills/variants.rs`)
+
+- **`VariantMetadata`** struct with provider, model, source tier, size, staleness
+- **`VariantSource`** enum: `HandAuthored`, `Generated`, `Experimental`
+- **`RESERVED_VARIANT_DIRS`** constant (`["generated", "experimental"]`) for defense-in-depth exclusion from provider scanning
+- **`scan_all_variants()`** — walks all three tiers to produce metadata (separate from runtime `scan_provider_variants` which loads into memory)
+- **4-rule validation gate**: size limit (with MIN_VARIANT_RATIO), required sections (configurable via `[variants]` in skill.toml), markdown well-formedness, tool reference lint (warn-only)
+- **`diff_variant()`** — frequency-map-based line counting with structural/content/cosmetic classification
+- **`reflect_skill()`** — pure computation producing per-variant impact assessments with recommendations
+- **`promote_variant()`** — copy-then-delete with hand-authored shadow check, validation gate, and expected-files-only cleanup
+
+### `skill.toml` `[variants]` Section
+
+```toml
+[variants]
+required_sections = ["Tools", "Constraints"]
+max_prompt_size = 32768
+```
+
+Backward-compatible via `#[serde(default)]` on `VariantsConfig` in `SkillManifest`.
+
+### `experimental/` Directory Convention
+
+- `experimental/<provider>/<model>/system_prompt.md` is a quarantined playground excluded from runtime resolution
+- Defense-in-depth: explicit `RESERVED_VARIANT_DIRS` check in `scan_provider_variants()` (before the existing `ProviderKind` parse which also excludes it)
+- Only reachable in production via `promote` which runs validation first
+
+## Key Decisions
+
+1. **Staleness uses mtime comparison** — simple and filesystem-native. Known limitation: git operations normalize timestamps. Git-based staleness deferred to v2.
+2. **Diff uses frequency maps** — not sets. Duplicate lines (blank lines, bullets) are counted correctly.
+3. **Headings matched at any level** — `#` through `######` all count for required-sections and structural diff classification.
+4. **Promote blocks when hand-authored variant exists** — the hand-authored variant would shadow the promoted generated variant at runtime, making the promotion invisible.
+5. **Variant module is pure computation** — no DB access, no async. All data from filesystem reads and `SkillManifest` fields.
+6. **`skills_dirty` flag after promote** — server sets `AgentState.skills_dirty` to `true` so the next message handler reloads the registry.
+
+## Patterns Worth Reusing
+
+- **`RESERVED_VARIANT_DIRS` defense-in-depth**: when adding new reserved directory names alongside existing implicit guards (like `ProviderKind` parse failure), add an explicit constant check first so future refactors don't accidentally bypass the guard.
+- **Copy-then-delete with expected-files-only cleanup**: when promoting/moving files, delete only the files you expect (`system_prompt.md`, `skill.toml`), then `remove_dir` if empty. Never `remove_dir_all` — unexpected files should be preserved with a warning.
+- **`VariantsConfig` backward-compatible manifest extension**: use `#[serde(default)]` on a new struct field in `SkillManifest` so existing skill.toml files parse without changes.


### PR DESCRIPTION
## Summary

- Add `crates/mika-agent/src/skills/variants.rs` — shared variant management module with metadata scanning, 4-rule validation gate, diff/reflection reports, and promote operation
- Add `experimental/` directory convention excluded from runtime resolution via `RESERVED_VARIANT_DIRS` defense-in-depth
- Add `[variants]` section to `skill.toml` manifest (backward-compatible) for configurable validation rules
- Add `mika skills variants` CLI subcommand family (list, status, diff, reflect, validate, promote, regen) with `--format text|json`
- Add 7 HTTP API endpoints at `/api/v1/skills/variants/*` with dashboard auth for reads and `skills_dirty` refresh after promote
- Add dashboard "Skills > Variants" page with skill list, variant table, diff viewer, reflection report, and promote action with confirmation modal
- 30 unit tests covering scanning, validation rules, diff classification, reflection, and promote flows

Closes #541

## Test plan

- [x] `cargo test -p mika-agent --lib` — 1893 tests pass (30 new variant tests)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — formatted
- [x] Dashboard TypeScript compiles without errors
- [x] Dashboard ESLint passes
- [ ] Manual: run `mika skills variants list <skill>` and `mika skills variants status` against a real agent with installed skills
- [ ] Manual: verify dashboard Skill Variants page renders at `/skill-variants`
- [ ] Manual: test promote flow with an experimental variant directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>