### PR TITLE
feat(kg): lexical graph ingestion — chunk solution docs, embed, link (#689)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2",
  "sqlite-vec",
  "subtle",
  "tempfile",

--- a/crates/mika-agent/Cargo.toml
+++ b/crates/mika-agent/Cargo.toml
@@ -52,6 +52,7 @@ mika-a2a.workspace = true
 dashmap.workspace = true
 url.workspace = true
 regex.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/mika-agent/src/kg/chunker.rs
+++ b/crates/mika-agent/src/kg/chunker.rs
@@ -1,0 +1,343 @@
+//! # Markdown-Aware Document Chunker
+//!
+//! Deterministic, pure-function chunker for the lexical graph layer (#689).
+//! Splits markdown documents into [`Chunk`]s suitable for entity extraction
+//! and relationship linking.
+//!
+//! ## Algorithm
+//!
+//! 1. Strip YAML frontmatter (delimited by `---`) into its own chunk.
+//! 2. Split the body on `## ` section headers.
+//! 3. Window-split any section exceeding [`MAX_CHUNK_CHARS`] into overlapping
+//!    windows of [`MAX_CHUNK_CHARS`] with [`OVERLAP_CHARS`] overlap.
+//! 4. Assign monotonic [`Chunk::seq_id`] starting at 0.
+//!
+//! All size arithmetic uses **char counts**, not byte counts, so multibyte
+//! UTF-8 sequences are handled correctly.
+
+/// Maximum number of characters per chunk before window splitting.
+const MAX_CHUNK_CHARS: usize = 2000;
+
+/// Overlap in characters between consecutive window-split chunks.
+const OVERLAP_CHARS: usize = 200;
+
+/// A single chunk of document text with a monotonic sequence identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chunk {
+    /// Monotonic sequence number starting at 0.
+    pub seq_id: u32,
+    /// The chunk text content.
+    pub text: String,
+}
+
+/// Split a markdown document into deterministic, overlapping chunks.
+///
+/// Pure function — no I/O, no randomness. Same input always produces
+/// the same output. An empty (or whitespace-only) document returns an
+/// empty `Vec`.
+pub fn chunk_doc(text: &str) -> Vec<Chunk> {
+    if text.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut sections: Vec<String> = Vec::new();
+
+    // Phase 1: separate YAML frontmatter from body.
+    let body = if text.starts_with("---\n") || text.starts_with("---\r\n") {
+        // Find the closing `---` that ends frontmatter.
+        let after_opening = if text.starts_with("---\r\n") { 5 } else { 4 };
+        if let Some(end_pos) = find_frontmatter_end(&text[after_opening..]) {
+            let frontmatter = &text[..after_opening + end_pos];
+            let frontmatter = frontmatter.trim();
+            if !frontmatter.is_empty() {
+                sections.push(frontmatter.to_string());
+            }
+            let rest = &text[after_opening + end_pos..];
+            // Skip past the closing `---` line.
+            skip_closing_delimiter(rest)
+        } else {
+            // No closing delimiter found — treat entire doc as body.
+            text
+        }
+    } else {
+        text
+    };
+
+    // Phase 2: split body on `## ` section headers.
+    let body_sections = split_on_h2(body);
+    for section in body_sections {
+        let trimmed = section.trim();
+        if !trimmed.is_empty() {
+            sections.push(trimmed.to_string());
+        }
+    }
+
+    // Phase 3: window-split oversized sections.
+    let mut chunks = Vec::new();
+    let mut seq_id: u32 = 0;
+    for section in sections {
+        let char_count = section.chars().count();
+        if char_count <= MAX_CHUNK_CHARS {
+            chunks.push(Chunk {
+                seq_id,
+                text: section,
+            });
+            seq_id += 1;
+        } else {
+            let windows = window_split(&section, MAX_CHUNK_CHARS, OVERLAP_CHARS);
+            for window in windows {
+                chunks.push(Chunk {
+                    seq_id,
+                    text: window,
+                });
+                seq_id += 1;
+            }
+        }
+    }
+
+    chunks
+}
+
+/// Find the position of the closing `---` delimiter within the frontmatter body.
+///
+/// `text` is the content *after* the opening `---\n`. Returns the byte offset
+/// of the start of the closing `---` line, or `None` if not found.
+fn find_frontmatter_end(text: &str) -> Option<usize> {
+    for (i, line) in text.lines().enumerate() {
+        // The closing delimiter must be `---` on its own line (possibly with
+        // trailing whitespace).
+        if line.trim() == "---" {
+            // Compute byte offset of this line within `text`.
+            let offset = text.lines().take(i).fold(0usize, |acc, l| {
+                // Each line consumed `l.len()` bytes plus the newline.
+                // `str::lines()` strips \n and \r\n, so we need to account
+                // for the original separator.
+                let sep = if text.as_bytes().get(acc + l.len()) == Some(&b'\r') {
+                    2
+                } else {
+                    1
+                };
+                acc + l.len() + sep
+            });
+            return Some(offset);
+        }
+    }
+    None
+}
+
+/// Skip past the closing `---` delimiter line (including its trailing newline).
+fn skip_closing_delimiter(text: &str) -> &str {
+    // `text` starts at the `---` closing line.
+    if let Some(newline_pos) = text.find('\n') {
+        &text[newline_pos + 1..]
+    } else {
+        // No newline after `---` — nothing left.
+        ""
+    }
+}
+
+/// Split body text on `## ` markdown headers.
+///
+/// Each section includes its `## ` header line. Text before the first `## `
+/// becomes the first section (the preamble).
+fn split_on_h2(text: &str) -> Vec<&str> {
+    let mut sections = Vec::new();
+    let mut last_start = 0;
+
+    // We look for `\n## ` as the split point (section headers must be at
+    // line start). The very first character could also be `## `.
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+
+    if text.starts_with("## ") {
+        // First section starts at 0 with a header; we'll find the next split.
+    }
+
+    let mut i = 0;
+    while i < len {
+        // Check for `\n## ` pattern.
+        if bytes[i] == b'\n' && i + 3 < len && &bytes[i + 1..i + 4] == b"## " {
+            // Found a split point at i+1 (the `#` char).
+            if i + 1 > last_start {
+                sections.push(&text[last_start..i + 1]); // include the \n
+            }
+            last_start = i + 1;
+            i += 4;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Remaining tail.
+    if last_start < len {
+        sections.push(&text[last_start..]);
+    }
+
+    sections
+}
+
+/// Split a string into windows of `max_chars` characters with `overlap` overlap.
+///
+/// All arithmetic is char-based for Unicode safety.
+fn window_split(text: &str, max_chars: usize, overlap: usize) -> Vec<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let total = chars.len();
+    let mut windows = Vec::new();
+    let mut start = 0;
+
+    while start < total {
+        let end = (start + max_chars).min(total);
+        let window: String = chars[start..end].iter().collect();
+        windows.push(window);
+        if end == total {
+            break;
+        }
+        let step = max_chars.saturating_sub(overlap);
+        if step == 0 {
+            break; // safety: avoid infinite loop
+        }
+        start += step;
+    }
+
+    windows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_small_doc() {
+        let doc = "Hello, this is a small document.\n\nIt has no sections.";
+        let chunks = chunk_doc(doc);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].seq_id, 0);
+        assert_eq!(chunks[0].text, doc.trim());
+    }
+
+    #[test]
+    fn section_split_three_sections() {
+        let doc = "\
+## Section One
+
+Content of section one.
+
+## Section Two
+
+Content of section two.
+
+## Section Three
+
+Content of section three.
+";
+        let chunks = chunk_doc(doc);
+        assert_eq!(chunks.len(), 3, "expected 3 chunks, got {chunks:?}");
+        assert_eq!(chunks[0].seq_id, 0);
+        assert_eq!(chunks[1].seq_id, 1);
+        assert_eq!(chunks[2].seq_id, 2);
+        assert!(chunks[0].text.starts_with("## Section One"));
+        assert!(chunks[1].text.starts_with("## Section Two"));
+        assert!(chunks[2].text.starts_with("## Section Three"));
+    }
+
+    #[test]
+    fn window_split_oversized_section() {
+        // Build a single section that exceeds MAX_CHUNK_CHARS.
+        let filler = "a".repeat(MAX_CHUNK_CHARS + 500);
+        let doc = format!("## Big Section\n\n{filler}");
+        let chunks = chunk_doc(&doc);
+        assert!(
+            chunks.len() >= 2,
+            "oversized section should produce multiple chunks, got {}",
+            chunks.len()
+        );
+
+        // Verify overlap: the end of chunk 0 should overlap with the start of chunk 1.
+        let c0_chars: Vec<char> = chunks[0].text.chars().collect();
+        let c1_chars: Vec<char> = chunks[1].text.chars().collect();
+        let c0_tail: String = c0_chars[c0_chars.len() - OVERLAP_CHARS..].iter().collect();
+        let c1_head: String = c1_chars[..OVERLAP_CHARS].iter().collect();
+        assert_eq!(c0_tail, c1_head, "overlap region should match");
+    }
+
+    #[test]
+    fn frontmatter_handling() {
+        let doc = "\
+---
+title: My Document
+tags: [a, b]
+---
+
+Preamble text.
+
+## First Section
+
+Content here.
+
+## Second Section
+
+More content.
+";
+        let chunks = chunk_doc(doc);
+        assert_eq!(chunks.len(), 4, "expected 4 chunks, got {chunks:?}");
+        assert_eq!(chunks[0].seq_id, 0);
+        assert!(
+            chunks[0].text.starts_with("---"),
+            "chunk 0 should be frontmatter"
+        );
+        assert!(
+            chunks[0].text.contains("title: My Document"),
+            "frontmatter should contain title"
+        );
+        assert_eq!(chunks[1].seq_id, 1);
+        assert!(
+            chunks[1].text.contains("Preamble text"),
+            "chunk 1 should be preamble"
+        );
+        assert_eq!(chunks[2].seq_id, 2);
+        assert!(chunks[2].text.starts_with("## First Section"));
+        assert_eq!(chunks[3].seq_id, 3);
+        assert!(chunks[3].text.starts_with("## Second Section"));
+    }
+
+    #[test]
+    fn determinism() {
+        let doc = "## A\n\nHello\n\n## B\n\nWorld";
+        let run1 = chunk_doc(doc);
+        let run2 = chunk_doc(doc);
+        assert_eq!(run1, run2, "same input must produce identical output");
+    }
+
+    #[test]
+    fn utf8_edge_multibyte_boundary() {
+        // Build a string of multibyte chars that forces a split boundary.
+        // U+1F600 (grinning face) is 4 bytes per char.
+        let emoji = "\u{1F600}";
+        let long_emoji = emoji.repeat(MAX_CHUNK_CHARS + 100);
+        let doc = format!("## Emoji\n\n{long_emoji}");
+        // Must not panic.
+        let chunks = chunk_doc(&doc);
+        assert!(
+            chunks.len() >= 2,
+            "should split oversized emoji section without panic"
+        );
+        // Verify each chunk is valid UTF-8 (guaranteed by String, but let's
+        // also check char counts are within bounds).
+        for chunk in &chunks {
+            let cc = chunk.text.chars().count();
+            assert!(
+                cc <= MAX_CHUNK_CHARS,
+                "chunk {} has {} chars, exceeds max",
+                chunk.seq_id,
+                cc
+            );
+        }
+    }
+
+    #[test]
+    fn empty_doc_returns_empty() {
+        assert!(chunk_doc("").is_empty());
+        assert!(chunk_doc("   ").is_empty());
+        assert!(chunk_doc("\n\n").is_empty());
+    }
+}

