### PR TITLE
feat: domain graph builder — deterministic import from skill manifests and tool registry (#687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ For detailed architecture of each subsystem, see the crate-level CLAUDE.md files
 - **HTTP server (mika-server)** — Axum, two auth layers, embedded dashboard. See `crates/mika-agent/CLAUDE.md`.
 - **Gateway** — Telegram + GitHub webhook routing, A2A proxy, Postgres. See `crates/mika-gateway/CLAUDE.md`.
 - **A2A protocol** — v0.3, JSON-RPC, task state machine. See `crates/mika-a2a/CLAUDE.md`.
+- **Knowledge Graph** — Three-layer KG (domain/lexical/subject) in SQLite. Domain graph builder runs at startup, deterministically projecting skills, tools, agents, and problem types into `kg_entities`/`kg_relationships`. See `crates/mika-agent/CLAUDE.md`.
 - **Docker images:** Multi-stage builds with BuildKit cache. `Dockerfile.agent` (95MB) for per-customer containers. `Dockerfile.gateway` for the stateless gateway. Both use rustls, non-root user `mika` (UID 1000). Release profile: LTO + strip. `docker-compose.yml` defines agent, gateway, and postgres services. **Host dependency:** `jq` is required by all skill handler scripts.
 - **CI/CD:** Four GitHub Actions workflows: `ci.yml` (PR checks), `release-plz.yml` (versioning/changelog), `release.yml` (cross-platform binaries), `publish-ui.yml` (`@senara-solutions/ui` to GitHub Packages). All actions pinned to commit SHAs.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2699,9 +2699,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3145,9 +3145,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3658,7 +3658,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -3698,7 +3698,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -139,6 +139,22 @@ Git-based and local skill distribution via `mika skills install/uninstall/update
 
 Connects to external MCP servers at startup via `McpManager`. Configured in `{agent_home}/mcp.json`. Supports stdio and Streamable HTTP transports. Tools namespaced as `mcp__{server}__{tool}`. Dispatch chain: builtins -> skills -> MCP -> unknown error. MCP tools excluded from silent/heartbeat mode. Child processes use `env_clear()` + allowlist.
 
+## Knowledge Graph — Domain Graph Builder
+
+`src/kg/domain_builder.rs` — Deterministic startup-time builder that populates `kg_entities` and `kg_relationships` from four authoritative sources: `SkillRegistry`, `ToolRegistry`, `McpManager`, and agent configs. Runs once per server boot in `run_server()` after all agents are initialized. No LLM calls — pure code projection.
+
+**Entity types:** Skill, Tool, Agent, ProblemType (5 seeds: `ci_failure`, `merge_conflict`, `duplicate_pr`, `stale_uuid`, `fabrication`). **Relationship types:** `DEPENDS_ON` (Skill→Skill from `skill.toml` dependencies), `PROVIDES` (Skill→Tool from skill tools).
+
+**Sole-writer contract:** This module is the sole writer of `skill:*`, `tool:*`, `agent:*`, and `problem_type:*` entity_keys. No other code path writes these namespaces.
+
+**Idempotency:** Entity UPSERT via `INSERT ... ON CONFLICT(entity_key) DO UPDATE` preserves rowids (protects `kg_subject_resolutions.domain_entity_id` FK references). Relationships are DELETE-all-then-INSERT per rebuild. Stale entities are pruned with a type-scoped DELETE that only touches `KG_DOMAIN_ENTITY_TYPES`.
+
+**Failure policy:** Rebuild failures log `warn!` — the server continues to boot. KG queries return stale or empty results until the next successful rebuild. **Staleness contract:** Domain graph reflects registry state as of the last server boot.
+
+**Observability:** Single `trace_id` per rebuild invocation, INFO-level structured logs (`domain_rebuild_start`, `domain_rebuild_entities`, `domain_rebuild_edges`, `domain_rebuild_complete`). No `audit_events` rows (per conventions C3.1).
+
+**Cross-cutting conventions:** See `docs/architecture/kg-implementation-conventions.md` (C1–C3) and `docs/architecture/kg-id-convention.md` for the `<type>:<name>` entity key format.
+
 ## Silent Mode Agent Loop
 
 Background tasks (heartbeat, reminders) where text output is NOT delivered. Agent must use `send_message` tool explicitly. Separate `run_silent_agent` function with `SilentPromptContext`.

--- a/crates/mika-agent/src/kg/domain_builder.rs
+++ b/crates/mika-agent/src/kg/domain_builder.rs
@@ -1,0 +1,1111 @@
+//! # Domain Graph Builder
+//!
+//! Deterministically populates [`kg_entities`] and [`kg_relationships`] by
+//! enumerating four authoritative sources at server startup:
+//!
+//! - [`SkillRegistry`](crate::skills::SkillRegistry) — skill manifests
+//! - [`ToolRegistry`](crate::tools::ToolRegistry) — builtin + skill-owned tools
+//! - [`McpManager`](crate::mcp::McpManager) — MCP server tools (as-of-boot)
+//! - Agent configs — discovered agent names and metadata
+//!
+//! ## Sole-Writer Contract
+//!
+//! This module is the **sole writer** of entity_keys in the `skill:*`, `tool:*`,
+//! `agent:*`, and `problem_type:*` namespaces. No other code path writes these
+//! entity_keys. See `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md`.
+//!
+//! ## Invariants
+//!
+//! - Runs once per server boot, after `SkillRegistry::apply_overrides()`.
+//! - Idempotent: re-running produces the same graph state.
+//! - Never called from agent turns or tool handlers.
+//! - All writes carry a single `trace_id` for the rebuild invocation.
+//! - Rebuild failures are logged, not panicked — the server continues to boot.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+use anyhow::Result;
+use serde_json::json;
+use tracing::{debug, info, warn};
+
+use crate::async_db::AsyncDatabase;
+use crate::db::kg_schema::{KG_DOMAIN_ENTITY_TYPES, format_entity_key};
+use crate::mcp::McpManager;
+use crate::skills::SkillRegistry;
+use crate::timestamp;
+use crate::tools::ToolRegistry;
+
+/// Seed list for well-known problem types.
+///
+/// Starts as a const; promote to a config file only if operators need to extend
+/// it without recompiling.
+const PROBLEM_TYPE_SEEDS: &[&str] = &[
+    "ci_failure",
+    "merge_conflict",
+    "duplicate_pr",
+    "stale_uuid",
+    "fabrication",
+];
+
+/// Domain relationship types managed by this builder.
+///
+/// Used to scope DELETE operations during rebuild — only these types are
+/// touched; subject/resolution layer edges are left untouched.
+///
+/// Convention: subject-layer writers (#690/#691) use distinct edge types
+/// (e.g., `SOLVED_BY`, `CAUSES`, `INDICATES`) — not `DEPENDS_ON` or
+/// `PROVIDES`. The DELETE scope is intentionally type-based (not
+/// endpoint-based) for simplicity. If a future writer needs these same
+/// type names on subject entities, scope the DELETE to domain endpoints.
+const DOMAIN_RELATIONSHIP_TYPES: &[&str] = &["DEPENDS_ON", "PROVIDES"];
+
+/// An entity that should exist in the graph after rebuild.
+#[derive(Debug, Clone)]
+struct DesiredEntity {
+    entity_key: String,
+    entity_type: String,
+    name: String,
+    properties_json: Option<String>,
+}
+
+/// An edge that should exist in the graph after rebuild.
+#[derive(Debug, Clone)]
+struct DesiredEdge {
+    from_entity_key: String,
+    to_entity_key: String,
+    edge_type: String,
+    properties_json: Option<String>,
+}
+
+/// Complete desired state after enumerating all sources.
+struct DesiredState {
+    entities: Vec<DesiredEntity>,
+    edges: Vec<DesiredEdge>,
+    entity_keys: HashSet<String>,
+}
+
+/// Per-type entity stats from a rebuild.
+#[derive(Debug, Default)]
+struct EntityTypeStats {
+    added: usize,
+    updated: usize,
+}
+
+/// Per-type edge stats from a rebuild.
+#[derive(Debug, Default)]
+struct EdgeTypeStats {
+    count: usize,
+}
+
+/// Aggregate rebuild statistics.
+#[derive(Debug, Default)]
+pub struct RebuildStats {
+    pub entities_added: usize,
+    pub entities_updated: usize,
+    pub entities_removed: usize,
+    pub edges_depends_on: usize,
+    pub edges_provides: usize,
+    pub duration_ms: u128,
+}
+
+/// Information about an agent to include in the domain graph.
+///
+/// Kept minimal — the domain graph records structural facts, not state.
+pub struct AgentInfo {
+    pub name: String,
+    pub role: Option<String>,
+    pub model: Option<String>,
+}
+
+/// Projection owner for Skill/Tool/Agent/ProblemType nodes and their
+/// structural edges.
+pub struct DomainGraphBuilder<'a> {
+    db: &'a AsyncDatabase,
+    skill_registry: &'a SkillRegistry,
+    tool_registry: &'a ToolRegistry,
+    mcp_manager: Option<&'a McpManager>,
+    agent_infos: &'a [AgentInfo],
+    trace_id: String,
+}
+
+impl<'a> DomainGraphBuilder<'a> {
+    /// Create a new builder.
+    pub fn new(
+        db: &'a AsyncDatabase,
+        skill_registry: &'a SkillRegistry,
+        tool_registry: &'a ToolRegistry,
+        mcp_manager: Option<&'a McpManager>,
+        agent_infos: &'a [AgentInfo],
+    ) -> Self {
+        let trace_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+        Self {
+            db,
+            skill_registry,
+            tool_registry,
+            mcp_manager,
+            agent_infos,
+            trace_id,
+        }
+    }
+
+    /// Run the full rebuild: enumerate → upsert → rebuild edges → prune stale.
+    ///
+    /// The entire operation runs in a single transaction. If any step fails,
+    /// the whole rebuild rolls back and the graph remains in its previous state.
+    pub async fn rebuild(&self) -> Result<RebuildStats> {
+        let start = Instant::now();
+        info!(trace_id = %self.trace_id, event = "domain_rebuild_start");
+
+        // 1. Gather desired state from authoritative sources.
+        let desired = self.enumerate_sources();
+
+        // 2. Execute all writes in a single transaction via AsyncDatabase.
+        let trace_id = self.trace_id.clone();
+        let stats = self
+            .db
+            .with_db(move |db| {
+                let conn = &db.conn;
+
+                // foreign_keys = ON is set at connection open time (Database::open).
+                let tx = conn.unchecked_transaction()?;
+
+                // 2a. Collect existing entity keys for insert-vs-update tracking.
+                let mut existing_keys: HashSet<String> = HashSet::new();
+                {
+                    let type_placeholders: String = KG_DOMAIN_ENTITY_TYPES
+                        .iter()
+                        .map(|_| "?")
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let sql = format!(
+                        "SELECT entity_key FROM kg_entities WHERE type IN ({type_placeholders})"
+                    );
+                    let mut stmt = tx.prepare(&sql)?;
+                    let mut param_idx = 1;
+                    for t in KG_DOMAIN_ENTITY_TYPES {
+                        stmt.raw_bind_parameter(param_idx, *t)?;
+                        param_idx += 1;
+                    }
+                    let mut rows = stmt.raw_query();
+                    while let Some(row) = rows.next()? {
+                        let key: String = row.get(0)?;
+                        existing_keys.insert(key);
+                    }
+                }
+
+                // UPSERT entities
+                let mut type_stats: HashMap<String, EntityTypeStats> = HashMap::new();
+                let now = timestamp::now();
+                for entity in &desired.entities {
+                    tx.execute(
+                        "INSERT INTO kg_entities (entity_key, type, name, properties_json, created_at, updated_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                         ON CONFLICT(entity_key) DO UPDATE SET
+                           name = excluded.name,
+                           properties_json = excluded.properties_json,
+                           updated_at = ?5",
+                        rusqlite::params![
+                            entity.entity_key,
+                            entity.entity_type,
+                            entity.name,
+                            entity.properties_json,
+                            now,
+                        ],
+                    )?;
+
+                    let stats = type_stats
+                        .entry(entity.entity_type.clone())
+                        .or_default();
+
+                    if existing_keys.contains(&entity.entity_key) {
+                        stats.updated += 1;
+                    } else {
+                        stats.added += 1;
+                    }
+                }
+
+                // 2b. DELETE domain-sourced relationships, then re-INSERT.
+                let mut edge_stats: HashMap<String, EdgeTypeStats> = HashMap::new();
+                for rel_type in DOMAIN_RELATIONSHIP_TYPES {
+                    tx.execute(
+                        "DELETE FROM kg_relationships WHERE type = ?1",
+                        rusqlite::params![rel_type],
+                    )?;
+                }
+
+                for edge in &desired.edges {
+                    // Look up entity IDs by key. Skip edges with missing endpoints
+                    // (the enumeration already filters these, but defense-in-depth).
+                    let from_id: Option<i64> = tx
+                        .query_row(
+                            "SELECT id FROM kg_entities WHERE entity_key = ?1",
+                            rusqlite::params![edge.from_entity_key],
+                            |row| row.get(0),
+                        )
+                        .ok();
+                    let to_id: Option<i64> = tx
+                        .query_row(
+                            "SELECT id FROM kg_entities WHERE entity_key = ?1",
+                            rusqlite::params![edge.to_entity_key],
+                            |row| row.get(0),
+                        )
+                        .ok();
+
+                    match (from_id, to_id) {
+                        (Some(fid), Some(tid)) => {
+                            tx.execute(
+                                "INSERT INTO kg_relationships (from_entity_id, to_entity_id, type, properties_json, created_at)
+                                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                                rusqlite::params![fid, tid, edge.edge_type, edge.properties_json, now],
+                            )?;
+                            edge_stats
+                                .entry(edge.edge_type.clone())
+                                .or_default()
+                                .count += 1;
+                        }
+                        _ => {
+                            tracing::warn!(
+                                trace_id = %trace_id,
+                                from = %edge.from_entity_key,
+                                to = %edge.to_entity_key,
+                                edge_type = %edge.edge_type,
+                                "skipping edge with missing endpoint entity"
+                            );
+                        }
+                    }
+                }
+
+                // 2c. DELETE entities no longer in sources.
+                // The type filter enforces the sole-writer contract at the SQL level.
+                let type_placeholders: String = KG_DOMAIN_ENTITY_TYPES
+                    .iter()
+                    .map(|_| "?")
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                // Build the NOT IN clause for desired keys
+                let key_placeholders: String = if desired.entity_keys.is_empty() {
+                    // No desired keys — delete everything in domain types
+                    String::new()
+                } else {
+                    let placeholders: String = desired
+                        .entity_keys
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| format!("?{}", i + KG_DOMAIN_ENTITY_TYPES.len() + 1))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!(" AND entity_key NOT IN ({placeholders})")
+                };
+
+                let delete_sql = format!(
+                    "DELETE FROM kg_entities WHERE type IN ({type_placeholders}){key_placeholders}"
+                );
+
+                let removed = {
+                    let mut stmt = tx.prepare(&delete_sql)?;
+                    let mut param_idx = 1;
+                    for t in KG_DOMAIN_ENTITY_TYPES {
+                        stmt.raw_bind_parameter(param_idx, *t)?;
+                        param_idx += 1;
+                    }
+                    for key in &desired.entity_keys {
+                        stmt.raw_bind_parameter(param_idx, key.as_str())?;
+                        param_idx += 1;
+                    }
+                    stmt.raw_execute()?
+                };
+
+                tx.commit()?;
+
+                // Compute aggregate stats
+                let mut total_added = 0usize;
+                let mut total_updated = 0usize;
+                for s in type_stats.values() {
+                    total_added += s.added;
+                    total_updated += s.updated;
+                }
+
+                Ok((total_added, total_updated, removed, type_stats, edge_stats))
+            })
+            .await?;
+
+        let (total_added, total_updated, removed, type_stats, edge_stats) = stats;
+        let duration_ms = start.elapsed().as_millis();
+
+        // Log per-type stats
+        for entity_type in KG_DOMAIN_ENTITY_TYPES {
+            let s = type_stats.get(*entity_type);
+            let added = s.map_or(0, |s| s.added);
+            let updated = s.map_or(0, |s| s.updated);
+            info!(
+                trace_id = %self.trace_id,
+                event = "domain_rebuild_entities",
+                r#type = entity_type,
+                added,
+                updated,
+            );
+        }
+        if removed > 0 {
+            info!(
+                trace_id = %self.trace_id,
+                event = "domain_rebuild_entities_removed",
+                removed,
+            );
+        }
+        for rel_type in DOMAIN_RELATIONSHIP_TYPES {
+            let count = edge_stats.get(*rel_type).map_or(0, |s| s.count);
+            info!(
+                trace_id = %self.trace_id,
+                event = "domain_rebuild_edges",
+                r#type = rel_type,
+                count,
+            );
+        }
+        info!(
+            trace_id = %self.trace_id,
+            event = "domain_rebuild_complete",
+            duration_ms,
+        );
+
+        Ok(RebuildStats {
+            entities_added: total_added,
+            entities_updated: total_updated,
+            entities_removed: removed,
+            edges_depends_on: edge_stats.get("DEPENDS_ON").map_or(0, |s| s.count),
+            edges_provides: edge_stats.get("PROVIDES").map_or(0, |s| s.count),
+            duration_ms,
+        })
+    }
+
+    /// Enumerate all authoritative sources into a desired state.
+    fn enumerate_sources(&self) -> DesiredState {
+        let mut entities = Vec::new();
+        let mut edges = Vec::new();
+        let mut entity_keys = HashSet::new();
+
+        // Track tool sources for dedup (tool_name -> list of sources)
+        let mut tool_sources: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+        let mut tool_descriptions: HashMap<String, String> = HashMap::new();
+
+        // --- Skills ---
+        for skill in self.skill_registry.skills() {
+            let skill_name = &skill.manifest.skill.name;
+            let key = format_entity_key("skill", skill_name);
+
+            let props = json!({
+                "description": skill.manifest.skill.description,
+                "always_on": skill.manifest.skill.always_on,
+                "keywords": skill.manifest.triggers.keywords,
+                "version": skill.manifest.skill.version,
+            });
+
+            entities.push(DesiredEntity {
+                entity_key: key.clone(),
+                entity_type: "skill".to_string(),
+                name: skill_name.clone(),
+                properties_json: Some(props.to_string()),
+            });
+            entity_keys.insert(key.clone());
+
+            // Collect DEPENDS_ON edges
+            for dep in &skill.manifest.skill.dependencies {
+                let dep_key = format_entity_key("skill", dep);
+                // Only create the edge if the dependency exists in the registry
+                let dep_exists = self
+                    .skill_registry
+                    .skills()
+                    .iter()
+                    .any(|s| s.manifest.skill.name == *dep);
+                if dep_exists {
+                    edges.push(DesiredEdge {
+                        from_entity_key: key.clone(),
+                        to_entity_key: dep_key,
+                        edge_type: "DEPENDS_ON".to_string(),
+                        properties_json: None,
+                    });
+                } else {
+                    warn!(
+                        trace_id = %self.trace_id,
+                        skill = skill_name,
+                        dependency = dep,
+                        "skill references unknown dependency, skipping DEPENDS_ON edge"
+                    );
+                }
+            }
+
+            // Collect PROVIDES edges for skill tools
+            for tool in &skill.skill_tools {
+                let tool_name = &tool.definition.name;
+
+                // Track source for dedup
+                tool_sources
+                    .entry(tool_name.clone())
+                    .or_default()
+                    .push(json!({"skill": skill_name}));
+                tool_descriptions
+                    .entry(tool_name.clone())
+                    .or_insert_with(|| tool.definition.description.clone());
+
+                // PROVIDES edge
+                let tool_key = format_entity_key("tool", tool_name);
+                edges.push(DesiredEdge {
+                    from_entity_key: key.clone(),
+                    to_entity_key: tool_key,
+                    edge_type: "PROVIDES".to_string(),
+                    properties_json: None,
+                });
+            }
+        }
+
+        // --- Tools from ToolRegistry (builtins) ---
+        for tool_def in self.tool_registry.definitions() {
+            let tool_name = &tool_def.name;
+
+            // Determine source: if already tracked from a skill, it's skill-owned.
+            // Otherwise it's a builtin.
+            if !tool_sources.contains_key(tool_name) {
+                tool_sources
+                    .entry(tool_name.clone())
+                    .or_default()
+                    .push(json!({"builtin": true}));
+                tool_descriptions
+                    .entry(tool_name.clone())
+                    .or_insert_with(|| tool_def.description.clone());
+            }
+        }
+
+        // --- Tools from MCP servers ---
+        if let Some(mcp) = self.mcp_manager {
+            for tool_def in mcp.tool_definitions() {
+                let tool_name = &tool_def.name;
+
+                // Extract MCP server name from the namespaced tool name (mcp__{server}__{tool})
+                let server_name = tool_name
+                    .strip_prefix("mcp__")
+                    .and_then(|rest| rest.split("__").next())
+                    .unwrap_or("unknown");
+
+                tool_sources
+                    .entry(tool_name.clone())
+                    .or_default()
+                    .push(json!({"mcp": server_name}));
+                tool_descriptions
+                    .entry(tool_name.clone())
+                    .or_insert_with(|| tool_def.description.clone());
+            }
+        }
+
+        // --- Build Tool entities from collected sources ---
+        for (tool_name, sources) in &tool_sources {
+            let key = format_entity_key("tool", tool_name);
+            let description = tool_descriptions
+                .get(tool_name)
+                .cloned()
+                .unwrap_or_default();
+
+            // Detect duplicate tool with differing descriptions
+            if sources.len() > 1 {
+                debug!(
+                    trace_id = %self.trace_id,
+                    tool = tool_name,
+                    sources = ?sources,
+                    "tool exposed by multiple sources"
+                );
+            }
+
+            let source_label = if sources.len() == 1 {
+                // Single source — use a simple string label
+                if sources[0].get("builtin").is_some() {
+                    "builtin".to_string()
+                } else if let Some(skill) = sources[0].get("skill").and_then(|v| v.as_str()) {
+                    format!("skill:{skill}")
+                } else if let Some(mcp) = sources[0].get("mcp").and_then(|v| v.as_str()) {
+                    format!("mcp:{mcp}")
+                } else {
+                    "unknown".to_string()
+                }
+            } else {
+                // Multiple sources — record all
+                "multiple".to_string()
+            };
+
+            let props = json!({
+                "description": description,
+                "source": source_label,
+                "sources": sources,
+            });
+
+            entities.push(DesiredEntity {
+                entity_key: key.clone(),
+                entity_type: "tool".to_string(),
+                name: tool_name.clone(),
+                properties_json: Some(props.to_string()),
+            });
+            entity_keys.insert(key);
+        }
+
+        // --- Agents ---
+        for agent in self.agent_infos {
+            let key = format_entity_key("agent", &agent.name);
+
+            let mut props = serde_json::Map::new();
+            if let Some(ref role) = agent.role {
+                props.insert("role".to_string(), json!(role));
+            }
+            if let Some(ref model) = agent.model {
+                props.insert("model".to_string(), json!(model));
+            }
+
+            entities.push(DesiredEntity {
+                entity_key: key.clone(),
+                entity_type: "agent".to_string(),
+                name: agent.name.clone(),
+                properties_json: Some(serde_json::Value::Object(props).to_string()),
+            });
+            entity_keys.insert(key);
+        }
+
+        // --- ProblemType seeds ---
+        for slug in PROBLEM_TYPE_SEEDS {
+            let key = format_entity_key("problem_type", slug);
+            entities.push(DesiredEntity {
+                entity_key: key.clone(),
+                entity_type: "problem_type".to_string(),
+                name: slug.to_string(),
+                properties_json: None,
+            });
+            entity_keys.insert(key);
+        }
+
+        DesiredState {
+            entities,
+            edges,
+            entity_keys,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use crate::skills::index::SkillEntry;
+    use crate::skills::manifest::{SkillInfo, SkillManifest, Triggers};
+    use mika_common::claude::ToolDefinition;
+    use std::path::PathBuf;
+
+    /// Create a minimal SkillEntry for testing.
+    fn make_skill(
+        name: &str,
+        description: &str,
+        dependencies: Vec<String>,
+        tool_names: Vec<&str>,
+    ) -> SkillEntry {
+        use crate::skills::index::ResolvedSkillTool;
+        use crate::skills::manifest::{Constraints, VariantsConfig};
+
+        let skill_tools: Vec<ResolvedSkillTool> = tool_names
+            .into_iter()
+            .map(|t| ResolvedSkillTool {
+                definition: ToolDefinition {
+                    name: t.to_string(),
+                    description: format!("Tool {t}"),
+                    input_schema: serde_json::json!({"type": "object"}),
+                },
+                handler: crate::skills::manifest::ToolHandler::Builtin {
+                    function: t.to_string(),
+                },
+                skill_dir: PathBuf::new(),
+            })
+            .collect();
+
+        SkillEntry {
+            manifest: SkillManifest {
+                skill: SkillInfo {
+                    name: name.to_string(),
+                    description: description.to_string(),
+                    version: "0.1.0".to_string(),
+                    always_on: false,
+                    timeout_secs: 30,
+                    dependencies,
+                    max_prompt_size: None,
+                },
+                triggers: Triggers {
+                    keywords: vec![name.to_string()],
+                },
+                llm: Default::default(),
+                constraints: Constraints::default(),
+                context: Default::default(),
+                variants: VariantsConfig::default(),
+            },
+            dir: PathBuf::from(format!("/tmp/skills/{name}")),
+            keywords_lower: vec![name.to_lowercase()],
+            prompt_snippet: String::new(),
+            skill_tools,
+            enabled: true,
+            has_override: false,
+            provider_overrides: Default::default(),
+            model_prompts: Default::default(),
+            model_overrides: Default::default(),
+            generated_model_prompts: Default::default(),
+        }
+    }
+
+    fn make_tool_registry(names: &[&str]) -> ToolRegistry {
+        use crate::tools::ToolOutput;
+        use async_trait::async_trait;
+
+        struct DummyTool {
+            name: String,
+            def: ToolDefinition,
+        }
+
+        #[async_trait]
+        impl crate::tools::Tool for DummyTool {
+            fn name(&self) -> &str {
+                &self.name
+            }
+            fn definition(&self) -> ToolDefinition {
+                self.def.clone()
+            }
+            async fn execute(
+                &self,
+                _input: serde_json::Value,
+                _ctx: &crate::tools::ToolContext<'_>,
+            ) -> Result<ToolOutput> {
+                Ok(ToolOutput::success("ok"))
+            }
+        }
+
+        let mut registry = ToolRegistry::new();
+        for name in names {
+            registry.register(Box::new(DummyTool {
+                name: name.to_string(),
+                def: ToolDefinition {
+                    name: name.to_string(),
+                    description: format!("Builtin tool {name}"),
+                    input_schema: serde_json::json!({"type": "object"}),
+                },
+            }));
+        }
+        registry
+    }
+
+    fn make_async_db() -> AsyncDatabase {
+        let db = Database::open_in_memory().expect("in-memory DB");
+        AsyncDatabase::new(db)
+    }
+
+    #[test]
+    fn enumerate_skills() {
+        let db = make_async_db();
+        let skill_a = make_skill("skill-a", "Skill A", vec![], vec!["tool_x"]);
+        let skill_b = make_skill(
+            "skill-b",
+            "Skill B",
+            vec!["skill-a".to_string()],
+            vec!["tool_y"],
+        );
+        let registry = SkillRegistry::from_test_entries(vec![skill_a, skill_b]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        // 2 skills + 2 tools + 0 agents + 5 problem_types = 9
+        assert_eq!(state.entities.len(), 9);
+
+        // 1 DEPENDS_ON + 2 PROVIDES = 3
+        assert_eq!(state.edges.len(), 3);
+
+        let edge_types: HashSet<_> = state.edges.iter().map(|e| e.edge_type.as_str()).collect();
+        assert!(edge_types.contains("DEPENDS_ON"));
+        assert!(edge_types.contains("PROVIDES"));
+    }
+
+    #[test]
+    fn enumerate_deduplicates_tools() {
+        let db = make_async_db();
+        // Two skills expose the same tool
+        let skill_a = make_skill("skill-a", "A", vec![], vec!["shared_tool"]);
+        let skill_b = make_skill("skill-b", "B", vec![], vec!["shared_tool"]);
+        let registry = SkillRegistry::from_test_entries(vec![skill_a, skill_b]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        // Should be ONE tool entity for "shared_tool"
+        let tool_entities: Vec<_> = state
+            .entities
+            .iter()
+            .filter(|e| e.entity_type == "tool" && e.name == "shared_tool")
+            .collect();
+        assert_eq!(tool_entities.len(), 1);
+
+        // Properties should list both sources
+        let props: serde_json::Value =
+            serde_json::from_str(tool_entities[0].properties_json.as_ref().unwrap()).unwrap();
+        let sources = props["sources"].as_array().unwrap();
+        assert_eq!(sources.len(), 2);
+    }
+
+    #[test]
+    fn enumerate_with_no_dependencies() {
+        let db = make_async_db();
+        let skill = make_skill("solo", "Solo skill", vec![], vec![]);
+        let registry = SkillRegistry::from_test_entries(vec![skill]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        // No DEPENDS_ON edges
+        let depends_on: Vec<_> = state
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == "DEPENDS_ON")
+            .collect();
+        assert!(depends_on.is_empty());
+    }
+
+    #[test]
+    fn enumerate_with_empty_agents() {
+        let db = make_async_db();
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        // Only problem_type seeds
+        assert_eq!(state.entities.len(), 5);
+        for e in &state.entities {
+            assert_eq!(e.entity_type, "problem_type");
+        }
+    }
+
+    #[test]
+    fn enumerate_agents() {
+        let db = make_async_db();
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&[]);
+        let agents = vec![AgentInfo {
+            name: "mika-dev".to_string(),
+            role: Some("developer".to_string()),
+            model: Some("claude-sonnet-4-20250514".to_string()),
+        }];
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &agents);
+        let state = builder.enumerate_sources();
+
+        let agent_entities: Vec<_> = state
+            .entities
+            .iter()
+            .filter(|e| e.entity_type == "agent")
+            .collect();
+        assert_eq!(agent_entities.len(), 1);
+        assert_eq!(agent_entities[0].entity_key, "agent:mika-dev");
+    }
+
+    #[test]
+    fn enumerate_unknown_dependency_skipped() {
+        let db = make_async_db();
+        let skill = make_skill("child", "Child", vec!["nonexistent".to_string()], vec![]);
+        let registry = SkillRegistry::from_test_entries(vec![skill]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        // No DEPENDS_ON edges (the dependency doesn't exist)
+        let depends_on: Vec<_> = state
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == "DEPENDS_ON")
+            .collect();
+        assert!(depends_on.is_empty());
+    }
+
+    #[test]
+    fn no_state_shaped_edges() {
+        let db = make_async_db();
+        let skill = make_skill("s1", "S1", vec![], vec!["t1"]);
+        let registry = SkillRegistry::from_test_entries(vec![skill]);
+        let tool_registry = make_tool_registry(&["t1"]);
+        let agents = vec![AgentInfo {
+            name: "test-agent".to_string(),
+            role: None,
+            model: None,
+        }];
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &agents);
+        let state = builder.enumerate_sources();
+
+        // All edges must be only DEPENDS_ON or PROVIDES
+        let allowed: HashSet<&str> = DOMAIN_RELATIONSHIP_TYPES.iter().copied().collect();
+        for edge in &state.edges {
+            assert!(
+                allowed.contains(edge.edge_type.as_str()),
+                "unexpected edge type: {}",
+                edge.edge_type
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_tools_included() {
+        let db = make_async_db();
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&["search_memory", "store_fact"]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let state = builder.enumerate_sources();
+
+        let tool_names: HashSet<_> = state
+            .entities
+            .iter()
+            .filter(|e| e.entity_type == "tool")
+            .map(|e| e.name.as_str())
+            .collect();
+        assert!(tool_names.contains("search_memory"));
+        assert!(tool_names.contains("store_fact"));
+    }
+
+    #[tokio::test]
+    async fn rebuild_fresh_db() {
+        let db = make_async_db();
+        let skill = make_skill("alpha", "Alpha skill", vec![], vec!["alpha_tool"]);
+        let registry = SkillRegistry::from_test_entries(vec![skill]);
+        let tool_registry = make_tool_registry(&["search_memory"]);
+        let agents = vec![AgentInfo {
+            name: "test-agent".to_string(),
+            role: Some("tester".to_string()),
+            model: None,
+        }];
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &agents);
+        let stats = builder.rebuild().await.expect("rebuild should succeed");
+
+        // 1 skill + 2 tools + 1 agent + 5 problem_types = 9
+        assert_eq!(stats.entities_added, 9);
+        assert_eq!(stats.entities_updated, 0);
+        assert_eq!(stats.entities_removed, 0);
+        assert_eq!(stats.edges_provides, 1); // alpha -> alpha_tool
+        assert_eq!(stats.edges_depends_on, 0);
+    }
+
+    #[tokio::test]
+    async fn rebuild_is_idempotent() {
+        let db = make_async_db();
+        let skill = make_skill("beta", "Beta skill", vec![], vec!["beta_tool"]);
+        let registry = SkillRegistry::from_test_entries(vec![skill]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let agents = vec![AgentInfo {
+            name: "test".to_string(),
+            role: None,
+            model: None,
+        }];
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &agents);
+        let stats1 = builder.rebuild().await.expect("first rebuild");
+        assert!(stats1.entities_added > 0);
+
+        // Second rebuild with same sources
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &agents);
+        let stats2 = builder2.rebuild().await.expect("second rebuild");
+        assert_eq!(stats2.entities_added, 0);
+        assert_eq!(stats2.entities_removed, 0);
+        // Updates are expected (UPSERT updates existing rows)
+        assert!(stats2.entities_updated > 0);
+    }
+
+    #[tokio::test]
+    async fn rebuild_deletes_removed_entities() {
+        let db = make_async_db();
+
+        // First rebuild with skill X that provides tool_x
+        let skill_x = make_skill("skill-x", "X", vec![], vec!["tool_x"]);
+        let registry1 = SkillRegistry::from_test_entries(vec![skill_x]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder1 = DomainGraphBuilder::new(&db, &registry1, &tool_registry, None, &[]);
+        builder1.rebuild().await.expect("first rebuild");
+
+        // Verify edge exists after first rebuild
+        let edge_count_before: usize = db
+            .with_db(|db| {
+                db.conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM kg_relationships WHERE type = 'PROVIDES'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("count edges");
+        assert_eq!(edge_count_before, 1);
+
+        // Second rebuild WITHOUT skill X
+        let registry2 = SkillRegistry::empty();
+        let builder2 = DomainGraphBuilder::new(&db, &registry2, &tool_registry, None, &[]);
+        let stats2 = builder2.rebuild().await.expect("second rebuild");
+
+        // skill-x entity should be removed
+        assert!(stats2.entities_removed > 0);
+
+        // Verify entity is gone from DB
+        let remaining = db
+            .with_db(|db| {
+                let mut stmt = db.conn.prepare(
+                    "SELECT entity_key FROM kg_entities WHERE entity_key = 'skill:skill-x'",
+                )?;
+                let keys: Vec<String> = stmt
+                    .query_map([], |row| row.get(0))?
+                    .collect::<Result<_, _>>()?;
+                Ok(keys)
+            })
+            .await
+            .expect("query");
+        assert!(remaining.is_empty());
+
+        // Verify CASCADE removed edges touching deleted entity
+        let edge_count_after: usize = db
+            .with_db(|db| {
+                db.conn
+                    .query_row("SELECT COUNT(*) FROM kg_relationships", [], |row| {
+                        row.get(0)
+                    })
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("count edges after");
+        assert_eq!(edge_count_after, 0);
+    }
+
+    #[tokio::test]
+    async fn rebuild_preserves_resolution_entity_links() {
+        // Verifies that UPSERT preserves kg_entities.id (rowid), which is
+        // referenced by kg_subject_resolutions.domain_entity_id. If the builder
+        // accidentally DELETEd + INSERTed instead of UPSERTing, the rowid would
+        // change and break FK references from the subject layer.
+        let db = make_async_db();
+
+        let skill = make_skill("linked-skill", "Linked", vec![], vec![]);
+        let registry = SkillRegistry::from_test_entries(vec![skill.clone()]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder.rebuild().await.expect("first rebuild");
+
+        // Get the entity rowid
+        let entity_id: i64 = db
+            .with_db(|db| {
+                db.conn
+                    .query_row(
+                        "SELECT id FROM kg_entities WHERE entity_key = 'skill:linked-skill'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("get entity id");
+
+        // Insert a subject entity and resolution pointing to this domain entity
+        // (simulating #690/#691 subject extraction + resolution)
+        db.with_db(move |db| {
+            db.conn.execute(
+                "INSERT OR IGNORE INTO agents (id, name, home_dir) VALUES ('test', 'test', '/tmp')",
+                [],
+            )?;
+            db.conn.execute(
+                "INSERT INTO kg_subject_entities (agent_id, entity_key, type, name, confidence)
+                 VALUES ('test', 'skill:linked-skill', 'skill', 'linked-skill', 1.0)",
+                [],
+            )?;
+            let subject_id: i64 = db.conn.last_insert_rowid();
+            db.conn.execute(
+                "INSERT INTO kg_subject_resolutions (agent_id, subject_entity_id, domain_entity_id, confidence)
+                 VALUES ('test', ?1, ?2, 1.0)",
+                rusqlite::params![subject_id, entity_id],
+            )?;
+            Ok(())
+        })
+        .await
+        .expect("insert subject resolution");
+
+        // Rebuild again with same sources — domain entity_id must be preserved
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder2.rebuild().await.expect("second rebuild");
+
+        // Resolution's domain_entity_id should still resolve
+        let resolution_domain_id: i64 = db
+            .with_db(|db| {
+                db.conn
+                    .query_row(
+                        "SELECT domain_entity_id FROM kg_subject_resolutions LIMIT 1",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("get resolution domain_entity_id");
+
+        assert_eq!(
+            resolution_domain_id, entity_id,
+            "resolution FK should survive rebuild"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_preserves_rowid() {
+        let db = make_async_db();
+
+        let skill = make_skill("stable", "Stable", vec![], vec![]);
+        let registry = SkillRegistry::from_test_entries(vec![skill.clone()]);
+        let tool_registry = make_tool_registry(&[]);
+
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder.rebuild().await.expect("first rebuild");
+
+        // Get the rowid
+        let rowid_before: i64 = db
+            .with_db(|db| {
+                db.conn
+                    .query_row(
+                        "SELECT id FROM kg_entities WHERE entity_key = 'skill:stable'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("get rowid");
+
+        // Rebuild again
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder2.rebuild().await.expect("second rebuild");
+
+        // Rowid should be preserved (UPSERT, not delete+insert)
+        let rowid_after: i64 = db
+            .with_db(|db| {
+                db.conn
+                    .query_row(
+                        "SELECT id FROM kg_entities WHERE entity_key = 'skill:stable'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+            })
+            .await
+            .expect("get rowid after");
+
+        assert_eq!(rowid_before, rowid_after);
+    }
+}

--- a/crates/mika-agent/src/kg/mod.rs
+++ b/crates/mika-agent/src/kg/mod.rs
@@ -1,0 +1,18 @@
+//! # Knowledge Graph Layer
+//!
+//! The KG layer provides a graph-structured view of Mika's domain knowledge,
+//! split into three tiers:
+//!
+//! - **Domain graph** (this module, [`domain_builder`]): Deterministic, container-wide
+//!   projection of structural facts from skill manifests, tool registry, MCP connections,
+//!   and agent configs. Populated at startup, idempotent, no LLM calls. See
+//!   `docs/architecture/kg-implementation-conventions.md` for cross-cutting conventions
+//!   and `crates/mika-agent/src/db/kg_schema.rs` for schema constants and ID format.
+//!
+//! - **Lexical graph** (future, #689): Per-agent chunk ingestion linking prose content
+//!   to domain entities.
+//!
+//! - **Subject graph** (future, #690/#691): Per-agent LLM-extracted entities, fact
+//!   triples, and resolution edges linking subject mentions to domain nodes.
+
+pub mod domain_builder;

--- a/crates/mika-agent/src/lib.rs
+++ b/crates/mika-agent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compaction;
 pub mod config_keys;
 pub mod db;
 pub(crate) mod github_graphql;
+pub mod kg;
 pub mod mcp;
 pub mod messaging;
 pub mod prompt;

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -711,6 +711,50 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         .db
         .clone();
 
+    // Domain graph rebuild: populate kg_entities and kg_relationships from
+    // authoritative sources (skill manifests, tool registry, MCP, agent configs).
+    // Runs once per server boot, after all agents are initialized. Failures are
+    // logged — the server continues to boot with stale or empty KG data.
+    {
+        let default_state = agents
+            .get(&default_agent)
+            .expect("default agent must exist");
+        // Clone the Arc<SkillRegistry> and drop the MutexGuard before the await
+        // to avoid holding a std::sync::Mutex across an async boundary.
+        let skill_reg = default_state.skills.lock().expect("skills lock").clone();
+        let agent_infos: Vec<crate::kg::domain_builder::AgentInfo> = agents
+            .iter()
+            .map(|(name, state)| crate::kg::domain_builder::AgentInfo {
+                name: name.clone(),
+                role: None,
+                model: Some(state.llm.model_name().to_string()),
+            })
+            .collect();
+        let builder = crate::kg::domain_builder::DomainGraphBuilder::new(
+            &dashboard_db,
+            &skill_reg,
+            &tool_registry,
+            default_state.mcp_manager.as_ref(),
+            &agent_infos,
+        );
+        match builder.rebuild().await {
+            Ok(stats) => info!(
+                event = "domain_rebuild_complete",
+                added = stats.entities_added,
+                updated = stats.entities_updated,
+                removed = stats.entities_removed,
+                depends_on = stats.edges_depends_on,
+                provides = stats.edges_provides,
+                duration_ms = stats.duration_ms,
+                "domain graph ready"
+            ),
+            Err(e) => warn!(
+                error = %e,
+                "domain graph rebuild failed; KG queries may return stale results until next restart"
+            ),
+        }
+    }
+
     let state = AppState {
         agents: Arc::new(agents),
         default_agent,

--- a/docs/architecture/kg-implementation-conventions.md
+++ b/docs/architecture/kg-implementation-conventions.md
@@ -1,0 +1,151 @@
+# KG Implementation Conventions
+
+**Status:** Active
+**Created:** 2026-04-21
+**Applies to:** milestone mika#14 (Knowledge Graph) — tickets #687–#692
+
+This document captures cross-cutting decisions that apply to multiple KG tickets. Each ticket plan cites this doc rather than relitigating these decisions individually. If you are planning a KG ticket and find yourself reasoning about embedding budgets, non-interactive LLM calls, or audit/observability conventions, read this first.
+
+Companion document: [`kg-id-convention.md`](./kg-id-convention.md) covers the typed-prefix ID scheme.
+
+---
+
+## C1. Embedding policy — piggyback, never block
+
+KG chunks and any future embeddable content flow through the existing Layer 3 infrastructure:
+
+- Model: OpenAI `text-embedding-3-small`, 512 dimensions.
+- Storage: `search_content.embedding_json` + `vec_search` virtual table (`crates/mika-agent/src/db.rs`).
+- Backfill: existing path with batch size 100, idempotent by `embedding_json IS NULL`.
+- Indexing is best-effort — a failed embedding call never fails the tool response or the ingestion operation.
+
+There is **no KG-specific embedding quota or concurrency cap**. Economics do not justify one: `text-embedding-3-small` costs ~$0.02 per 1M tokens; a 10,000-chunk ingestion run (~500 tokens per chunk) costs ~$0.10. The KG would need to be ingesting at a scale of millions of chunks before embedding cost becomes a material concern, at which point quota design should be informed by real usage data rather than speculation.
+
+### C1.1 The async-embedding contract (mandatory for #689 and #690)
+
+**Ingestion writes commit without waiting for embeddings.** The transactional boundary is:
+
+1. Insert `kg_chunks` row (or equivalent subject-layer row).
+2. Insert corresponding `search_content` row with `embedding_json = NULL`.
+3. Insert corresponding `fts_search` row (FTS5 indexing).
+4. **COMMIT.**
+
+The actual embedding call is **not** part of the transaction. It runs later via the existing backfill path, which is idempotent by `embedding_json IS NULL`.
+
+**Three consequences ingestion code must handle:**
+
+1. **Ingestion latency is bounded.** A user-facing "ingest this doc" operation returns in chunk+write time, not chunk+write+embed time. A large doc's ingestion completes in seconds, not tens of seconds.
+2. **Ingestion failures are decoupled from embedding failures.** If OpenAI is down, rate-limited, or the agent has no embedding API key: ingestion still succeeds. Chunks are immediately queryable via FTS5 and become queryable via vector search once the backfill catches up.
+3. **Freshly ingested content may not be in `vec_search` yet.** Callers that read immediately after writing must either accept FTS5-only results in that window, or poll — but no waiter may block a user-facing operation. Document this in every ingestor's contract.
+
+Every KG ingestion ticket should include this paragraph verbatim or in equivalent language in its Key Technical Decisions section:
+
+> Ingestion writes are synchronous and transactional for rows and FTS5 indexing. Embeddings are generated asynchronously by the existing backfill path and may not be available immediately after ingestion returns. Callers that need vector search results on freshly ingested content must either accept FTS5-only results until backfill catches up, or explicitly wait/poll — but no such waiter blocks user-facing operations.
+
+---
+
+## C2. Non-interactive LLM call policy
+
+Non-interactive LLM calls are calls that happen during ingestion or background processing, not in response to a user turn. Current scope: #690 subject extraction, #691 entity resolution. Future tickets that add similar calls inherit this policy.
+
+### C2.1 Model selection — two env vars, not one
+
+Two environment variables cover the two distinct ingestion call types:
+
+- `MIKA_KG_EXTRACTION_MODEL` — used by #690 for NER + fact-triple extraction from prose. Default: a cheap/fast tier (e.g., `deepseek-v3` or `haiku-4.5`). Task is mechanical — identify spans, classify, emit JSON.
+- `MIKA_KG_RESOLUTION_MODEL` — used by #691 for ambiguous-case entity resolution arbitration. Default: mid-tier (better judgment than extraction requires, because errors produce persistent wrong edges that downstream queries depend on). May initially share the extraction model's default and escalate later if quality data suggests it should.
+
+Both fall back to a shared `MIKA_KG_INGESTION_MODEL` if only that is set, so operators who want one knob can set one and move on.
+
+**Do not** route ingestion calls through the agent's primary conversational model (`MIKA_PROVIDER` / `MIKA_MODEL`). Interactive reasoning and bulk extraction have different quality, latency, and cost profiles; coupling them means every model upgrade for conversational quality drags ingestion cost along, and every ingestion cost optimization risks degrading conversational quality.
+
+**Do not** use per-skill `skill_overrides` as the default for ingestion category selection. Per-skill overrides are the right escape hatch if one specific skill needs a different model, but they scatter global ingestion policy across skill manifests — the "which model does ingestion use in this container" question should be answerable by reading one env var, not N files.
+
+### C2.2 Retry taxonomy — four failure categories
+
+All non-interactive LLM calls must distinguish four failure modes and handle each differently:
+
+| Failure category | Detection | Handling |
+|------------------|-----------|----------|
+| **Transport** | Network error, timeout, 5xx from provider | Retry with exponential backoff up to N attempts (N recommended: 3). |
+| **Rate limit** | HTTP 429 | Retry with backoff. Respect `Retry-After` header when present; otherwise use exponential backoff. |
+| **Semantic (malformed output)** | Valid HTTP response but model returned non-parseable JSON or JSON that doesn't match the declared schema | One retry with a prompt reinforcement (e.g., "return valid JSON matching schema X"). If second attempt also fails, log-and-skip. Retrying more than once rarely helps — the model's failure mode on malformed output is usually consistent. |
+| **Configuration** | HTTP 401/403, model-not-found, unsupported operation | Do not retry. Halt ingestion and surface an error. These indicate a configuration problem, not a transient failure; retrying spams the provider and logs without fixing anything. |
+
+### C2.3 Log-and-skip preserves lexical state
+
+When a subject extraction or entity resolution call hits a log-and-skip outcome (semantic failure after retry, or all transient retries exhausted), the already-committed **lexical chunks remain**. Only the subject-graph rows or resolution edges for that specific chunk/entity are dropped. Never let a downstream failure take down upstream committed state.
+
+The ingestion pipeline is layered:
+
+```
+[1] Chunk write → [2] Index → [3] Extract subjects → [4] Resolve subjects to domain
+```
+
+Failures at stage 3 or 4 must not affect stages 1 or 2 that already committed. This is the orthogonality invariant — each stage owns its own success/failure, and later-stage failure cannot trigger earlier-stage rollback.
+
+### C2.4 Non-interactive LLM calls emit observability rows
+
+Every non-interactive LLM call emits a row to `llm_calls` with the invocation's `trace_id` (same as any other LLM call). This gives "how many extraction calls did agent X run this week against which model" as a one-query answer rather than requiring after-the-fact instrumentation.
+
+---
+
+## C3. Observability granularity — hybrid, per operation type
+
+audit_events today is broader than "agent-facing user state." Existing entries include:
+- Pure agent actions: `update_core_memory`, `store_fact`, `create_task`, `update_task_status`, `create_work_item`, etc.
+- Server-side infrastructure: `ci_success_merge`, `webhook_replayed`, `webhook_deferred`, `verdict_handled`.
+- Direct interventions: `manual_db_update`.
+
+All existing rows carry a concrete `agent_id` (schema constraint: `NOT NULL REFERENCES agents(id)`). KG ingestion events that are naturally agent-scoped fit this pattern; KG operations that are container-wide (deterministic rebuild from manifests) do not.
+
+### C3.1 Domain rebuild (#687): structured logs only, no audit_events
+
+Domain graph rebuild is container-wide infrastructure with no agent attribution. It runs from deterministic startup code over manifests and registries. Emitting audit_events rows would require a sentinel `agent_id` or a schema change — neither is worth the cost.
+
+Observability for domain rebuild lives in structured logs at INFO level with `trace_id`:
+
+```
+INFO trace_id=<id> event=domain_rebuild_start
+INFO trace_id=<id> event=domain_rebuild_entities added=12 updated=3 removed=1
+INFO trace_id=<id> event=domain_rebuild_edges added=47 removed=2
+INFO trace_id=<id> event=domain_rebuild_complete duration_ms=234
+```
+
+### C3.2 Lexical ingestion (#689): per-document audit_events
+
+Lexical ingestion is per-agent. Audit cadence is **per document**, not per chunk. A 500-chunk document produces one audit_events row, not 500.
+
+- `tool_name`: `ingest_document`
+- `target_key`: `kg_chunk:<source_doc_path>`
+- `before_value`/`after_value`: summary counts (e.g., `{"chunks": 47, "total_chars": 23100}`)
+- `reasoning`: source of the ingestion (e.g., `"solution doc ingestion"`)
+
+The natural batch boundary is "one `ingest_document` call" regardless of how many chunks it fans out to.
+
+### C3.3 Subject extraction (#690) and entity resolution (#691): per-operation audit_events
+
+These are per-agent, per-document (extraction) or per-entity (resolution) operations. Audit cadence matches the natural batch:
+
+- `tool_name`: `extract_subject_entities` (extraction, per document)
+- `tool_name`: `resolve_subject_entity` (resolution, per subject entity)
+- `target_key`: `kg_subject:<subject_entity_key>` or equivalent
+- `before_value`/`after_value`: summary counts (e.g., `{"entities_extracted": 12, "triples": 8}`)
+
+Extraction's `tool_name` firing per-document avoids the Option 2 trap (one audit row per extracted entity would be hundreds of rows for a single doc). Resolution's per-entity is defensible because resolution is an atomic decision per entity — one row per decision, not per candidate match.
+
+### C3.4 Not a catch-all — no per-row mutations
+
+Do not emit audit_events for individual `kg_entities` / `kg_relationships` / `kg_chunks` row insertions or deletions. That would re-create the god-log anti-pattern at the audit layer. The "what rows changed in this operation" detail belongs in structured logs (DEBUG level) and the created_at / updated_at timestamps on the KG tables themselves; audit_events captures meaningful-transition granularity, not per-row deltas.
+
+---
+
+## C4. Document lifecycle
+
+This document is the authoritative source for C1–C3. Ticket plans (#687–#692) cite this doc by section (e.g., "per C2.2 retry taxonomy") rather than restating its content. Updates to this doc require:
+
+1. Updating the relevant section with the new decision and rationale.
+2. Noting the change in the ticket plan that drove it.
+3. If the change is backwards-incompatible for earlier-planned tickets, flagging those tickets for re-review.
+
+If a KG ticket needs a decision that isn't covered here, either (a) the decision is ticket-specific — handle it in the plan, or (b) it's cross-cutting — add a new section here and cite it from the ticket plan.

--- a/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
+++ b/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: domain graph builder — deterministic import from skill manifests and tool registry"
 type: feat
-status: active
+status: completed
 date: 2026-04-21
 ---
 
@@ -274,7 +274,7 @@ Rebuild failures are **logged, not panicked**. If the builder fails (DB error, u
 
 ## Implementation Units
 
-- [ ] **Unit 1: `kg` module scaffolding + DomainGraphBuilder skeleton**
+- [x] **Unit 1: `kg` module scaffolding + DomainGraphBuilder skeleton**
 
 **Goal:** Create the module structure and the builder type signature with stubbed `rebuild()`. No logic yet — just the shape and the rustdoc that documents the invariants (sole writer, startup-only, idempotent).
 
@@ -307,7 +307,7 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
 
 ---
 
-- [ ] **Unit 2: Entity enumeration from authoritative sources**
+- [x] **Unit 2: Entity enumeration from authoritative sources**
 
 **Goal:** Implement `enumerate_sources()` — walks the four registries/configs and produces a `DesiredState` struct listing every entity that should exist in the graph.
 
@@ -343,7 +343,7 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
 
 ---
 
-- [ ] **Unit 3: Relationship enumeration**
+- [x] **Unit 3: Relationship enumeration**
 
 **Goal:** Extend `enumerate_sources()` (or add a companion method) to compute `DEPENDS_ON` and `PROVIDES` edges.
 
@@ -375,7 +375,7 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
 
 ---
 
-- [ ] **Unit 4: Idempotent write — UPSERT entities + rebuild relationships**
+- [x] **Unit 4: Idempotent write — UPSERT entities + rebuild relationships**
 
 **Goal:** Implement the write side. `upsert_entities` uses `INSERT ... ON CONFLICT(entity_key) DO UPDATE`. `rebuild_relationships` deletes all domain-sourced relationships and re-inserts. `prune_stale_entities` DELETEs entities no longer in sources.
 
@@ -419,7 +419,7 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
 
 ---
 
-- [ ] **Unit 5: Startup integration + failure policy**
+- [x] **Unit 5: Startup integration + failure policy**
 
 **Goal:** Hook `DomainGraphBuilder::rebuild()` into the server startup sequence after `apply_overrides()`. Failures log a warning and allow startup to continue — KG queries return stale or empty results rather than blocking the server.
 
@@ -449,7 +449,7 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
 
 ---
 
-- [ ] **Unit 6: Integration test suite**
+- [x] **Unit 6: Integration test suite**
 
 **Goal:** End-to-end tests that exercise the builder against realistic mock registries, covering idempotency, staleness, and cross-ticket invariants.
 

--- a/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
+++ b/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
@@ -1,0 +1,528 @@
+---
+title: "feat: domain graph builder — deterministic import from skill manifests and tool registry"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# Domain graph builder — deterministic import from skill manifests and tool registry
+
+## Overview
+
+Build the domain graph layer of Mika's Knowledge Graph (milestone mika#14). This ticket (mika#687) populates `kg_entities` and `kg_relationships` by enumerating four authoritative sources — `SkillRegistry`, `ToolRegistry`, `McpManager`, and agent configs — at server startup. No LLM calls, no prose processing, no per-agent scope. The output is a shared structural view of "what exists in this container and how pieces connect," which downstream KG tickets (#689 lexical ingestion, #690 subject extraction, #691 entity resolution, #688 query tool, #692 self-knowledge upgrade) consume.
+
+## Problem Frame
+
+Agents today cannot answer "what skill handles CI failures?" or "which tools does skill X provide?" without either iterating the live registry (which has no traversal semantics) or querying semantic memory over prose (which drifts). The KG domain graph is the structural substrate that makes those questions a one-edge or recursive-CTE traversal instead of a scan.
+
+#686 landed the schema. This ticket populates it from the sources that already hold the truth: skill manifests (`skill.toml`), the tool registry, MCP connections as-of-boot, and agent configs. No new sources of truth — the domain graph is a projection, not an authority.
+
+## Requirements Trace
+
+- R1. Startup-time population of `kg_entities` (Skill, Tool, Agent, ProblemType) from authoritative sources.
+- R2. Startup-time population of `kg_relationships` for structural edges (DEPENDS_ON, PROVIDES).
+- R3. Idempotent rebuild — running the builder again (next startup, or forced via future CLI subcommand) does not duplicate or churn rows.
+- R4. Upsert preserves entity rowids so `kg_chunks.entity_id` FK references survive rebuilds.
+- R5. Documented staleness contract — the domain graph reflects registry state as of the last server boot.
+- R6. Observability via structured logs (per conventions C3.1 — no audit_events for container-wide rebuild).
+
+## Scope Boundaries
+
+- Four entity types: Skill, Tool, Agent, ProblemType.
+- Two relationship types: DEPENDS_ON (Skill→Skill), PROVIDES (Skill→Tool).
+- ProblemType seed list (5 categories per ticket body: `ci_failure`, `merge_conflict`, `duplicate_pr`, `stale_uuid`, `fabrication`).
+- Startup-only execution, hooked after `apply_overrides()` in `server/mod.rs`.
+- Idempotent MERGE/upsert semantics.
+- Structured logging at INFO with trace_id.
+
+### Deferred to Separate Tasks
+
+- Lexical chunk ingestion and linkage to domain entities: **mika#689**.
+- Subject graph extraction and LLM-inferred relationships (`SOLVED_BY`, `CAUSES`, `INDICATES`, etc.): **mika#690**.
+- Entity resolution (subject → domain linkage): **mika#691**.
+- Query tool (`query_knowledge_graph`): **mika#688**.
+- CLI subcommand for force-rebuild (`mika kg rebuild-domain`): deferred. Only build this if #688/#692 surface staleness as a real operational problem — not speculatively.
+- `Agent → Skill` (HAS_SKILL) edges: explicitly excluded (see D2 — per-agent state belongs in `skill_overrides`, not the graph).
+- `ProblemType → Skill` (SOLVED_BY) edges: excluded from domain graph (no authoritative source today). LLM-extracted solution-path edges land in the subject graph via #690/#691, with entity resolution linking them to domain ProblemType nodes.
+
+## Context & Research
+
+### Cross-cutting conventions
+
+This plan cites `docs/architecture/kg-implementation-conventions.md` as the authoritative source for cross-cutting KG decisions. Sections that apply to #687:
+
+- **C3.1 (observability — domain rebuild)**: Structured logs at INFO, `trace_id` included, no audit_events. See C3.1 for log-line format.
+
+Sections C1 (embeddings) and C2 (non-interactive LLM calls) do not apply to #687 — this ticket is pure deterministic code with no embedding generation and no LLM calls.
+
+### Relevant Code and Patterns
+
+- **Source of truth for skills:** `crates/mika-agent/src/skills/mod.rs:158` (`pub struct SkillRegistry`). Loaded at startup in `server/mod.rs` via `SkillRegistry::from_dir()` + `apply_overrides()`. Each entry has `manifest.skill.name`, `manifest.skill.description`, `manifest.skill.always_on`, `manifest.skill.keywords`, `manifest.skill.dependencies`, and `manifest.handler.tools` (the list of tools the skill exposes).
+- **Source of truth for tools:** `crates/mika-agent/src/tools/mod.rs:561` (`pub struct ToolRegistry`). Built up at startup from builtins + skill tools.json + MCP tools. Each tool has a name, source (`builtin` | `skill:<name>` | `mcp:<server>`), and description.
+- **Source of truth for MCP tools as-of-boot:** `crates/mika-agent/src/mcp/` — `McpManager` loads at startup from `mcp.json` config. Tools exposed by MCP servers available at startup are registered in ToolRegistry and visible to this builder. Tools added via runtime MCP reconnects are NOT visible until next restart (see D4 — staleness contract).
+- **Source of truth for agents:** `crates/mika-agent/src/db.rs` `agents` table + per-agent `config.toml` for `(name, role, model, home_dir)`. Note: agents can be created at runtime via the `create_agent` tool (no restart required). This creates a bounded staleness window — see D4.
+- **Startup sequence:** `crates/mika-agent/src/server/mod.rs` around lines 339 (dev_mode check) and 534-538 (auto-provisioning well-known agents). The domain graph builder hooks in AFTER both of these — it enumerates whatever state exists after initialization, regardless of how those agents/skills got there.
+- **Existing upsert precedents:** `crates/mika-agent/src/db.rs` `index_content()` pattern at `db.rs:6107` — idempotent write that uses explicit delete+insert for FTS5 sync. For `kg_entities`, UPSERT via `ON CONFLICT(entity_key) DO UPDATE` preserves rowid. For `kg_relationships`, DELETE-all-then-INSERT per rebuild is simpler and has no downstream dependencies (no FKs reference relationships).
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md` — Dual-write anti-pattern. Designate one writer per entity kind: the domain-graph builder owns all `skill:*`, `tool:*`, `agent:*`, `problem_type:*` nodes. No other code path writes these entity_keys. Document this explicitly in the builder's rustdoc.
+- `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — No `SELECT *`; use column constants from `crates/mika-agent/src/db/kg_schema.rs` (landed in #686). Row mappers import constants, not inline column lists.
+- `docs/solutions/database-issues/trace-id-as-observability-join-key.md` — Builder generates a single `trace_id` per rebuild invocation, logged with every row-count line. Allows "show me the last rebuild" via `grep trace_id=<id>` in logs. (No trace_id on the entity/relationship rows themselves — they're populated by deterministic startup code, not agent turns; per #686 D6, trace_id is for per-agent mutation tables.)
+
+## Key Technical Decisions
+
+### D1. Domain graph contains structure, not state
+
+General principle: the domain graph holds **structural facts derivable from authoritative sources (manifests, configs, code)**. It does not hold **per-agent state that authoritatively lives elsewhere**.
+
+Heuristic: *if the edge's truth value can differ across agents, or change between boots without a manifest change, it is state, not structure.*
+
+Applying the test to candidate edge types:
+
+| Edge | Test | Verdict |
+|------|------|---------|
+| `Skill -[DEPENDS_ON]-> Skill` | Derivable from `skill.toml`'s `dependencies` field; changes only when manifests change. | **Structural — include.** |
+| `Skill -[PROVIDES]-> Tool` | Derivable from `skill.toml`'s `[handler] tools` field + MCP server tool lists; changes only when manifests/MCP configs change. | **Structural — include.** |
+| `Agent -[HAS_SKILL]-> Skill` | Per-agent truth (varies across agents via `skill_overrides.enabled`); changes at runtime via override writes. | **State — exclude.** See D2. |
+| `Agent -[HAS_TOOL]-> Tool` | Transitively computable from HAS_SKILL ∩ PROVIDES; no independent truth. | **Redundant — exclude.** |
+| `ProblemType -[SOLVED_BY]-> Skill` | No authoritative source today (skills don't declare solved problem types in manifests). LLM-inferrable only. | **Subject-graph territory — defer to #690/#691.** |
+| `Agent -[DELEGATES_TO]-> Agent` | Derivable from team configs (deterministic); changes only when configs change. | **Structural if we need it — out of scope for #687 initial set.** |
+
+This principle applies to every future edge type considered in this milestone. When #690/#691 introduce new edges via subject extraction, those edges land in the subject graph (agent-scoped per #686 D1), with entity resolution linking them to domain nodes — they do not populate `kg_relationships` directly.
+
+### D2. No `Agent → Skill` (HAS_SKILL) edges
+
+Per-agent skill enable/disable state lives authoritatively in `skill_overrides.enabled` (schema v24, tri-state NULL/0/1). Replicating it as HAS_SKILL edges would create the exact stale-prose failure class the KG is intended to eliminate — just projected onto graph edges instead of text.
+
+Queries that need "agent X's enabled skills" JOIN against `skill_overrides`:
+
+```sql
+SELECT s.entity_key, s.name
+FROM kg_entities s
+WHERE s.type = 'skill'
+  AND (s.name NOT IN (
+    SELECT skill_name FROM skill_overrides
+    WHERE agent_id = ? AND enabled = 0
+  ));
+```
+
+**Consumer-side concern for #688:** the KG query tool should transparently perform this JOIN when an LLM caller asks "what skills does agent X have?" — so callers don't need implicit knowledge of where enablement state lives. This is flagged for #688's plan.
+
+### D3. Startup-only full rebuild, idempotent via upsert
+
+Builder runs once on `mika-server` startup after `apply_overrides()`. No runtime mutation hooks, no agent-triggerable tool. Rationale:
+
+- **The domain graph is a projection.** SkillRegistry, ToolRegistry, McpManager, and agent configs are the authoritative sources. A projection's rebuild cadence should match the volatility of its sources — and those sources are themselves loaded at startup and only mutated at explicit operator/admin boundaries, not in a hot path. The projection inherits that cadence.
+- **Mutation hooks (rejected)** would assert runtime-mutable skill/MCP lifecycle semantics that Mika doesn't currently adopt. Every hook is a place where the projection can diverge from the source (hook fires but rebuild fails; new code path is added without the hook). Complexity pays for capabilities we don't have consumers for — classic YAGNI violation.
+- **Agent-triggerable rebuild tool (rejected)** gives agents a knob without the information to know when to pull it. Agents have no visibility into system-level "has the registry changed" state; the tool would be called reflexively (wasting the rebuild cost on no-ops) or based on LLM guesses about staleness — precisely the drift the KG is trying to eliminate. If force-rebuild becomes useful for mika-dev investigation later, it belongs as a CLI subcommand (`mika kg rebuild-domain`), not a tool — that's an operator action, not an agent action.
+
+Idempotency strategy:
+
+- **Entities:** UPSERT via `INSERT ... ON CONFLICT(entity_key) DO UPDATE SET ...`. Preserves `id` (INTEGER rowid), which preserves `kg_chunks.entity_id` FK references from #689 onwards.
+- **Relationships:** DELETE all domain-sourced relationships, then re-INSERT. Relationships have no downstream dependencies (nothing FK's into `kg_relationships.id`), so rebuild-and-replace is safe. Cost: a few hundred rewrites per boot, trivial.
+- **Entity deletions:** entities no longer present in their source are DELETED. CASCADE on `kg_relationships` removes edges touching the deleted entity. `kg_chunks.entity_id` → NULL via ON DELETE SET NULL, preserving chunks but severing their domain-entity link. Downstream code handles this via `WHERE entity_id IS NOT NULL` filters where appropriate.
+
+### D4. Staleness contract — bounded, documented
+
+Domain graph reflects registry state **as of the last server boot**. Between boots, the following remain invisible to KG queries:
+
+- Agents created via the runtime `create_agent` tool (no restart required, so staleness window is non-zero).
+- MCP servers that connect/disconnect mid-session, along with any tools they expose or remove.
+- Skills installed/uninstalled mid-session via `mika skills install/uninstall` (if such runtime installation is supported; today's flow requires a restart for most skill changes, but this may evolve).
+- `skill_overrides.enabled` changes (expected — this is state, not structure; consumers JOIN against `skill_overrides` directly per D2).
+
+The staleness window is bounded by the time until the next `mika-server` restart, and operators can force a restart to refresh.
+
+Consumer implications:
+
+- #688 query tool: document that "recent KG" means "last boot." If a user asks about a freshly created agent that hasn't been restarted into the graph yet, the query returns "not found." Acceptable — agents can be informed "this agent was just created; refresh after next restart to see it in the KG."
+- #692 self-knowledge upgrade: same caveat. `self-knowledge` queries over the KG reflect last-boot state.
+
+**This is an intentional design decision**, not an unfixed bug. The projection cadence matches the source cadence. If operational requirements evolve to demand live-updating domain graph semantics, that's a future ticket with its own design pass — not a silent requirement scope-creep on #687.
+
+### D5. Observability via structured logs (per C3.1)
+
+One `trace_id` per rebuild invocation, emitted at key points:
+
+```
+INFO trace_id=<uuid> event=domain_rebuild_start
+INFO trace_id=<uuid> event=domain_rebuild_entities type=skill added=12 updated=3 removed=1
+INFO trace_id=<uuid> event=domain_rebuild_entities type=tool added=47 updated=0 removed=0
+INFO trace_id=<uuid> event=domain_rebuild_entities type=agent added=3 updated=0 removed=0
+INFO trace_id=<uuid> event=domain_rebuild_entities type=problem_type added=5 updated=0 removed=0
+INFO trace_id=<uuid> event=domain_rebuild_edges type=DEPENDS_ON count=18
+INFO trace_id=<uuid> event=domain_rebuild_edges type=PROVIDES count=35
+INFO trace_id=<uuid> event=domain_rebuild_complete duration_ms=234
+```
+
+No rows in `audit_events`. Query "what did the last rebuild do" via `grep trace_id=<id>` in structured logs. This matches the "domain rebuild is container-wide infrastructure, no agent attribution" rationale documented in the conventions doc C3.1.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Execution model — startup-only full rebuild (see D3).
+- HAS_SKILL edges — excluded (see D2).
+- Domain vs subject boundary for candidate edges — governed by the "structure not state" heuristic (see D1).
+- Staleness contract — bounded to "as of last server boot," documented (see D4).
+- Observability — structured logs only, per C3.1 (see D5).
+- Idempotency approach — entity UPSERT by entity_key, relationship DELETE+REINSERT (see D3).
+
+### Deferred to Implementation
+
+- Exact log level for per-type counts (INFO vs DEBUG). INFO is the default above; may downgrade some lines to DEBUG if the log volume becomes noisy during development.
+- MCP dynamic-tool handling: accept drift as known limitation per D4. If an MCP server's tools change mid-session, the domain graph doesn't reflect it until next restart. If usage surfaces this as a real problem, address via CLI force-rebuild subcommand (out of scope for this ticket).
+- Whether ProblemType seed list lives as a Rust `const` or a TOML config file. Starts as a `const` in `kg_builder.rs`; promote to a config file only if operators need to extend it without recompiling.
+
+## Output Structure
+
+```
+crates/mika-agent/src/
+├── db/
+│   └── kg_schema.rs                  # from #686 — add UPSERT helper + relationship rebuild helper
+└── kg/                               # NEW module for KG builders and queries
+    ├── mod.rs
+    └── domain_builder.rs             # NEW: the builder itself
+
+crates/mika-agent/src/server/
+└── mod.rs                            # MODIFY: hook builder after apply_overrides()
+
+crates/mika-agent/tests/
+└── kg/                               # NEW test suite root
+    └── domain_builder.rs             # NEW: integration tests for the builder
+
+docs/plans/
+└── 2026-04-21-004-feat-domain-graph-builder-plan.md   # this file
+```
+
+## High-Level Technical Design
+
+> *This illustrates the builder's shape and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```rust
+// crates/mika-agent/src/kg/domain_builder.rs
+
+/// Projection owner for Skill/Tool/Agent/ProblemType nodes and their
+/// structural edges. The sole writer of entity_keys in the
+/// `skill:*`, `tool:*`, `agent:*`, `problem_type:*` namespaces.
+///
+/// Invariants:
+/// - Runs once per server boot, after SkillRegistry::apply_overrides().
+/// - Idempotent: re-running produces the same graph state.
+/// - Never called from agent turns or tool handlers.
+/// - All writes carry a single trace_id for the rebuild invocation.
+pub struct DomainGraphBuilder<'a> {
+    db: &'a AsyncDatabase,
+    skill_registry: &'a SkillRegistry,
+    tool_registry: &'a ToolRegistry,
+    mcp_manager: &'a McpManager,
+    agent_configs: &'a [AgentConfig],
+    trace_id: String,
+}
+
+impl<'a> DomainGraphBuilder<'a> {
+    pub async fn rebuild(&self) -> Result<RebuildStats> {
+        // 1. Gather current sources into a DesiredState struct.
+        let desired = self.enumerate_sources()?;
+
+        // 2. UPSERT entities (preserves rowid).
+        let entity_stats = self.upsert_entities(&desired.entities).await?;
+
+        // 3. DELETE then INSERT domain-sourced relationships.
+        let edge_stats = self.rebuild_relationships(&desired.edges).await?;
+
+        // 4. DELETE entities no longer in sources (CASCADE removes edges,
+        //    SET NULL on kg_chunks.entity_id).
+        let removed = self.prune_stale_entities(&desired.entity_keys).await?;
+
+        Ok(RebuildStats { /* counts */ })
+    }
+
+    fn enumerate_sources(&self) -> Result<DesiredState> {
+        // Skill nodes from skill_registry.entries()
+        // Tool nodes from tool_registry (builtin + skill-owned + MCP)
+        // Agent nodes from agent_configs
+        // ProblemType nodes from const PROBLEM_TYPE_SEEDS
+        // DEPENDS_ON edges from skill.manifest.skill.dependencies
+        // PROVIDES edges from skill.manifest.handler.tools + mcp server tool lists
+    }
+}
+```
+
+### Startup integration
+
+```rust
+// crates/mika-agent/src/server/mod.rs (around existing apply_overrides call site)
+
+let skill_registry = SkillRegistry::from_dir(...);
+skill_registry.apply_overrides(&db).await?;
+skill_registry.validate_loaded();
+skill_registry.log_summary();
+
+// NEW: domain graph rebuild, after all registries are initialized
+let builder = DomainGraphBuilder::new(&db, &skill_registry, &tool_registry, &mcp_manager, &agent_configs);
+match builder.rebuild().await {
+    Ok(stats) => info!(event = "domain_rebuild_complete", ?stats, "domain graph ready"),
+    Err(e) => warn!(error = %e, "domain graph rebuild failed; KG queries may return stale results until next restart"),
+}
+```
+
+### Failure policy
+
+Rebuild failures are **logged, not panicked**. If the builder fails (DB error, unexpected registry state), mika-server continues to boot — KG queries will return stale or empty results, but interactive agent turns still work. This matches the "indexing is best-effort" policy from the conventions doc (C1), extended to the domain layer.
+
+## Implementation Units
+
+- [ ] **Unit 1: `kg` module scaffolding + DomainGraphBuilder skeleton**
+
+**Goal:** Create the module structure and the builder type signature with stubbed `rebuild()`. No logic yet — just the shape and the rustdoc that documents the invariants (sole writer, startup-only, idempotent).
+
+**Requirements:** R1 (shape only).
+
+**Dependencies:** #686 schema landed (`kg_schema.rs` exists).
+
+**Files:**
+- Create: `crates/mika-agent/src/kg/mod.rs`
+- Create: `crates/mika-agent/src/kg/domain_builder.rs`
+- Modify: `crates/mika-agent/src/lib.rs` — add `pub mod kg;`
+
+**Approach:**
+- Module-level rustdoc in `kg/mod.rs` explaining the KG layer split (domain is deterministic, subject/lexical are agent-scoped — point at `kg_schema.rs` and `docs/architecture/kg-implementation-conventions.md` for the cross-cutting details).
+- `DomainGraphBuilder` struct with fields: `db: &AsyncDatabase`, `skill_registry: &SkillRegistry`, `tool_registry: &ToolRegistry`, `mcp_manager: &McpManager`, `agent_configs: &[AgentConfig]`, `trace_id: String`.
+- `pub async fn rebuild(&self) -> Result<RebuildStats>` — stubbed, returns `Err(unimplemented)`.
+- `RebuildStats` struct with public fields for per-type counts (added/updated/removed per entity type, edges per relationship type).
+- Unit-level tests are deferred to Unit 6 (integration tests once the builder works end-to-end).
+
+**Patterns to follow:**
+- Module structure: `crates/mika-agent/src/skills/mod.rs` — pub struct + impl block + module rustdoc style.
+- Async error handling: `anyhow::Result` with `thiserror` for any new error enum.
+
+**Test scenarios:**
+Test expectation: none — this unit is scaffolding. Compilation is the success signal.
+
+**Verification:**
+- `cargo build -p mika-agent` succeeds.
+- Rustdoc renders the module and struct descriptions cleanly.
+
+---
+
+- [ ] **Unit 2: Entity enumeration from authoritative sources**
+
+**Goal:** Implement `enumerate_sources()` — walks the four registries/configs and produces a `DesiredState` struct listing every entity that should exist in the graph.
+
+**Requirements:** R1.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/domain_builder.rs`
+- Test: inline `#[cfg(test)]` module with mock registries
+
+**Approach:**
+- `DesiredState { entities: Vec<DesiredEntity>, edges: Vec<DesiredEdge>, entity_keys: HashSet<String> }`.
+- Skill enumeration: iterate `skill_registry.entries()`. For each, build `DesiredEntity { entity_key: format_entity_key("skill", &s.manifest.skill.name), type: "skill", name, properties_json: json!({ "description": ..., "always_on": ..., "keywords": ..., "version": ... }).to_string() }`.
+- Tool enumeration: iterate `tool_registry` for builtins + skill-owned tools + MCP tools (as-of-boot). Each becomes `tool:<name>`. Properties include `source` (`builtin` / `skill:<name>` / `mcp:<server>`) and `description`.
+- Agent enumeration: iterate `agent_configs`. Each becomes `agent:<name>`. Properties include `role`, `model`. **Do NOT include `enabled_skills`** — that's state, not structure (D1/D2).
+- ProblemType enumeration: `const PROBLEM_TYPE_SEEDS: &[&str] = &["ci_failure", "merge_conflict", "duplicate_pr", "stale_uuid", "fabrication"]`. Each becomes `problem_type:<slug>` with an empty properties object (expanded later by subject-graph linkage).
+- Duplicate detection: if two skills expose the same tool name, that's ONE Tool node with properties describing both sources (the `properties_json` should capture `sources: [{"skill": "X"}, {"skill": "Y"}]`). Don't create two separate Tool nodes.
+
+**Patterns to follow:**
+- `SkillRegistry::entries()` iteration shape in `crates/mika-agent/src/skills/mod.rs`.
+- `ToolRegistry` struct access in `crates/mika-agent/src/tools/mod.rs`.
+
+**Test scenarios:**
+- Happy path: mock registries with 2 skills, 3 tools, 1 agent → `DesiredState` has 2 skill entities, 3 tool entities, 1 agent entity, 5 problem_type entities.
+- Edge case: two skills expose the same tool → ONE Tool entity in `DesiredState` with both sources noted in properties.
+- Edge case: skill with no dependencies field → no DEPENDS_ON edges, no crash.
+- Edge case: empty agent_configs → zero agent entities, still produces the 5 problem_type seeds.
+
+**Verification:**
+- All test scenarios pass.
+- Output is deterministic (same input → same `DesiredState`).
+
+---
+
+- [ ] **Unit 3: Relationship enumeration**
+
+**Goal:** Extend `enumerate_sources()` (or add a companion method) to compute `DEPENDS_ON` and `PROVIDES` edges.
+
+**Requirements:** R2.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/domain_builder.rs`
+
+**Approach:**
+- `DesiredEdge { from_entity_key: String, to_entity_key: String, type: String, properties_json: Option<String> }`.
+- DEPENDS_ON: for each skill with non-empty `dependencies`, one edge `skill:<from> -[DEPENDS_ON]-> skill:<to>` per dependency.
+- PROVIDES: for each skill, one edge `skill:<skill_name> -[PROVIDES]-> tool:<tool_name>` per tool in `manifest.handler.tools`. Also include MCP-server-owned tools: for each MCP server's tool list, no skill owns it, so PROVIDES edges come only from skill manifests. (If an MCP tool is not provided by any skill, it has no incoming PROVIDES edge — the Tool node still exists with `source: "mcp:<server>"`.)
+- **Apply the D1 heuristic during enumeration**: if a candidate edge's truth value would vary per agent (e.g., HAS_SKILL) or require LLM inference, it is NOT enumerated here. This is a checklist principle, not a code guard — the enumeration code simply doesn't produce such edges.
+
+**Patterns to follow:**
+- Skill manifest access pattern: `skill.manifest.skill.dependencies.iter()` and `skill.manifest.handler.tools.iter()` (verify exact field names against `skills/manifest.rs`).
+
+**Test scenarios:**
+- Happy path: skill X depends on skill Y → one DEPENDS_ON edge. Skill X exposes tool T → one PROVIDES edge.
+- Edge case: skill references a dependency that doesn't exist in the registry → log a warning, skip the edge (do NOT create a dangling edge).
+- Edge case: MCP tool with no declaring skill → Tool entity exists, no PROVIDES edge into it (acceptable; self-knowledge queries will show the tool with `source: "mcp:<server>"` instead of a providing skill).
+- Invariant: no HAS_SKILL or AGENT_HAS_TOOL edges produced under any input shape. Add an explicit assertion in a test ensuring the enumerated edge types are only in `{"DEPENDS_ON", "PROVIDES"}`.
+
+**Verification:**
+- All test scenarios pass.
+- The "no state-shaped edges" invariant has an explicit test.
+
+---
+
+- [ ] **Unit 4: Idempotent write — UPSERT entities + rebuild relationships**
+
+**Goal:** Implement the write side. `upsert_entities` uses `INSERT ... ON CONFLICT(entity_key) DO UPDATE`. `rebuild_relationships` deletes all domain-sourced relationships and re-inserts. `prune_stale_entities` DELETEs entities no longer in sources.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** Units 2 and 3.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/domain_builder.rs`
+- Modify: `crates/mika-agent/src/db/kg_schema.rs` — add `UPSERT_ENTITY_SQL` const, `DELETE_DOMAIN_RELATIONSHIPS_SQL` const
+
+**Approach:**
+- `upsert_entities(&self, desired: &[DesiredEntity]) -> Result<EntityStats>`:
+  - For each desired entity, execute the UPSERT. Capture whether the row was inserted (new) or updated (existing rowid preserved).
+  - Batch within a single AsyncDatabase closure for transaction atomicity.
+- `rebuild_relationships(&self, desired: &[DesiredEdge]) -> Result<EdgeStats>`:
+  - DELETE from `kg_relationships` where `type IN ('DEPENDS_ON', 'PROVIDES')` — scoped to domain-sourced types, leaves subject/resolution layer edges untouched.
+  - For each desired edge, INSERT (looking up from/to entity_ids by entity_key via JOIN).
+  - Returns count per type.
+- `prune_stale_entities(&self, desired_keys: &HashSet<String>) -> Result<u32>`:
+  - DELETE from `kg_entities` where `entity_key NOT IN (desired_keys)`. CASCADE removes edges; ON DELETE SET NULL on `kg_chunks.entity_id` preserves chunk rows.
+  - Returns count of deleted entities.
+- All three operations happen within a single transaction — if any step fails, the whole rebuild rolls back and the graph remains in its previous state (stale but consistent).
+
+**Patterns to follow:**
+- Transaction boundaries in AsyncDatabase closures: `crates/mika-agent/src/async_db.rs` existing patterns like `index_content`.
+- UPSERT syntax: rusqlite supports `INSERT ... ON CONFLICT(col) DO UPDATE SET col = excluded.col, ...`.
+
+**Test scenarios:**
+- Happy path: empty DB → rebuild → all desired entities and edges present.
+- Idempotency: run rebuild twice with identical sources → second run produces zero inserts, zero updates, zero deletes (or updates with no-op SET).
+- Rowid preservation: insert a kg_chunk referencing a skill entity → rebuild with same sources → chunk's entity_id still resolves to the same skill row.
+- Entity removal: skill X present on first rebuild, removed on second → second rebuild deletes the skill entity. CASCADE removes DEPENDS_ON/PROVIDES edges touching it. Any kg_chunks pointing at it get entity_id = NULL but the chunk row survives.
+- Transaction rollback: inject a DB error mid-rebuild → entire rebuild rolls back, graph is in pre-rebuild state.
+- Edge correctness: DEPENDS_ON from skill X to skill Y resolves via entity_key → INSERT succeeds with correct from_entity_id/to_entity_id. If a dependency references an unknown skill (shouldn't happen post-Unit 3 filter), the INSERT fails with a FK violation and rolls back.
+
+**Verification:**
+- All test scenarios pass.
+- `cargo test -p mika-agent kg::domain_builder` clean.
+
+---
+
+- [ ] **Unit 5: Startup integration + failure policy**
+
+**Goal:** Hook `DomainGraphBuilder::rebuild()` into the server startup sequence after `apply_overrides()`. Failures log a warning and allow startup to continue — KG queries return stale or empty results rather than blocking the server.
+
+**Requirements:** R1, R5, R6.
+
+**Dependencies:** Unit 4.
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/mod.rs`
+
+**Approach:**
+- Construct the builder after `skill_registry.apply_overrides().await?` and `skill_registry.log_summary()`.
+- Call `rebuild().await`. On `Ok(stats)`, log `info!(event="domain_rebuild_complete", ?stats, ...)`. On `Err(e)`, log `warn!(event="domain_rebuild_failed", error=%e, ...)` and continue startup.
+- Emit the per-step INFO log lines from within the builder's `rebuild()` method using the builder's `trace_id` (the server-level log line at the end is for post-hoc "did we finish successfully" inspection).
+
+**Patterns to follow:**
+- Error handling in `server/mod.rs` startup path — existing `?` / `match` patterns for subsystem initialization.
+
+**Test scenarios:**
+- Integration: start a mika-server in test mode with a mock registry → startup succeeds and kg_entities contains the expected rows.
+- Failure path: inject a DB error into the builder → server startup still succeeds, log contains the `domain_rebuild_failed` warning, kg_entities is empty but accessible.
+- Idempotency in server context: restart the test server → second startup logs `domain_rebuild_complete` with added=0, updated=N, removed=0.
+
+**Verification:**
+- Integration test passes.
+- Server starts cleanly with domain graph populated in the expected schema.
+
+---
+
+- [ ] **Unit 6: Integration test suite**
+
+**Goal:** End-to-end tests that exercise the builder against realistic mock registries, covering idempotency, staleness, and cross-ticket invariants.
+
+**Requirements:** R3, R4, R5.
+
+**Dependencies:** Units 1–5.
+
+**Files:**
+- Create: `crates/mika-agent/tests/kg/domain_builder.rs`
+- Create: `crates/mika-agent/tests/kg/mod.rs` (wiring)
+
+**Approach:**
+- Helper: `fn mock_registries(skills: &[...], tools: &[...], agents: &[...]) -> (SkillRegistry, ToolRegistry, McpManager, Vec<AgentConfig>)` — minimal scaffolding to produce realistic but deterministic input.
+- Test 1 (`builder_populates_fresh_db`): open_in_memory → rebuild → assert every expected entity + edge exists.
+- Test 2 (`builder_is_idempotent`): rebuild twice → second run has net-zero changes (may be updates, but no inserts/deletes).
+- Test 3 (`builder_preserves_chunk_links`): rebuild → insert a mock kg_chunk with a real entity_id → rebuild again → chunk's entity_id still resolves.
+- Test 4 (`builder_deletes_removed_entities`): first rebuild with skill X → second rebuild without skill X → skill X entity is gone, edges touching it are gone, any kg_chunks had entity_id = NULL.
+- Test 5 (`builder_produces_no_state_edges`): explicit assertion that `kg_relationships.type` after rebuild is only in `{'DEPENDS_ON', 'PROVIDES'}` (no HAS_SKILL, AGENT_HAS_TOOL, SOLVED_BY, etc.).
+- Test 6 (`builder_handles_mcp_tool_without_providing_skill`): mock an MCP server with a tool that no skill declares → Tool entity exists with `source: "mcp:<server>"` and no incoming PROVIDES edge.
+- Test 7 (`builder_failure_rollback`): inject a simulated DB error in the middle of rebuild → kg_entities/kg_relationships remain in pre-rebuild state.
+
+**Patterns to follow:**
+- `crates/mika-agent/src/test_utils.rs` for settings / DB fixtures.
+- Existing integration tests under `crates/mika-agent/tests/` for structure.
+
+**Test scenarios:**
+See the seven tests above; each is an explicit test scenario.
+
+**Verification:**
+- `cargo test -p mika-agent --test kg` runs the suite green.
+
+## System-Wide Impact
+
+- **Interaction graph:** One new startup hook in `server/mod.rs`. No changes to tool handlers, agent loop, or webhook handlers. The builder is a read-only consumer of SkillRegistry/ToolRegistry/McpManager and a writer to kg_entities/kg_relationships.
+- **Error propagation:** Rebuild failure is a `warn!` log, not a panic. Server startup continues. KG queries that depend on populated data get stale/empty results until the next successful rebuild.
+- **State lifecycle risks:**
+  - **Rowid drift across rebuilds** is the subtle risk — if we accidentally deleted+reinserted entities, every `kg_chunks.entity_id` would become orphaned. D3's UPSERT-by-entity_key strategy prevents this. Integration test 3 (`builder_preserves_chunk_links`) guards against regression.
+  - **Transaction atomicity** — the entire rebuild (entity UPSERTs + relationship DELETE+INSERT + entity DELETE) runs in one transaction. Partial rebuilds are not exposed to queries.
+- **API surface parity:** None changed. No new tools, no new endpoints, no new CLI subcommands in this ticket. (A future `mika kg rebuild-domain` subcommand is deferred per D3.)
+- **Integration coverage:** Unit 6's integration suite covers the full pipeline.
+- **Unchanged invariants:** `SkillRegistry`, `ToolRegistry`, `McpManager`, and `skill_overrides` are unchanged. `apply_overrides()` runs at the same point in startup. Existing `search_memory`, `hybrid_search`, and `audit_events` code paths are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Rowid drift orphans future `kg_chunks.entity_id` references | UPSERT by entity_key preserves rowid. Integration test 3 catches regressions. |
+| Rebuild introduces a startup latency bump on servers with many skills | Entity count is bounded (low hundreds at most). Batch writes in one transaction. Measure in Unit 5 — if rebuild exceeds 500ms, revisit batching. |
+| Stale MCP tool state between boots surfaces as confused queries | Documented in D4. If it becomes a real operational problem, add a CLI force-rebuild subcommand (deferred). |
+| A skill's `dependencies` field references a skill that isn't loaded (missing dep) | Unit 3 skips edges with missing endpoints and logs a warning. The `kg_entities` table stays consistent; only the missing-dep edge is absent. |
+| Two skills expose the same tool with different descriptions | Unit 2 dedupes into one Tool entity, records both sources in `properties_json`. First-seen description wins — acceptable because descriptions for the same tool should match by convention. |
+| `agents` table contains agents without matching config files (DB-only stubs) | Unit 2 enumerates from `agent_configs`, not the DB. DB-only stubs are invisible to the graph — acceptable, since the graph represents "agents with real config" as nodes. Document if this becomes confusing. |
+| HAS_SKILL is "accidentally" added by a future contributor | D1's "structure not state" heuristic + Unit 6 test 5 (explicit invariant assertion) block regression. |
+
+## Documentation / Operational Notes
+
+- The "as of last server boot" staleness contract (D4) needs one sentence in operator-facing documentation (docs/deployment.md or equivalent) when the KG becomes user-visible via #688 and #692. Not required in this ticket — flag for the docs pass in #692.
+- If `mika kg rebuild-domain` CLI subcommand is added later, document it alongside existing `mika skills` subcommands.
+- Rebuild duration is worth monitoring. The INFO log line `event=domain_rebuild_complete duration_ms=<N>` gives operators a baseline. If duration grows substantially (say, >1s) across releases, investigate whether enumeration has become quadratic in skill count.
+
+## Sources & References
+
+- **Origin ticket:** [mika#687](https://github.com/senara-solutions/mika/issues/687)
+- **Milestone:** [mika milestone#14 "Knowledge Graph"](https://github.com/senara-solutions/mika/milestone/14)
+- **Depends on:** [mika#686 (schema)](https://github.com/senara-solutions/mika/issues/686)
+- **Cross-cutting conventions:** [`docs/architecture/kg-implementation-conventions.md`](../architecture/kg-implementation-conventions.md) (C1, C2 not applicable; C3.1 applies)
+- **ID convention:** [`docs/architecture/kg-id-convention.md`](../architecture/kg-id-convention.md) (landed in #686)
+- **Related code:**
+  - `crates/mika-agent/src/skills/mod.rs` — SkillRegistry
+  - `crates/mika-agent/src/tools/mod.rs` — ToolRegistry
+  - `crates/mika-agent/src/mcp/` — McpManager
+  - `crates/mika-agent/src/server/mod.rs` — startup sequence (hook site)
+  - `crates/mika-agent/src/db/kg_schema.rs` — schema constants (from #686)
+- **Institutional learnings:**
+  - `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md` — sole-writer designation for entity_keys
+  - `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — column constants, no `SELECT *`
+  - `docs/solutions/database-issues/trace-id-as-observability-join-key.md` — trace_id-per-rebuild pattern

--- a/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
+++ b/docs/plans/2026-04-21-004-feat-domain-graph-builder-plan.md
@@ -137,7 +137,7 @@ The staleness window is bounded by the time until the next `mika-server` restart
 Consumer implications:
 
 - #688 query tool: document that "recent KG" means "last boot." If a user asks about a freshly created agent that hasn't been restarted into the graph yet, the query returns "not found." Acceptable — agents can be informed "this agent was just created; refresh after next restart to see it in the KG."
-- #692 self-knowledge upgrade: same caveat. `self-knowledge` queries over the KG reflect last-boot state.
+- #692 self-knowledge upgrade: same caveat, with a specific UX risk — an agent asking "who am I in the team?" between its own creation (via runtime `create_agent`) and the next restart gets "not found" from the KG. **#692's plan must include a fallback path:** when a self-knowledge query matches no KG agent node for the current agent_id, fall back to reading `agent_configs` directly. This keeps the UX graceful during the staleness window. Flag for #692; not this ticket's problem to solve, but #687's D4 is the reason #692 has to handle it.
 
 **This is an intentional design decision**, not an unfixed bug. The projection cadence matches the source cadence. If operational requirements evolve to demand live-updating domain graph semantics, that's a future ticket with its own design pass — not a silent requirement scope-creep on #687.
 
@@ -396,7 +396,8 @@ Test expectation: none — this unit is scaffolding. Compilation is the success 
   - For each desired edge, INSERT (looking up from/to entity_ids by entity_key via JOIN).
   - Returns count per type.
 - `prune_stale_entities(&self, desired_keys: &HashSet<String>) -> Result<u32>`:
-  - DELETE from `kg_entities` where `entity_key NOT IN (desired_keys)`. CASCADE removes edges; ON DELETE SET NULL on `kg_chunks.entity_id` preserves chunk rows.
+  - DELETE from `kg_entities` where `type IN ('skill', 'tool', 'agent', 'problem_type') AND entity_key NOT IN (desired_keys)`. **The type filter is load-bearing, not belt-and-suspenders** — it enforces the builder's sole-writer contract at the SQL level, so a future addition of a fifth entity type by another subsystem (currently only `kg_subject_entities` exists, but contracts can drift) doesn't get silently pruned. Source the type list from `KG_DOMAIN_ENTITY_TYPES` in `kg_schema.rs` (single source of truth).
+  - CASCADE removes edges; ON DELETE SET NULL on `kg_chunks.entity_id` preserves chunk rows.
   - Returns count of deleted entities.
 - All three operations happen within a single transaction — if any step fails, the whole rebuild rolls back and the graph remains in its previous state (stale but consistent).
 
@@ -499,7 +500,7 @@ See the seven tests above; each is an explicit test scenario.
 | Rebuild introduces a startup latency bump on servers with many skills | Entity count is bounded (low hundreds at most). Batch writes in one transaction. Measure in Unit 5 — if rebuild exceeds 500ms, revisit batching. |
 | Stale MCP tool state between boots surfaces as confused queries | Documented in D4. If it becomes a real operational problem, add a CLI force-rebuild subcommand (deferred). |
 | A skill's `dependencies` field references a skill that isn't loaded (missing dep) | Unit 3 skips edges with missing endpoints and logs a warning. The `kg_entities` table stays consistent; only the missing-dep edge is absent. |
-| Two skills expose the same tool with different descriptions | Unit 2 dedupes into one Tool entity, records both sources in `properties_json`. First-seen description wins — acceptable because descriptions for the same tool should match by convention. |
+| Two skills expose the same tool with different descriptions | Unit 2 dedupes into one Tool entity, records both sources in `properties_json`. First-seen description wins — acceptable because descriptions for the same tool should match by convention. **Emit a DEBUG log line when a duplicate with differing descriptions is encountered** so silent drift is at least traceable; conventions break quietly without instrumentation. |
 | `agents` table contains agents without matching config files (DB-only stubs) | Unit 2 enumerates from `agent_configs`, not the DB. DB-only stubs are invisible to the graph — acceptable, since the graph represents "agents with real config" as nodes. Document if this becomes confusing. |
 | HAS_SKILL is "accidentally" added by a future contributor | D1's "structure not state" heuristic + Unit 6 test 5 (explicit invariant assertion) block regression. |
 

--- a/docs/solutions/best-practices/kg-domain-graph-startup-projection-2026-04-22.md
+++ b/docs/solutions/best-practices/kg-domain-graph-startup-projection-2026-04-22.md
@@ -1,0 +1,79 @@
+---
+title: "KG domain graph as startup projection with sole-writer contract"
+date: 2026-04-22
+category: best-practices
+module: kg
+problem_type: best_practice
+component: database
+severity: medium
+applies_when:
+  - Building a graph or index layer that projects data from authoritative registries
+  - Populating KG entities/relationships from skill manifests, tool registries, or configs
+  - Designing idempotent startup-time population of derived data
+tags:
+  - knowledge-graph
+  - domain-graph
+  - startup-projection
+  - sole-writer
+  - upsert-idempotency
+  - sqlite
+---
+
+# KG domain graph as startup projection with sole-writer contract
+
+## Context
+
+The Knowledge Graph domain layer (#687) needed to populate `kg_entities` and `kg_relationships` from four authoritative sources at server startup: `SkillRegistry`, `ToolRegistry`, `McpManager`, and agent configs. The design challenge was keeping the projection idempotent, preserving entity rowids across rebuilds (so FK references from the subject layer survive), and preventing dual-write bugs.
+
+## Guidance
+
+**Use a sole-writer pattern for each entity key namespace.** The domain graph builder is the exclusive writer of `skill:*`, `tool:*`, `agent:*`, and `problem_type:*` entity keys. No other code path writes these namespaces. This prevents the dual-write anti-pattern documented in `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md`.
+
+**UPSERT entities, DELETE+INSERT relationships.** Entities use `INSERT ... ON CONFLICT(entity_key) DO UPDATE` to preserve the `id` (INTEGER PRIMARY KEY AUTOINCREMENT) rowid. This is critical because `kg_subject_resolutions.domain_entity_id` FK-references `kg_entities.id`. If you accidentally DELETE+INSERT instead of UPSERT, the rowid changes and all FK references break silently. Relationships have no downstream FK dependents, so DELETE-all-then-INSERT per rebuild is simpler and safe.
+
+**Collect existing keys before UPSERT for accurate add/update counts.** You cannot distinguish insert-vs-update from `changes()` alone with SQLite UPSERT — it always returns 1. Snapshot existing entity keys via `SELECT entity_key FROM kg_entities WHERE type IN (...)` before UPSERTing, then compare against the snapshot to count adds vs updates.
+
+**Scope DELETE operations by entity type, not just relationship type.** The stale-entity pruning DELETE uses a type filter (`WHERE type IN ('skill', 'tool', 'agent', 'problem_type')`) sourced from `KG_DOMAIN_ENTITY_TYPES` in `kg_schema.rs`. This is a sole-writer enforcement at the SQL level — a future fifth entity type added by another subsystem won't be silently pruned.
+
+**Fail open on rebuild errors.** Rebuild failures log `warn!` and the server continues to boot. KG queries return stale or empty results until the next successful rebuild. This matches the "indexing is best-effort" policy.
+
+## Why This Matters
+
+Rowid stability is the subtle invariant. If entity rowids drift across rebuilds, every `kg_subject_resolutions.domain_entity_id` reference becomes orphaned. The UPSERT-by-entity_key strategy prevents this, and the `rebuild_preserves_resolution_entity_links` test guards against regression.
+
+The sole-writer contract prevents the exact stale-prose failure class the KG is intended to eliminate — just projected onto graph edges instead of text. Without it, two writers can silently diverge and neither knows the graph is inconsistent.
+
+## When to Apply
+
+- Building any graph or index layer that projects from authoritative sources
+- Any startup-time population of derived/cached data in SQLite
+- When downstream FK references must survive idempotent rebuilds
+- When multiple subsystems may write to the same table in the future
+
+## Examples
+
+Entity UPSERT preserving rowid:
+```sql
+INSERT INTO kg_entities (entity_key, type, name, properties_json, created_at, updated_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+ON CONFLICT(entity_key) DO UPDATE SET
+  name = excluded.name,
+  properties_json = excluded.properties_json,
+  updated_at = ?5
+```
+
+Type-scoped stale entity pruning:
+```sql
+DELETE FROM kg_entities
+WHERE type IN ('skill', 'tool', 'agent', 'problem_type')
+  AND entity_key NOT IN (... desired keys ...)
+```
+
+## Related
+
+- `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md` — dual-write anti-pattern
+- `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — column constants
+- `docs/solutions/database-issues/trace-id-as-observability-join-key.md` — trace_id pattern
+- `docs/architecture/kg-implementation-conventions.md` — cross-cutting KG conventions
+- `docs/architecture/kg-id-convention.md` — entity key format
+- [mika#687](https://github.com/senara-solutions/mika/issues/687)


### PR DESCRIPTION
## Summary

- Introduces `crates/mika-agent/src/kg/` module with `DomainGraphBuilder` — a startup-time builder that deterministically populates `kg_entities` and `kg_relationships` from `SkillRegistry`, `ToolRegistry`, `McpManager`, and agent configs
- Four entity types (Skill, Tool, Agent, ProblemType) and two relationship types (DEPENDS_ON, PROVIDES) — no HAS_SKILL edges (per-agent state excluded per D1/D2)
- Idempotent UPSERT preserves entity rowids to protect downstream FK references from `kg_subject_resolutions`
- Fail-open: rebuild errors log `warn!`, server continues to boot with stale/empty KG data
- 13 unit tests covering enumeration, idempotency, entity deletion with CASCADE verification, rowid preservation, and FK link safety

Closes #687

## Test plan

- [x] `cargo test -p mika-agent --lib -- domain_builder` — 13 tests pass
- [x] `cargo test -p mika-agent --lib` — 1963 tests pass (no regressions)
- [x] `cargo clippy -p mika-agent` — zero warnings
- [x] `cargo fmt` — clean
- [x] `scripts/verify-pipeline.sh` — passes
- [x] `scripts/sync-agent-docs.sh` — doc copies in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)