### PR TITLE
feat(kg): subject graph extraction — LLM-based NER + fact triples (#690)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # Brave Search API key for web search skill (optional; get free key at brave.com/search/api)
 # MIKA_BRAVE_API_KEY=BSA...
 
+# ── Knowledge Graph LLM (optional) ──
+# Shared fallback model for KG extraction and resolution. Format: provider/model
+# MIKA_KG_INGESTION_MODEL=anthropic/claude-haiku-4-5-20251001
+# Model for NER + fact-triple extraction (#690). Falls back to KG_INGESTION_MODEL.
+# MIKA_KG_EXTRACTION_MODEL=anthropic/claude-haiku-4-5-20251001
+
 # ── Provider Selection ──
 # Set in config.toml (not here): llm_provider = "anthropic"
 # Available: anthropic, openai, openrouter, groq, ollama, mistral, google, deepseek

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ For detailed architecture of each subsystem, see the crate-level CLAUDE.md files
 - **HTTP server (mika-server)** — Axum, two auth layers, embedded dashboard. See `crates/mika-agent/CLAUDE.md`.
 - **Gateway** — Telegram + GitHub webhook routing, A2A proxy, Postgres. See `crates/mika-gateway/CLAUDE.md`.
 - **A2A protocol** — v0.3, JSON-RPC, task state machine. See `crates/mika-a2a/CLAUDE.md`.
-- **Knowledge Graph** — Three-layer KG (domain/lexical/subject) in SQLite. Domain graph builder runs at startup, deterministically projecting skills, tools, agents, and problem types into `kg_entities`/`kg_relationships`. See `crates/mika-agent/CLAUDE.md`.
+- **Knowledge Graph** — Three-layer KG (domain/lexical/subject) in SQLite. Domain graph builder (deterministic, startup) projects skills/tools/agents/problem_types into `kg_entities`/`kg_relationships`. Lexical ingestor (#689) chunks `docs/solutions/**/*.md` per-agent into `kg_chunks` + FTS5/vec search. Subject extractor (#690) runs LLM-based NER to extract entities and fact triples from chunks into `kg_subject_entities`/`kg_subject_relationships` with provenance tracking. Extraction runs async at startup (background per-agent) and sync on compound hook. See `crates/mika-agent/CLAUDE.md`.
 - **Docker images:** Multi-stage builds with BuildKit cache. `Dockerfile.agent` (95MB) for per-customer containers. `Dockerfile.gateway` for the stateless gateway. Both use rustls, non-root user `mika` (UID 1000). Release profile: LTO + strip. `docker-compose.yml` defines agent, gateway, and postgres services. **Host dependency:** `jq` is required by all skill handler scripts.
 - **CI/CD:** Four GitHub Actions workflows: `ci.yml` (PR checks), `release-plz.yml` (versioning/changelog), `release.yml` (cross-platform binaries), `publish-ui.yml` (`@senara-solutions/ui` to GitHub Packages). All actions pinned to commit SHAs.
 
@@ -109,6 +109,10 @@ See `.env.example` for the full list. Per-provider API keys (set the one for you
 
 Optional (web search):
 - `MIKA_BRAVE_API_KEY` — Brave Search API key for `web_search` builtin skill (get free key at https://brave.com/search/api/)
+
+Optional (Knowledge Graph LLM):
+- `MIKA_KG_INGESTION_MODEL` — Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled.
+- `MIKA_KG_EXTRACTION_MODEL` — Model for NER + fact-triple extraction (#690). Falls back to `MIKA_KG_INGESTION_MODEL` if unset. Task is mechanical JSON extraction — cheap/fast tier recommended.
 
 Optional (GitHub App — preferred over PAT for agent operations):
 - `MIKA_GITHUB_APP_ID` — GitHub App ID (u64). Required for GitHub App authentication.

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -155,6 +155,24 @@ Connects to external MCP servers at startup via `McpManager`. Configured in `{ag
 
 **Cross-cutting conventions:** See `docs/architecture/kg-implementation-conventions.md` (C1–C3) and `docs/architecture/kg-id-convention.md` for the `<type>:<name>` entity key format.
 
+## Knowledge Graph — Subject Extractor
+
+`src/kg/subject_extractor.rs` — Per-agent LLM-based extraction of named entities and fact triples from previously-ingested documents (#690). Uses constrained NER with approved entity/relationship types and structural validation (not just prompt-based).
+
+**Approved entity types:** `skill`, `tool`, `agent`, `problem_type`, `solution_path`, `failure_mode`, `pattern`. **Approved relationship types:** `SOLVED_BY`, `USES`, `CALLS`, `INDICATES`, `PREVENTS`, `CAUSED_BY`, `MENTIONS` — each with from/to type constraints enforced in code.
+
+**Sole-writer contract:** This module is the sole writer of `kg_subject_entities`, `kg_subject_relationships`, `kg_chunk_subjects`, `kg_chunk_subject_relationships`, and `kg_extractions` rows.
+
+**Execution contexts (D2):** (1) Startup: background `tokio::spawn` per agent after lexical ingestion, non-blocking. (2) Compound hook: synchronous inline after doc write via `IngestionOrchestrator`, failure non-fatal (C2.3 log-and-skip).
+
+**Extraction flow (D1, D4):** Read full doc from disk → insert `[CHUNK N]` markers at chunk boundaries → LLM call → parse/validate JSON output → UPSERT entities and relationships with provenance in single transaction.
+
+**Re-extraction (D5):** Three-phase capture → reingest → reconcile. `IngestionOrchestrator` (`src/kg/ingestion_orchestrator.rs`) coordinates #689 and #690 — neither module calls the other directly. Scoped orphan sweep deletes entities/relationships that lost all provenance after doc change.
+
+**Pending-doc detection (D7):** `kg_extractions` tracking table — one row per (agent_id, source_doc_path) recording completed extraction. Pending query: docs with `kg_chunks` rows but no `kg_extractions` row.
+
+**LLM policy (C2):** Model from `MIKA_KG_EXTRACTION_MODEL` → `MIKA_KG_INGESTION_MODEL` fallback. Retry taxonomy per C2.2 (transport: 3 attempts with backoff; semantic: one retry with prompt reinforcement; config: no retry). Log-and-skip per C2.3. `llm_calls` rows per C2.4. Audit events per C3.3.
+
 ## Silent Mode Agent Loop
 
 Background tasks (heartbeat, reminders) where text output is NOT delivered. Agent must use `send_message` tool explicitly. Separate `run_silent_agent` function with `SilentPromptContext`.

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -348,6 +348,8 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `embedding_model` | `String` | `text-embedding-3-small` | `MIKA_EMBEDDING_MODEL` | OpenAI embedding model ID. |
 | `embedding_dimensions` | `u32` | `512` | `MIKA_EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `brave_api_key` | `Option<String>` | None | `MIKA_BRAVE_API_KEY` | Brave Search API key for `web_search` builtin skill. Get a free key at https://brave.com/search/api/. |
+| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled. |
+| `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -528,6 +530,8 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |
 | `MIKA_OPENAI_API_KEY` | No | OpenAI API key (LLM + Layer 3 vector search) |
 | `MIKA_BRAVE_API_KEY` | No | Brave Search API key for web search skill |
+| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format) |
+| `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/crates/mika-agent/src/kg/ingestion_orchestrator.rs
+++ b/crates/mika-agent/src/kg/ingestion_orchestrator.rs
@@ -1,0 +1,238 @@
+//! # Ingestion Orchestrator
+//!
+//! Coordinates the lexical ingestor (#689) and subject extractor (#690).
+//! Neither module has knowledge of the other's internals — the orchestrator
+//! owns the sequencing (per D9 in the #690 plan).
+//!
+//! ## Responsibilities
+//!
+//! 1. **Compound hook** — after a doc is written, ingest chunks then extract
+//!    subjects synchronously inline.
+//! 2. **Re-extraction on doc change** — three-phase capture → reingest →
+//!    reconcile (D5).
+//!
+//! ## Sole-Writer Separation
+//!
+//! - `LexicalIngestor` is the sole writer of `kg_chunks` and `search_content`.
+//! - `SubjectExtractor` is the sole writer of `kg_subject_entities`,
+//!   `kg_subject_relationships`, and provenance tables.
+//! - This module calls both but writes nothing itself.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use tracing::{info, warn};
+
+use mika_common::llm::LlmProvider;
+
+use crate::async_db::AsyncDatabase;
+
+use super::lexical_ingestor::LexicalIngestor;
+use super::subject_extractor::SubjectExtractor;
+
+/// Coordinates lexical ingestion and subject extraction.
+///
+/// Provides the compound hook entry point and re-extraction flow.
+pub struct IngestionOrchestrator {
+    db: AsyncDatabase,
+    docs_root: PathBuf,
+    /// LLM provider for extraction. `None` when extraction is disabled
+    /// (no `MIKA_KG_EXTRACTION_MODEL` configured).
+    extraction_llm: Option<Arc<dyn LlmProvider>>,
+    trace_id: String,
+    session_id: String,
+}
+
+impl IngestionOrchestrator {
+    /// Create a new orchestrator.
+    ///
+    /// - `extraction_llm`: `None` to disable extraction (lexical ingestion
+    ///   still runs).
+    pub fn new(
+        db: AsyncDatabase,
+        docs_root: PathBuf,
+        extraction_llm: Option<Arc<dyn LlmProvider>>,
+        trace_id: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Self {
+        let trace_id = trace_id
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace('-', ""));
+        Self {
+            db,
+            docs_root,
+            extraction_llm,
+            trace_id,
+            session_id: session_id.unwrap_or("compound").to_owned(),
+        }
+    }
+
+    /// Compound hook: ingest a freshly-written document, then extract subjects.
+    ///
+    /// Called after `/ce:compound` writes a doc. Lexical ingestion is synchronous
+    /// and must succeed. Subject extraction is synchronous but failure is
+    /// non-fatal (log-and-skip per C2.3) — the doc stays pending for next
+    /// startup extraction.
+    pub async fn ingest_and_extract(&self, abs_path: &Path) -> Result<CompoundResult> {
+        let agent_id = self.db.agent_id.clone();
+
+        // 1. Lexical ingestion (synchronous, must succeed).
+        let ingestor = LexicalIngestor::new(
+            self.db.clone(),
+            self.docs_root.clone(),
+            Some(&self.trace_id),
+        )
+        .with_session(&self.session_id);
+
+        let ingest_stats = ingestor.ingest_single_doc(abs_path).await?;
+
+        let rel_path = self.relative_path(abs_path);
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            doc = %rel_path,
+            outcome = ?ingest_stats.outcome,
+            chunks_added = ingest_stats.chunks_added,
+            event = "compound_ingest_complete",
+        );
+
+        // 2. Subject extraction (synchronous, non-fatal).
+        let extraction_stats = if let Some(ref llm) = self.extraction_llm {
+            let extractor = SubjectExtractor::new(
+                self.db.clone(),
+                llm.clone(),
+                self.docs_root.clone(),
+                Some(&self.trace_id),
+            );
+
+            match extractor.extract_document(&rel_path, None).await {
+                Ok(stats) => {
+                    // Record extraction so it's not re-extracted at startup.
+                    extractor
+                        .record_extraction_public(
+                            &rel_path,
+                            llm.model_name(),
+                            stats.entities_upserted,
+                            stats.relationships_upserted,
+                        )
+                        .await;
+                    Some(stats)
+                }
+                Err(e) => {
+                    warn!(
+                        trace_id = %self.trace_id,
+                        agent_id = %agent_id,
+                        doc = %rel_path,
+                        error = %e,
+                        event = "compound_extraction_failed",
+                        "extraction failed — doc stays pending per C2.3"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(CompoundResult {
+            ingest_stats,
+            extraction_stats,
+        })
+    }
+
+    /// Re-extraction on doc change: three-phase capture → reingest → reconcile.
+    ///
+    /// Phase 1: Capture previous provenance state.
+    /// Phase 2: Re-ingest chunks (handled by `LexicalIngestor`).
+    /// Phase 3: Re-extract with previous state for orphan sweep.
+    pub async fn reingest_and_reextract(&self, abs_path: &Path) -> Result<CompoundResult> {
+        let rel_path = self.relative_path(abs_path);
+
+        // Phase 1: Capture previous state before any deletion.
+        let previous_state = if let Some(ref llm) = self.extraction_llm {
+            let extractor = SubjectExtractor::new(
+                self.db.clone(),
+                llm.clone(),
+                self.docs_root.clone(),
+                Some(&self.trace_id),
+            );
+            Some(extractor.capture_previous_state(&rel_path).await?)
+        } else {
+            None
+        };
+
+        // Phase 2: Re-ingest (deletes old chunks, writes new chunks).
+        let ingestor = LexicalIngestor::new(
+            self.db.clone(),
+            self.docs_root.clone(),
+            Some(&self.trace_id),
+        )
+        .with_session(&self.session_id);
+
+        let ingest_stats = ingestor.ingest_single_doc(abs_path).await?;
+
+        // Phase 3: Re-extract with previous state for orphan sweep.
+        let extraction_stats = match (&self.extraction_llm, previous_state) {
+            (Some(llm), Some(prev)) => {
+                let extractor = SubjectExtractor::new(
+                    self.db.clone(),
+                    llm.clone(),
+                    self.docs_root.clone(),
+                    Some(&self.trace_id),
+                );
+
+                match extractor.extract_document(&rel_path, Some(prev)).await {
+                    Ok(stats) => {
+                        extractor
+                            .record_extraction_public(
+                                &rel_path,
+                                llm.model_name(),
+                                stats.entities_upserted,
+                                stats.relationships_upserted,
+                            )
+                            .await;
+                        Some(stats)
+                    }
+                    Err(e) => {
+                        warn!(
+                            trace_id = %self.trace_id,
+                            doc = %rel_path,
+                            error = %e,
+                            event = "reextraction_failed",
+                            "re-extraction failed — doc stays pending"
+                        );
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+
+        Ok(CompoundResult {
+            ingest_stats,
+            extraction_stats,
+        })
+    }
+
+    /// Convert an absolute path to a repo-relative path.
+    fn relative_path(&self, abs_path: &Path) -> String {
+        if let Some(repo_root) = self.docs_root.parent().and_then(|p| p.parent()) {
+            abs_path
+                .strip_prefix(repo_root)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| abs_path.to_string_lossy().to_string())
+        } else {
+            abs_path.to_string_lossy().to_string()
+        }
+    }
+}
+
+/// Result of a compound ingest + extract operation.
+#[derive(Debug)]
+pub struct CompoundResult {
+    pub ingest_stats: super::lexical_ingestor::DocStats,
+    pub extraction_stats: Option<super::subject_extractor::ExtractionStats>,
+}

--- a/crates/mika-agent/src/kg/mod.rs
+++ b/crates/mika-agent/src/kg/mod.rs
@@ -13,9 +13,12 @@
 //!   `docs/solutions/**/*.md` into `kg_chunks` + `search_content`. Content-hash
 //!   idempotent, runs at startup after domain rebuild.
 //!
-//! - **Subject graph** (future, #690/#691): Per-agent LLM-extracted entities, fact
-//!   triples, and resolution edges linking subject mentions to domain nodes.
+//! - **Subject graph** ([`subject_extractor`], #690): Per-agent LLM-extracted
+//!   entities and fact triples from compound docs. Uses constrained NER with
+//!   approved entity/relationship types.
 
 pub mod chunker;
 pub mod domain_builder;
+pub mod ingestion_orchestrator;
 pub mod lexical_ingestor;
+pub mod subject_extractor;

--- a/crates/mika-agent/src/kg/subject_extractor.rs
+++ b/crates/mika-agent/src/kg/subject_extractor.rs
@@ -1,0 +1,1514 @@
+//! # Subject Graph Extractor
+//!
+//! Per-agent LLM-based extraction of named entities and fact triples from
+//! previously-ingested documents (#690). For each document, the extractor:
+//!
+//! 1. Reads the full doc from disk.
+//! 2. Reads chunk boundaries from `kg_chunks` for the doc.
+//! 3. Builds a prompt with chunk boundary markers (`[CHUNK N]`).
+//! 4. Calls the LLM to extract entities and relationships.
+//! 5. Validates output against approved types and constraints.
+//! 6. Writes entities, relationships, and provenance in a single transaction.
+//!
+//! ## Sole-Writer Contract
+//!
+//! This module is the sole writer of `kg_subject_entities`,
+//! `kg_subject_relationships`, `kg_chunk_subjects`,
+//! `kg_chunk_subject_relationships`, and `kg_extractions` rows.
+//! No other code path writes these.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use mika_common::llm::{LlmMessage, LlmProvider, LlmRequest, LlmRole};
+
+use crate::async_db::AsyncDatabase;
+
+// ---------------------------------------------------------------------------
+// Constants — approved types and relationship constraints
+// ---------------------------------------------------------------------------
+
+/// Approved subject entity types.
+pub const APPROVED_ENTITY_TYPES: &[&str] = &[
+    "skill",
+    "tool",
+    "agent",
+    "problem_type",
+    "solution_path",
+    "failure_mode",
+    "pattern",
+];
+
+/// Approved relationship types with from/to type constraints.
+pub const APPROVED_RELATIONSHIP_TYPES: &[RelationshipConstraint] = &[
+    RelationshipConstraint {
+        rel_type: "SOLVED_BY",
+        from_types: &["problem_type"],
+        to_types: &["solution_path"],
+    },
+    RelationshipConstraint {
+        rel_type: "USES",
+        from_types: &["solution_path"],
+        to_types: &["skill"],
+    },
+    RelationshipConstraint {
+        rel_type: "CALLS",
+        from_types: &["solution_path"],
+        to_types: &["tool"],
+    },
+    RelationshipConstraint {
+        rel_type: "INDICATES",
+        from_types: &["failure_mode"],
+        to_types: &["problem_type"],
+    },
+    RelationshipConstraint {
+        rel_type: "PREVENTS",
+        from_types: &["pattern"],
+        to_types: &["problem_type"],
+    },
+    RelationshipConstraint {
+        rel_type: "CAUSED_BY",
+        from_types: &["problem_type"],
+        to_types: &["problem_type"],
+    },
+    RelationshipConstraint {
+        rel_type: "MENTIONS",
+        // any type can mention an agent
+        from_types: &[
+            "skill",
+            "tool",
+            "agent",
+            "problem_type",
+            "solution_path",
+            "failure_mode",
+            "pattern",
+        ],
+        to_types: &["agent"],
+    },
+];
+
+/// Relationship type constraint.
+pub struct RelationshipConstraint {
+    pub rel_type: &'static str,
+    pub from_types: &'static [&'static str],
+    pub to_types: &'static [&'static str],
+}
+
+/// Session ID sentinel for audit events emitted during extraction.
+const EXTRACTION_SESSION_ID: &str = "extraction";
+
+// ---------------------------------------------------------------------------
+// Extraction output types (D4 — what the LLM produces)
+// ---------------------------------------------------------------------------
+
+/// Raw LLM extraction output — deserialized from JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractionOutput {
+    pub entities: Vec<ExtractedEntity>,
+    pub relationships: Vec<ExtractedRelationship>,
+}
+
+/// A single extracted entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedEntity {
+    #[serde(rename = "type")]
+    pub entity_type: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub chunk_indices: Vec<usize>,
+    pub confidence: f64,
+}
+
+/// A single extracted relationship.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedRelationship {
+    pub from_type: String,
+    pub from_name: String,
+    pub to_type: String,
+    pub to_name: String,
+    #[serde(rename = "type")]
+    pub rel_type: String,
+    pub chunk_indices: Vec<usize>,
+    pub confidence: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Validation (Unit 3)
+// ---------------------------------------------------------------------------
+
+/// Validation error with details for C2.2 semantic retry reinforcement.
+#[derive(Debug, Clone)]
+pub struct ValidationError {
+    pub message: String,
+    pub details: Vec<String>,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)?;
+        for detail in &self.details {
+            write!(f, "\n  - {detail}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+/// Validate extraction output against D3/D4 constraints.
+///
+/// Returns the validated output with any filtered entities/relationships removed,
+/// or a `ValidationError` if the output is structurally invalid.
+pub fn validate_extraction_output(
+    output: &ExtractionOutput,
+    max_chunk_index: usize,
+) -> Result<ExtractionOutput, ValidationError> {
+    let mut errors = Vec::new();
+    let mut valid_entities = Vec::new();
+    let mut valid_entity_keys: HashSet<String> = HashSet::new();
+
+    // Validate entities
+    for (i, entity) in output.entities.iter().enumerate() {
+        let mut entity_errors = Vec::new();
+
+        if !APPROVED_ENTITY_TYPES.contains(&entity.entity_type.as_str()) {
+            entity_errors.push(format!(
+                "entity[{i}]: unapproved type '{}'. Approved: {:?}",
+                entity.entity_type, APPROVED_ENTITY_TYPES
+            ));
+        }
+
+        if entity.name.trim().is_empty() {
+            entity_errors.push(format!("entity[{i}]: name is empty"));
+        }
+
+        if entity.name.contains(':') {
+            entity_errors.push(format!(
+                "entity[{i}]: name '{}' contains ':' (breaks entity_key convention)",
+                entity.name
+            ));
+        }
+
+        if entity.chunk_indices.is_empty() {
+            entity_errors.push(format!("entity[{i}]: chunk_indices is empty"));
+        }
+
+        if entity
+            .chunk_indices
+            .iter()
+            .any(|&idx| idx > max_chunk_index)
+        {
+            entity_errors.push(format!(
+                "entity[{i}]: chunk_indices contains index > max ({max_chunk_index})"
+            ));
+        }
+
+        if !(0.0..=1.0).contains(&entity.confidence) {
+            entity_errors.push(format!(
+                "entity[{i}]: confidence {} out of range [0.0, 1.0]",
+                entity.confidence
+            ));
+        }
+
+        if entity_errors.is_empty() {
+            let key = format!("{}:{}", entity.entity_type, entity.name);
+            valid_entity_keys.insert(key);
+            valid_entities.push(entity.clone());
+        } else {
+            errors.extend(entity_errors);
+        }
+    }
+
+    // Validate relationships
+    let mut valid_relationships = Vec::new();
+    for (i, rel) in output.relationships.iter().enumerate() {
+        let mut rel_errors = Vec::new();
+
+        // Check relationship type is approved
+        let constraint = APPROVED_RELATIONSHIP_TYPES
+            .iter()
+            .find(|c| c.rel_type == rel.rel_type);
+
+        match constraint {
+            None => {
+                rel_errors.push(format!(
+                    "relationship[{i}]: unapproved type '{}'. Approved: {:?}",
+                    rel.rel_type,
+                    APPROVED_RELATIONSHIP_TYPES
+                        .iter()
+                        .map(|c| c.rel_type)
+                        .collect::<Vec<_>>()
+                ));
+            }
+            Some(c) => {
+                // Check from/to type constraints
+                if !c.from_types.contains(&rel.from_type.as_str()) {
+                    rel_errors.push(format!(
+                        "relationship[{i}]: '{}' from_type '{}' not in {:?}",
+                        rel.rel_type, rel.from_type, c.from_types
+                    ));
+                }
+                if !c.to_types.contains(&rel.to_type.as_str()) {
+                    rel_errors.push(format!(
+                        "relationship[{i}]: '{}' to_type '{}' not in {:?}",
+                        rel.rel_type, rel.to_type, c.to_types
+                    ));
+                }
+            }
+        }
+
+        // Check that referenced entities exist in the output
+        let from_key = format!("{}:{}", rel.from_type, rel.from_name);
+        let to_key = format!("{}:{}", rel.to_type, rel.to_name);
+        if !valid_entity_keys.contains(&from_key) {
+            rel_errors.push(format!(
+                "relationship[{i}]: from entity '{from_key}' not in entities list"
+            ));
+        }
+        if !valid_entity_keys.contains(&to_key) {
+            rel_errors.push(format!(
+                "relationship[{i}]: to entity '{to_key}' not in entities list"
+            ));
+        }
+
+        if rel.chunk_indices.is_empty() {
+            rel_errors.push(format!("relationship[{i}]: chunk_indices is empty"));
+        }
+
+        if !(0.0..=1.0).contains(&rel.confidence) {
+            rel_errors.push(format!(
+                "relationship[{i}]: confidence {} out of range [0.0, 1.0]",
+                rel.confidence
+            ));
+        }
+
+        if rel_errors.is_empty() {
+            valid_relationships.push(rel.clone());
+        } else {
+            errors.extend(rel_errors);
+        }
+    }
+
+    // If all entities and relationships were rejected, that's a validation error.
+    // If some passed and some were filtered, return the valid subset with warnings.
+    if valid_entities.is_empty() && !output.entities.is_empty() {
+        return Err(ValidationError {
+            message: "all entities rejected by validation".to_string(),
+            details: errors,
+        });
+    }
+
+    // Log warnings for filtered items but don't fail
+    if !errors.is_empty() {
+        warn!(
+            filtered_count = errors.len(),
+            event = "extraction_validation_filtered",
+            "some extracted items filtered by validation"
+        );
+    }
+
+    Ok(ExtractionOutput {
+        entities: valid_entities,
+        relationships: valid_relationships,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Extraction stats
+// ---------------------------------------------------------------------------
+
+/// Statistics from a single document extraction.
+#[derive(Debug, Clone, Default)]
+pub struct ExtractionStats {
+    pub entities_extracted: usize,
+    pub relationships_extracted: usize,
+    pub entities_upserted: usize,
+    pub relationships_upserted: usize,
+    pub orphans_removed: usize,
+}
+
+/// Statistics from a batch extraction run.
+#[derive(Debug, Clone, Default)]
+pub struct BatchStats {
+    pub docs_total: usize,
+    pub docs_extracted: usize,
+    pub docs_skipped: usize,
+    pub docs_failed: usize,
+    pub total_entities: usize,
+    pub total_relationships: usize,
+    pub duration_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Previous state for re-extraction (D5)
+// ---------------------------------------------------------------------------
+
+/// Previous provenance state, captured before re-ingestion.
+/// `None` for fresh extraction (first-time or compound hook).
+#[derive(Debug, Clone)]
+pub struct PreviousState {
+    pub entity_ids: Vec<i64>,
+    pub relationship_ids: Vec<i64>,
+}
+
+// ---------------------------------------------------------------------------
+// SubjectExtractor (Units 2, 4, 5)
+// ---------------------------------------------------------------------------
+
+/// Sole writer of `kg_subject_entities`, `kg_subject_relationships`,
+/// `kg_chunk_subjects`, and `kg_chunk_subject_relationships`.
+///
+/// All extraction goes through `extract_document()`. Invocation-context-agnostic.
+pub struct SubjectExtractor {
+    db: AsyncDatabase,
+    llm: Arc<dyn LlmProvider>,
+    trace_id: String,
+    docs_root: PathBuf,
+}
+
+impl SubjectExtractor {
+    /// Create a new extractor.
+    ///
+    /// - `db`: async database handle (carries `agent_id` implicitly).
+    /// - `llm`: LLM provider for extraction (from `MIKA_KG_EXTRACTION_MODEL`).
+    /// - `docs_root`: root directory for docs (for resolving relative paths).
+    /// - `trace_id`: optional trace ID for observability.
+    pub fn new(
+        db: AsyncDatabase,
+        llm: Arc<dyn LlmProvider>,
+        docs_root: PathBuf,
+        trace_id: Option<&str>,
+    ) -> Self {
+        let trace_id = trace_id
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().replace('-', ""));
+        Self {
+            db,
+            llm,
+            trace_id,
+            docs_root,
+        }
+    }
+
+    /// Core extraction entry point — invocation-context-agnostic.
+    ///
+    /// Reads the full doc from disk, builds a prompt with chunk markers,
+    /// calls the LLM, validates output, and writes to DB in a single transaction.
+    pub async fn extract_document(
+        &self,
+        doc_path: &str,
+        previous_state: Option<PreviousState>,
+    ) -> Result<ExtractionStats> {
+        let agent_id = self.db.agent_id.clone();
+
+        // 1. Resolve absolute path and read doc from disk.
+        let abs_path = self.resolve_doc_path(doc_path);
+        let doc_text = std::fs::read_to_string(&abs_path)
+            .with_context(|| format!("failed to read doc: {}", abs_path.display()))?;
+
+        if doc_text.trim().is_empty() {
+            return Ok(ExtractionStats::default());
+        }
+
+        // 2. Read chunk boundaries from kg_chunks.
+        let chunks = self.get_chunk_boundaries(doc_path).await?;
+        if chunks.is_empty() {
+            warn!(
+                trace_id = %self.trace_id,
+                agent_id = %agent_id,
+                doc = %doc_path,
+                event = "extraction_no_chunks",
+                "no chunks found for doc — skipping extraction"
+            );
+            return Ok(ExtractionStats::default());
+        }
+
+        let max_chunk_index = chunks.len().saturating_sub(1);
+
+        // 3. Build prompt with chunk boundary markers.
+        let annotated_text = self.build_annotated_text(&doc_text, &chunks);
+        let prompt = self.build_extraction_prompt(&annotated_text);
+
+        // 4. LLM call with C2.2 retry taxonomy.
+        let start = Instant::now();
+        let extraction_output = self.call_llm_with_retry(&prompt).await?;
+        let latency_ms = start.elapsed().as_millis() as u64;
+
+        // 5. Parse and validate output.
+        let validated = match extraction_output {
+            Some(ref output) => match validate_extraction_output(output, max_chunk_index) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(
+                        trace_id = %self.trace_id,
+                        agent_id = %agent_id,
+                        doc = %doc_path,
+                        error = %e,
+                        event = "extraction_validation_failed",
+                        "extraction output failed validation — log-and-skip per C2.3"
+                    );
+                    return Ok(ExtractionStats::default());
+                }
+            },
+            None => {
+                // LLM returned nothing usable after retries
+                return Ok(ExtractionStats::default());
+            }
+        };
+
+        let stats = ExtractionStats {
+            entities_extracted: validated.entities.len(),
+            relationships_extracted: validated.relationships.len(),
+            ..Default::default()
+        };
+
+        // 6. Store llm_calls row (C2.4).
+        if let Some(ref raw_output) = extraction_output {
+            self.store_llm_call(doc_path, latency_ms, raw_output).await;
+        }
+
+        // 7. Write entities, relationships, provenance in single transaction.
+        let final_stats = self
+            .write_extraction_results(doc_path, &validated, &chunks, previous_state)
+            .await
+            .with_context(|| format!("failed to write extraction results for {doc_path}"))?;
+
+        // 8. Emit audit event (D11).
+        self.emit_audit_event(doc_path, &final_stats).await;
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            doc = %doc_path,
+            entities = final_stats.entities_upserted,
+            relationships = final_stats.relationships_upserted,
+            orphans_removed = final_stats.orphans_removed,
+            latency_ms = latency_ms,
+            event = "extraction_complete",
+        );
+
+        Ok(ExtractionStats {
+            entities_extracted: stats.entities_extracted,
+            relationships_extracted: stats.relationships_extracted,
+            entities_upserted: final_stats.entities_upserted,
+            relationships_upserted: final_stats.relationships_upserted,
+            orphans_removed: final_stats.orphans_removed,
+        })
+    }
+
+    /// Enumerate and extract all pending docs for the agent (D7).
+    pub async fn extract_pending(&self) -> Result<BatchStats> {
+        let start = Instant::now();
+        let agent_id = self.db.agent_id.clone();
+        let model_name = self.llm.model_name().to_string();
+
+        // Query pending docs via kg_extractions tracking table.
+        let pending_docs = self.get_pending_docs().await?;
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            pending_docs = pending_docs.len(),
+            event = "subject_extraction_start",
+        );
+
+        if pending_docs.is_empty() {
+            return Ok(BatchStats {
+                duration_ms: start.elapsed().as_millis() as u64,
+                ..Default::default()
+            });
+        }
+
+        let mut stats = BatchStats {
+            docs_total: pending_docs.len(),
+            ..Default::default()
+        };
+
+        for (i, doc_path) in pending_docs.iter().enumerate() {
+            match self.extract_document(doc_path, None).await {
+                Ok(doc_stats) => {
+                    stats.docs_extracted += 1;
+                    stats.total_entities += doc_stats.entities_upserted;
+                    stats.total_relationships += doc_stats.relationships_upserted;
+
+                    // Write kg_extractions tracking row.
+                    self.record_extraction(
+                        doc_path,
+                        &model_name,
+                        doc_stats.entities_upserted,
+                        doc_stats.relationships_upserted,
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    stats.docs_failed += 1;
+                    warn!(
+                        trace_id = %self.trace_id,
+                        agent_id = %agent_id,
+                        doc = %doc_path,
+                        error = %e,
+                        event = "extraction_doc_failed",
+                        "extraction failed — doc stays pending per C2.3"
+                    );
+                }
+            }
+
+            // Progress logging every 10 docs.
+            if (i + 1) % 10 == 0 {
+                info!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    completed = i + 1,
+                    remaining = pending_docs.len() - (i + 1),
+                    duration_ms = start.elapsed().as_millis() as u64,
+                    event = "subject_extraction_progress",
+                );
+            }
+        }
+
+        stats.docs_skipped = stats.docs_total - stats.docs_extracted - stats.docs_failed;
+        stats.duration_ms = start.elapsed().as_millis() as u64;
+
+        info!(
+            trace_id = %self.trace_id,
+            agent_id = %agent_id,
+            completed = stats.docs_extracted,
+            failed = stats.docs_failed,
+            entities = stats.total_entities,
+            relationships = stats.total_relationships,
+            duration_ms = stats.duration_ms,
+            event = "subject_extraction_complete",
+        );
+
+        Ok(stats)
+    }
+
+    /// Public wrapper for `record_extraction` — used by the ingestion
+    /// orchestrator to mark a doc as extracted after compound hook extraction.
+    pub async fn record_extraction_public(
+        &self,
+        doc_path: &str,
+        model: &str,
+        entities: usize,
+        relationships: usize,
+    ) {
+        self.record_extraction(doc_path, model, entities, relationships)
+            .await;
+    }
+
+    /// Capture previous provenance state before re-ingestion (D5, Phase 1).
+    pub async fn capture_previous_state(&self, doc_path: &str) -> Result<PreviousState> {
+        let agent_id = self.db.agent_id.clone();
+        let doc_path = doc_path.to_owned();
+
+        self.db
+            .with_db(move |db| {
+                let entity_ids: Vec<i64> = {
+                    let mut stmt = db.conn.prepare(
+                        "SELECT DISTINCT cs.subject_entity_id
+                         FROM kg_chunk_subjects cs
+                         JOIN kg_chunks c ON cs.chunk_id = c.id
+                         WHERE c.agent_id = ?1 AND c.source_doc_path = ?2",
+                    )?;
+                    stmt.query_map(rusqlite::params![agent_id, doc_path], |row| row.get(0))?
+                        .filter_map(|r| r.ok())
+                        .collect()
+                };
+
+                let relationship_ids: Vec<i64> = {
+                    let mut stmt = db.conn.prepare(
+                        "SELECT DISTINCT csr.subject_relationship_id
+                         FROM kg_chunk_subject_relationships csr
+                         JOIN kg_chunks c ON csr.chunk_id = c.id
+                         WHERE c.agent_id = ?1 AND c.source_doc_path = ?2",
+                    )?;
+                    stmt.query_map(rusqlite::params![agent_id, doc_path], |row| row.get(0))?
+                        .filter_map(|r| r.ok())
+                        .collect()
+                };
+
+                Ok(PreviousState {
+                    entity_ids,
+                    relationship_ids,
+                })
+            })
+            .await
+    }
+
+    // -- Internal helpers --
+
+    /// Resolve a repo-relative doc path to an absolute path.
+    fn resolve_doc_path(&self, doc_path: &str) -> PathBuf {
+        // docs_root is typically <repo>/docs/solutions. The repo root is
+        // two levels up. Doc paths stored in DB are repo-relative.
+        if let Some(repo_root) = self.docs_root.parent().and_then(|p| p.parent()) {
+            repo_root.join(doc_path)
+        } else {
+            self.docs_root.join(doc_path)
+        }
+    }
+
+    /// Get chunk boundaries from kg_chunks for this doc.
+    async fn get_chunk_boundaries(&self, doc_path: &str) -> Result<Vec<ChunkBoundary>> {
+        let agent_id = self.db.agent_id.clone();
+        let doc_path = doc_path.to_owned();
+
+        self.db
+            .with_db(move |db| {
+                let mut stmt = db.conn.prepare(
+                    "SELECT id, seq_id FROM kg_chunks
+                     WHERE agent_id = ?1 AND source_doc_path = ?2
+                     ORDER BY seq_id ASC",
+                )?;
+                let chunks: Vec<ChunkBoundary> = stmt
+                    .query_map(rusqlite::params![agent_id, doc_path], |row| {
+                        Ok(ChunkBoundary {
+                            id: row.get(0)?,
+                            _seq_id: row.get(1)?,
+                        })
+                    })?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                Ok(chunks)
+            })
+            .await
+    }
+
+    /// Build annotated text with `[CHUNK N]` markers.
+    fn build_annotated_text(&self, doc_text: &str, chunks: &[ChunkBoundary]) -> String {
+        // We need to insert chunk markers into the text. Since we don't have
+        // exact byte offsets, we use the chunker's algorithm to split and
+        // re-join with markers.
+        let chunk_texts: Vec<super::chunker::Chunk> = super::chunker::chunk_doc(doc_text);
+
+        let mut annotated = String::with_capacity(doc_text.len() + chunks.len() * 12);
+        for (i, chunk) in chunk_texts.iter().enumerate() {
+            if i > 0 {
+                annotated.push('\n');
+            }
+            annotated.push_str(&format!("[CHUNK {i}] "));
+            annotated.push_str(&chunk.text);
+        }
+
+        annotated
+    }
+
+    /// Build the extraction prompt.
+    fn build_extraction_prompt(&self, annotated_text: &str) -> (String, String) {
+        let system = format!(
+            r#"You are a knowledge graph extraction agent. Extract named entities and fact triples from the following document.
+
+Return ONLY valid JSON matching this schema:
+{{
+  "entities": [
+    {{
+      "type": "<entity_type>",
+      "name": "<lowercase_underscore_name>",
+      "description": "<brief description>",
+      "chunk_indices": [<int>, ...],
+      "confidence": <0.0-1.0>
+    }}
+  ],
+  "relationships": [
+    {{
+      "from_type": "<entity_type>",
+      "from_name": "<name>",
+      "to_type": "<entity_type>",
+      "to_name": "<name>",
+      "type": "<relationship_type>",
+      "chunk_indices": [<int>, ...],
+      "confidence": <0.0-1.0>
+    }}
+  ]
+}}
+
+Approved entity types: {approved_entity_types}
+Approved relationship types: {approved_rel_types}
+
+Relationship type constraints:
+- SOLVED_BY: from problem_type to solution_path
+- USES: from solution_path to skill
+- CALLS: from solution_path to tool
+- INDICATES: from failure_mode to problem_type
+- PREVENTS: from pattern to problem_type
+- CAUSED_BY: from problem_type to problem_type
+- MENTIONS: from any type to agent
+
+Rules:
+- Entity names must be lowercase with underscores (e.g., "state_drift", "self_dev")
+- Entity names must NOT contain colons
+- Each entity and relationship must reference chunk indices where evidence appears
+- Only extract entities and relationships you are confident about
+- If the document has no extractable entities, return {{"entities": [], "relationships": []}}
+- Return ONLY the JSON object, no markdown fencing, no explanation"#,
+            approved_entity_types = APPROVED_ENTITY_TYPES.join(", "),
+            approved_rel_types = APPROVED_RELATIONSHIP_TYPES
+                .iter()
+                .map(|c| c.rel_type)
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+
+        (system, annotated_text.to_string())
+    }
+
+    /// Call the LLM with C2.2 retry taxonomy.
+    async fn call_llm_with_retry(
+        &self,
+        prompt: &(String, String),
+    ) -> Result<Option<ExtractionOutput>> {
+        let (system, user_text) = prompt;
+
+        let request = LlmRequest {
+            model: self.llm.model_name().to_string(),
+            system: Some(system.clone()),
+            messages: vec![LlmMessage {
+                role: LlmRole::User,
+                content: mika_common::llm::LlmContent::Text(user_text.clone()),
+            }],
+            tools: None,
+            max_tokens: self.llm.max_tokens(),
+            thinking: None,
+        };
+
+        // Attempt 1
+        match self.llm.send_message(&request).await {
+            Ok(response) => {
+                let text = response.text_content();
+                match self.parse_extraction_json(&text) {
+                    Ok(output) => Ok(Some(output)),
+                    Err(parse_err) => {
+                        // Semantic failure — one retry with reinforcement (C2.2)
+                        warn!(
+                            trace_id = %self.trace_id,
+                            error = %parse_err,
+                            event = "extraction_parse_failed_retry",
+                            "malformed JSON from LLM — retrying with reinforcement"
+                        );
+                        self.retry_with_reinforcement(&request, &text).await
+                    }
+                }
+            }
+            Err(e) if is_retryable_error(&e) => {
+                // Transport/rate-limit retry
+                for attempt in 1..=2 {
+                    let backoff = std::time::Duration::from_millis(1000 * 2u64.pow(attempt));
+                    tokio::time::sleep(backoff).await;
+                    match self.llm.send_message(&request).await {
+                        Ok(response) => {
+                            let text = response.text_content();
+                            return match self.parse_extraction_json(&text) {
+                                Ok(output) => Ok(Some(output)),
+                                Err(_) => self.retry_with_reinforcement(&request, &text).await,
+                            };
+                        }
+                        Err(retry_err) if is_retryable_error(&retry_err) => continue,
+                        Err(retry_err) => {
+                            warn!(
+                                trace_id = %self.trace_id,
+                                error = %retry_err,
+                                attempt = attempt + 1,
+                                event = "extraction_transport_failed",
+                            );
+                            return Ok(None);
+                        }
+                    }
+                }
+                warn!(
+                    trace_id = %self.trace_id,
+                    event = "extraction_transport_exhausted",
+                    "all transport retries exhausted — log-and-skip"
+                );
+                Ok(None)
+            }
+            Err(e) => {
+                // Configuration error — do not retry (C2.2)
+                warn!(
+                    trace_id = %self.trace_id,
+                    error = %e,
+                    event = "extraction_config_error",
+                    "non-retryable LLM error — log-and-skip"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Retry with prompt reinforcement after semantic failure.
+    async fn retry_with_reinforcement(
+        &self,
+        original_request: &LlmRequest,
+        bad_output: &str,
+    ) -> Result<Option<ExtractionOutput>> {
+        let reinforcement = format!(
+            "Your previous response was not valid JSON. The output was:\n{}\n\n\
+             Please return ONLY a valid JSON object with \"entities\" and \"relationships\" arrays. \
+             No markdown fencing, no explanation, no text outside the JSON.",
+            &bad_output[..bad_output.len().min(500)]
+        );
+
+        let mut retry_request = original_request.clone();
+        retry_request.messages.push(LlmMessage {
+            role: LlmRole::Assistant,
+            content: mika_common::llm::LlmContent::Text(bad_output.to_string()),
+        });
+        retry_request.messages.push(LlmMessage {
+            role: LlmRole::User,
+            content: mika_common::llm::LlmContent::Text(reinforcement),
+        });
+
+        match self.llm.send_message(&retry_request).await {
+            Ok(response) => {
+                let text = response.text_content();
+                match self.parse_extraction_json(&text) {
+                    Ok(output) => Ok(Some(output)),
+                    Err(e) => {
+                        warn!(
+                            trace_id = %self.trace_id,
+                            error = %e,
+                            event = "extraction_semantic_exhausted",
+                            "semantic retry also failed — log-and-skip per C2.3"
+                        );
+                        Ok(None)
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    trace_id = %self.trace_id,
+                    error = %e,
+                    event = "extraction_retry_transport_failed",
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Parse extraction JSON from LLM response text.
+    fn parse_extraction_json(&self, text: &str) -> Result<ExtractionOutput> {
+        // Strip markdown code fences if present
+        let cleaned = text
+            .trim()
+            .strip_prefix("```json")
+            .or_else(|| text.trim().strip_prefix("```"))
+            .unwrap_or(text.trim());
+        let cleaned = cleaned.strip_suffix("```").unwrap_or(cleaned).trim();
+
+        serde_json::from_str(cleaned).with_context(|| {
+            format!(
+                "failed to parse extraction JSON: {}",
+                &cleaned[..cleaned.len().min(200)]
+            )
+        })
+    }
+
+    /// Write extraction results to DB in a single transaction (D5).
+    async fn write_extraction_results(
+        &self,
+        _doc_path: &str,
+        output: &ExtractionOutput,
+        chunks: &[ChunkBoundary],
+        previous_state: Option<PreviousState>,
+    ) -> Result<ExtractionStats> {
+        let agent_id = self.db.agent_id.clone();
+        let trace_id = self.trace_id.clone();
+        let entities = output.entities.clone();
+        let relationships = output.relationships.clone();
+        let chunk_lookup: HashMap<usize, i64> =
+            chunks.iter().enumerate().map(|(i, c)| (i, c.id)).collect();
+
+        self.db
+            .with_db(move |db| {
+                let tx = db.conn.unchecked_transaction()?;
+                let mut stats = ExtractionStats::default();
+
+                // -- UPSERT entities --
+                let mut entity_id_map: HashMap<String, i64> = HashMap::new();
+                for entity in &entities {
+                    let entity_key = format!("{}:{}", entity.entity_type, entity.name);
+                    let props = entity
+                        .description
+                        .as_ref()
+                        .map(|d| format!(r#"{{"description":{}}}"#, serde_json::to_string(d).unwrap_or_default()));
+
+                    tx.execute(
+                        "INSERT INTO kg_subject_entities (agent_id, entity_key, type, name, confidence, properties_json, trace_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                         ON CONFLICT(agent_id, entity_key) DO UPDATE SET
+                            confidence = MAX(excluded.confidence, kg_subject_entities.confidence),
+                            properties_json = COALESCE(excluded.properties_json, kg_subject_entities.properties_json),
+                            trace_id = excluded.trace_id",
+                        rusqlite::params![
+                            agent_id,
+                            entity_key,
+                            entity.entity_type,
+                            entity.name,
+                            entity.confidence,
+                            props,
+                            trace_id,
+                        ],
+                    )?;
+
+                    // Get the entity ID (whether inserted or existing).
+                    let entity_id: i64 = tx.query_row(
+                        "SELECT id FROM kg_subject_entities WHERE agent_id = ?1 AND entity_key = ?2",
+                        rusqlite::params![agent_id, entity_key],
+                        |row| row.get(0),
+                    )?;
+                    entity_id_map.insert(entity_key, entity_id);
+                    stats.entities_upserted += 1;
+
+                    // -- INSERT chunk-subject provenance --
+                    for &chunk_idx in &entity.chunk_indices {
+                        if let Some(&chunk_id) = chunk_lookup.get(&chunk_idx) {
+                            tx.execute(
+                                "INSERT OR IGNORE INTO kg_chunk_subjects
+                                    (agent_id, chunk_id, subject_entity_id, extraction_trace_id)
+                                 VALUES (?1, ?2, ?3, ?4)",
+                                rusqlite::params![agent_id, chunk_id, entity_id, trace_id],
+                            )?;
+                        }
+                    }
+                }
+
+                // -- UPSERT relationships --
+                for rel in &relationships {
+                    let from_key = format!("{}:{}", rel.from_type, rel.from_name);
+                    let to_key = format!("{}:{}", rel.to_type, rel.to_name);
+
+                    let from_id = match entity_id_map.get(&from_key) {
+                        Some(&id) => id,
+                        None => continue, // Entity filtered during validation
+                    };
+                    let to_id = match entity_id_map.get(&to_key) {
+                        Some(&id) => id,
+                        None => continue,
+                    };
+
+                    tx.execute(
+                        "INSERT INTO kg_subject_relationships
+                            (agent_id, from_entity_id, to_entity_id, type, confidence, properties_json, trace_id)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                         ON CONFLICT(agent_id, from_entity_id, to_entity_id, type) DO UPDATE SET
+                            confidence = MAX(excluded.confidence, kg_subject_relationships.confidence),
+                            properties_json = COALESCE(excluded.properties_json, kg_subject_relationships.properties_json),
+                            trace_id = excluded.trace_id",
+                        rusqlite::params![
+                            agent_id,
+                            from_id,
+                            to_id,
+                            rel.rel_type,
+                            rel.confidence,
+                            Option::<String>::None,
+                            trace_id,
+                        ],
+                    )?;
+
+                    let rel_id: i64 = tx.query_row(
+                        "SELECT id FROM kg_subject_relationships
+                         WHERE agent_id = ?1 AND from_entity_id = ?2 AND to_entity_id = ?3 AND type = ?4",
+                        rusqlite::params![agent_id, from_id, to_id, rel.rel_type],
+                        |row| row.get(0),
+                    )?;
+                    stats.relationships_upserted += 1;
+
+                    // -- INSERT chunk-relationship provenance --
+                    for &chunk_idx in &rel.chunk_indices {
+                        if let Some(&chunk_id) = chunk_lookup.get(&chunk_idx) {
+                            tx.execute(
+                                "INSERT OR IGNORE INTO kg_chunk_subject_relationships
+                                    (agent_id, chunk_id, subject_relationship_id, extraction_trace_id)
+                                 VALUES (?1, ?2, ?3, ?4)",
+                                rusqlite::params![agent_id, chunk_id, rel_id, trace_id],
+                            )?;
+                        }
+                    }
+                }
+
+                // -- Scoped orphan sweep (D5 phase 3, step 7-8) --
+                if let Some(prev) = previous_state {
+                    // Delete entities from previous set that now have zero provenance
+                    if !prev.entity_ids.is_empty() {
+                        let placeholders: Vec<String> =
+                            prev.entity_ids.iter().map(|_| "?".to_string()).collect();
+                        let sql = format!(
+                            "DELETE FROM kg_subject_entities
+                             WHERE id IN ({placeholders})
+                               AND id NOT IN (SELECT subject_entity_id FROM kg_chunk_subjects WHERE agent_id = ?)",
+                            placeholders = placeholders.join(",")
+                        );
+                        let mut stmt = tx.prepare(&sql)?;
+                        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = prev
+                            .entity_ids
+                            .iter()
+                            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+                            .collect();
+                        params.push(Box::new(agent_id.clone()));
+                        stats.orphans_removed +=
+                            stmt.execute(rusqlite::params_from_iter(params))? as usize;
+                    }
+
+                    // Delete relationships from previous set that now have zero provenance
+                    if !prev.relationship_ids.is_empty() {
+                        let placeholders: Vec<String> = prev
+                            .relationship_ids
+                            .iter()
+                            .map(|_| "?".to_string())
+                            .collect();
+                        let sql = format!(
+                            "DELETE FROM kg_subject_relationships
+                             WHERE id IN ({placeholders})
+                               AND id NOT IN (SELECT subject_relationship_id FROM kg_chunk_subject_relationships WHERE agent_id = ?)",
+                            placeholders = placeholders.join(",")
+                        );
+                        let mut stmt = tx.prepare(&sql)?;
+                        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = prev
+                            .relationship_ids
+                            .iter()
+                            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+                            .collect();
+                        params.push(Box::new(agent_id));
+                        stats.orphans_removed +=
+                            stmt.execute(rusqlite::params_from_iter(params))? as usize;
+                    }
+                }
+
+                tx.commit()?;
+                Ok(stats)
+            })
+            .await
+    }
+
+    /// Get pending docs (D7 — docs with chunks but no kg_extractions row).
+    async fn get_pending_docs(&self) -> Result<Vec<String>> {
+        let agent_id = self.db.agent_id.clone();
+
+        self.db
+            .with_db(move |db| {
+                let mut stmt = db.conn.prepare(
+                    "SELECT DISTINCT c.source_doc_path
+                     FROM kg_chunks c
+                     WHERE c.agent_id = ?1
+                       AND NOT EXISTS (
+                         SELECT 1 FROM kg_extractions e
+                         WHERE e.agent_id = c.agent_id AND e.source_doc_path = c.source_doc_path
+                       )
+                     ORDER BY c.source_doc_path",
+                )?;
+                let paths: Vec<String> = stmt
+                    .query_map(rusqlite::params![agent_id], |row| row.get(0))?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                Ok(paths)
+            })
+            .await
+    }
+
+    /// Record a successful extraction in kg_extractions (D7).
+    async fn record_extraction(
+        &self,
+        doc_path: &str,
+        model: &str,
+        entities: usize,
+        relationships: usize,
+    ) {
+        let agent_id = self.db.agent_id.clone();
+        let doc_path_owned = doc_path.to_owned();
+        let model = model.to_owned();
+        let trace_id = self.trace_id.clone();
+
+        if let Err(e) = self
+            .db
+            .with_db(move |db| {
+                db.conn.execute(
+                    "INSERT INTO kg_extractions
+                        (agent_id, source_doc_path, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(agent_id, source_doc_path) DO UPDATE SET
+                        extraction_model = excluded.extraction_model,
+                        entities_extracted = excluded.entities_extracted,
+                        relationships_extracted = excluded.relationships_extracted,
+                        extraction_trace_id = excluded.extraction_trace_id,
+                        created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+                    rusqlite::params![agent_id, doc_path_owned, model, entities as i64, relationships as i64, trace_id],
+                )?;
+                Ok(())
+            })
+            .await
+        {
+            warn!(
+                trace_id = %self.trace_id,
+                error = %e,
+                event = "extraction_record_failed",
+            );
+        }
+    }
+
+    /// Store an llm_calls row (C2.4).
+    async fn store_llm_call(&self, _doc_path: &str, latency_ms: u64, _output: &ExtractionOutput) {
+        let call_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let provider = self.llm.provider_name().to_string();
+        let model = self.llm.model_name().to_string();
+
+        if let Err(e) = self
+            .db
+            .save_llm_call(
+                &call_id,
+                EXTRACTION_SESSION_ID,
+                Some(&self.trace_id),
+                &provider,
+                &model,
+                0, // input_tokens not available from extraction calls
+                0, // output_tokens not available
+                None,
+                None,
+                latency_ms,
+                Some("end_turn"),
+                "success",
+                None,
+                0,
+                Some("kg_extraction"),
+            )
+            .await
+        {
+            warn!(
+                trace_id = %self.trace_id,
+                error = %e,
+                event = "extraction_llm_call_record_failed",
+            );
+        }
+    }
+
+    /// Emit a per-document audit event (C3.3).
+    async fn emit_audit_event(&self, doc_path: &str, stats: &ExtractionStats) {
+        let target_key = format!("kg_subject:{doc_path}");
+        let after_value = format!(
+            r#"{{"entities_extracted":{},"relationships_extracted":{},"entities_upserted":{},"relationships_upserted":{},"orphans_removed":{}}}"#,
+            stats.entities_extracted,
+            stats.relationships_extracted,
+            stats.entities_upserted,
+            stats.relationships_upserted,
+            stats.orphans_removed,
+        );
+
+        if let Err(e) = self
+            .db
+            .log_audit_event(
+                EXTRACTION_SESSION_ID,
+                "extract_subject_entities",
+                &target_key,
+                None,
+                Some(&after_value),
+                Some("subject graph extraction"),
+                Some(&self.trace_id),
+            )
+            .await
+        {
+            warn!(
+                trace_id = %self.trace_id,
+                doc = %doc_path,
+                error = %e,
+                event = "extraction_audit_event_failed",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper types and functions
+// ---------------------------------------------------------------------------
+
+/// Chunk boundary info from `kg_chunks`.
+#[derive(Debug, Clone)]
+struct ChunkBoundary {
+    id: i64,
+    _seq_id: i64,
+}
+
+/// Check if an LLM error is retryable (transport/rate-limit).
+fn is_retryable_error(e: &mika_common::llm::LlmError) -> bool {
+    e.is_retryable()
+}
+
+/// Helper trait for extracting text content from LlmResponse.
+trait LlmResponseExt {
+    fn text_content(&self) -> String;
+}
+
+impl LlmResponseExt for mika_common::llm::LlmResponse {
+    fn text_content(&self) -> String {
+        self.content
+            .iter()
+            .filter_map(|c| match c {
+                mika_common::llm::LlmResponseContent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_empty_output() {
+        let output = ExtractionOutput {
+            entities: vec![],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert!(validated.entities.is_empty());
+        assert!(validated.relationships.is_empty());
+    }
+
+    #[test]
+    fn validate_valid_entity() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "problem_type".to_string(),
+                name: "fabrication".to_string(),
+                description: Some("LLM generates ungrounded content".to_string()),
+                chunk_indices: vec![0, 2],
+                confidence: 0.9,
+            }],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().entities.len(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_unapproved_entity_type() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "unknown_type".to_string(),
+                name: "test".to_string(),
+                description: None,
+                chunk_indices: vec![0],
+                confidence: 0.8,
+            }],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        // All entities rejected → error
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_colon_in_name() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "problem_type".to_string(),
+                name: "bad:name".to_string(),
+                description: None,
+                chunk_indices: vec![0],
+                confidence: 0.8,
+            }],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_chunk_indices() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "problem_type".to_string(),
+                name: "test".to_string(),
+                description: None,
+                chunk_indices: vec![],
+                confidence: 0.8,
+            }],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_confidence() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "problem_type".to_string(),
+                name: "test".to_string(),
+                description: None,
+                chunk_indices: vec![0],
+                confidence: 1.5,
+            }],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_valid_relationship() {
+        let output = ExtractionOutput {
+            entities: vec![
+                ExtractedEntity {
+                    entity_type: "problem_type".to_string(),
+                    name: "fabrication".to_string(),
+                    description: None,
+                    chunk_indices: vec![0],
+                    confidence: 0.9,
+                },
+                ExtractedEntity {
+                    entity_type: "solution_path".to_string(),
+                    name: "grounding_validation".to_string(),
+                    description: None,
+                    chunk_indices: vec![1],
+                    confidence: 0.85,
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                from_type: "problem_type".to_string(),
+                from_name: "fabrication".to_string(),
+                to_type: "solution_path".to_string(),
+                to_name: "grounding_validation".to_string(),
+                rel_type: "SOLVED_BY".to_string(),
+                chunk_indices: vec![0, 1],
+                confidence: 0.85,
+            }],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert_eq!(validated.relationships.len(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_wrong_relationship_direction() {
+        let output = ExtractionOutput {
+            entities: vec![
+                ExtractedEntity {
+                    entity_type: "problem_type".to_string(),
+                    name: "fabrication".to_string(),
+                    description: None,
+                    chunk_indices: vec![0],
+                    confidence: 0.9,
+                },
+                ExtractedEntity {
+                    entity_type: "solution_path".to_string(),
+                    name: "fix".to_string(),
+                    description: None,
+                    chunk_indices: vec![1],
+                    confidence: 0.85,
+                },
+            ],
+            relationships: vec![ExtractedRelationship {
+                // SOLVED_BY should go from problem_type to solution_path, not reversed
+                from_type: "solution_path".to_string(),
+                from_name: "fix".to_string(),
+                to_type: "problem_type".to_string(),
+                to_name: "fabrication".to_string(),
+                rel_type: "SOLVED_BY".to_string(),
+                chunk_indices: vec![0, 1],
+                confidence: 0.85,
+            }],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        // Relationship filtered, entities survive
+        let validated = result.unwrap();
+        assert_eq!(validated.entities.len(), 2);
+        assert_eq!(validated.relationships.len(), 0);
+    }
+
+    #[test]
+    fn validate_rejects_dangling_relationship() {
+        let output = ExtractionOutput {
+            entities: vec![ExtractedEntity {
+                entity_type: "problem_type".to_string(),
+                name: "fabrication".to_string(),
+                description: None,
+                chunk_indices: vec![0],
+                confidence: 0.9,
+            }],
+            relationships: vec![ExtractedRelationship {
+                from_type: "problem_type".to_string(),
+                from_name: "fabrication".to_string(),
+                to_type: "solution_path".to_string(),
+                to_name: "nonexistent".to_string(), // Not in entities
+                rel_type: "SOLVED_BY".to_string(),
+                chunk_indices: vec![0],
+                confidence: 0.85,
+            }],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert_eq!(validated.entities.len(), 1);
+        assert_eq!(validated.relationships.len(), 0); // Filtered
+    }
+
+    #[test]
+    fn validate_filters_partial_bad_entities() {
+        let output = ExtractionOutput {
+            entities: vec![
+                ExtractedEntity {
+                    entity_type: "problem_type".to_string(),
+                    name: "good_entity".to_string(),
+                    description: None,
+                    chunk_indices: vec![0],
+                    confidence: 0.9,
+                },
+                ExtractedEntity {
+                    entity_type: "bad_type".to_string(),
+                    name: "bad_entity".to_string(),
+                    description: None,
+                    chunk_indices: vec![1],
+                    confidence: 0.8,
+                },
+            ],
+            relationships: vec![],
+        };
+        let result = validate_extraction_output(&output, 5);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert_eq!(validated.entities.len(), 1);
+        assert_eq!(validated.entities[0].name, "good_entity");
+    }
+
+    #[test]
+    fn parse_extraction_json_strips_markdown() {
+        // Test the JSON parsing logic directly
+        let json = r#"```json
+{"entities": [], "relationships": []}
+```"#;
+        let cleaned = json
+            .trim()
+            .strip_prefix("```json")
+            .or_else(|| json.trim().strip_prefix("```"))
+            .unwrap_or(json.trim());
+        let cleaned = cleaned.strip_suffix("```").unwrap_or(cleaned).trim();
+        let result: Result<ExtractionOutput, _> = serde_json::from_str(cleaned);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.entities.is_empty());
+        assert!(output.relationships.is_empty());
+    }
+
+    #[test]
+    fn parse_extraction_json_plain() {
+        let json = r#"{"entities": [], "relationships": []}"#;
+        let result: Result<ExtractionOutput, _> = serde_json::from_str(json);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -798,6 +798,65 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 "docs/solutions not found — skipping lexical ingestion"
             );
         }
+
+        // Subject graph extraction: LLM-based NER + fact triples from
+        // previously-ingested chunks (#690). Runs asynchronously in the
+        // background after lexical ingestion — does not block server readiness.
+        // Per D2: startup extraction spawns one background task per agent.
+        match settings.make_kg_extraction_provider() {
+            Some(Ok(extraction_llm)) => {
+                for (agent_name, agent_state) in &agents {
+                    let db = agent_state.db.clone();
+                    let llm = extraction_llm.clone();
+                    let docs_root_clone = docs_root.clone();
+                    let agent_name_clone = agent_name.clone();
+
+                    tokio::spawn(async move {
+                        let extractor = crate::kg::subject_extractor::SubjectExtractor::new(
+                            db,
+                            llm,
+                            docs_root_clone,
+                            None,
+                        );
+                        match extractor.extract_pending().await {
+                            Ok(stats) => {
+                                if stats.docs_extracted > 0 || stats.docs_failed > 0 {
+                                    info!(
+                                        event = "subject_extraction_ready",
+                                        agent_id = %agent_name_clone,
+                                        docs_extracted = stats.docs_extracted,
+                                        docs_failed = stats.docs_failed,
+                                        entities = stats.total_entities,
+                                        relationships = stats.total_relationships,
+                                        duration_ms = stats.duration_ms,
+                                        "subject extraction complete"
+                                    );
+                                }
+                            }
+                            Err(e) => warn!(
+                                error = %e,
+                                agent_id = %agent_name_clone,
+                                "subject extraction failed; entities may be stale until next restart"
+                            ),
+                        }
+                    });
+                }
+            }
+            Some(Err(e)) => {
+                warn!(
+                    error = %e,
+                    event = "extraction_disabled",
+                    "failed to create KG extraction provider — subject extraction disabled"
+                );
+            }
+            None => {
+                info!(
+                    event = "extraction_disabled",
+                    reason = "no extraction model configured",
+                    "subject extraction disabled — set MIKA_KG_EXTRACTION_MODEL or MIKA_KG_INGESTION_MODEL to enable"
+                );
+            }
+        }
     }
 
     let state = AppState {

--- a/crates/mika-agent/src/test_utils.rs
+++ b/crates/mika-agent/src/test_utils.rs
@@ -295,6 +295,8 @@ pub mod test_helpers {
             store_llm_calls: true,
             store_tool_calls: true,
             log_llm_bodies: false,
+            kg_ingestion_model: None,
+            kg_extraction_model: None,
         }
     }
 }

--- a/crates/mika-agent/tests/eval/harness.rs
+++ b/crates/mika-agent/tests/eval/harness.rs
@@ -303,5 +303,7 @@ fn dummy_settings() -> Settings {
         store_llm_calls: true,
         store_tool_calls: true,
         log_llm_bodies: false,
+        kg_ingestion_model: None,
+        kg_extraction_model: None,
     }
 }

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -746,6 +746,18 @@ pub struct Settings {
     #[serde(default)]
     pub log_llm_bodies: bool,
 
+    // -- KG (Knowledge Graph) model settings --
+    /// KG ingestion model — shared fallback for extraction and resolution models.
+    /// Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`).
+    /// If unset, KG features requiring LLM calls are disabled.
+    #[serde(default)]
+    pub kg_ingestion_model: Option<String>,
+
+    /// KG extraction model — used for NER + fact-triple extraction (#690).
+    /// Falls back to `kg_ingestion_model` if unset.
+    #[serde(default)]
+    pub kg_extraction_model: Option<String>,
+
     /// Resolved home directory path (populated after load, not from config file)
     #[serde(skip)]
     pub home_dir: PathBuf,
@@ -986,6 +998,42 @@ impl Settings {
             api_key: api_key.map(String::from),
         };
         crate::llm::create_provider(&spec, self.llm_max_tokens)
+    }
+
+    /// Create an LLM provider for KG extraction (NER + fact triples).
+    ///
+    /// Resolution order: `MIKA_KG_EXTRACTION_MODEL` → `MIKA_KG_INGESTION_MODEL` → `None`.
+    /// Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`).
+    /// Returns `None` when no KG model is configured (extraction disabled).
+    pub fn make_kg_extraction_provider(
+        &self,
+    ) -> Option<anyhow::Result<Arc<dyn crate::llm::LlmProvider>>> {
+        let model_str = self
+            .kg_extraction_model
+            .as_deref()
+            .or(self.kg_ingestion_model.as_deref())?;
+
+        Some(self.make_provider_from_model_string(model_str))
+    }
+
+    /// Parse a `provider/model` string and create an LLM provider.
+    ///
+    /// Reusable by `make_kg_extraction_provider` and future `make_kg_resolution_provider`.
+    fn make_provider_from_model_string(
+        &self,
+        model_str: &str,
+    ) -> anyhow::Result<Arc<dyn crate::llm::LlmProvider>> {
+        let (provider_str, model) = model_str
+            .split_once('/')
+            .ok_or_else(|| anyhow::anyhow!(
+                "KG model string must be in 'provider/model' format (e.g., 'anthropic/claude-haiku-4-5-20251001'), got: {model_str}"
+            ))?;
+
+        let provider: crate::llm::ProviderKind = provider_str
+            .parse()
+            .map_err(|e: String| anyhow::anyhow!(e))?;
+
+        self.make_provider_for(provider, Some(model))
     }
 
     /// Create an EmbeddingClient if OpenAI API key is configured.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,6 +348,8 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `embedding_model` | `String` | `text-embedding-3-small` | `MIKA_EMBEDDING_MODEL` | OpenAI embedding model ID. |
 | `embedding_dimensions` | `u32` | `512` | `MIKA_EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `brave_api_key` | `Option<String>` | None | `MIKA_BRAVE_API_KEY` | Brave Search API key for `web_search` builtin skill. Get a free key at https://brave.com/search/api/. |
+| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled. |
+| `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -528,6 +530,8 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |
 | `MIKA_OPENAI_API_KEY` | No | OpenAI API key (LLM + Layer 3 vector search) |
 | `MIKA_BRAVE_API_KEY` | No | Brave Search API key for web search skill |
+| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format) |
+| `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/docs/plans/2026-04-21-006-feat-subject-graph-extraction-plan.md
+++ b/docs/plans/2026-04-21-006-feat-subject-graph-extraction-plan.md
@@ -162,7 +162,7 @@ Resolved during planning. The extraction prompt produces a JSON object with thre
 **Key properties:**
 
 - `chunk_indices` on both entities and relationships. These map to the `[CHUNK N]` markers in the prompt and drive `kg_chunk_subjects` / `kg_chunk_subject_relationships` provenance rows.
-- `confidence` on both entities and relationships. Extraction-time confidence from the LLM. Stored on `kg_subject_entities.properties_json` (entities) and `kg_subject_relationships.confidence` (relationships). Downstream consumers (#688, #692) can filter by threshold.
+- `confidence` on both entities and relationships. Extraction-time confidence from the LLM. Stored as dedicated columns: `kg_subject_entities.confidence` (per D15) and `kg_subject_relationships.confidence`. Both have `CHECK (confidence >= 0.0 AND confidence <= 1.0)`. Downstream consumers (#688, #692) can filter by threshold via indexed column queries, not JSON extraction.
 - `type` + `name` on entities compose to `entity_key` via the `type || ':' || name` convention (per #686 D3).
 - Entity `description` is optional free text stored in `properties_json`.
 
@@ -227,33 +227,56 @@ Resolved during planning. `SubjectExtractor.extract_document(doc_path, agent_id,
 
 The extractor is invocation-context-agnostic — no assumptions about being on the main runtime, no coupling to server state. This keeps the migration path to a dedicated worker (Option 3 from planning) open if scale demands it.
 
-### D7. Pending-doc query drives extraction (idempotent)
+### D7. `kg_extractions` tracking table drives pending-doc query
 
-Resolved during planning. The extractor determines what needs extraction by querying data shape, not tracking explicit state:
+Resolved during planning, revised during review. The extractor tracks extraction state explicitly via a `kg_extractions` table — one row per (agent_id, source_doc_path) recording that extraction has completed.
 
 ```sql
--- Docs with chunks but no subject provenance
+CREATE TABLE kg_extractions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    source_doc_path TEXT NOT NULL,
+    extraction_model TEXT NOT NULL,
+    entities_extracted INTEGER NOT NULL DEFAULT 0,
+    relationships_extracted INTEGER NOT NULL DEFAULT 0,
+    extraction_trace_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE (agent_id, source_doc_path)
+);
+CREATE INDEX idx_kg_extractions_agent ON kg_extractions(agent_id);
+```
+
+**Pending-doc query:**
+
+```sql
 SELECT DISTINCT c.source_doc_path
 FROM kg_chunks c
 WHERE c.agent_id = ?
   AND NOT EXISTS (
-    SELECT 1 FROM kg_chunk_subjects cs
-    WHERE cs.chunk_id = c.id
+    SELECT 1 FROM kg_extractions e
+    WHERE e.agent_id = c.agent_id AND e.source_doc_path = c.source_doc_path
   )
 ```
 
-This query drives startup extraction and handles all failure modes:
-- Server crash mid-extraction: incomplete docs have chunks but no provenance → pending on next startup.
-- Provider down at startup: retries exhaust → docs remain pending → picked up on next startup.
-- New docs from compound hook: if hook extraction fails (C2.3 log-and-skip), doc stays pending → picked up at next startup.
+This query is authoritative regardless of how many entities a doc produces — zero-entity docs get a `kg_extractions` row with `entities_extracted = 0`, correctly marking them as "done." Without this table, zero-entity docs would re-extract on every startup (the provenance-absence query can't distinguish "not yet extracted" from "extracted, produced nothing").
 
-No explicit state enum, no `kg_extractions` tracking table. The data shape is the state. Matches C1.1's embedding backfill pattern (idempotent by `embedding_json IS NULL`).
+**Additional benefits:**
+- "Has this doc ever been extracted, when, with which model?" is a one-query answer.
+- Model-version invalidation: if extraction logic or model changes, `DELETE FROM kg_extractions WHERE extraction_model != ?` makes all docs pending for re-extraction under the new model.
+- Structured extraction observability that `audit_events` (log entries, not queryable state) can't provide.
 
-**Periodic retry (deferred):** A background task re-running the pending query every N hours would catch "provider was flaky at startup, recovered later." Deferred to implementation — build without it, add if "stale extraction due to startup-time provider failure" becomes an observed pattern.
+This is schema amendment D14 to #686, batched with D11-D13.
 
-### D8. Schema amendments to #686 — D11, D12, D13
+**Failure handling:**
+- Server crash mid-extraction: no `kg_extractions` row written → doc remains pending on next startup.
+- Provider down at startup: retries exhaust → doc stays pending → picked up on next startup.
+- Compound hook failure: doc stays pending → picked up at next startup.
 
-Surfaced during #690 planning. All three are new tables for subject-layer cross-table relationships. They follow the pattern identified across the milestone: *every first-class KG table has relationships to other first-class tables that need their own tables*.
+**Periodic retry (deferred):** A background task re-running the pending query every N hours would catch "provider was flaky at startup, recovered later." Deferred — build without it, add if observed.
+
+### D8. Schema amendments to #686 — D11, D12, D13, D14, D15
+
+Surfaced during #690 planning and review. D11-D13 are new tables for subject-layer cross-table relationships. D14 is the extraction tracking table. D15 is a column addition to `kg_subject_entities`. All follow the meta-principle: schema gaps surfaced by downstream tickets get folded into the pre-ship schema.
 
 **D11. `kg_subject_relationships`** — subject-to-subject edges (fact triples).
 
@@ -308,9 +331,30 @@ CREATE INDEX idx_kg_csr_chunk ON kg_chunk_subject_relationships(agent_id, chunk_
 CREATE INDEX idx_kg_csr_rel ON kg_chunk_subject_relationships(agent_id, subject_relationship_id);
 ```
 
-These three tables complete the subject layer's provenance model. The convention to add to `kg-implementation-conventions.md`: "Every first-class KG table has relationships to other first-class tables; those relationships need their own tables with their own provenance." D11-D13 should be folded into #686's v25 schema if still pre-ship, or batched as v25→v26 if v25 has shipped.
+**D14. `kg_extractions`** — extraction tracking (per-agent, per-doc). See D7 for schema and rationale.
 
-### D9. Observability — per-doc audit_events + progress logging
+**D15. `confidence REAL NOT NULL` column on `kg_subject_entities`** — symmetric with `kg_subject_relationships.confidence`. Extraction-time confidence should be a queryable, constraint-checked column, not buried in `properties_json`. Downstream consumers (#688 query tool, #692 self-knowledge) will filter by confidence threshold — that needs an indexable column, not JSON extraction.
+
+```sql
+-- Amendment to kg_subject_entities (from #686 schema sketch):
+-- ADD: confidence REAL NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0)
+```
+
+These five amendments (D11-D15) complete the subject layer's schema. The convention to add to `kg-implementation-conventions.md`: "Every first-class KG table has relationships to other first-class tables; those relationships need their own tables with their own provenance." All five should be folded into #686's v25 schema if still pre-ship, or batched as a single v25→v26 migration if v25 has shipped.
+
+### D9. Orchestration ownership and provider scope
+
+Resolved during review.
+
+**Orchestration:** The ingestion orchestrator (a coordinator module, not #689's lexical ingestor directly) owns the re-extraction sequence. #689's role ends at chunk writes; #690's `extract_document` is called by the orchestrator with `previous_state` already captured. Neither #689 nor #690 has knowledge of the other's internals — the orchestrator calls `capture_previous_state → delete_old_chunks → write_new_chunks → extract_document(previous_state)`. This avoids tight coupling between #689 and #690 at the code level.
+
+**Provider scope:** One extraction `LlmProvider` instance per server, shared across all agents and all invocation contexts (startup background, compound hook, create_agent). Per-agent model overrides are not supported for extraction — that's the `skill_overrides` anti-pattern from C2.1. The "which model does extraction use?" question is answerable by reading one env var (`MIKA_KG_EXTRACTION_MODEL`), not N config files.
+
+### D10. Entity identity is the full entity_key — UPSERT does not merge across types
+
+Resolved during review. `entity_key = type || ':' || name` per the CHECK constraint. If the LLM extracts `problem_type:fabrication` in run 1 and hallucinates `failure_mode:fabrication` in run 2, these are **two different entities** with different entity_keys. UPSERT on `(agent_id, entity_key)` does not merge them — they coexist as independent subject entities. This is intentional: entity identity includes type, not just name.
+
+### D11. Observability — per-doc audit_events + progress logging
 
 Per C3.3. Each per-doc extraction emits one `audit_events` row:
 
@@ -338,11 +382,16 @@ Every LLM call emits an `llm_calls` row per C2.4.
 - Output schema — structured JSON with chunk-index annotations (see D4).
 - Re-extraction lifecycle — three-phase capture → reingest → reconcile (see D5).
 - Single extractor, multiple invokers (see D6).
-- Pending-doc detection — idempotent by data shape (see D7).
-- Schema amendments — D11/D12/D13 folded back into #686 (see D8).
-- Subject-to-subject relationship storage — `kg_subject_relationships` table, not `kg_relationships` extension (D11).
-- Chunk-subject provenance — `kg_chunk_subjects` join table with `extraction_trace_id` (D12).
-- Relationship-chunk provenance — `kg_chunk_subject_relationships` join table (D13, surfaced during re-extraction design).
+- Pending-doc detection — `kg_extractions` tracking table (see D7).
+- Schema amendments — D11-D15 folded back into #686 (see D8).
+- Subject-to-subject relationship storage — `kg_subject_relationships` table, not `kg_relationships` extension (#686 D11).
+- Chunk-subject provenance — `kg_chunk_subjects` join table with `extraction_trace_id` (#686 D12).
+- Relationship-chunk provenance — `kg_chunk_subject_relationships` join table (#686 D13, surfaced during re-extraction design).
+- Extraction tracking — `kg_extractions` table (#686 D14, surfaced during review).
+- Entity confidence as column — `kg_subject_entities.confidence` (#686 D15, surfaced during review).
+- Orchestration ownership — ingestion orchestrator owns re-extraction sequence, not #689 calling #690 (see D9).
+- Entity identity — full entity_key, UPSERT does not merge across types (see D10).
+- Provider scope — one extraction LlmProvider per server, shared across agents (see D9).
 
 ### Deferred to Implementation
 
@@ -352,6 +401,7 @@ Every LLM call emits an `llm_calls` row per C2.4.
 - Whether `create_agent` auto-triggers extraction immediately or waits for next startup (implement the cleaner version if straightforward, defer if not).
 - Large-doc section-level fallback threshold (suggested 30K tokens — implement only when trigger case exists).
 - Periodic retry for stale-at-startup extraction (deferred until failure mode is observed).
+- Chunk boundary marker format — `[CHUNK N]` may be ambiguous with literal content in source docs (e.g., someone pastes example output containing `[CHUNK 5]`). Consider `<<CHUNK_BOUNDARY idx="N">>` or similar unambiguous delimiter during prompt iteration.
 
 ## Output Structure
 
@@ -425,9 +475,10 @@ impl SubjectExtractor {
 
     /// Enumerate and extract all pending docs for an agent.
     pub async fn extract_pending(&self, agent_id: &str) -> Result<BatchStats> {
-        // Query: docs with chunks but no kg_chunk_subjects provenance (D7).
+        // Query: docs with chunks but no kg_extractions row (D7).
         // For each: extract_document(agent_id, doc_path, None).
-        // Log progress per D9.
+        // On success: write kg_extractions row.
+        // Log progress per D11.
     }
 }
 ```
@@ -451,11 +502,11 @@ Expected output: { "entities": [...], "relationships": [...] }
 
 ## Implementation Units
 
-- [ ] **Unit 1: Schema amendments (D11/D12/D13)**
+- [ ] **Unit 1: Schema amendments (#686 D11-D15)**
 
-**Goal:** Add `kg_subject_relationships`, `kg_chunk_subjects`, `kg_chunk_subject_relationships` tables to the KG schema migration. Column constants in `kg_schema.rs`.
+**Goal:** Add `kg_subject_relationships`, `kg_chunk_subjects`, `kg_chunk_subject_relationships`, `kg_extractions` tables, and `confidence` column on `kg_subject_entities`, to the KG schema migration. Column constants in `kg_schema.rs`.
 
-**Requirements:** D8 (D11/D12/D13).
+**Requirements:** D8 (#686 D11-D15).
 
 **Dependencies:** #686 schema (v25 base).
 
@@ -560,7 +611,7 @@ Expected output: { "entities": [...], "relationships": [...] }
 
 **Files:** `crates/mika-agent/src/kg/subject_extractor.rs`.
 
-**Approach:** Run the pending-doc query (D7). Iterate docs, call `extract_document` for each. Log progress every 10 docs or 60 seconds (whichever comes first). Log completion summary. Failures per doc are logged and skipped (C2.3) — they remain pending for next startup.
+**Approach:** Run the pending-doc query against `kg_extractions` (D7). Iterate docs, call `extract_document` for each. On success, write `kg_extractions` row. Log progress every 10 docs or 60 seconds (whichever comes first). Log completion summary. Failures per doc are logged and skipped (C2.3) — no `kg_extractions` row written, so they remain pending for next startup.
 
 **Test scenarios:**
 - 0 pending docs → returns immediately, logs "nothing to extract."
@@ -595,20 +646,21 @@ Expected output: { "entities": [...], "relationships": [...] }
 
 ---
 
-- [ ] **Unit 7: Re-extraction integration with #689**
+- [ ] **Unit 7: Re-extraction integration via ingestion orchestrator**
 
-**Goal:** Wire the three-phase re-extraction flow (D5) into #689's doc-change handler.
+**Goal:** Wire the three-phase re-extraction flow (D5) via an ingestion orchestrator that owns the sequence (D9).
 
-**Requirements:** D5.
+**Requirements:** D5, D9.
 
 **Dependencies:** Units 4, 6.
 
-**Files:** `crates/mika-agent/src/kg/lexical_ingestor.rs` (capture previous state before re-ingest), `crates/mika-agent/src/kg/subject_extractor.rs` (reconciliation).
+**Files:** `crates/mika-agent/src/kg/ingestion_orchestrator.rs` (NEW — coordinates #689 and #690), `crates/mika-agent/src/kg/subject_extractor.rs` (reconciliation).
 
-**Approach:**
-- Before #689 deletes old chunks for a changed doc, capture `PreviousState` (entity_ids and relationship_ids linked to this doc's chunks).
-- After #689 writes new chunks, call `extract_document(doc, Some(previous_state))`.
-- The single-transaction reconciliation in Unit 4 handles the rest.
+**Approach:** The ingestion orchestrator owns the re-extraction sequence. #689's lexical ingestor and #690's subject extractor are called by the orchestrator — neither calls the other directly.
+- Orchestrator calls `capture_previous_state(agent_id, doc_path)` → reads provenance before any deletion.
+- Orchestrator calls #689's `reingest_document(doc_path)` → deletes old chunks, writes new chunks.
+- Orchestrator calls #690's `extract_document(doc_path, Some(previous_state))` → extraction + reconciliation.
+- This decouples #689 from #690 at the code level.
 
 **Test scenarios:**
 - Doc edited, entity removed → entity with no other provenance is deleted.
@@ -627,13 +679,5 @@ Expected output: { "entities": [...], "relationships": [...] }
 | Doc exceeds 30K tokens | Log warning, skip extraction for this doc. Flag for future section-level fallback. |
 | LLM returns entities with names containing `:` | Validate `name` field does not contain `:` (would break `entity_key = type || ':' || name` CHECK constraint). Reject entity, log warning. |
 | Duplicate entity_key from same doc (LLM extracts `problem_type:fabrication` twice) | UPSERT handles — second insertion updates properties. Single provenance row per (chunk, entity) via UNIQUE constraint. |
-| Zero entities extracted from a doc | Valid outcome — some docs (e.g., pure configuration guides) may have no extractable entities. Write no rows, emit audit_event with `entities_extracted: 0`. Doc is marked as "extracted" by having been processed (no longer returned by pending query if we track extraction completion — see D7 note below). |
-
-**D7 edge case — zero-entity docs and the pending query:**
-
-The pending-doc query (D7) checks for absence of `kg_chunk_subjects` rows. A doc with zero extracted entities has no provenance rows — it would be re-extracted every startup. Two options:
-
-1. Accept the re-extraction cost (~$0.0003 per doc). It's idempotent and the cost is noise. Simplest.
-2. Write a sentinel `kg_chunk_subjects` row with a special `subject_entity_id` (e.g., pointing to a synthetic "no entities" sentinel entity).
-
-Option 1 is recommended — re-extracting a zero-entity doc costs less than the engineering complexity of a sentinel. If the fraction of zero-entity docs becomes large enough to matter, add the sentinel then. YAGNI.
+| Zero entities extracted from a doc | Valid outcome — some docs (e.g., pure configuration guides) may have no extractable entities. Write `kg_extractions` row with `entities_extracted: 0`. Doc is correctly marked as "done" and not re-extracted on next startup (D7). |
+| LLM extracts same name under different type across runs (e.g., `problem_type:fabrication` then `failure_mode:fabrication`) | These are two different entities (different entity_key). UPSERT does not merge them. Intentional — entity identity includes type, not just name (D10). |

--- a/docs/plans/2026-04-21-006-feat-subject-graph-extraction-plan.md
+++ b/docs/plans/2026-04-21-006-feat-subject-graph-extraction-plan.md
@@ -1,0 +1,639 @@
+---
+title: "feat: subject graph extraction — LLM-based NER + fact triples from compound docs"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# Subject graph extraction — LLM-based NER + fact triples from compound docs
+
+## Overview
+
+Populate the subject graph layer of Mika's Knowledge Graph (milestone mika#14, ticket mika#690). For each agent, extract named entities and fact triples from previously-ingested documents (#689's `kg_chunks`) using per-document LLM calls. Produce `kg_subject_entities`, `kg_subject_relationships`, `kg_chunk_subjects`, and `kg_chunk_subject_relationships` rows. Per-agent scope (per #686 D1). No entity resolution in this ticket — linking subject entities to domain entities is #691's concern.
+
+This is the first KG ticket that introduces **non-interactive LLM calls** (per C2 in the conventions doc). All LLM-related conventions from C2 apply: model selection via `MIKA_KG_EXTRACTION_MODEL`, four-category retry taxonomy (C2.2), log-and-skip preserving lexical state (C2.3), `llm_calls` observability rows (C2.4).
+
+## Problem Frame
+
+#689 landed the lexical layer — chunked docs, indexed, searchable via FTS5 and vector. But chunks are unstructured text: "the fabrication bug was caused by state drift in core memory" is a sentence, not a traversable graph edge. An agent asking "what problems are caused by state drift?" must scan chunks by keyword, read the prose, and infer relationships — exactly the LLM-in-the-loop failure mode the KG replaces.
+
+The subject graph makes those implicit relationships explicit. Extraction produces `problem_type:fabrication -[CAUSED_BY]-> problem_type:state_drift -[SOLVED_BY]-> solution_path:pre_persistence_validation` as first-class graph edges, traversable by CTE, queryable by #688's query tool, and surfaceable by #692's self-knowledge upgrade.
+
+## Requirements Trace
+
+- R1. Per-doc LLM extraction producing subject entities and fact triples from previously-ingested chunks.
+- R2. Startup extraction runs asynchronously in the background after server readiness (does not block health check).
+- R3. Compound-hook extraction runs synchronously inline (~1 doc, <2s).
+- R4. Constrained extraction: only approved entity types and approved relationship types.
+- R5. Per-chunk provenance for both entities and relationships via join tables.
+- R6. Re-extraction on doc change: three-phase capture → reingest → reconcile transactionally.
+- R7. Observability per C2.4 (llm_calls rows) and C3.3 (per-doc audit_events, progress logging).
+
+## Scope Boundaries
+
+- Entity extraction, relationship extraction, chunk provenance, re-extraction lifecycle.
+- No entity resolution (subject → domain): **mika#691**.
+- No query tool: **mika#688**.
+- No self-knowledge upgrade: **mika#692**.
+- No LLM prompt design in this plan — exact prompt wording deferred to implementation (empirical). This plan specifies the **output schema** the prompt must produce.
+
+### Deferred to Separate Tasks
+
+- Entity resolution (fuzzy matching + LLM disambiguation of subject → domain): **mika#691**.
+- KG query tool (`query_knowledge_graph`): **mika#688**.
+- Self-knowledge upgrade: **mika#692**.
+
+## Context & Research
+
+### Cross-cutting conventions
+
+This plan cites `docs/architecture/kg-implementation-conventions.md` as the authoritative source for cross-cutting decisions. Sections that apply to #690:
+
+- **C1.1 (async-embedding contract):** Subject entities with text content (e.g., descriptions) that need embedding follow the same async pattern — write rows synchronously, embeddings generated later by backfill.
+- **C2 (non-interactive LLM call policy):** All of C2 applies. #690 is the primary consumer of `MIKA_KG_EXTRACTION_MODEL` (C2.1). Retry taxonomy (C2.2), log-and-skip (C2.3), and `llm_calls` observability (C2.4) are all mandatory.
+- **C3.3 (observability — subject extraction):** Per-document `audit_events` with `tool_name: "extract_subject_entities"`, progress logging for background runs.
+
+### #686, #687, #689 dependencies
+
+- **#686 schema:** `kg_subject_entities` shape (UNIQUE(agent_id, entity_key), trace_id per D6, CHECK constraint per D3). Schema amendments D11 (`kg_subject_relationships`), D12 (`kg_chunk_subjects`), D13 (`kg_chunk_subject_relationships`) — surfaced during #690 planning and folded back.
+- **#687 dependency:** Domain rebuild completes before extraction starts. Extraction does not read `kg_entities` directly — that's #691's concern. But the startup ordering (domain → lexical → subject) is preserved.
+- **#689 dependency:** Chunks must exist before extraction runs. Per-doc extraction reads the full doc from disk (not chunk text from DB) but uses chunk boundary info for provenance.
+
+### Relevant Code and Patterns
+
+- **LLM provider infrastructure:** `crates/mika-common/src/llm/mod.rs:305` — `create_provider(spec, max_tokens)` takes a `ModelSpec` and returns `Arc<dyn LlmProvider>`. #690 creates a dedicated provider instance from `MIKA_KG_EXTRACTION_MODEL` env var (per C2.1).
+- **LlmProvider trait:** `send_message(&self, request: &LlmRequest) -> Result<LlmResponse, LlmError>`. Request includes system prompt, messages, optional tool definitions. #690 uses a single user message with the doc text + extraction instructions, no tools — structured JSON output extracted from the response text.
+- **llm_calls table:** `crates/mika-agent/src/db.rs` — existing `store_llm_call` pattern. #690 writes one row per extraction call (per C2.4).
+- **Existing provider kinds:** 11 providers via `ProviderKind` enum. `MIKA_KG_EXTRACTION_MODEL` resolves through the same `Settings` → `ModelSpec` → `create_provider` pipeline.
+- **Async spawn pattern:** `tokio::spawn` for background tasks. Server startup uses `tokio::spawn` for embedding backfill already — extraction follows the same pattern.
+- **kg_chunks schema:** `UNIQUE(agent_id, source_doc_path, seq_id)`, `source_doc_hash TEXT NOT NULL`. Chunks are keyed by doc path + sequence.
+
+### Institutional Learnings
+
+- `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md` — Sole-writer designation: #690's `SubjectExtractor` is the sole writer of subject-typed `entity_key`s in `kg_subject_entities`, all rows in `kg_subject_relationships`, all rows in `kg_chunk_subjects`, and all rows in `kg_chunk_subject_relationships`. No other code path writes these.
+- `docs/solutions/database-issues/trace-id-as-observability-join-key.md` — One `trace_id` per extraction invocation (per-agent, per-run). Stamped on all rows written in that invocation. Separate `extraction_trace_id` on provenance join tables (per Vincent's refinement in D12).
+- `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — Column constants for new tables in `kg_schema.rs`.
+
+## Key Technical Decisions
+
+### D1. Per-doc extraction with chunk boundary markers
+
+Resolved during planning. The LLM sees the **full document text** per extraction call, not individual chunks. Chunk boundary markers (`[CHUNK 0]`, `[CHUNK 1]`, ...) are inserted between chunks in the prompt so the LLM can attribute extractions to source chunks in its output.
+
+Rationale: extraction needs cross-chunk context to produce coherent fact triples. A relationship like `problem_type:fabrication -[CAUSED_BY]-> problem_type:state_drift` may span chunks (problem stated in chunk 1, cause identified in chunk 3, solution in chunk 5). Per-chunk extraction structurally cannot produce cross-chunk relationships — it treats each chunk in isolation, losing discourse structure, coreference, and logical flow. Per-doc sees the whole document and produces the complete relationship set.
+
+The cost delta is secondary to the quality delta. Per-doc produces fact triples that per-chunk structurally cannot produce, and those triples are the core value of the subject layer for #692's self-knowledge queries.
+
+**Large-doc escape hatch:** For docs exceeding 30K tokens (unlikely for `docs/solutions/` at 2-10K tokens, but possible for future content), fall back to section-level extraction where sections are identified by `##` heading structure. Flag as a known boundary condition — implement only when the trigger case exists.
+
+### D2. Async background extraction at startup, sync on compound hook
+
+Resolved during planning. Two execution contexts:
+
+**Startup:** After server readiness (domain rebuild + chunk ingestion complete), spawn one background extraction task per agent. Tasks run concurrently (per-agent parallelism), internally serial per doc. Server is ready for queries immediately; subject entities appear progressively as extraction completes. Matches C1.1's bounded-staleness pattern — agents see FTS5/vec results immediately, subject graph fills in asynchronously.
+
+**Compound hook:** `/ce:compound` writes a doc → #689 `ingest_document` (sync) → #690 `extract_document` (sync, 1 call, <2s). The authoring agent gets immediate subject-graph queryability for the doc they just wrote. Failure follows C2.3 log-and-skip — extraction failure does not fail the compound write.
+
+**`create_agent`:** After the tool writes the new agent, spawn a background extraction task for that agent's pending docs. Same code path as startup, single-agent scope.
+
+Concurrency model: per-agent parallelism bounds peak LLM concurrency to N (agent count). Rate-limit handling per C2.2 is per-agent-local. If the provider rate-limits, individual agents' extractors back off independently.
+
+### D3. Constrained extraction — approved types and relationship types only
+
+Resolved during planning. Extraction is constrained to a fixed set of entity types and relationship types. The LLM prompt specifies the allowed types; the output validator rejects any extraction with an unapproved type.
+
+**Approved entity types:**
+
+| Type prefix | Source | Description |
+|-------------|--------|-------------|
+| `skill:` | Well-known (domain graph) | References to skills by name |
+| `tool:` | Well-known (domain graph) | References to tools by name |
+| `agent:` | Well-known (domain graph) | References to agents by name |
+| `problem_type:` | Both (domain seed + discovered) | Bug categories, failure modes |
+| `solution_path:` | Discovered | Named solution strategies |
+| `failure_mode:` | Discovered | Specific failure patterns |
+| `pattern:` | Discovered | Recurring architectural/workflow patterns |
+
+Well-known types (skill, tool, agent) produce subject entities here; #691 resolves them to domain entities. Discovered types (solution_path, failure_mode, pattern) live purely in the subject graph — they have no domain counterpart unless a future ticket adds domain seeds for them.
+
+**Approved relationship types:**
+
+| Relationship | From type(s) | To type(s) |
+|-------------|-------------|------------|
+| `SOLVED_BY` | problem_type | solution_path |
+| `USES` | solution_path | skill |
+| `CALLS` | solution_path | tool |
+| `INDICATES` | failure_mode | problem_type |
+| `PREVENTS` | pattern | problem_type |
+| `CAUSED_BY` | problem_type | problem_type |
+| `MENTIONS` | any | agent |
+
+The type constraint is structural (validated in code), not prompt-only. The prompt instructs the LLM to produce only approved types; the validator rejects non-compliant output at the JSON parsing layer. Per `feedback_prompt_enforcement_fragile.md`: structural guards, not prompt-text rules.
+
+### D4. Output schema — what the LLM must produce
+
+Resolved during planning. The extraction prompt produces a JSON object with three arrays. Exact prompt wording deferred to implementation (empirical); this plan specifies the **output contract**.
+
+```json
+{
+  "entities": [
+    {
+      "type": "problem_type",
+      "name": "fabrication",
+      "description": "LLM generates content not grounded in tool results",
+      "chunk_indices": [0, 2, 5],
+      "confidence": 0.9
+    }
+  ],
+  "relationships": [
+    {
+      "from_type": "problem_type",
+      "from_name": "fabrication",
+      "to_type": "problem_type",
+      "to_name": "state_drift",
+      "type": "CAUSED_BY",
+      "chunk_indices": [2, 3],
+      "confidence": 0.85
+    }
+  ]
+}
+```
+
+**Key properties:**
+
+- `chunk_indices` on both entities and relationships. These map to the `[CHUNK N]` markers in the prompt and drive `kg_chunk_subjects` / `kg_chunk_subject_relationships` provenance rows.
+- `confidence` on both entities and relationships. Extraction-time confidence from the LLM. Stored on `kg_subject_entities.properties_json` (entities) and `kg_subject_relationships.confidence` (relationships). Downstream consumers (#688, #692) can filter by threshold.
+- `type` + `name` on entities compose to `entity_key` via the `type || ':' || name` convention (per #686 D3).
+- Entity `description` is optional free text stored in `properties_json`.
+
+**Validation rules (structural, not prompt-only):**
+
+1. Top-level must be an object with `entities` and `relationships` arrays.
+2. Every entity must have `type` in the approved list, non-empty `name`, and non-empty `chunk_indices`.
+3. Every relationship must have `type` in the approved list, valid `from_type`/`from_name` and `to_type`/`to_name` that reference entities in the same response, and non-empty `chunk_indices`.
+4. Relationship type constraints are enforced (e.g., `SOLVED_BY` must go from `problem_type` to `solution_path`).
+5. Malformed JSON or schema violations trigger the C2.2 semantic-failure retry (one retry with prompt reinforcement, then log-and-skip).
+
+### D5. Delete-and-re-extract on doc change (three-phase reconciliation)
+
+Resolved during planning. When #689 re-ingests a changed doc (per #689 D4/D6), subject extraction must reconcile. The naive "delete then re-extract" exposes intermediate partial state and can spuriously delete entities shared across docs.
+
+**Three-phase flow:**
+
+**Phase 1 — Capture (before #689 re-ingestion):**
+Read the set of subject entities and relationships previously linked to this doc's chunks:
+```sql
+SELECT DISTINCT cs.subject_entity_id
+FROM kg_chunk_subjects cs
+JOIN kg_chunks c ON cs.chunk_id = c.id
+WHERE c.agent_id = ? AND c.source_doc_path = ?
+```
+Store as `previous_entity_ids` and `previous_relationship_ids`. This set scopes the orphan sweep in Phase 3.
+
+**Phase 2 — Reingest (#689's existing flow):**
+#689 deletes old chunks, writes new chunks, within its own transaction. Chunk deletion CASCADE-deletes `kg_chunk_subjects` and `kg_chunk_subject_relationships` rows for those chunks.
+
+**Phase 3 — Re-extract and reconcile (single transaction):**
+1. Run per-doc extraction on the new doc text (LLM call, outside transaction).
+2. `BEGIN TRANSACTION`.
+3. UPSERT new entities: `INSERT INTO kg_subject_entities ... ON CONFLICT(agent_id, entity_key) DO UPDATE SET properties_json = ..., updated_at = ...`. Preserves `id` so existing relationships and resolutions survive.
+4. INSERT new `kg_chunk_subjects` provenance rows (new chunks → entities).
+5. UPSERT new relationships: `INSERT INTO kg_subject_relationships ... ON CONFLICT(agent_id, from_entity_id, to_entity_id, type) DO UPDATE SET confidence = ..., properties_json = ...`.
+6. INSERT new `kg_chunk_subject_relationships` provenance rows (new chunks → relationships).
+7. Scoped orphan sweep — delete entities from `previous_entity_ids` that now have zero provenance:
+   ```sql
+   DELETE FROM kg_subject_entities
+   WHERE id IN (<previous_entity_ids>)
+     AND id NOT IN (SELECT subject_entity_id FROM kg_chunk_subjects WHERE agent_id = ?)
+   ```
+   CASCADE handles `kg_subject_relationships`, `kg_subject_resolutions`, `kg_chunk_subjects`.
+8. Scoped orphan sweep for relationships from `previous_relationship_ids` with zero provenance.
+9. `COMMIT`.
+
+**Correctness properties:**
+- Entities shared across docs survive (they still have provenance from other docs' chunks).
+- Entities unique to the edited doc that the new text still mentions survive (UPSERT in step 3 + new provenance in step 4).
+- Entities unique to the edited doc that the new text no longer mentions are correctly deleted (zero provenance after step 4 → caught by step 7).
+- No observable intermediate state — steps 2-9 are in one transaction.
+
+### D6. Single extractor, multiple invokers
+
+Resolved during planning. `SubjectExtractor.extract_document(doc_path, agent_id, previous_state: Option<PreviousState>)` is the sole extraction entry point. All invokers call it:
+
+- **Startup background:** `extract_pending(agent_id)` enumerates docs needing extraction (see D7), calls `extract_document` for each.
+- **Compound hook:** calls `extract_document` with `previous_state: None` (fresh doc, no orphan sweep).
+- **`create_agent`:** spawns `extract_pending(new_agent_id)` as background task.
+- **Re-extraction on doc change:** calls `extract_document` with `previous_state: Some(...)` for the three-phase flow.
+
+The extractor is invocation-context-agnostic — no assumptions about being on the main runtime, no coupling to server state. This keeps the migration path to a dedicated worker (Option 3 from planning) open if scale demands it.
+
+### D7. Pending-doc query drives extraction (idempotent)
+
+Resolved during planning. The extractor determines what needs extraction by querying data shape, not tracking explicit state:
+
+```sql
+-- Docs with chunks but no subject provenance
+SELECT DISTINCT c.source_doc_path
+FROM kg_chunks c
+WHERE c.agent_id = ?
+  AND NOT EXISTS (
+    SELECT 1 FROM kg_chunk_subjects cs
+    WHERE cs.chunk_id = c.id
+  )
+```
+
+This query drives startup extraction and handles all failure modes:
+- Server crash mid-extraction: incomplete docs have chunks but no provenance → pending on next startup.
+- Provider down at startup: retries exhaust → docs remain pending → picked up on next startup.
+- New docs from compound hook: if hook extraction fails (C2.3 log-and-skip), doc stays pending → picked up at next startup.
+
+No explicit state enum, no `kg_extractions` tracking table. The data shape is the state. Matches C1.1's embedding backfill pattern (idempotent by `embedding_json IS NULL`).
+
+**Periodic retry (deferred):** A background task re-running the pending query every N hours would catch "provider was flaky at startup, recovered later." Deferred to implementation — build without it, add if "stale extraction due to startup-time provider failure" becomes an observed pattern.
+
+### D8. Schema amendments to #686 — D11, D12, D13
+
+Surfaced during #690 planning. All three are new tables for subject-layer cross-table relationships. They follow the pattern identified across the milestone: *every first-class KG table has relationships to other first-class tables that need their own tables*.
+
+**D11. `kg_subject_relationships`** — subject-to-subject edges (fact triples).
+
+```sql
+CREATE TABLE kg_subject_relationships (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    from_entity_id INTEGER NOT NULL REFERENCES kg_subject_entities(id) ON DELETE CASCADE,
+    to_entity_id INTEGER NOT NULL REFERENCES kg_subject_entities(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    confidence REAL NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    properties_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    trace_id TEXT,
+    UNIQUE (agent_id, from_entity_id, to_entity_id, type)
+);
+CREATE INDEX idx_kg_subj_rel_from ON kg_subject_relationships(agent_id, from_entity_id, type);
+CREATE INDEX idx_kg_subj_rel_to ON kg_subject_relationships(agent_id, to_entity_id, type);
+CREATE INDEX idx_kg_subj_rel_type ON kg_subject_relationships(agent_id, type);
+```
+
+**D12. `kg_chunk_subjects`** — entity provenance (chunk → subject entity, many-to-many).
+
+```sql
+CREATE TABLE kg_chunk_subjects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    chunk_id INTEGER NOT NULL REFERENCES kg_chunks(id) ON DELETE CASCADE,
+    subject_entity_id INTEGER NOT NULL REFERENCES kg_subject_entities(id) ON DELETE CASCADE,
+    extraction_trace_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE (agent_id, chunk_id, subject_entity_id)
+);
+CREATE INDEX idx_kg_cs_chunk ON kg_chunk_subjects(agent_id, chunk_id);
+CREATE INDEX idx_kg_cs_entity ON kg_chunk_subjects(agent_id, subject_entity_id);
+CREATE INDEX idx_kg_cs_trace ON kg_chunk_subjects(agent_id, extraction_trace_id);
+```
+
+**D13. `kg_chunk_subject_relationships`** — relationship provenance (chunk → subject relationship, many-to-many).
+
+```sql
+CREATE TABLE kg_chunk_subject_relationships (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    chunk_id INTEGER NOT NULL REFERENCES kg_chunks(id) ON DELETE CASCADE,
+    subject_relationship_id INTEGER NOT NULL REFERENCES kg_subject_relationships(id) ON DELETE CASCADE,
+    extraction_trace_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE (agent_id, chunk_id, subject_relationship_id)
+);
+CREATE INDEX idx_kg_csr_chunk ON kg_chunk_subject_relationships(agent_id, chunk_id);
+CREATE INDEX idx_kg_csr_rel ON kg_chunk_subject_relationships(agent_id, subject_relationship_id);
+```
+
+These three tables complete the subject layer's provenance model. The convention to add to `kg-implementation-conventions.md`: "Every first-class KG table has relationships to other first-class tables; those relationships need their own tables with their own provenance." D11-D13 should be folded into #686's v25 schema if still pre-ship, or batched as v25→v26 if v25 has shipped.
+
+### D9. Observability — per-doc audit_events + progress logging
+
+Per C3.3. Each per-doc extraction emits one `audit_events` row:
+
+- `tool_name`: `extract_subject_entities`
+- `target_key`: `kg_subject:<source_doc_path>`
+- `before_value`/`after_value`: summary counts (e.g., `{"entities_extracted": 12, "relationships": 8}`)
+
+Background extraction progress logging:
+
+```
+INFO trace_id=<id> event=subject_extraction_start agent_id=<a> pending_docs=200
+INFO trace_id=<id> event=subject_extraction_progress agent_id=<a> completed=50 remaining=150 duration_ms=240000
+INFO trace_id=<id> event=subject_extraction_complete agent_id=<a> completed=200 failed=3 duration_ms=720000
+```
+
+Every LLM call emits an `llm_calls` row per C2.4.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Extraction granularity — per-doc with chunk boundary markers (see D1).
+- Execution model — async background at startup, sync on compound hook (see D2).
+- Entity and relationship types — constrained to approved lists (see D3).
+- Output schema — structured JSON with chunk-index annotations (see D4).
+- Re-extraction lifecycle — three-phase capture → reingest → reconcile (see D5).
+- Single extractor, multiple invokers (see D6).
+- Pending-doc detection — idempotent by data shape (see D7).
+- Schema amendments — D11/D12/D13 folded back into #686 (see D8).
+- Subject-to-subject relationship storage — `kg_subject_relationships` table, not `kg_relationships` extension (D11).
+- Chunk-subject provenance — `kg_chunk_subjects` join table with `extraction_trace_id` (D12).
+- Relationship-chunk provenance — `kg_chunk_subject_relationships` join table (D13, surfaced during re-extraction design).
+
+### Deferred to Implementation
+
+- Exact LLM prompt wording for extraction (empirical — iterate during implementation).
+- Extraction model default (`MIKA_KG_EXTRACTION_MODEL` default value — haiku-4.5 or deepseek-v3, to be determined by cost/quality testing).
+- Progress logging interval (every N docs or every M seconds — tune during implementation).
+- Whether `create_agent` auto-triggers extraction immediately or waits for next startup (implement the cleaner version if straightforward, defer if not).
+- Large-doc section-level fallback threshold (suggested 30K tokens — implement only when trigger case exists).
+- Periodic retry for stale-at-startup extraction (deferred until failure mode is observed).
+
+## Output Structure
+
+```
+crates/mika-agent/src/
+├── db.rs                            # ADD: kg_schema amendments (D11/D12/D13 table constants)
+├── db/kg_schema.rs                  # ADD: column constants for new tables
+└── kg/
+    ├── mod.rs                       # MODIFY: add `pub mod subject_extractor;`
+    ├── domain_builder.rs            # (from #687 — unchanged)
+    ├── chunker.rs                   # (from #689 — unchanged)
+    ├── lexical_ingestor.rs          # (from #689 — MODIFY: hook extraction after ingest)
+    └── subject_extractor.rs         # NEW: per-doc extraction, output validation, DB writes
+
+crates/mika-agent/src/server/
+└── mod.rs                           # MODIFY: spawn background extraction after startup
+
+crates/mika-agent/tests/
+└── kg/
+    └── subject_extractor.rs         # NEW: extraction integration tests
+
+docs/plans/
+└── 2026-04-21-006-feat-subject-graph-extraction-plan.md   # this file
+```
+
+## High-Level Technical Design
+
+> *Directional guidance for review, not implementation specification.*
+
+```rust
+// crates/mika-agent/src/kg/subject_extractor.rs
+
+/// Sole writer of kg_subject_entities, kg_subject_relationships,
+/// kg_chunk_subjects, and kg_chunk_subject_relationships.
+///
+/// Invariants:
+/// - All extraction goes through extract_document().
+/// - Output JSON validated structurally, not just by prompt.
+/// - Re-extraction uses three-phase reconciliation (D5).
+/// - All writes carry trace_id for the extraction invocation.
+pub struct SubjectExtractor {
+    db: AsyncDatabase,
+    llm: Arc<dyn LlmProvider>,  // from MIKA_KG_EXTRACTION_MODEL
+    trace_id: String,
+}
+
+/// Previous provenance state, captured before re-ingestion.
+/// None for fresh extraction (first-time or compound hook).
+pub struct PreviousState {
+    entity_ids: Vec<i64>,
+    relationship_ids: Vec<i64>,
+}
+
+impl SubjectExtractor {
+    /// Core extraction entry point — invocation-context-agnostic.
+    pub async fn extract_document(
+        &self,
+        agent_id: &str,
+        doc_path: &str,
+        previous_state: Option<PreviousState>,
+    ) -> Result<ExtractionStats> {
+        // 1. Read full doc from disk.
+        // 2. Read chunk boundaries from kg_chunks for this (agent_id, doc_path).
+        // 3. Build prompt with chunk boundary markers.
+        // 4. LLM call (with C2.2 retry on failure).
+        // 5. Parse + validate output JSON (D4 schema).
+        // 6. Write entities, relationships, provenance in single transaction (D5 phase 3).
+        // 7. If previous_state is Some, run scoped orphan sweep.
+        // 8. Emit audit_events row.
+    }
+
+    /// Enumerate and extract all pending docs for an agent.
+    pub async fn extract_pending(&self, agent_id: &str) -> Result<BatchStats> {
+        // Query: docs with chunks but no kg_chunk_subjects provenance (D7).
+        // For each: extract_document(agent_id, doc_path, None).
+        // Log progress per D9.
+    }
+}
+```
+
+### Extraction prompt shape (directional, not final)
+
+```
+System: You are a knowledge graph extraction agent. Extract named entities
+and fact triples from the following document. Return ONLY valid JSON
+matching the specified schema.
+
+[Approved entity types: skill, tool, agent, problem_type, solution_path,
+ failure_mode, pattern]
+[Approved relationship types: SOLVED_BY, USES, CALLS, INDICATES, PREVENTS,
+ CAUSED_BY, MENTIONS]
+
+User: [CHUNK 0] <chunk 0 text> [CHUNK 1] <chunk 1 text> ... [CHUNK N] <chunk N text>
+
+Expected output: { "entities": [...], "relationships": [...] }
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Schema amendments (D11/D12/D13)**
+
+**Goal:** Add `kg_subject_relationships`, `kg_chunk_subjects`, `kg_chunk_subject_relationships` tables to the KG schema migration. Column constants in `kg_schema.rs`.
+
+**Requirements:** D8 (D11/D12/D13).
+
+**Dependencies:** #686 schema (v25 base).
+
+**Files:** `crates/mika-agent/src/db.rs` (migration), `crates/mika-agent/src/db/kg_schema.rs` (constants).
+
+**Approach:** If #686 is still pre-ship, fold into v25 directly. If shipped, v25→v26 migration following the same pattern as v24→v25. Add to `migrate_v1()` for clean-slate convergence.
+
+**Test scenarios:**
+- Forward-test: v25→v26 migration applies cleanly on a DB with existing kg_entities/kg_chunks data.
+- Clean-slate: fresh DB has all three new tables.
+- FK CASCADE: deleting a kg_subject_entity CASCADE-deletes its kg_chunk_subjects and kg_subject_relationships rows.
+- UNIQUE constraints prevent duplicate provenance/relationship rows.
+
+**Verification:** `cargo test -p mika-agent -- migrations`
+
+---
+
+- [ ] **Unit 2: LLM provider for extraction model**
+
+**Goal:** Create a dedicated `LlmProvider` instance from `MIKA_KG_EXTRACTION_MODEL` (with `MIKA_KG_INGESTION_MODEL` fallback per C2.1).
+
+**Requirements:** C2.1.
+
+**Dependencies:** `mika-common` LLM infrastructure.
+
+**Files:** `crates/mika-agent/src/kg/subject_extractor.rs` (provider creation), `crates/mika-common/src/config.rs` (env var resolution).
+
+**Approach:** Parse `MIKA_KG_EXTRACTION_MODEL` as `provider/model` string (e.g., `anthropic/claude-haiku-4-5-20251001`). Resolve API key from the provider's existing env var. Fall back to `MIKA_KG_INGESTION_MODEL`, then to a hardcoded default. Create via `create_provider()`.
+
+**Test scenarios:**
+- Explicit model set → uses that model.
+- Fallback chain: extraction unset → ingestion → default.
+- Missing API key for configured provider → clear error at startup, not a silent failure mid-extraction.
+
+**Verification:** Unit tests with mock provider.
+
+---
+
+- [ ] **Unit 3: Output schema validation**
+
+**Goal:** Parse and validate extraction LLM output against D4's schema. Reject malformed JSON, unapproved types, and relationship type constraint violations.
+
+**Requirements:** D3, D4.
+
+**Dependencies:** None (pure data validation).
+
+**Files:** `crates/mika-agent/src/kg/subject_extractor.rs` (validation module).
+
+**Approach:** Deserialize into typed structs (`ExtractionOutput`, `ExtractedEntity`, `ExtractedRelationship`). Validate entity types against `APPROVED_ENTITY_TYPES` const, relationship types against `APPROVED_RELATIONSHIP_TYPES` const with from/to type constraints. Return `ValidationError` with specific failure details for the C2.2 semantic-retry prompt reinforcement.
+
+**Test scenarios:**
+- Valid JSON with approved types → accepted.
+- Unknown entity type → rejected with message naming the type.
+- Relationship with wrong from/to types → rejected.
+- Missing chunk_indices → rejected.
+- Empty entities array → accepted (some docs may have no extractable entities).
+- Malformed JSON → rejected, triggers retry.
+
+**Verification:** `cargo test -p mika-agent -- subject_extractor::validation`
+
+---
+
+- [ ] **Unit 4: Core extraction logic — extract_document**
+
+**Goal:** The single entry point: read doc, build prompt with chunk markers, LLM call with C2.2 retry, validate output, write to DB in single transaction.
+
+**Requirements:** D1, D4, D5, D6, C2.2, C2.3.
+
+**Dependencies:** Units 1-3.
+
+**Files:** `crates/mika-agent/src/kg/subject_extractor.rs`.
+
+**Approach:**
+1. Read full doc from disk. Read `kg_chunks` for this (agent_id, doc_path) to get chunk boundaries (seq_id ordering).
+2. Build prompt: system message with approved types/schemas, user message with doc text annotated by `[CHUNK N]` markers.
+3. Call LLM. On transport/rate-limit failure: retry per C2.2 (up to 3 attempts with backoff). On semantic failure (malformed JSON): one retry with prompt reinforcement, then log-and-skip per C2.3.
+4. Validate output (Unit 3).
+5. If `previous_state` is Some: execute D5 three-phase reconciliation in single transaction.
+6. If `previous_state` is None: write entities (UPSERT), relationships (UPSERT), provenance rows in single transaction.
+7. Emit `llm_calls` row (C2.4).
+8. Emit `audit_events` row (D9).
+9. Return `ExtractionStats`.
+
+**Test scenarios:**
+- Fresh extraction: entities, relationships, provenance all written correctly.
+- Re-extraction with unchanged content: UPSERT produces same rows, no orphans.
+- Re-extraction with changed content: old-only entities deleted, new entities added, shared entities survive.
+- LLM returns malformed JSON: retry fires, then log-and-skip. No partial writes.
+- LLM returns empty entities: succeeds with zero entities written (doc has no extractable content).
+
+**Verification:** Integration tests with `MockLlmProvider`.
+
+---
+
+- [ ] **Unit 5: Background extraction — extract_pending**
+
+**Goal:** Enumerate pending docs per agent, extract each, log progress.
+
+**Requirements:** D2, D7, D9.
+
+**Dependencies:** Unit 4.
+
+**Files:** `crates/mika-agent/src/kg/subject_extractor.rs`.
+
+**Approach:** Run the pending-doc query (D7). Iterate docs, call `extract_document` for each. Log progress every 10 docs or 60 seconds (whichever comes first). Log completion summary. Failures per doc are logged and skipped (C2.3) — they remain pending for next startup.
+
+**Test scenarios:**
+- 0 pending docs → returns immediately, logs "nothing to extract."
+- N pending docs → extracts all, logs progress and completion.
+- Mid-run failure on doc K → docs 0..K-1 extracted, K skipped (logged), K+1..N continue.
+- Provider entirely down → all docs fail, all remain pending.
+
+**Verification:** Integration tests with mock.
+
+---
+
+- [ ] **Unit 6: Startup and compound hook integration**
+
+**Goal:** Wire extraction into the server startup sequence (background spawn) and compound hook (synchronous inline).
+
+**Requirements:** D2.
+
+**Dependencies:** Unit 5.
+
+**Files:** `crates/mika-agent/src/server/mod.rs` (startup spawn), `crates/mika-agent/src/kg/lexical_ingestor.rs` (compound hook integration).
+
+**Approach:**
+- Startup: after `LexicalIngestor.ingest_all()` completes, `tokio::spawn` one `extract_pending(agent_id)` task per agent.
+- Compound hook: after `ingest_document(doc)`, call `extract_document(doc, None)` synchronously. Wrap in catch — extraction failure must not fail the compound write.
+
+**Test scenarios:**
+- Server starts, extraction tasks spawned for each agent.
+- Compound doc written → both chunks and subject entities available immediately.
+- Compound hook extraction fails → doc ingested successfully, extraction pending for next startup.
+
+**Verification:** Integration test verifying startup sequence ordering; compound hook test with mock.
+
+---
+
+- [ ] **Unit 7: Re-extraction integration with #689**
+
+**Goal:** Wire the three-phase re-extraction flow (D5) into #689's doc-change handler.
+
+**Requirements:** D5.
+
+**Dependencies:** Units 4, 6.
+
+**Files:** `crates/mika-agent/src/kg/lexical_ingestor.rs` (capture previous state before re-ingest), `crates/mika-agent/src/kg/subject_extractor.rs` (reconciliation).
+
+**Approach:**
+- Before #689 deletes old chunks for a changed doc, capture `PreviousState` (entity_ids and relationship_ids linked to this doc's chunks).
+- After #689 writes new chunks, call `extract_document(doc, Some(previous_state))`.
+- The single-transaction reconciliation in Unit 4 handles the rest.
+
+**Test scenarios:**
+- Doc edited, entity removed → entity with no other provenance is deleted.
+- Doc edited, entity still present → entity survives with updated provenance.
+- Doc edited, new entity added → new entity and provenance created.
+- Doc edited, shared entity between two docs → entity survives (provenance from other doc remains).
+
+**Verification:** Integration test with two docs sharing an entity, editing one.
+
+## Error Handling & Edge Cases
+
+| Scenario | Expected behavior |
+|----------|------------------|
+| LLM provider not configured (`MIKA_KG_EXTRACTION_MODEL` unset, no fallback) | Extraction disabled at startup. Log `warn!(event="extraction_disabled", reason="no extraction model configured")`. Chunks still ingested, subject layer stays empty. |
+| Provider rate-limited mid-extraction | Per-agent backoff per C2.2. Other agents' extraction continues. Rate-limited agent retries affected doc on next attempt. |
+| Doc exceeds 30K tokens | Log warning, skip extraction for this doc. Flag for future section-level fallback. |
+| LLM returns entities with names containing `:` | Validate `name` field does not contain `:` (would break `entity_key = type || ':' || name` CHECK constraint). Reject entity, log warning. |
+| Duplicate entity_key from same doc (LLM extracts `problem_type:fabrication` twice) | UPSERT handles — second insertion updates properties. Single provenance row per (chunk, entity) via UNIQUE constraint. |
+| Zero entities extracted from a doc | Valid outcome — some docs (e.g., pure configuration guides) may have no extractable entities. Write no rows, emit audit_event with `entities_extracted: 0`. Doc is marked as "extracted" by having been processed (no longer returned by pending query if we track extraction completion — see D7 note below). |
+
+**D7 edge case — zero-entity docs and the pending query:**
+
+The pending-doc query (D7) checks for absence of `kg_chunk_subjects` rows. A doc with zero extracted entities has no provenance rows — it would be re-extracted every startup. Two options:
+
+1. Accept the re-extraction cost (~$0.0003 per doc). It's idempotent and the cost is noise. Simplest.
+2. Write a sentinel `kg_chunk_subjects` row with a special `subject_entity_id` (e.g., pointing to a synthetic "no entities" sentinel entity).
+
+Option 1 is recommended — re-extracting a zero-entity doc costs less than the engineering complexity of a sentinel. If the fraction of zero-entity docs becomes large enough to matter, add the sentinel then. YAGNI.

--- a/docs/solutions/best-practices/kg-subject-extraction-constrained-ner-2026-04-22.md
+++ b/docs/solutions/best-practices/kg-subject-extraction-constrained-ner-2026-04-22.md
@@ -1,0 +1,93 @@
+---
+title: "Subject graph extraction uses constrained NER with structural validation"
+date: 2026-04-22
+category: best-practices
+module: kg
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding LLM-based extraction to a knowledge graph pipeline
+  - Building NER systems that produce typed entities and relationships
+  - Designing extraction output schemas for graph ingestion
+tags:
+  - knowledge-graph
+  - subject-extraction
+  - llm-extraction
+  - ner
+  - constrained-types
+  - validation
+---
+
+# Subject graph extraction uses constrained NER with structural validation
+
+## Context
+
+Mika's Knowledge Graph (#690) needs to extract named entities and fact triples from solution docs using LLM-based NER. The extracted entities must conform to an approved type system (`skill`, `tool`, `agent`, `problem_type`, `solution_path`, `failure_mode`, `pattern`) and relationships must follow directional constraints (e.g., `SOLVED_BY` only goes from `problem_type` to `solution_path`).
+
+Relying solely on prompt instructions to enforce these constraints is fragile — LLMs hallucinate types, ignore directional rules, and produce malformed JSON. The `feedback_prompt_enforcement_fragile.md` solution documents this pattern.
+
+## Guidance
+
+Use a two-layer validation strategy: **prompt instructs, code enforces**.
+
+1. **Prompt layer**: Tell the LLM the approved types, relationship constraints, and output schema. This guides output quality but is not trusted for correctness.
+
+2. **Structural validation layer**: After parsing the JSON response, validate every entity type against `APPROVED_ENTITY_TYPES`, every relationship type against `APPROVED_RELATIONSHIP_TYPES` with from/to type constraints, and reject entities with names containing `:` (which would break the `entity_key = type || ':' || name` convention).
+
+3. **Partial acceptance**: When some entities pass and others fail validation, keep the valid subset rather than rejecting the entire extraction. This maximizes extraction yield from a single LLM call. Only reject entirely when ALL entities are invalid.
+
+4. **UPSERT semantics**: Use `INSERT ... ON CONFLICT DO UPDATE` with `MAX(excluded.confidence, existing.confidence)` to preserve the highest confidence seen across extractions. This makes extraction idempotent — re-extracting the same doc produces the same result.
+
+5. **Provenance tracking**: Every entity and relationship links back to source chunks via join tables (`kg_chunk_subjects`, `kg_chunk_subject_relationships`). This enables the three-phase re-extraction reconciliation (D5) — capture previous provenance, reingest chunks, re-extract with scoped orphan sweep.
+
+6. **Tracking table for pending detection**: A `kg_extractions` table records which docs have been extracted. The pending-doc query joins `kg_chunks` against `kg_extractions` to find docs needing extraction. Zero-entity docs get a tracking row with `entities_extracted = 0` — without this, they would re-extract on every startup.
+
+## Why This Matters
+
+Prompt-only enforcement leads to invalid graph edges that downstream consumers (query tool, self-knowledge) treat as truth. A `failure_mode:fabrication -[SOLVED_BY]-> skill:self_dev` edge with wrong types would mislead the agent's self-knowledge answers. Structural validation catches these at extraction time, before they enter the graph.
+
+The UPSERT + provenance pattern makes the extractor idempotent and crash-safe — if the server crashes mid-extraction, no tracking row is written and the doc remains pending for next startup. No manual cleanup required.
+
+## When to Apply
+
+- Building any LLM-based extraction pipeline that feeds a typed graph or database
+- When extraction output must conform to a schema with enum constraints
+- When the same document may be re-extracted (content changes, model upgrades)
+- When extraction needs to be crash-safe and resumable
+
+## Examples
+
+Approved relationship constraints with from/to type enforcement:
+
+```rust
+pub const APPROVED_RELATIONSHIP_TYPES: &[RelationshipConstraint] = &[
+    RelationshipConstraint {
+        rel_type: "SOLVED_BY",
+        from_types: &["problem_type"],
+        to_types: &["solution_path"],
+    },
+    // ... other constrained types
+];
+```
+
+Validation filters invalid items rather than rejecting the whole response:
+
+```rust
+// If some entities pass and some fail, return the valid subset
+if valid_entities.is_empty() && !output.entities.is_empty() {
+    return Err(ValidationError { ... }); // All rejected = error
+}
+// Otherwise return partial results with warnings
+Ok(ExtractionOutput {
+    entities: valid_entities,
+    relationships: valid_relationships,
+})
+```
+
+## Related
+
+- `docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md` — lexical layer composed write pattern
+- `docs/solutions/best-practices/kg-domain-graph-startup-projection-2026-04-22.md` — domain layer deterministic projection
+- `docs/architecture/kg-implementation-conventions.md` — cross-cutting KG conventions (C2 LLM policy, C3 observability)
+- `docs/plans/2026-04-21-006-feat-subject-graph-extraction-plan.md` — full implementation plan


### PR DESCRIPTION
## Summary

- **Subject extractor** (`SubjectExtractor`): Per-doc LLM-based extraction with constrained NER (7 approved entity types, 7 approved relationship types with from/to constraints). Structural validation in code, not just prompt. C2.2 retry taxonomy, C2.3 log-and-skip, C2.4 llm_calls observability, C3.3 per-doc audit events.
- **Background extraction**: Pending-doc query via `kg_extractions` tracking table. Spawned per-agent at startup after lexical ingestion. Zero-entity docs correctly marked as done.
- **Ingestion orchestrator**: Coordinates lexical ingestor (#689) and subject extractor — neither calls the other directly. Compound hook (sync inline) and three-phase re-extraction (D5: capture → reingest → reconcile with scoped orphan sweep).
- **Config**: `MIKA_KG_EXTRACTION_MODEL` and `MIKA_KG_INGESTION_MODEL` env vars with `provider/model` format parsing and fallback chain.

## Test plan

- [x] All 1989 existing tests pass (`cargo test -p mika-agent --lib`)
- [x] 14 new subject_extractor validation tests (approved/unapproved types, colon-in-name, empty chunk_indices, out-of-range confidence, relationship direction constraints, dangling relationships, partial filtering, JSON parsing with markdown fences)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Pre-commit hooks pass (no-secrets, no-large-files, rust-fmt, rust-clippy)
- [ ] Integration test with real LLM provider (manual — requires `MIKA_KG_EXTRACTION_MODEL` configured)

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)