--- a/crates/mika-agent/src/kg/lexical_ingestor.rs
+++ b/crates/mika-agent/src/kg/lexical_ingestor.rs
@@ -23,7 +23,6 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::Result;
-use rusqlite::OptionalExtension;
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
@@ -220,77 +219,94 @@ impl LexicalIngestor {
 
     /// Core single-doc ingestion logic shared by `ingest_all` and
     /// `ingest_single_doc`.
+    ///
+    /// All DB mutations (hash check → delete old chunks → insert new chunks →
+    /// index for FTS) happen in a **single `with_db` transaction** so readers
+    /// never see a flash-of-empty state for the document.
     async fn ingest_single_doc_inner(&self, abs_path: &Path) -> Result<DocStats> {
         let raw = std::fs::read(abs_path)?;
         let normalized = normalize_content(&raw);
-
-        if normalized.trim().is_empty() {
-            return Ok(DocStats {
-                outcome: DocOutcome::Skipped,
-                chunks_added: 0,
-                chunks_deleted: 0,
-            });
-        }
-
-        let new_hash = compute_hash(&normalized);
         let rel_path = self
             .relative_path(abs_path)
             .unwrap_or_else(|| abs_path.to_string_lossy().to_string());
 
-        // Check existing hash in DB.
-        let agent_id = self.db.agent_id.clone();
-        let rel_path_for_query = rel_path.clone();
-        let existing_hash: Option<String> = self
-            .db
-            .with_db(move |db| {
-                let mut stmt = db.conn.prepare(
-                    "SELECT DISTINCT source_doc_hash FROM kg_chunks
-                     WHERE agent_id = ?1 AND source_doc_path = ?2",
-                )?;
-                let hashes: Vec<String> = stmt
-                    .query_map(rusqlite::params![agent_id, rel_path_for_query], |row| {
-                        row.get(0)
-                    })?
-                    .filter_map(|r| r.ok())
-                    .collect();
-                if hashes.len() == 1 {
-                    Ok(Some(hashes.into_iter().next().unwrap()))
-                } else {
-                    // Empty or multiple distinct hashes — force re-ingest.
-                    Ok(None)
-                }
-            })
-            .await?;
-
-        // Skip if unchanged.
-        if existing_hash.as_deref() == Some(&new_hash) {
+        // If the file is empty after normalization, clean up any stale chunks
+        // from a previous run where the doc had content.
+        if normalized.trim().is_empty() {
+            let chunks_deleted = self.delete_doc_chunks(&rel_path).await.unwrap_or(0);
             return Ok(DocStats {
                 outcome: DocOutcome::Skipped,
                 chunks_added: 0,
-                chunks_deleted: 0,
+                chunks_deleted,
             });
         }
 
-        // Delete existing chunks for this doc (if any) before re-inserting.
-        let chunks_deleted = if existing_hash.is_some() {
-            self.delete_doc_chunks(&rel_path).await?
-        } else {
-            0
-        };
-
-        // Chunk and insert.
+        let new_hash = compute_hash(&normalized);
         let chunks = chunk_doc(&normalized);
-        let chunks_added = chunks.len();
 
         let agent_id = self.db.agent_id.clone();
-        let rel_path_for_insert = rel_path.clone();
-        let new_hash_for_insert = new_hash;
+        let rel_path_owned = rel_path.clone();
+        let new_hash_owned = new_hash;
         let trace_id = self.trace_id.clone();
 
-        self.db
+        // Single with_db call: hash check + delete + insert are one transaction.
+        // This eliminates the empty-window gap between delete and insert.
+        let (chunks_added, chunks_deleted, was_skipped) = self
+            .db
             .with_db(move |db| {
+                // 1. Hash check: is the doc unchanged?
+                let existing_hashes: Vec<String> = {
+                    let mut stmt = db.conn.prepare(
+                        "SELECT DISTINCT source_doc_hash FROM kg_chunks
+                         WHERE agent_id = ?1 AND source_doc_path = ?2",
+                    )?;
+                    stmt.query_map(rusqlite::params![agent_id, rel_path_owned], |row| {
+                        row.get(0)
+                    })?
+                    .filter_map(|r| r.ok())
+                    .collect()
+                };
+
+                // Single matching hash → unchanged, skip.
+                if existing_hashes.len() == 1 && existing_hashes[0] == new_hash_owned {
+                    return Ok((0usize, 0usize, true));
+                }
+
+                // 2. Atomic delete + insert in one transaction.
                 let tx = db.conn.unchecked_transaction()?;
 
+                // Delete existing chunks (if any). Always delete when chunks
+                // exist — handles both the normal re-ingest case and the
+                // inconsistent-hashes corruption case.
+                let mut deleted = 0usize;
+                if !existing_hashes.is_empty() {
+                    // Clean up search_content/FTS/vec for each chunk.
+                    let chunk_ids: Vec<i64> = {
+                        let mut stmt = tx.prepare(
+                            "SELECT id FROM kg_chunks WHERE agent_id = ?1 AND source_doc_path = ?2",
+                        )?;
+                        stmt.query_map(rusqlite::params![agent_id, rel_path_owned], |row| {
+                            row.get(0)
+                        })?
+                        .filter_map(|r| r.ok())
+                        .collect()
+                    };
+
+                    for &chunk_id in &chunk_ids {
+                        // Call delete_search_content on the Database which uses
+                        // the same connection as the transaction (unchecked_transaction
+                        // borrows the connection, so db.conn writes are inside tx).
+                        db.delete_search_content(&agent_id, KG_CHUNK_SOURCE_TYPE, chunk_id)?;
+                    }
+
+                    deleted = chunk_ids.len();
+                    tx.execute(
+                        "DELETE FROM kg_chunks WHERE agent_id = ?1 AND source_doc_path = ?2",
+                        rusqlite::params![agent_id, rel_path_owned],
+                    )?;
+                }
+
+                // 3. Insert new chunks + index_content in the same transaction.
                 for chunk in &chunks {
                     tx.execute(
                         "INSERT INTO kg_chunks (agent_id, seq_id, source_doc_path, source_doc_hash, trace_id)
@@ -298,17 +314,18 @@ impl LexicalIngestor {
                         rusqlite::params![
                             agent_id,
                             chunk.seq_id,
-                            rel_path_for_insert,
-                            new_hash_for_insert,
+                            rel_path_owned,
+                            new_hash_owned,
                             trace_id,
                         ],
                     )?;
 
                     let chunk_rowid = tx.last_insert_rowid();
 
-                    // Index the chunk text for FTS + embedding backfill.
-                    // Call index_content directly on the Database, which uses
-                    // the same underlying connection (inside the transaction).
+                    // SAFETY: db.index_content uses db.conn which is the same
+                    // connection that tx wraps (via unchecked_transaction). All
+                    // writes through db.conn are inside this transaction and
+                    // will commit or rollback atomically.
                     db.index_content(
                         &agent_id,
                         KG_CHUNK_SOURCE_TYPE,
@@ -318,9 +335,17 @@ impl LexicalIngestor {
                 }
 
                 tx.commit()?;
-                Ok(())
+                Ok((chunks.len(), deleted, false))
             })
             .await?;
+
+        if was_skipped {
+            return Ok(DocStats {
+                outcome: DocOutcome::Skipped,
+                chunks_added: 0,
+                chunks_deleted: 0,
+            });
+        }
 
         Ok(DocStats {
             outcome: DocOutcome::Ingested,
@@ -330,6 +355,10 @@ impl LexicalIngestor {
     }
 
     /// Delete all chunks for a document, including search_content cleanup.
+    ///
+    /// Uses [`Database::delete_search_content`] for the symmetric cleanup of
+    /// `search_content` + `fts_search` + `vec_search` to avoid duplicating
+    /// delete logic that would diverge when new search tables are added.
     ///
     /// Returns the number of chunks deleted.
     async fn delete_doc_chunks(&self, rel_path: &str) -> Result<usize> {
@@ -350,31 +379,12 @@ impl LexicalIngestor {
                         .collect()
                 };
 
-                // For each chunk, clean up search_content + FTS + vec.
+                // Symmetric delete: use the canonical delete_search_content which
+                // handles search_content + fts_search + vec_search cleanup.
+                // db.delete_search_content uses db.conn which is the same connection
+                // as tx (via unchecked_transaction), so writes are transactional.
                 for &chunk_id in &chunk_ids {
-                    let existing: Option<(i64, String)> = tx
-                        .query_row(
-                            "SELECT id, content FROM search_content
-                              WHERE agent_id = ?1 AND source_type = ?2 AND source_id = ?3",
-                            rusqlite::params![agent_id, KG_CHUNK_SOURCE_TYPE, chunk_id],
-                            |r| Ok((r.get(0)?, r.get(1)?)),
-                        )
-                        .optional()?;
-
-                    if let Some((sc_id, content)) = existing {
-                        let _ = tx.execute(
-                            "INSERT INTO fts_search(fts_search, rowid, content) VALUES ('delete', ?1, ?2)",
-                            rusqlite::params![sc_id, content],
-                        );
-                        let _ = tx.execute(
-                            "DELETE FROM vec_search WHERE rowid = ?1",
-                            rusqlite::params![sc_id],
-                        );
-                        tx.execute(
-                            "DELETE FROM search_content WHERE id = ?1",
-                            rusqlite::params![sc_id],
-                        )?;
-                    }
+                    db.delete_search_content(&agent_id, KG_CHUNK_SOURCE_TYPE, chunk_id)?;
                 }
 
                 let count = chunk_ids.len();

--- a/crates/mika-agent/src/kg/lexical_ingestor.rs
+++ b/crates/mika-agent/src/kg/lexical_ingestor.rs
@@ -1,0 +1,610 @@
+//! # Lexical Graph Ingestor
+//!
+//! Per-agent ingestion of `docs/solutions/**/*.md` into the lexical layer of
+//! the Knowledge Graph (#689). Each document is:
+//!
+//! 1. Read and normalized (BOM strip, LF line endings, trailing-ws strip).
+//! 2. Content-hashed (SHA-256) for idempotent skip-on-unchanged.
+//! 3. Chunked via [`super::chunker::chunk_doc`].
+//! 4. Written to `kg_chunks` + `search_content` + `fts_search` in a single
+//!    transaction (per conventions C1.1 — embeddings backfilled async).
+//!
+//! Documents removed from disk are pruned (symmetric delete via
+//! [`Database::delete_search_content`]).
+//!
+//! ## Sole-Writer Contract
+//!
+//! This module is the sole writer of `kg_chunks` rows and of
+//! `source_type="kg_chunk"` entries in `search_content`. No other code path
+//! should write these.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::Result;
+use rusqlite::OptionalExtension;
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+
+use crate::async_db::AsyncDatabase;
+use crate::db::kg_schema::KG_CHUNK_SOURCE_TYPE;
+
+use super::chunker::chunk_doc;
+
+/// Statistics returned from a full ingestion run.
+#[derive(Debug, Clone)]
+pub struct IngestStats {
+    pub docs_scanned: usize,
+    pub docs_skipped_unchanged: usize,
+    pub docs_ingested: usize,
+    pub docs_pruned: usize,
+    pub chunks_added: usize,
+    pub chunks_deleted: usize,
+    pub duration_ms: u64,
+}
+
+/// Statistics returned from a single-doc ingestion.
+#[derive(Debug, Clone)]
+pub struct DocStats {
+    pub outcome: DocOutcome,
+    pub chunks_added: usize,
+    pub chunks_deleted: usize,
+}
+
+/// Outcome of ingesting a single document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocOutcome {
+    /// Doc was unchanged (content hash matched) — skipped.
+    Skipped,
+    /// Doc was new or changed — (re)ingested.
+    Ingested,
+    /// Doc was pruned (no longer on disk).
+    Pruned,
+}
+
+/// Session ID sentinel for audit events emitted during startup ingestion.
+const STARTUP_SESSION_ID: &str = "startup";
+
+/// Per-agent lexical graph ingestor.
+///
+/// Scans a docs directory, chunks markdown files, and writes them into
+/// `kg_chunks` + `search_content` with content-hash idempotency.
+pub struct LexicalIngestor {
+    db: AsyncDatabase,
+    docs_root: PathBuf,
+    trace_id: String,
+    /// Session ID for audit events. Defaults to [`STARTUP_SESSION_ID`] for
+    /// startup scans; compound hook callers may pass the active session.
+    session_id: String,
+}
+
+impl LexicalIngestor {
+    /// Create a new ingestor.
+    ///
+    /// - `db`: async database handle (carries `agent_id` implicitly).
+    /// - `docs_root`: root directory to scan for `*.md` files.
+    /// - `trace_id`: optional trace ID for observability. If `None`, a fresh
+    ///   UUID is generated.
+    pub fn new(db: AsyncDatabase, docs_root: PathBuf, trace_id: Option<&str>) -> Self {
+        let trace_id = trace_id
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace('-', ""));
+        Self {
+            db,
+            docs_root,
+            trace_id,
+            session_id: STARTUP_SESSION_ID.to_owned(),
+        }
+    }
+
+    /// Create an ingestor with a specific session ID (for compound hook use).
+    pub fn with_session(mut self, session_id: &str) -> Self {
+        self.session_id = session_id.to_owned();
+        self
+    }
+
+    /// Ingest all `*.md` files under `docs_root` for the agent.
+    ///
+    /// Returns statistics about the run. Failures on individual documents are
+    /// logged and skipped — the run continues.
+    pub async fn ingest_all(&self) -> Result<IngestStats> {
+        let start = Instant::now();
+        let agent_id = self.db.agent_id.clone();
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            docs_root = %self.docs_root.display(),
+            event = "lexical_ingest_start",
+        );
+
+        // 1. Walk docs_root for *.md files.
+        let on_disk = self.scan_docs()?;
+
+        let mut stats = IngestStats {
+            docs_scanned: on_disk.len(),
+            docs_skipped_unchanged: 0,
+            docs_ingested: 0,
+            docs_pruned: 0,
+            chunks_added: 0,
+            chunks_deleted: 0,
+            duration_ms: 0,
+        };
+
+        // 2. For each file: read, normalize, hash, compare, ingest if changed.
+        for path in &on_disk {
+            let rel_path = self
+                .relative_path(path)
+                .unwrap_or_else(|| path.to_string_lossy().to_string());
+
+            match self.ingest_single_doc_inner(path).await {
+                Ok(doc_stats) => {
+                    // Emit per-document audit event (C3.2).
+                    self.emit_audit_event(&rel_path, &doc_stats).await;
+
+                    match doc_stats.outcome {
+                        DocOutcome::Skipped => stats.docs_skipped_unchanged += 1,
+                        DocOutcome::Ingested => {
+                            stats.docs_ingested += 1;
+                            stats.chunks_added += doc_stats.chunks_added;
+                            stats.chunks_deleted += doc_stats.chunks_deleted;
+                        }
+                        DocOutcome::Pruned => {
+                            stats.docs_pruned += 1;
+                            stats.chunks_deleted += doc_stats.chunks_deleted;
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        trace_id = %self.trace_id,
+                        agent_id = %agent_id,
+                        doc = %path.display(),
+                        error = %e,
+                        event = "lexical_ingest_doc_failed",
+                    );
+                }
+            }
+        }
+
+        // 3. Prune removed docs.
+        let on_disk_paths: HashSet<String> = on_disk
+            .iter()
+            .filter_map(|p| self.relative_path(p))
+            .collect();
+
+        match self.prune_removed_docs(&on_disk_paths).await {
+            Ok((pruned_count, deleted_chunks)) => {
+                stats.docs_pruned += pruned_count;
+                stats.chunks_deleted += deleted_chunks;
+            }
+            Err(e) => {
+                warn!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    error = %e,
+                    event = "lexical_prune_failed",
+                );
+            }
+        }
+
+        stats.duration_ms = start.elapsed().as_millis() as u64;
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            docs_scanned = stats.docs_scanned,
+            docs_skipped = stats.docs_skipped_unchanged,
+            docs_ingested = stats.docs_ingested,
+            docs_pruned = stats.docs_pruned,
+            chunks_added = stats.chunks_added,
+            chunks_deleted = stats.chunks_deleted,
+            duration_ms = stats.duration_ms,
+            event = "lexical_ingest_complete",
+        );
+
+        Ok(stats)
+    }
+
+    /// Ingest a single document by absolute path.
+    ///
+    /// Called by the compound hook for immediate ingestion of freshly-written
+    /// docs. Uses the same hash-check + ingest-if-changed logic as the bulk
+    /// path.
+    pub async fn ingest_single_doc(&self, path: &Path) -> Result<DocStats> {
+        self.ingest_single_doc_inner(path).await
+    }
+
+    // -- Internal helpers --
+
+    /// Core single-doc ingestion logic shared by `ingest_all` and
+    /// `ingest_single_doc`.
+    async fn ingest_single_doc_inner(&self, abs_path: &Path) -> Result<DocStats> {
+        let raw = std::fs::read(abs_path)?;
+        let normalized = normalize_content(&raw);
+
+        if normalized.trim().is_empty() {
+            return Ok(DocStats {
+                outcome: DocOutcome::Skipped,
+                chunks_added: 0,
+                chunks_deleted: 0,
+            });
+        }
+
+        let new_hash = compute_hash(&normalized);
+        let rel_path = self
+            .relative_path(abs_path)
+            .unwrap_or_else(|| abs_path.to_string_lossy().to_string());
+
+        // Check existing hash in DB.
+        let agent_id = self.db.agent_id.clone();
+        let rel_path_for_query = rel_path.clone();
+        let existing_hash: Option<String> = self
+            .db
+            .with_db(move |db| {
+                let mut stmt = db.conn.prepare(
+                    "SELECT DISTINCT source_doc_hash FROM kg_chunks
+                     WHERE agent_id = ?1 AND source_doc_path = ?2",
+                )?;
+                let hashes: Vec<String> = stmt
+                    .query_map(rusqlite::params![agent_id, rel_path_for_query], |row| {
+                        row.get(0)
+                    })?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                if hashes.len() == 1 {
+                    Ok(Some(hashes.into_iter().next().unwrap()))
+                } else {
+                    // Empty or multiple distinct hashes — force re-ingest.
+                    Ok(None)
+                }
+            })
+            .await?;
+
+        // Skip if unchanged.
+        if existing_hash.as_deref() == Some(&new_hash) {
+            return Ok(DocStats {
+                outcome: DocOutcome::Skipped,
+                chunks_added: 0,
+                chunks_deleted: 0,
+            });
+        }
+
+        // Delete existing chunks for this doc (if any) before re-inserting.
+        let chunks_deleted = if existing_hash.is_some() {
+            self.delete_doc_chunks(&rel_path).await?
+        } else {
+            0
+        };
+
+        // Chunk and insert.
+        let chunks = chunk_doc(&normalized);
+        let chunks_added = chunks.len();
+
+        let agent_id = self.db.agent_id.clone();
+        let rel_path_for_insert = rel_path.clone();
+        let new_hash_for_insert = new_hash;
+        let trace_id = self.trace_id.clone();
+
+        self.db
+            .with_db(move |db| {
+                let tx = db.conn.unchecked_transaction()?;
+
+                for chunk in &chunks {
+                    tx.execute(
+                        "INSERT INTO kg_chunks (agent_id, seq_id, source_doc_path, source_doc_hash, trace_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                        rusqlite::params![
+                            agent_id,
+                            chunk.seq_id,
+                            rel_path_for_insert,
+                            new_hash_for_insert,
+                            trace_id,
+                        ],
+                    )?;
+
+                    let chunk_rowid = tx.last_insert_rowid();
+
+                    // Index the chunk text for FTS + embedding backfill.
+                    // Call index_content directly on the Database, which uses
+                    // the same underlying connection (inside the transaction).
+                    db.index_content(
+                        &agent_id,
+                        KG_CHUNK_SOURCE_TYPE,
+                        Some(chunk_rowid),
+                        &chunk.text,
+                    )?;
+                }
+
+                tx.commit()?;
+                Ok(())
+            })
+            .await?;
+
+        Ok(DocStats {
+            outcome: DocOutcome::Ingested,
+            chunks_added,
+            chunks_deleted,
+        })
+    }
+
+    /// Delete all chunks for a document, including search_content cleanup.
+    ///
+    /// Returns the number of chunks deleted.
+    async fn delete_doc_chunks(&self, rel_path: &str) -> Result<usize> {
+        let agent_id = self.db.agent_id.clone();
+        let rel_path = rel_path.to_owned();
+
+        self.db
+            .with_db(move |db| {
+                let tx = db.conn.unchecked_transaction()?;
+
+                // Get chunk IDs for this doc.
+                let chunk_ids: Vec<i64> = {
+                    let mut stmt = tx.prepare(
+                        "SELECT id FROM kg_chunks WHERE agent_id = ?1 AND source_doc_path = ?2",
+                    )?;
+                    stmt.query_map(rusqlite::params![agent_id, rel_path], |row| row.get(0))?
+                        .filter_map(|r| r.ok())
+                        .collect()
+                };
+
+                // For each chunk, clean up search_content + FTS + vec.
+                for &chunk_id in &chunk_ids {
+                    let existing: Option<(i64, String)> = tx
+                        .query_row(
+                            "SELECT id, content FROM search_content
+                              WHERE agent_id = ?1 AND source_type = ?2 AND source_id = ?3",
+                            rusqlite::params![agent_id, KG_CHUNK_SOURCE_TYPE, chunk_id],
+                            |r| Ok((r.get(0)?, r.get(1)?)),
+                        )
+                        .optional()?;
+
+                    if let Some((sc_id, content)) = existing {
+                        let _ = tx.execute(
+                            "INSERT INTO fts_search(fts_search, rowid, content) VALUES ('delete', ?1, ?2)",
+                            rusqlite::params![sc_id, content],
+                        );
+                        let _ = tx.execute(
+                            "DELETE FROM vec_search WHERE rowid = ?1",
+                            rusqlite::params![sc_id],
+                        );
+                        tx.execute(
+                            "DELETE FROM search_content WHERE id = ?1",
+                            rusqlite::params![sc_id],
+                        )?;
+                    }
+                }
+
+                let count = chunk_ids.len();
+                tx.execute(
+                    "DELETE FROM kg_chunks WHERE agent_id = ?1 AND source_doc_path = ?2",
+                    rusqlite::params![agent_id, rel_path],
+                )?;
+
+                tx.commit()?;
+                Ok(count)
+            })
+            .await
+    }
+
+    /// Find and delete chunks for docs no longer on disk.
+    async fn prune_removed_docs(&self, on_disk_paths: &HashSet<String>) -> Result<(usize, usize)> {
+        // Get all tracked doc paths from DB.
+        let agent_id = self.db.agent_id.clone();
+        let tracked_paths: Vec<String> = self
+            .db
+            .with_db(move |db| {
+                let mut stmt = db.conn.prepare(
+                    "SELECT DISTINCT source_doc_path FROM kg_chunks WHERE agent_id = ?1",
+                )?;
+                let paths: Vec<String> = stmt
+                    .query_map(rusqlite::params![agent_id], |row| row.get(0))?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                Ok(paths)
+            })
+            .await?;
+
+        let mut pruned = 0;
+        let mut deleted_chunks = 0;
+        for path in tracked_paths {
+            if !on_disk_paths.contains(&path) {
+                match self.delete_doc_chunks(&path).await {
+                    Ok(count) => {
+                        pruned += 1;
+                        deleted_chunks += count;
+
+                        // Emit prune audit event (C3.2).
+                        let prune_stats = DocStats {
+                            outcome: DocOutcome::Pruned,
+                            chunks_added: 0,
+                            chunks_deleted: count,
+                        };
+                        self.emit_audit_event(&path, &prune_stats).await;
+                    }
+                    Err(e) => {
+                        warn!(
+                            trace_id = %self.trace_id,
+                            doc = %path,
+                            error = %e,
+                            event = "lexical_prune_doc_failed",
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok((pruned, deleted_chunks))
+    }
+
+    /// Emit a per-document audit event per C3.2.
+    ///
+    /// Fire-and-forget: failures are logged but do not propagate.
+    async fn emit_audit_event(&self, rel_path: &str, doc_stats: &DocStats) {
+        let outcome = match doc_stats.outcome {
+            DocOutcome::Skipped => "skipped",
+            DocOutcome::Ingested => "ingested",
+            DocOutcome::Pruned => "pruned",
+        };
+
+        let after_value = format!(
+            r#"{{"chunks_added":{},"chunks_deleted":{}}}"#,
+            doc_stats.chunks_added, doc_stats.chunks_deleted,
+        );
+
+        let target_key = format!("kg_chunk:{rel_path}");
+
+        if let Err(e) = self
+            .db
+            .log_audit_event(
+                &self.session_id,
+                "ingest_document",
+                &target_key,
+                None,
+                Some(&after_value),
+                Some(outcome),
+                Some(&self.trace_id),
+            )
+            .await
+        {
+            warn!(
+                trace_id = %self.trace_id,
+                doc = %rel_path,
+                error = %e,
+                event = "lexical_audit_event_failed",
+            );
+        }
+    }
+
+    /// Walk `docs_root` recursively for `*.md` files.
+    fn scan_docs(&self) -> Result<Vec<PathBuf>> {
+        let mut files = Vec::new();
+        if self.docs_root.exists() {
+            self.walk_dir(&self.docs_root, &mut files)?;
+        }
+        files.sort(); // Deterministic ordering.
+        Ok(files)
+    }
+
+    fn walk_dir(&self, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                self.walk_dir(&path, out)?;
+            } else if path.extension().is_some_and(|ext| ext == "md") {
+                out.push(path);
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert an absolute path to a repo-relative path.
+    ///
+    /// `docs_root` is typically `<repo>/docs/solutions`, so the repo root is
+    /// two levels up. Paths stored in DB are always repo-relative (e.g.,
+    /// `docs/solutions/database-issues/foo.md`).
+    fn relative_path(&self, abs_path: &Path) -> Option<String> {
+        if let Some(repo_root) = self.docs_root.parent().and_then(|p| p.parent()) {
+            abs_path
+                .strip_prefix(repo_root)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+        } else {
+            abs_path
+                .strip_prefix(&self.docs_root)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+        }
+    }
+}
+
+/// Normalize document content for consistent hashing.
+///
+/// 1. Strip UTF-8 BOM if present.
+/// 2. Normalize line endings to LF (replace `\r\n` and `\r` with `\n`).
+/// 3. Strip trailing whitespace from each line.
+/// 4. Enforce single trailing newline.
+pub fn normalize_content(raw: &[u8]) -> String {
+    // Strip BOM.
+    let bytes = if raw.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &raw[3..]
+    } else {
+        raw
+    };
+
+    // Decode as UTF-8 (lossy — invalid sequences become U+FFFD).
+    let text = String::from_utf8_lossy(bytes);
+
+    // Normalize line endings: \r\n -> \n, then lone \r -> \n.
+    let text = text.replace("\r\n", "\n").replace('\r', "\n");
+
+    // Strip trailing whitespace from each line.
+    let lines: Vec<&str> = text.lines().map(|l| l.trim_end()).collect();
+    let mut result = lines.join("\n");
+
+    // Enforce single trailing newline.
+    let trimmed = result.trim_end_matches('\n');
+    result = format!("{trimmed}\n");
+
+    result
+}
+
+/// Compute SHA-256 hex digest of normalized content.
+pub fn compute_hash(normalized: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_bom() {
+        let with_bom = b"\xEF\xBB\xBFhello\n";
+        assert_eq!(normalize_content(with_bom), "hello\n");
+    }
+
+    #[test]
+    fn normalize_crlf_to_lf() {
+        let crlf = b"line1\r\nline2\r\n";
+        assert_eq!(normalize_content(crlf), "line1\nline2\n");
+    }
+
+    #[test]
+    fn normalize_lone_cr_to_lf() {
+        let cr = b"line1\rline2\r";
+        assert_eq!(normalize_content(cr), "line1\nline2\n");
+    }
+
+    #[test]
+    fn normalize_strips_trailing_ws() {
+        let text = b"hello   \nworld  \n";
+        assert_eq!(normalize_content(text), "hello\nworld\n");
+    }
+
+    #[test]
+    fn normalize_enforces_single_trailing_newline() {
+        assert_eq!(normalize_content(b"hello\n\n\n"), "hello\n");
+        assert_eq!(normalize_content(b"hello"), "hello\n");
+    }
+
+    #[test]
+    fn compute_hash_deterministic() {
+        let h1 = compute_hash("hello\n");
+        let h2 = compute_hash("hello\n");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // SHA-256 hex is 64 chars
+    }
+
+    #[test]
+    fn hash_changes_on_different_content() {
+        let h1 = compute_hash("hello\n");
+        let h2 = compute_hash("world\n");
+        assert_ne!(h1, h2);
+    }
+}

--- a/crates/mika-agent/src/kg/mod.rs
+++ b/crates/mika-agent/src/kg/mod.rs
@@ -9,10 +9,13 @@
 //!   `docs/architecture/kg-implementation-conventions.md` for cross-cutting conventions
 //!   and `crates/mika-agent/src/db/kg_schema.rs` for schema constants and ID format.
 //!
-//! - **Lexical graph** (future, #689): Per-agent chunk ingestion linking prose content
-//!   to domain entities.
+//! - **Lexical graph** ([`lexical_ingestor`], #689): Per-agent chunk ingestion of
+//!   `docs/solutions/**/*.md` into `kg_chunks` + `search_content`. Content-hash
+//!   idempotent, runs at startup after domain rebuild.
 //!
 //! - **Subject graph** (future, #690/#691): Per-agent LLM-extracted entities, fact
 //!   triples, and resolution edges linking subject mentions to domain nodes.
 
+pub mod chunker;
 pub mod domain_builder;
+pub mod lexical_ingestor;

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -755,6 +755,51 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         }
     }
 
+    // Lexical graph ingestion: chunk docs/solutions/**/*.md per agent, index
+    // into search_content for hybrid search. Runs after domain rebuild so each
+    // KG layer's startup work composes cleanly for #690+.
+    //
+    // docs_root is relative to the server working directory. In containers,
+    // the Dockerfile copies docs/ into the workdir.
+    {
+        let docs_root = std::env::current_dir()
+            .unwrap_or_default()
+            .join("docs")
+            .join("solutions");
+        if docs_root.exists() {
+            for (agent_name, agent_state) in &agents {
+                let ingestor = crate::kg::lexical_ingestor::LexicalIngestor::new(
+                    agent_state.db.clone(),
+                    docs_root.clone(),
+                    None,
+                );
+                match ingestor.ingest_all().await {
+                    Ok(stats) => info!(
+                        event = "lexical_ingest_complete",
+                        agent_id = %agent_name,
+                        docs_scanned = stats.docs_scanned,
+                        docs_ingested = stats.docs_ingested,
+                        docs_skipped = stats.docs_skipped_unchanged,
+                        docs_pruned = stats.docs_pruned,
+                        chunks_added = stats.chunks_added,
+                        duration_ms = stats.duration_ms,
+                        "lexical ingestion ready"
+                    ),
+                    Err(e) => warn!(
+                        error = %e,
+                        agent_id = %agent_name,
+                        "lexical ingestion failed; chunks may be stale until next restart"
+                    ),
+                }
+            }
+        } else {
+            info!(
+                docs_root = %docs_root.display(),
+                "docs/solutions not found — skipping lexical ingestion"
+            );
+        }
+    }
+
     let state = AppState {
         agents: Arc::new(agents),
         default_agent,

--- a/docs/plans/2026-04-21-005-feat-lexical-ingestion-plan.md
+++ b/docs/plans/2026-04-21-005-feat-lexical-ingestion-plan.md
@@ -178,7 +178,9 @@ DELETE kg_chunks → unindex_content(source_type="kg_chunk", source_id=<kg_chunk
 pub fn unindex_content(&self, source_type: &str, source_id: i64) -> Result<()>;
 ```
 
-It deletes the `search_content` row for the given `(source_type, source_id)` and removes the corresponding FTS5 entry. The `vec_search` row is keyed by `search_content.id` (rowid), so it's pruned by the FK-less design of FTS5-external-content: the vec_search row remains as an orphan keyed on a now-deleted rowid, but vec_search doesn't reference back so this is benign (the vec row is unreferenced and can be pruned by a periodic GC or left alone — embeddings without a search_content row are never returned by `hybrid_search` because the join filters them).
+It deletes from three tables atomically: `search_content` row, corresponding `fts_search` entry, and the `vec_search` row (by rowid matching `search_content.id`). The vec0 virtual table supports DELETE by rowid — `DELETE FROM vec_search WHERE rowid = ?`. All three deletes run in the same transaction as the `kg_chunks` DELETE.
+
+Without explicit vec_search cleanup, orphan vec rows accumulate indefinitely on every re-ingestion. Over months of operation, `vec_search` would grow unboundedly relative to `search_content` — each orphan costing memory for vec0's index structure. Synchronous cleanup in `unindex_content` avoids the need for a periodic GC mechanism.
 
 Both `index_content()` and `unindex_content()` must run within the same transaction as the `kg_chunks` INSERT/DELETE for atomicity.
 
@@ -213,7 +215,7 @@ Hard ordering between #687 and #689 isn't required by FK (per D5 there's no dire
 
 - Exact scan-path list (today: `docs/solutions/**/*.md`; may extend to `docs/adr/` / `docs/architecture/` in a later ticket if usage shows value).
 - Whether `search_content.source_id` can hold the kg_chunks INTEGER id directly without any adapter (should — both are INTEGER). Verify in Unit 2.
-- Compound doc detection: does `/ce:compound` always land files in `docs/solutions/`, or are there subdirectory conventions we should trigger on? Probably same tree; confirm during implementation.
+- Compound doc detection: `/ce:compound` lands files in `docs/solutions/` under category subdirectories (e.g., `docs/solutions/best-practices/`, `docs/solutions/database-issues/`). This is the same tree the startup scan covers (`docs/solutions/**/*.md`). The compound hook path and the scan path must be the same — if compound ever writes outside `docs/solutions/`, the startup fallback won't pick up the doc. Confirm at implementation time that no compound output lands elsewhere.
 
 ## Output Structure
 
@@ -286,15 +288,17 @@ docs/plans/
 
 **Approach:**
 - `pub fn unindex_content(&self, source_type: &str, source_id: i64) -> Result<()>` in `db.rs`:
-  - `DELETE FROM fts_search WHERE rowid = (SELECT id FROM search_content WHERE source_type = ? AND source_id = ?)` — FTS5 external-content model requires explicit delete.
+  - Capture `search_content.id` for the given `(source_type, source_id)`.
+  - `DELETE FROM vec_search WHERE rowid = ?` — vec0 supports DELETE by rowid; prevents orphan accumulation.
+  - `DELETE FROM fts_search WHERE rowid = ?` — FTS5 external-content model requires explicit delete.
   - `DELETE FROM search_content WHERE source_type = ? AND source_id = ?`.
-  - `vec_search` rows are orphaned by design (no FK to delete against) — leave them; `hybrid_search` joins through `search_content` so orphan vec rows never surface.
 - All statements in one transaction (caller's responsibility if they wrap multiple unindex calls; single-call use is atomic on its own).
 - `AsyncDatabase::unindex_content()` thin wrapper for the async callers.
 
 **Test scenarios:**
-- Happy path: index content, then unindex → subsequent `fts_search` MATCH returns zero rows; `search_content` row is gone.
+- Happy path: index content (with embedding), then unindex → `fts_search` MATCH returns zero rows; `search_content` row gone; `vec_search` row gone. All three tables cleaned.
 - Idempotency: unindex a non-existent (source_type, source_id) → no error, no-op.
+- Vec cleanup: index content, verify vec_search row exists, unindex, verify vec_search row is deleted (not orphaned).
 - Isolation: unindex source_type="kg_chunk", source_id=X → person/commitment/preference/event rows with the same numeric source_id are untouched.
 
 **Verification:** `cargo test -p mika-agent db::unindex_content` green.
@@ -340,6 +344,7 @@ docs/plans/
 - Deletion: run ingest, delete a doc file, re-run → doc's chunks pruned, stats report docs_pruned=1.
 - Transactional failure: inject DB error mid-ingestion → no partial state; all rollback.
 - Cross-agent isolation: ingest for agent A, then agent B, same docs → each agent has their own chunk rows, no cross-contamination.
+- Defensive hash mismatch: directly insert chunks for a doc with mismatched `source_doc_hash` values across rows (simulated corruption) → hash-check query returns multiple rows → triggers full delete+reinsert, all chunks end up with consistent hash.
 
 **Verification:** `cargo test -p mika-agent --test kg` suite green.
 
@@ -382,9 +387,10 @@ docs/plans/
 - Identify the call site in the `/ce:compound` skill handler or the post-write hook and wire up. (Location TBD during implementation — depends on where compound docs land and what mechanism exists for post-write hooks. If no hook mechanism exists, the compound handler explicitly calls into the ingestor after writing the file.)
 
 **Approach:**
-- Caller passes `(agent_id, absolute_path_of_compound_doc)`.
+- Caller passes `(agent_id, absolute_path_of_compound_doc, trace_id: Option<&str>)`.
+- When `trace_id` is `Some`, the ingestor stamps it on all `kg_chunks` rows — preserving the compound turn's trace_id for end-to-end observability (compound → ingestion → search hit). When `None` (startup scan path), the ingestor generates a fresh trace_id per scan invocation.
 - Ingestor does the same hash-check + ingest-if-changed logic as the bulk path.
-- Returns `Result<()>`. Caller logs on error but does not fail the compound operation itself.
+- Returns `Result<DocStats>` (consistent with `ingest_all`'s `Result<IngestStats>`). Caller can log stats or discard them. Returning `()` discards useful information.
 - Per D1, failure is fail-silently-with-warn-log — the authoring agent gets "your doc is saved; search will pick it up after next restart at latest."
 
 **Test scenarios:**
@@ -448,7 +454,7 @@ docs/plans/
 | Hash normalization misses an edge case (e.g., Unicode normalization forms NFC vs NFD) | Start with the documented 4-step normalization (BOM / line endings / trailing ws / trailing newline). If false-positive re-ingestions appear in logs (D3 observability), extend normalization as needed. NFC is a plausible later addition. |
 | Per-agent duplication at scale (100+ agents) becomes a real storage problem | Accept per D3, instrument per D3 (duration + chunk count logging), optimize later with real data. Not a #689 concern unless it's observed at implementation time. |
 | Compound hook races with other writers (two compounds in quick succession) | `kg_chunks` UNIQUE(agent_id, source_doc_path, seq_id) prevents dup-inserts. Two hooks for the same doc ingest serially via the AsyncDatabase write thread. |
-| Very large docs exceed single-transaction limits | SQLite supports multi-MB transactions trivially. A 10MB doc → ~5000 chunks × ~2000 bytes ≈ 10MB write. Well within limits. If this ever becomes an issue, split ingestion into per-doc transactions. |
+| Very large docs exceed single-transaction limits | SQLite handles thousands of INSERTs per transaction trivially. A 10MB doc → ~5000 chunks → ~10000 statements (INSERT kg_chunks + index_content each). Well within SQLite's practical limits. If this ever becomes an issue, split ingestion into per-doc transactions. |
 | Docs tree has non-markdown files that happen to have `.md` extension but aren't conventional | Chunker handles any UTF-8 text; invalid UTF-8 files would fail the normalize step and log a warn. Non-fatal. |
 
 ## Documentation / Operational Notes

--- a/docs/plans/2026-04-21-005-feat-lexical-ingestion-plan.md
+++ b/docs/plans/2026-04-21-005-feat-lexical-ingestion-plan.md
@@ -1,0 +1,477 @@
+---
+title: "feat: lexical graph ingestion — chunk solution docs, embed, link via search_content"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# Lexical graph ingestion — chunk solution docs, embed, link via search_content
+
+## Overview
+
+Populate the lexical layer of Mika's Knowledge Graph (milestone mika#14, ticket mika#689). For each agent, scan `docs/solutions/**/*.md`, chunk with markdown-aware splits, and produce `kg_chunks` rows + `search_content` + FTS5 + async embedding rows via the existing Layer 3 pipeline. Writes are per-agent (per #686 D1), idempotent by content hash, and ordered after the domain graph rebuild so downstream linkage tickets (#690, #691) have consistent state to consume.
+
+No LLM calls in #689. No direct chunk→domain entity linkage at ingest time (per #686 D9 — `kg_chunks.entity_id` does not exist; linkage goes through subject → resolution). Chunks are pure lexical units; their connection to the domain graph happens in #690/#691.
+
+## Problem Frame
+
+#686 landed the schema and #687 populated the domain graph. Neither gives agents semantic access to institutional knowledge — the `docs/solutions/**` tree and `/ce:compound`-produced docs are currently searchable only via grep. The lexical layer makes them first-class KG citizens: chunked, embedded, indexed, queryable via hybrid search alongside Layer 2 memory.
+
+The payoff is that #690's subject extraction has structured chunk rows to operate on (instead of re-reading docs from disk every time), and #692's `self-knowledge` upgrade can surface documented lessons with proper retrieval instead of static lookup.
+
+## Requirements Trace
+
+- R1. Startup-time per-agent ingestion of `docs/solutions/**/*.md`.
+- R2. Compound-hook ingestion: `/ce:compound` writing a new doc triggers immediate ingestion for the authoring agent only.
+- R3. Markdown-aware chunking: 2000 chars with 200-char overlap, split on `---` (frontmatter) and `##` (section headers).
+- R4. Content-hash-based idempotency: unchanged docs on re-run are a no-op.
+- R5. Deletion handling: docs removed from disk produce symmetric cleanup of `kg_chunks` + `search_content` + FTS5 + vec entries.
+- R6. Composed write contract: `kg_chunks` + `search_content` committed in a single transaction, embeddings backfilled async (per conventions C1.1).
+- R7. Ordering: ingestion runs strictly after #687's domain rebuild in the startup sequence.
+- R8. Observability: per-agent ingestion durations and chunk counts logged for future optimization data.
+
+## Scope Boundaries
+
+- Scan and ingestion of `docs/solutions/**/*.md` per agent.
+- Compound hook that calls into ingestion when `/ce:compound` writes a new doc.
+- Deterministic chunking (2000 chars, 200 overlap, markdown-aware).
+- Doc-level content-hash idempotency.
+- Composed write: `kg_chunks` row + `index_content()` call + transactional atomicity.
+- Symmetric deletion handling for removed docs + `unindex_content()` helper if not already present.
+- Per-agent per-ingestion-run log lines for observability.
+
+### Deferred to Separate Tasks
+
+- Subject graph extraction from chunk text (NER + fact triples): **mika#690**.
+- Entity resolution (subject → domain linkage, the canonical chunk→domain path): **mika#691**.
+- Query tool consuming KG chunks: **mika#688**.
+- `self-knowledge` upgrade using KG chunks: **mika#692**.
+- Shared-chunk optimization for `docs/solutions/**` (single chunk row for N agents instead of N copies): **deferred as a potential future optimization**, not a design question. See D3 — framed explicitly as "accept duplication now, optimize with real data if it ever matters."
+- Ingestion of other doc trees (`docs/adr/`, `docs/architecture/`, `docs/plans/`): out of scope. If/when needed, extend the scan path list in a small follow-up.
+- Chunk-level content-hash invalidation (vs the doc-level default): deferred, see D4 — only makes sense if specific content classes are large and frequently edited.
+
+## Context & Research
+
+### Cross-cutting conventions
+
+This plan cites `docs/architecture/kg-implementation-conventions.md` as the authoritative source for cross-cutting decisions. Sections that apply to #689:
+
+- **C1.1 (async-embedding contract):** Mandatory. Ingestion commits `kg_chunks` + `search_content` + FTS5 synchronously in a single transaction. Embeddings are generated asynchronously by the existing backfill path. Callers may see FTS5-only results in the window between ingestion commit and backfill catchup.
+- **C3.2 (observability — lexical ingestion):** Per-document audit_events (NOT per-chunk), `tool_name: "ingest_document"`, target_key `kg_chunk:<source_doc_path>`, counts in before_value/after_value.
+
+Sections C2 (non-interactive LLM) doesn't apply — #689 does no LLM calls.
+
+### #686 and #687 dependencies
+
+- **#686 schema decisions used:** `kg_chunks` shape (no `entity_id` per D9; `source_doc_hash NOT NULL` per D10; UNIQUE(agent_id, source_doc_path, seq_id) per D7; trace_id per D6).
+- **#687 dependency:** Domain rebuild must complete before per-agent lexical ingestion starts in the startup sequence. Ingestion doesn't FK into `kg_entities` directly (per D9 — no entity_id column), so this is a soft ordering rather than a hard constraint — but keeping it ordered preserves the "each layer's startup work composes cleanly" invariant for #690+'s benefit.
+
+### Relevant Code and Patterns
+
+- **Existing indexing pipeline:** `crates/mika-agent/src/db.rs:6107` (`index_content()`) — the write helper that `search_content` and `fts_search` go through for all source types. `#689` adds `source_type="kg_chunk"` as another caller. Backfill of embeddings is already hooked via startup path.
+- **`search_content` schema:** `crates/mika-agent/src/db.rs:1049-1059`. Current `source_type` values: `person`, `commitment`, `preference`, `event`. `source_id` is INTEGER; for `kg_chunk` it's `kg_chunks.id`.
+- **Embedding client:** `crates/mika-common/src/embedding.rs`. OpenAI text-embedding-3-small, 512 dims. Not called directly by #689 — embeddings land via backfill.
+- **No existing `unindex_content()`:** grep for `unindex_content` returns nothing. #689 introduces it as a symmetric helper to `index_content()`. Delete-from-kg_chunks path uses it to also delete from search_content + fts_search + vec_search in the same transaction.
+- **Solution-doc structure:** `docs/solutions/**/*.md` files have YAML frontmatter (title, category, date, tags, severity, modules_affected) followed by `---` separator and markdown body with `##` section headers. Sample: `docs/solutions/database-issues/iso8601-timestamp-migration.md`.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md` — Sole-writer designation: #689 is the sole writer of `kg_chunks` rows and of `source_type="kg_chunk"` entries in `search_content`. No other path should write these.
+- `docs/solutions/database-issues/iso8601-timestamp-migration.md` — ISO 8601 timestamps; all `created_at` columns use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')`.
+- `docs/solutions/database-issues/trace-id-as-observability-join-key.md` — One trace_id per ingestion invocation; stamped on every `kg_chunks` row in that batch for post-hoc investigation.
+- `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — Column list constants, no `SELECT *`. `KG_CHUNK_COLUMNS` lives in `kg_schema.rs` from #686.
+- `docs/solutions/logic-errors/startup-backfill-skips-embedding-generation.md` — Backfill is idempotent by `embedding_json IS NULL`; any new `source_type` inherits the existing backfill path automatically.
+
+## Key Technical Decisions
+
+### D1. Startup scan per agent + compound hook (authoring agent only)
+
+Per Vincent's feedback on the trigger model. On server startup, after `apply_overrides()` and after #687's domain rebuild completes, for each agent in `agent_configs`: scan `docs/solutions/**/*.md`, chunk new/changed docs (per D4 idempotency), write chunks.
+
+Additionally: `/ce:compound` writes a doc → the compound handler invokes ingestion for **the authoring agent only**. This keeps freshly-compounded lessons immediately queryable by the agent that just wrote them without waiting for restart. Peer agents see the new doc at next restart (bounded staleness per #687 D4 pattern).
+
+Failure policy for compound hook: **fail-silently with warn log**. If the ingestion call fails (DB error, whatever), log `warn!(event="compound_ingest_failed", doc=<path>, error=%e)` and continue. The doc is on disk and will be picked up at next restart, so ingestion is eventually consistent. The authoring agent's UX tolerates "the doc I just wrote isn't searchable yet, but will be after restart at latest" — acceptable per the C1.1 best-effort policy.
+
+### D2. Chunking: 2000 chars, 200 overlap, markdown-aware boundaries
+
+Per ticket body. Chunker:
+1. Splits on frontmatter-ending `---` first (so frontmatter is its own chunk or merged with the preamble).
+2. Within body, splits on `##` section headers.
+3. Further splits any section over 2000 chars into windows of 2000 with 200-char overlap.
+4. Assigns monotonic `seq_id` starting at 0 for each doc.
+
+Chunking is deterministic: same input → same chunks. This is load-bearing for D4's content-hash idempotency (changing the chunker algorithm requires re-ingestion of all existing docs; chunker stability is part of the write contract).
+
+Chunker lives in a standalone module (`crates/mika-agent/src/kg/chunker.rs`). No external dependencies beyond `regex` (already in Cargo.toml).
+
+### D3. Per-agent ingestion of shared docs: accept duplication, instrument for future data
+
+Per #686 D1, `kg_chunks.agent_id` is NOT NULL. For `docs/solutions/**/*.md` (shared docs on disk), every agent gets its own chunk rows — N copies of byte-identical text, N embeddings.
+
+**This is accepted as current behavior, not defended as the final architecture.** The embedding cost is trivial (~$0.02 for 200 docs × 500 tokens × 10 agents = 1M tokens at $0.02/1M). Storage is similarly cheap. The system stays architecturally simple — every chunk query is a single agent-scoped lookup, no special cases.
+
+**Framed as a deferred optimization, not an architectural position.** If KG storage or embedding cost ever surfaces as a real problem (e.g., container scales to 100+ agents, or solution-doc tree grows 10x), the optimization is to make `agent_id` nullable and treat NULL as "shared chunk, visible to all agents." That's a #686-schema-level change, not a #689 concern, and should be driven by actual usage data rather than speculation.
+
+Observability hook (per R8, C3.2): every per-agent ingestion run logs `event=ingest_duration agent=<id> chunks_added=<N> chunks_deleted=<M> docs_scanned=<K> duration_ms=<T>`. These numbers are the input to the future optimization decision, if it ever becomes one.
+
+### D4. Doc-level content-hash idempotency
+
+Per #686 D10, `kg_chunks.source_doc_hash TEXT NOT NULL` stores a SHA-256 hash of the source doc content after normalization:
+
+1. Strip UTF-8 BOM if present.
+2. Normalize line endings to LF (replace `\r\n` and `\r` with `\n`).
+3. Strip trailing whitespace from each line.
+4. Enforce single trailing newline (strip all trailing `\n`, then append exactly one).
+5. SHA-256 over the normalized byte sequence.
+
+Algorithm per doc on ingestion:
+
+1. Read doc from disk, normalize, compute hash.
+2. Query: `SELECT DISTINCT source_doc_hash FROM kg_chunks WHERE agent_id = ? AND source_doc_path = ?`.
+3. If result is `{computed_hash}` (single match) → skip: doc is unchanged.
+4. If result is `{}` → new doc, proceed to chunk + ingest.
+5. If result is `{different_hash}` or multiple hashes (shouldn't happen given UNIQUE, but defensive) → delete all chunks for (agent_id, source_doc_path), chunk, re-insert.
+
+**Doc-level granularity (not chunk-level)** chosen deliberately. Chunk-level would only re-embed actually-changed chunks but requires stable chunk boundaries across runs, which any chunking change would break. Doc-level is robust to chunker updates. If a future doc class is very large with localized edits (unlikely for solution docs at 100-500 lines), chunk-level invalidation is the optimization at that point.
+
+### D5. Chunk → domain entity linkage is NOT #689's concern
+
+Per #686 D9, `kg_chunks` has no `entity_id` column. #689 writes chunks with no knowledge of domain entities. Chunk → domain entity linkage goes through:
+
+```
+kg_chunks → kg_subject_entities (extracted by #690) → kg_subject_resolutions (linked by #691) → kg_entities
+```
+
+This is the canonical query path for "chunks about skill X." Any shortcut at ingestion time (frontmatter hints, path heuristics) is rejected: #689 does lexical ingestion, not domain inference. That's an architectural invariant, not a YAGNI punt.
+
+**Guidance to #688 (query tool):** queries like "show me chunks about skill:self-dev" use the multi-hop JOIN described above. All joins are on indexed columns; at agent-scoped cardinality, SQLite handles this efficiently.
+
+### D6. Deletion handling: prune chunks for docs removed from disk
+
+After the per-agent scan-and-ingest pass, #689 prunes chunks whose `source_doc_path` no longer exists on disk:
+
+```sql
+-- pseudocode
+on_disk = {path for path in glob("docs/solutions/**/*.md")}
+in_db = SELECT DISTINCT source_doc_path FROM kg_chunks WHERE agent_id = ?
+to_delete = in_db - on_disk
+for path in to_delete:
+    DELETE FROM kg_chunks WHERE agent_id = ? AND source_doc_path = ?
+    (+ unindex_content calls — see D7)
+```
+
+Runs in the same transaction as the ingestion writes. Mid-run failure leaves a consistent pre-run state.
+
+Matches #687's prune semantics (entity pruning by source presence). The ingestor owns its namespace (`kg_chunks` rows sourced from the solution-docs tree for its agent), and is responsible for cleaning up within that namespace.
+
+### D7. Delete-composition contract: symmetric to C1.1
+
+C1.1 defines the write contract: `INSERT kg_chunks → index_content()`. The delete contract is symmetric:
+
+```
+DELETE kg_chunks → unindex_content(source_type="kg_chunk", source_id=<kg_chunks.id>)
+```
+
+`unindex_content()` is a new helper (mirror of `index_content()`) that #689 introduces:
+
+```rust
+pub fn unindex_content(&self, source_type: &str, source_id: i64) -> Result<()>;
+```
+
+It deletes the `search_content` row for the given `(source_type, source_id)` and removes the corresponding FTS5 entry. The `vec_search` row is keyed by `search_content.id` (rowid), so it's pruned by the FK-less design of FTS5-external-content: the vec_search row remains as an orphan keyed on a now-deleted rowid, but vec_search doesn't reference back so this is benign (the vec row is unreferenced and can be pruned by a periodic GC or left alone — embeddings without a search_content row are never returned by `hybrid_search` because the join filters them).
+
+Both `index_content()` and `unindex_content()` must run within the same transaction as the `kg_chunks` INSERT/DELETE for atomicity.
+
+### D8. Order in startup sequence: after #687 domain rebuild
+
+Startup call order:
+
+```
+SkillRegistry::from_dir() → apply_overrides() → validate_loaded() → log_summary()
+    → DomainGraphBuilder.rebuild() [from #687]
+    → for each agent in agent_configs: LexicalIngestor.ingest_all(agent_id) [this ticket]
+    → [future] SubjectExtractor.run(agent_id) [from #690]
+```
+
+Hard ordering between #687 and #689 isn't required by FK (per D5 there's no direct FK between chunks and entities), but keeping the order preserves the "each KG layer's startup work completes before the next starts" invariant that downstream tickets assume. Document this as a startup sequence constraint in `server/mod.rs`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Trigger model (startup scan + compound hook for authoring agent; see D1).
+- Chunking strategy (2000/200 overlap with markdown boundaries; see D2).
+- Per-agent duplication of shared docs (accept, instrument, defer optimization; see D3).
+- Content-change detection (doc-level SHA-256 with normalization; see D4).
+- Chunk → domain linkage (deferred to #690/#691 pipeline; see D5).
+- Deletion handling (prune chunks for removed docs; see D6).
+- Delete-composition contract (`unindex_content()` helper, same transaction; see D7).
+- Startup ordering (after #687 domain rebuild; see D8).
+- Compound hook failure semantics (fail-silently with warn log; see D1).
+
+### Deferred to Implementation
+
+- Exact scan-path list (today: `docs/solutions/**/*.md`; may extend to `docs/adr/` / `docs/architecture/` in a later ticket if usage shows value).
+- Whether `search_content.source_id` can hold the kg_chunks INTEGER id directly without any adapter (should — both are INTEGER). Verify in Unit 2.
+- Compound doc detection: does `/ce:compound` always land files in `docs/solutions/`, or are there subdirectory conventions we should trigger on? Probably same tree; confirm during implementation.
+
+## Output Structure
+
+```
+crates/mika-agent/src/
+├── db.rs                            # ADD: unindex_content() helper (mirror of index_content)
+├── db/kg_schema.rs                  # REFERENCE: KG_CHUNK_COLUMNS, KG_CHUNK_SOURCE_TYPE from #686
+└── kg/
+    ├── mod.rs                       # MODIFY: add `pub mod chunker; pub mod lexical_ingestor;`
+    ├── domain_builder.rs            # (from #687 — unchanged)
+    ├── chunker.rs                   # NEW: deterministic markdown-aware chunker
+    └── lexical_ingestor.rs          # NEW: scan, hash, chunk, write
+
+crates/mika-agent/src/server/
+└── mod.rs                           # MODIFY: call LexicalIngestor after DomainGraphBuilder
+
+crates/mika-agent/tests/
+└── kg/
+    ├── chunker.rs                   # NEW: chunker determinism + boundary tests
+    └── lexical_ingestor.rs          # NEW: ingestion integration tests
+
+docs/plans/
+└── 2026-04-21-005-feat-lexical-ingestion-plan.md   # this file
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Deterministic markdown-aware chunker**
+
+**Goal:** Produce `fn chunk_doc(text: &str) -> Vec<Chunk>` that splits on `---` and `##` with 2000/200-char window fallback. Deterministic — same input always produces the same output.
+
+**Requirements:** R3.
+
+**Dependencies:** None (pure library code).
+
+**Files:**
+- Create: `crates/mika-agent/src/kg/chunker.rs`
+- Test: inline `#[cfg(test)] mod tests`
+
+**Approach:**
+- `pub struct Chunk { pub seq_id: u32, pub text: String }`.
+- Algorithm: split on frontmatter fence (`^---` lines separating YAML from body), then on `## ` section headers within the body. For sections exceeding 2000 chars, slide a 2000-char window with 200-char overlap.
+- Pure function: no I/O, no DB, no side effects. Takes `&str`, returns `Vec<Chunk>`.
+- Unicode-safe: count chars, not bytes. Overlap boundary respects UTF-8 char boundaries (split at the nearest prior char boundary if byte count exceeds 2000).
+
+**Test scenarios:**
+- Happy path: small doc (<2000 chars) with no `##` → one chunk containing the whole body.
+- Section split: doc with 3 `## ` sections, each under 2000 chars → 3 chunks.
+- Window split: one section exceeds 2000 chars → multiple chunks with 200-char overlap.
+- Frontmatter handling: doc with YAML frontmatter → frontmatter is chunk 0, sections start at seq_id 1 (or whatever the spec lands on — document the choice).
+- Determinism: same input yields same Vec<Chunk> (important for D4 content-hash idempotency).
+- UTF-8 edge: chunk boundary falls mid-multibyte-char → chunker backs off to previous char boundary, no panic.
+- Empty doc: returns empty Vec<Chunk>, no error.
+
+**Verification:** `cargo test -p mika-agent kg::chunker` green.
+
+---
+
+- [ ] **Unit 2: `unindex_content` helper**
+
+**Goal:** Add the symmetric delete helper to `index_content()`. `#689`'s delete path and any future ticket that wants to remove indexed content uses it.
+
+**Requirements:** R5, R7 (delete-composition contract).
+
+**Dependencies:** None (uses existing db.rs infrastructure).
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs`
+- Modify: `crates/mika-agent/src/async_db.rs` (wrap in AsyncDatabase closure, same pattern as `index_content`)
+
+**Approach:**
+- `pub fn unindex_content(&self, source_type: &str, source_id: i64) -> Result<()>` in `db.rs`:
+  - `DELETE FROM fts_search WHERE rowid = (SELECT id FROM search_content WHERE source_type = ? AND source_id = ?)` — FTS5 external-content model requires explicit delete.
+  - `DELETE FROM search_content WHERE source_type = ? AND source_id = ?`.
+  - `vec_search` rows are orphaned by design (no FK to delete against) — leave them; `hybrid_search` joins through `search_content` so orphan vec rows never surface.
+- All statements in one transaction (caller's responsibility if they wrap multiple unindex calls; single-call use is atomic on its own).
+- `AsyncDatabase::unindex_content()` thin wrapper for the async callers.
+
+**Test scenarios:**
+- Happy path: index content, then unindex → subsequent `fts_search` MATCH returns zero rows; `search_content` row is gone.
+- Idempotency: unindex a non-existent (source_type, source_id) → no error, no-op.
+- Isolation: unindex source_type="kg_chunk", source_id=X → person/commitment/preference/event rows with the same numeric source_id are untouched.
+
+**Verification:** `cargo test -p mika-agent db::unindex_content` green.
+
+---
+
+- [ ] **Unit 3: LexicalIngestor core — scan, hash, chunk, write**
+
+**Goal:** Implement `LexicalIngestor::ingest_all(agent_id) -> Result<IngestStats>`. Owns the per-agent ingestion run for the full `docs/solutions/**/*.md` tree.
+
+**Requirements:** R1, R3, R4, R6, R8.
+
+**Dependencies:** Units 1 and 2, #686 schema landed, #687 domain rebuild runs before this.
+
+**Files:**
+- Create: `crates/mika-agent/src/kg/lexical_ingestor.rs`
+- Modify: `crates/mika-agent/src/kg/mod.rs` (add `pub mod lexical_ingestor;`)
+
+**Approach:**
+- Struct `LexicalIngestor { db: &AsyncDatabase, docs_root: PathBuf, trace_id: String }`.
+- `fn normalize_content(raw: &[u8]) -> String`: strips BOM, normalizes line endings to LF, strips per-line trailing whitespace, enforces single trailing newline. Return UTF-8 String.
+- `fn compute_hash(normalized: &str) -> String`: hex-encoded SHA-256.
+- `async fn ingest_all(&self, agent_id: &str) -> Result<IngestStats>`:
+  1. Walk `docs_root` for `*.md` files.
+  2. For each file: read, normalize, compute hash.
+  3. Query DB: is there an existing `kg_chunks` row for `(agent_id, path)` with matching hash? If yes → skip. If different hash or no rows → `delete_doc_chunks` then `insert_doc_chunks`.
+  4. After all files processed, `prune_removed_docs(agent_id, on_disk_paths)`.
+  5. Return `IngestStats { docs_scanned, docs_skipped_unchanged, docs_reingested, docs_pruned, chunks_added, chunks_deleted, duration_ms }`.
+- `async fn insert_doc_chunks(&self, agent_id, path, hash, chunks)`: one transaction — for each chunk, INSERT `kg_chunks` row, then `index_content(source_type="kg_chunk", source_id=<inserted rowid>, text=chunk.text)`. Per C1.1, embeddings are NOT awaited here.
+- `async fn delete_doc_chunks(&self, agent_id, path)`: one transaction — SELECT ids, loop calling `unindex_content` for each, then DELETE from kg_chunks.
+- `async fn prune_removed_docs(&self, agent_id, on_disk_paths)`: one transaction — find DB-tracked paths not in `on_disk_paths`, delete those docs' chunks via `delete_doc_chunks`.
+- `async fn ingest_single_doc(&self, agent_id, path) -> Result<DocStats>`: called by the compound hook — hashes, compares, ingests if changed. Shares the hash-and-write code with `ingest_all`.
+
+**Patterns to follow:**
+- AsyncDatabase closure pattern for transactional writes.
+- `index_content` call shape from `db.rs:6107`.
+
+**Test scenarios:**
+- Happy path: empty DB, 3 docs on disk → all 3 ingested, returned stats match.
+- Idempotency: run twice with identical tree → second run scans 3, skips 3, chunks_added=0.
+- Change detection: edit one doc, re-run → 1 reingested (delete+reinsert chunks), 2 skipped.
+- Normalization: doc with CRLF line endings → hash matches LF-normalized version on subsequent LF save; no false-positive re-ingest.
+- Deletion: run ingest, delete a doc file, re-run → doc's chunks pruned, stats report docs_pruned=1.
+- Transactional failure: inject DB error mid-ingestion → no partial state; all rollback.
+- Cross-agent isolation: ingest for agent A, then agent B, same docs → each agent has their own chunk rows, no cross-contamination.
+
+**Verification:** `cargo test -p mika-agent --test kg` suite green.
+
+---
+
+- [ ] **Unit 4: Startup integration**
+
+**Goal:** Hook `LexicalIngestor::ingest_all` into the server startup sequence, per-agent, after #687's domain rebuild.
+
+**Requirements:** R1, R7, R8.
+
+**Dependencies:** Units 1–3; #687 integration landed.
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/mod.rs`
+
+**Approach:**
+- After the existing `DomainGraphBuilder.rebuild()` call (from #687), iterate `agent_configs`. For each agent: construct a `LexicalIngestor` with a fresh trace_id, call `ingest_all(agent_id).await`. On `Ok(stats)`, log `info!(event="lexical_ingest_complete", agent_id=%agent_id, ?stats)`. On `Err(e)`, log `warn!(event="lexical_ingest_failed", agent_id=%agent_id, error=%e)` and continue to the next agent.
+- Order is strictly after `DomainGraphBuilder.rebuild()`; document with a code comment.
+- Failure policy: per-agent failure does not abort startup; other agents still ingest.
+
+**Test scenarios:**
+- Integration: start server in test mode with 2 mock agents and 3 solution docs → post-startup, both agents have 3 docs' worth of chunks.
+- Failure isolation: inject DB error for agent A only → agent B still ingests successfully; server startup completes.
+
+**Verification:** `cargo test -p mika-agent --test startup_kg_integration` green.
+
+---
+
+- [ ] **Unit 5: Compound hook**
+
+**Goal:** Add a public entry point the `/ce:compound` skill handler can call to trigger immediate single-doc ingestion for the authoring agent.
+
+**Requirements:** R2.
+
+**Dependencies:** Units 1–3.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/lexical_ingestor.rs` — expose `ingest_single_doc(agent_id, path)` (from Unit 3) as the entry point.
+- Identify the call site in the `/ce:compound` skill handler or the post-write hook and wire up. (Location TBD during implementation — depends on where compound docs land and what mechanism exists for post-write hooks. If no hook mechanism exists, the compound handler explicitly calls into the ingestor after writing the file.)
+
+**Approach:**
+- Caller passes `(agent_id, absolute_path_of_compound_doc)`.
+- Ingestor does the same hash-check + ingest-if-changed logic as the bulk path.
+- Returns `Result<()>`. Caller logs on error but does not fail the compound operation itself.
+- Per D1, failure is fail-silently-with-warn-log — the authoring agent gets "your doc is saved; search will pick it up after next restart at latest."
+
+**Test scenarios:**
+- Happy path: compound writes a new doc → hook ingests it → doc is queryable via FTS5 immediately.
+- Pre-existing doc (content unchanged via this run) → no-op, fast.
+- Compound content changed (e.g., retroactive edit) → delete+reinsert chunks.
+- Failure path: inject DB error during compound ingestion → hook returns Err, compound skill logs warn, doc remains on disk and will ingest at next startup.
+
+**Verification:** Unit test + manual check via `/ce:compound` smoke test after wiring.
+
+---
+
+- [ ] **Unit 6: Audit event emission (per C3.2)**
+
+**Goal:** Per C3.2 in the conventions doc, emit `tool_name=ingest_document` audit_events at per-document granularity.
+
+**Requirements:** R8.
+
+**Dependencies:** Unit 3.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/lexical_ingestor.rs`
+
+**Approach:**
+- After successfully ingesting (or skipping, or reingesting) each doc, call the audit_events write path with:
+  - `tool_name="ingest_document"`
+  - `target_key="kg_chunk:<source_doc_path>"`
+  - `before_value=json!({"chunks_existed": <pre-count>, "prior_hash": <prior or null>})`
+  - `after_value=json!({"chunks_now": <post-count>, "new_hash": <new>})`
+  - `reasoning=json!({"source": "startup_scan" | "compound_hook", "outcome": "inserted" | "skipped" | "reingested"})`
+  - `trace_id` from the ingestor invocation.
+- **No audit_events for prune operations on their own** — deletions happen as part of a reingestion (included in the reingest's audit event) or as part of the end-of-run prune (which emits one audit event per pruned doc with outcome="pruned").
+
+**Test scenarios:**
+- New doc ingested → one audit_events row with outcome="inserted", chunks_now > 0.
+- Unchanged doc → one row with outcome="skipped", chunks_now == chunks_existed, new_hash == prior_hash.
+- Changed doc → one row with outcome="reingested", prior_hash != new_hash.
+- Removed doc (pruned) → one row with outcome="pruned", chunks_now=0.
+- Row count invariant: ingestion run over N docs produces exactly N audit_events rows.
+
+**Verification:** Unit test inspects audit_events after various ingestion scenarios.
+
+## System-Wide Impact
+
+- **Interaction graph:** New startup hook after #687; new compound-handler hook. No changes to agent loop, tool handlers, or webhook handlers. `search_memory` tool already works with the shared `search_content`/`fts_search`/`vec_search` infrastructure — ingesting `source_type="kg_chunk"` rows makes them searchable automatically.
+- **Error propagation:** Ingestion failures are `warn!` per-agent, not fatal. Server startup completes even if some or all agents' ingestion fails.
+- **State lifecycle risks:**
+  - **Delete composition without unindex_content** (if Unit 2 is skipped or broken): deleting `kg_chunks` rows leaves `search_content` + FTS5 + `vec_search` entries pointing at rowids that no longer exist → `hybrid_search` returns stale snippets with broken backlinks. Unit 2 is load-bearing.
+  - **Transactional atomicity** across `kg_chunks` INSERT + `index_content` call: per C1.1, both in one transaction. Partial writes never exposed to queries.
+  - **Compound-hook ordering**: the hook must fire AFTER the doc is written to disk, not before or during. Compound handler controls ordering; document the contract.
+- **API surface parity:** None changed. No new tools, no endpoints, no CLI subcommands.
+- **Integration coverage:** Unit 3's integration suite and Unit 4's startup integration test cover the pipeline end-to-end.
+- **Unchanged invariants:** `index_content()`, `hybrid_search()`, `search_memory` tool, `search_content` table shape, embedding backfill — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Unit 2's `unindex_content` is skipped or broken → orphan FTS/search_content rows | Unit 3's tests verify post-delete queries return zero rows for deleted doc paths. Unit 2 has its own isolation test. |
+| Chunker non-determinism breaks content-hash idempotency | Unit 1 has an explicit determinism test (same input → same Vec<Chunk>). Chunker is pure function, no I/O. |
+| Hash normalization misses an edge case (e.g., Unicode normalization forms NFC vs NFD) | Start with the documented 4-step normalization (BOM / line endings / trailing ws / trailing newline). If false-positive re-ingestions appear in logs (D3 observability), extend normalization as needed. NFC is a plausible later addition. |
+| Per-agent duplication at scale (100+ agents) becomes a real storage problem | Accept per D3, instrument per D3 (duration + chunk count logging), optimize later with real data. Not a #689 concern unless it's observed at implementation time. |
+| Compound hook races with other writers (two compounds in quick succession) | `kg_chunks` UNIQUE(agent_id, source_doc_path, seq_id) prevents dup-inserts. Two hooks for the same doc ingest serially via the AsyncDatabase write thread. |
+| Very large docs exceed single-transaction limits | SQLite supports multi-MB transactions trivially. A 10MB doc → ~5000 chunks × ~2000 bytes ≈ 10MB write. Well within limits. If this ever becomes an issue, split ingestion into per-doc transactions. |
+| Docs tree has non-markdown files that happen to have `.md` extension but aren't conventional | Chunker handles any UTF-8 text; invalid UTF-8 files would fail the normalize step and log a warn. Non-fatal. |
+
+## Documentation / Operational Notes
+
+- Compound skill documentation may need a line about "written docs become searchable via KG after the next handler invocation, or immediately if the compound hook is wired." Defer until #692's doc pass.
+- Ingestion duration logs (from Unit 4) are the operational signal for "is KG healthy." If durations exceed 10s per agent on startup, investigate.
+- No migration in #689 itself — all schema comes from #686. This ticket is code-only plus docs.
+
+## Sources & References
+
+- **Origin ticket:** [mika#689](https://github.com/senara-solutions/mika/issues/689)
+- **Milestone:** [mika milestone#14 "Knowledge Graph"](https://github.com/senara-solutions/mika/milestone/14)
+- **Depends on:** [mika#686 (schema, D9/D10 amendments)](https://github.com/senara-solutions/mika/issues/686), [mika#687 (domain rebuild)](https://github.com/senara-solutions/mika/issues/687)
+- **Cross-cutting conventions:** [`docs/architecture/kg-implementation-conventions.md`](../architecture/kg-implementation-conventions.md) (C1.1, C3.2 apply)
+- **ID convention:** [`docs/architecture/kg-id-convention.md`](../architecture/kg-id-convention.md)
+- **Related code:**
+  - `crates/mika-agent/src/db.rs:6107` — `index_content()`
+  - `crates/mika-agent/src/db.rs:1049-1059` — `search_content` schema
+  - `crates/mika-agent/src/kg/domain_builder.rs` — #687, runs before this
+  - `crates/mika-common/src/embedding.rs` — embedding pipeline (not called directly)
+- **Institutional learnings:**
+  - `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md`
+  - `docs/solutions/database-issues/iso8601-timestamp-migration.md`
+  - `docs/solutions/database-issues/trace-id-as-observability-join-key.md`
+  - `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md`
+  - `docs/solutions/logic-errors/startup-backfill-skips-embedding-generation.md`

--- a/docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md
+++ b/docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md
@@ -1,0 +1,85 @@
+---
+title: "KG lexical ingestion: composed write contract and transactional atomicity"
+module: kg
+date: 2026-04-22
+problem_type: best_practice
+component: database
+severity: medium
+applies_when:
+  - "Adding a new KG layer that writes to kg_chunks + search_content"
+  - "Implementing content-hash idempotency with delete-before-reinsert"
+  - "Writing startup ingestion hooks that run per-agent"
+tags:
+  - knowledge-graph
+  - lexical-ingestion
+  - composed-write
+  - transactional-atomicity
+  - search-content
+  - idempotency
+---
+
+# KG lexical ingestion: composed write contract and transactional atomicity
+
+## Context
+
+The KG lexical layer (#689) ingests `docs/solutions/**/*.md` per agent into `kg_chunks` + `search_content` with content-hash idempotency. The implementation surfaced several architectural patterns that apply to any future KG layer writer (subject extraction #690, entity resolution #691).
+
+## Guidance
+
+### Single-transaction composed writes
+
+The hash check, delete of old chunks, and insert of new chunks **must happen in a single `with_db` closure** to prevent a flash-of-empty window where concurrent readers see zero chunks for a doc that's being re-ingested.
+
+Wrong (two separate transactions):
+```
+let deleted = self.delete_doc_chunks(&path).await?;  // Transaction 1
+self.db.with_db(move |db| { /* insert */ }).await?;   // Transaction 2
+// Reader between T1 and T2 sees zero chunks!
+```
+
+Right (single transaction):
+```
+self.db.with_db(move |db| {
+    let tx = db.conn.unchecked_transaction()?;
+    // 1. Hash check
+    // 2. Delete old chunks + search_content cleanup
+    // 3. Insert new chunks + index_content
+    tx.commit()?;
+    Ok(())
+}).await?;
+```
+
+### Use `db.delete_search_content()` for symmetric cleanup
+
+When deleting chunks, use the canonical `Database::delete_search_content()` method instead of manually replicating the SQL for `search_content` + `fts_search` + `vec_search` cleanup. This ensures future search table additions are automatically covered.
+
+### Always delete when chunks exist (not just when hash matches)
+
+When the DB has chunks for a doc but the hash check returns multiple distinct hashes (corruption/invariant violation), always delete before re-inserting. Skipping the delete causes UNIQUE constraint failures and chunk accumulation.
+
+### `unchecked_transaction` + `db.conn` writes
+
+`db.conn.unchecked_transaction()` returns a `Transaction` that wraps the same connection. Writes through `db.conn` (e.g., `db.index_content()`) are inside the transaction because SQLite uses a single-connection model. Document this invariant with a `// SAFETY:` comment when mixing `tx.execute()` and `db.method()` calls.
+
+### Empty-doc cleanup
+
+When a doc normalizes to empty content (whitespace-only file), still check for and delete any stale chunks from a previous run where the doc had content. Don't just return "skipped" without cleanup.
+
+## Why This Matters
+
+The lexical layer is the first per-agent KG writer. Subject extraction (#690) and entity resolution (#691) will follow the same patterns. Getting the transactional contract right here prevents each downstream ticket from re-discovering the same pitfalls.
+
+The flash-of-empty bug is particularly subtle because it only manifests under concurrent access — startup ingestion of one agent while another agent's search query is in flight, or compound hook ingestion racing with a user query. It won't show up in serial unit tests.
+
+## When to Apply
+
+- Implementing any new KG layer writer (kg_chunks, kg_subject_entities, etc.)
+- Adding composed writes that span `kg_*` tables and `search_content`
+- Implementing content-hash idempotency with delete-before-reinsert patterns
+
+## Examples
+
+See `crates/mika-agent/src/kg/lexical_ingestor.rs` for the canonical implementation. Key methods:
+- `ingest_single_doc_inner()` — single-transaction hash check + delete + insert
+- `delete_doc_chunks()` — symmetric cleanup using `db.delete_search_content()`
+- `normalize_content()` + `compute_hash()` — content normalization for idempotent hashing


### PR DESCRIPTION
## Summary

Implements the lexical layer of the Knowledge Graph (milestone #14, ticket #689). Per-agent ingestion of `docs/solutions/**/*.md` into `kg_chunks` + `search_content` with:

- **Markdown-aware chunking**: 2000-char windows with 200-char overlap, split on frontmatter `---` and `## ` section headers
- **Content-hash idempotency**: SHA-256 over normalized content (BOM strip, LF normalization, trailing-ws strip) — unchanged docs are skipped on re-run
- **Composed transactional writes**: hash check → delete old chunks → insert new chunks → index for FTS, all in a single `with_db` transaction (no flash-of-empty window)
- **Symmetric delete cleanup**: uses `db.delete_search_content()` to clean up `search_content` + `fts_search` + `vec_search` atomically
- **Startup integration**: runs per-agent after domain graph rebuild (#687)
- **Compound hook entry point**: `ingest_single_doc()` for immediate ingestion of freshly-written docs
- **Per-document audit events**: `tool_name=ingest_document` per C3.2 conventions

### New files
- `crates/mika-agent/src/kg/chunker.rs` — deterministic pure-function chunker (7 tests)
- `crates/mika-agent/src/kg/lexical_ingestor.rs` — scan, hash, chunk, write pipeline (7 tests)

### Modified files
- `crates/mika-agent/src/kg/mod.rs` — export new modules
- `crates/mika-agent/src/server/mod.rs` — startup hook after domain rebuild
- `crates/mika-agent/Cargo.toml` — add `sha2` dependency

### Design decisions
- Uses existing `delete_search_content()` instead of creating a new `unindex_content()` helper (Unit 2)
- Single `with_db` transaction for delete+insert prevents concurrent reader visibility gaps
- Always deletes existing chunks before re-inserting, even with inconsistent hashes (corruption recovery)
- Empty-after-normalization docs trigger cleanup of stale chunks

Closes #689

## Test plan

- [x] `cargo test -p mika-agent --lib -- chunker` — 7 tests (happy path, section split, window split, frontmatter, determinism, UTF-8, empty doc)
- [x] `cargo test -p mika-agent --lib -- lexical_ingestor` — 7 tests (BOM strip, CRLF/CR normalization, trailing ws, trailing newline, hash determinism)
- [x] `cargo test -p mika-agent --lib` — all 1977 tests pass
- [x] `cargo clippy -p mika-agent` — no warnings
- [x] `cargo fmt -p mika-agent` — clean
- [ ] Integration tests for full ingest_all pipeline (idempotency, change detection, pruning, cross-agent isolation) — deferred to follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)