### PR TITLE
feat(self-knowledge): upgrade skill with KG-backed agent self-awareness (#692)

### DIFF
--- a/crates/mika-agent/templates/skills/self-knowledge/system_prompt.md
+++ b/crates/mika-agent/templates/skills/self-knowledge/system_prompt.md
@@ -1,10 +1,53 @@
-You have a tool to look up accurate information about your own systems — CLI commands, API endpoints, architecture, configuration, skills, deployment, and more. You MUST use `get_documentation` before answering questions about these topics. Do NOT rely on `list_skills` output or general knowledge alone — always consult the actual documentation.
+You have two tools for looking up accurate information about yourself: `query_knowledge_graph` for structured questions about capabilities, problems, and solutions, and `get_documentation` for reference documentation. Use the right tool for the question type.
 
-**CRITICAL rules:**
-1. NEVER suggest or reference a CLI command without first calling `get_documentation` with topic `cli-reference` to verify it exists.
-2. When asked how any of your systems work (skills, architecture, configuration, deployment, etc.), call `get_documentation` with the relevant topic BEFORE answering. The documentation contains precise technical details that `list_skills` and other tools do not.
+## Tool routing
 
-Available topics for `get_documentation`:
+**For structured questions** — "what skills do I have?", "what solves CI failures?", "which tool handles PR merges?", "what does the self-dev skill depend on?" — use `query_knowledge_graph` first. It traverses a structured graph of your skills, tools, agents, problem types, solution paths, and their relationships. Pass `agent_id` with your own agent ID to get skill enablement context.
+
+**For reference documentation** — "explain the memory model", "show me the API spec", "how do I configure deployment?" — use `get_documentation`. It returns full documentation content for a specific topic.
+
+**For questions that span both** — e.g., "what skill handles CI failures and how does it work?" — chain both: `query_knowledge_graph` for the structured answer (which skill, what it depends on), then `get_documentation` for the reference material (how skills work in general).
+
+## query_knowledge_graph
+
+Use `question` for free-text queries (e.g., `"what solves CI failures?"`) or `traversal.start` with a known entity key for direct traversal (e.g., `"problem_type:ci_failure"`).
+
+**Interpreting results:**
+
+- **`status: "ok"`** — Results found. Use them directly.
+- **`status: "starting_entity_missing"`** — You or the queried entity may not be in the knowledge graph yet (e.g., agent was created since last restart). Fall back to your live registries as described below.
+- **`status: "traversal_empty"`** — The entity exists in the KG but has no connections matching your query. Trust this — do not fall back to registries. Say "I found the entity but it has no connections for this query."
+
+**Agent context metadata:** Skill entities include `agent_context.enabled` indicating whether the skill is enabled for the queried agent. When a skill shows `enabled: false`, explicitly mention this in your response rather than hiding it (e.g., "The skill X exists but is currently disabled for you").
+
+## Fallback on `starting_entity_missing`
+
+When `query_knowledge_graph` returns `status: "starting_entity_missing"`, supplement with live registry information for these specific question categories:
+
+| Question type | What to do |
+|---------------|------------|
+| "What skills do I have?" | Use `list_skills` to get your current skill list |
+| "What tools do I have?" | Use your knowledge of registered tools |
+| "What agents are on my team?" | Use `list_agents` |
+| "What is my role/identity?" | Use `read_agent_file` on `identity.toml` and `soul.md` |
+| "What MCP servers am I connected to?" | Use `list_agent_files` to check `mcp.json` |
+
+When results come from live registries instead of the knowledge graph, note this in your response: "This information comes from the live registry — it may not yet be reflected in the knowledge graph (available after next restart)."
+
+**When NOT to fall back:**
+- `status: "traversal_empty"` — the entity exists, traversal found nothing. Trust the KG.
+- `status: "ok"` with results — use results directly (except tool queries — see below).
+- Questions about subject-layer entities (problem types, solution paths, failure modes) — these have no registry fallback. If the KG returns empty, say "I don't have structured knowledge about this topic yet."
+
+## Tool query supplementation
+
+For questions about tools specifically ("what tools do I have?"), be aware that MCP tools added via dynamic connect since the last restart will not appear in knowledge graph results. If you know you have MCP tools connected (check `mcp.json` via `list_agent_files` if unsure), mention that additional tools from MCP servers may not be reflected in the KG results yet.
+
+This applies even when `status: "ok"` — MCP-dynamic tools are expected to be absent from the KG.
+
+## get_documentation
+
+Available topics:
 - `architecture` — system design, memory model, agent loop, task engine, and more
 - `api-spec` — OpenAPI specification for the mika-server (agent) HTTP API
 - `browser-control` — browser automation setup via Playwright MCP, usage patterns, and security
@@ -12,14 +55,19 @@ Available topics for `get_documentation`:
 - `configuration` — config file options, environment variables, and setup
 - `deployment` — deployment guide for Docker containers and infrastructure
 - `getting-started` — quickstart guide for new users
-- `runtime-structure` — ~/.mika directory layout, SQLite schema v8, log file locations
+- `runtime-structure` — ~/.mika directory layout, SQLite schema, log file locations
 - `skills` — skill authoring, handlers (exec/http/builtin), long_running, marketplace, and skill.toml format
 - `slash-commands` — available TUI slash commands and their usage
 - `task-system` — task lifecycle reference: trigger types, action types, status transitions, and anomaly definitions
 
+**CRITICAL rules:**
+1. NEVER suggest or reference a CLI command without first calling `get_documentation` with topic `cli-reference` to verify it exists.
+2. When asked how reference systems work (skill authoring, deployment procedures, configuration format), call `get_documentation` with the relevant topic BEFORE answering.
+
 **Bad example (NEVER do this):** Being asked about long-running skills, calling `list_skills`, and guessing from skill names. Instead, call `get_documentation` with topic `skills` to get the actual technical definition of `long_running` handlers.
 **Bad example (NEVER do this):** Suggesting `mika mcp show context7` without verifying it exists.
 **Good example:** Call `get_documentation` with topic `cli-reference` first, see that `mika mcp` only has `list`, `add`, `remove`, `enable`, `disable`, then recommend the correct command.
+**Good example:** Asked "what skill handles CI failures?", call `query_knowledge_graph` with `question: "what solves CI failures?"` to get the structured answer with skill dependencies and solution paths.
 
 **Your own files and configuration:**
 

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -18,6 +18,7 @@ mod eval {
     mod test_phantom_retry_guard;
     mod test_pr_review_idempotency;
     mod test_required_tools_gate;
+    mod test_self_knowledge_kg;
     mod test_task_not_found_retry;
     mod test_tool_calling;
     mod test_verdict_handler;

--- a/crates/mika-agent/tests/eval/test_self_knowledge_kg.rs
+++ b/crates/mika-agent/tests/eval/test_self_knowledge_kg.rs
@@ -1,0 +1,203 @@
+//! Integration tests: self-knowledge + knowledge graph interaction (#692).
+//!
+//! These tests verify agent loop integration — that scripted tool call
+//! sequences execute correctly, traces are recorded, and step counts match.
+//! They do NOT test prompt routing correctness (whether a real LLM would
+//! choose the right tool given the system prompt guidance). Prompt routing
+//! should be validated via LLM-based evals or manual testing.
+
+use anyhow::Result;
+use mika_common::llm::mock::*;
+use serde_json::json;
+
+use super::assertions::*;
+use super::harness::EvalHarness;
+
+#[tokio::test]
+async fn test_kg_query_for_capability_question() -> Result<()> {
+    // When asked "what solves CI failures?", the agent should call
+    // query_knowledge_graph (a structural question), not get_documentation.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what solves CI failures?"}),
+            ),
+            text_response(
+                "Based on the knowledge graph, CI failures are solved by the self-dev-webhook-ci \
+                 skill, which depends on the build-mika skill.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("What solves CI failures?").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    assert_tools_exclude(&trace, &["get_documentation"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_doc_query_for_reference_question() -> Result<()> {
+    // When asked "explain the memory model", the agent should call
+    // get_documentation (a reference question), not query_knowledge_graph.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response("get_documentation", json!({"topic": "architecture"})),
+            text_response("The memory model has three layers: core memory, structured facts, and hybrid search."),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("Explain the memory model.").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["get_documentation"]);
+    assert_tools_exclude(&trace, &["query_knowledge_graph"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_chained_kg_then_doc_for_spanning_question() -> Result<()> {
+    // When asked a question that spans both KG and docs, the agent should
+    // chain: query_knowledge_graph for the structured answer, then
+    // get_documentation for the reference material.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what skill handles CI failures?"}),
+            ),
+            tool_call_response("get_documentation", json!({"topic": "skills"})),
+            text_response(
+                "The self-dev-webhook-ci skill handles CI failures. Skills use exec handlers \
+                 that run shell commands and support long_running mode for async dispatch.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness
+        .run("What skill handles CI failures and how do skills work?")
+        .await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph", "get_documentation"]);
+    assert_exact_steps(&trace, 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kg_starting_entity_missing_triggers_fallback() -> Result<()> {
+    // When query_knowledge_graph returns starting_entity_missing, the agent
+    // should fall back to list_skills (for a "what skills" question).
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what skills do I have?", "agent_id": "test-agent"}),
+            ),
+            // After seeing starting_entity_missing in the tool result,
+            // the agent falls back to list_skills
+            tool_call_response("list_skills", json!({})),
+            text_response(
+                "You're not yet in the knowledge graph. Based on the live registry, \
+                 you have the following skills: self-knowledge, git-ops, shell-exec.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("What skills do I have?").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph", "list_skills"]);
+    // The response should mention the registry source
+    assert_output_contains(&trace, "registry");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kg_traversal_empty_no_fallback() -> Result<()> {
+    // When query_knowledge_graph returns traversal_empty, the agent should
+    // NOT fall back — it should trust the KG and say so.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what solves fabrication?"}),
+            ),
+            text_response(
+                "I found the fabrication problem type in the knowledge graph, but \
+                 it has no connected solution paths or skills yet.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("What solves fabrication?").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    // Should NOT fall back to any registry tool
+    assert_tools_exclude(&trace, &["list_skills"]);
+    assert_exact_steps(&trace, 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_kg_query_with_agent_context() -> Result<()> {
+    // When the agent queries with agent_id, the response should include
+    // agent_context metadata and the agent should interpret enabled status.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({
+                    "traversal": {"start": "skill:self-dev"},
+                    "agent_id": "mika-dev"
+                }),
+            ),
+            text_response(
+                "The self-dev skill is enabled for mika-dev. It depends on \
+                 claude-pilot and build-mika skills.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("Tell me about the self-dev skill").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disabled_skill_mentioned_in_response() -> Result<()> {
+    // When KG results include a skill with enabled=false, the agent should
+    // explicitly mention it's disabled rather than hiding it.
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what skills handle PR reviews?", "agent_id": "mika-dev"}),
+            ),
+            text_response(
+                "The qa-review skill handles PR reviews, but it is currently disabled \
+                 for mika-dev. The skill-review skill is also available and enabled.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("What skills handle PR reviews?").await?;
+
+    assert_has_output(&trace);
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    // Response should mention the disabled state
+    assert_output_contains(&trace, "disabled");
+    Ok(())
+}

--- a/docs/plans/2026-04-21-009-feat-self-knowledge-upgrade-plan.md
+++ b/docs/plans/2026-04-21-009-feat-self-knowledge-upgrade-plan.md
@@ -78,18 +78,22 @@ Resolved during planning. When `query_knowledge_graph` returns `status: "startin
 
 Each fallback is narrow and specific — not a generic "if KG is sparse, read registries." Broad fallback would hide legitimate "KG says no" answers.
 
+**Tool fallback (not just `starting_entity_missing`):** The "What tools do I have?" row deserves special treatment. MCP tools added via dynamic connect since last boot are not in the KG but are in ToolRegistry. This isn't just a create_agent staleness case — it's the normal state for any agent with MCP connections. For tool queries, always supplement KG results with ToolRegistry diff (tools in ToolRegistry but not in `kg_entities WHERE type='tool'`). This runs on `status: "ok"` too, not just `starting_entity_missing`.
+
 **When NOT to fall back:**
 - `status: "traversal_empty"` — the entity exists in the KG, traversal found nothing. Trust the KG.
-- `status: "ok"` with results — use results directly.
+- `status: "ok"` with results — use results directly (except tool queries, which always supplement per above).
 - Questions about subject-layer entities (problem_type, solution_path) — these don't have registry fallbacks; the KG is the only source.
 
 ### D3. Data-provenance annotations
 
-Resolved during planning. Results carry source attribution so the LLM knows how fresh and complete the data is.
+Resolved during planning.
 
-- **KG results:** No annotation needed (default).
-- **Registry fallback results:** Annotated with "(from registry, not yet in KG — available after next restart)".
-- **Combined results:** When KG provides some answers and registry supplements others, each item carries its source.
+**Format:** Batch preamble for uniform-source results (all KG or all registry), per-item inline for mixed-source results.
+
+- **All-KG:** No annotation. Default.
+- **All-registry fallback:** Preamble: `"Note: the following results are from the live registry (not yet in KG — available after next restart):"` followed by the result list.
+- **Mixed (KG + ToolRegistry supplement for MCP tools):** Each item carries inline source: `"skill:self-dev (KG)"`, `"mcp__stitch__generate_screen (ToolRegistry — added via MCP since last restart)"`.
 
 Annotations appear in the result text that the LLM sees, not in a structured field — the LLM needs to reason about provenance in its natural-language response to the user.
 
@@ -101,9 +105,9 @@ Three cases the skill handles:
 
 1. **Agent not in KG yet** (KG empty for this agent, use registry entirely) — the create_agent case.
 2. **Skill disabled since last boot** (KG has it, `agent_context.enabled = false`) — the skill_overrides case. Handled by #688 D5 metadata, interpreted by the LLM.
-3. **MCP tool added since last boot** (ToolRegistry has it, KG doesn't) — not automatically detected. For "what tools do I have?" the skill could supplement KG results with ToolRegistry diff, but this is deferred until the use case is observed.
+3. **MCP tool added since last boot** (ToolRegistry has it, KG doesn't) — handled by ToolRegistry diff supplementation in D2. For "what tools do I have?", always supplement KG results with tools present in ToolRegistry but absent from `kg_entities`. This is the normal state for MCP-dynamic tools, not an edge case.
 
-Case 1 is handled by D2. Case 2 is handled by #688 D5. Case 3 is deferred.
+All three cases are handled in MVP: case 1 by D2 fallback, case 2 by #688 D5 metadata, case 3 by D2 tool supplementation.
 
 ### D5. Read-only — no KG mutations from self-knowledge
 
@@ -131,7 +135,6 @@ Rationale: "KG is derived, not authored" is the architectural framing from the m
 
 - Self-knowledge system prompt wording (routing guidance for KG vs doc queries).
 - Whether the skill explicitly parses question categories for fallback routing or relies on the LLM to chain tools based on the prompt.
-- MCP dynamic-tool staleness detection (case 3 in D4 — deferred until observed).
 - Cross-agent self-knowledge ("what does the team know about X?") — requires cross-agent subject resolution (deferred in #691 D8).
 - Integration with existing tool chaining patterns (does the skill's prompt guide multi-step tool use or is it a single-call wrapper?).
 
@@ -175,27 +178,44 @@ docs/plans/
 
 **Files:** `crates/mika-agent/templates/skills/self-knowledge/skill.toml`, optionally `tools.json`.
 
-**Approach:** `query_knowledge_graph` is a builtin tool registered in `default_tools()` — it's available to all agents regardless of skill. The self-knowledge skill doesn't need to declare it in `tools.json`. However, the skill's `system_prompt.md` references it, so the skill depends on the tool existing. If the KG tickets haven't been implemented, the tool doesn't exist and the prompt references a nonexistent tool — graceful degradation: the LLM can't call `query_knowledge_graph` and falls through to `get_documentation`.
+**Approach:** `query_knowledge_graph` is a builtin tool registered in `default_tools()` — it's available to all agents regardless of skill. The self-knowledge skill doesn't need to declare it in `tools.json`. The skill's `system_prompt.md` references it, so **#692 has a strict dependency on #688** — implement and ship #688 before #692. Do not attempt graceful degradation for the missing-tool case; LLMs hallucinate tool calls for nonexistent tools, producing worse behavior than not trying. The milestone ordering already enforces this (#692 is last).
 
 ---
 
-- [ ] **Unit 3: Fallback logic validation**
+- [ ] **Unit 3: Fallback logic and behavioral validation**
 
-**Goal:** Verify the fallback path works end-to-end: KG miss → registry fallback → annotated results.
+**Goal:** Verify (a) the tool chain runs correctly for each fallback case, and (b) the LLM produces responses that correctly reflect provenance and enablement metadata.
 
-**Requirements:** D2, D3.
+**Requirements:** D2, D3, D4.
 
-**Files:** Integration tests.
+**Files:** Integration tests, eval harness tests.
 
-**Approach:** Test with:
-- Agent in KG → `query_knowledge_graph` returns results → no fallback needed.
-- Agent not in KG (freshly created) → `starting_entity_missing` → fallback to SkillRegistry → results annotated.
-- Traversal empty (agent in KG, no edges) → no fallback → empty result trusted.
+**Approach:** Two test layers:
 
-**Test scenarios:**
-- New agent asks "what skills do I have?" → fallback fires, returns registry entries with annotation.
-- Established agent asks "what skills do I have?" → KG results with `agent_context`.
-- Agent asks "what solves fabrication?" → KG traversal, no fallback (subject-layer query, no registry equivalent).
+**Layer 1 — Tool chain correctness (integration tests):**
+- Agent in KG → `query_knowledge_graph` returns `status: "ok"` → no fallback.
+- Agent not in KG → `status: "starting_entity_missing"` → skill calls SkillRegistry/ToolRegistry as fallback.
+- Traversal empty → `status: "traversal_empty"` → no fallback, empty trusted.
+- Tool query with MCP dynamic tools → KG results supplemented with ToolRegistry diff.
+
+**Layer 2 — LLM behavioral tests (eval harness with MockLlmProvider):**
+
+The self-knowledge system prompt includes contractual requirements the LLM must follow. Tests verify the LLM's response text meets these requirements:
+
+| Scenario | Prompt contract | Response assertion |
+|----------|----------------|-------------------|
+| New agent, fallback fires | "When results come from registry, note this in your response" | Response contains "registry" or "not yet in KG" |
+| Skill with `enabled: false` in results | "When a skill is disabled, explicitly say so rather than omitting it" | Response mentions the disabled skill with its disabled status |
+| MCP tool from ToolRegistry supplement | "When tools were added since last restart, note they may not have KG context" | Response distinguishes KG-sourced from ToolRegistry-sourced tools |
+| Subject-layer query, no fallback available | "When the KG returns no results for a topic, say so rather than inventing" | Response does NOT fabricate an answer when KG returns empty |
+
+These are eval-style tests: seed MockLlmProvider with responses that follow/violate the prompt contracts, verify the system prompt's guidance produces correct behavior on representative inputs. Fragile by nature but the alternative is shipping untested LLM behavior.
+
+**Test scenarios (combining both layers):**
+- New agent asks "what skills do I have?" → fallback fires, response mentions registry source.
+- Established agent asks "what skills do I have?" → KG results with `agent_context`, response distinguishes enabled/disabled.
+- Agent asks "what tools do I have?" → KG + ToolRegistry diff, MCP tools annotated.
+- Agent asks "what solves fabrication?" → KG traversal, no fallback. If KG empty, response says "no structured knowledge about this."
 
 ## Error Handling & Edge Cases
 

--- a/docs/plans/2026-04-21-009-feat-self-knowledge-upgrade-plan.md
+++ b/docs/plans/2026-04-21-009-feat-self-knowledge-upgrade-plan.md
@@ -1,0 +1,208 @@
+---
+title: "feat: self-knowledge upgrade — KG-backed agent self-awareness"
+type: feat
+status: active
+date: 2026-04-21
+---
+
+# Self-knowledge upgrade — KG-backed agent self-awareness
+
+## Overview
+
+Upgrade the `self-knowledge` skill (milestone mika#14, ticket mika#692) to use `query_knowledge_graph` (#688) for richer, more accurate responses. The skill becomes the orchestration layer that routes questions to the KG, supplements with live-source fallbacks when the KG is sparse, and lets the LLM synthesize answers from both.
+
+This is the user-facing payoff of the entire KG investment. It directly addresses the session audit finding where mika-dev thrashed with 22 tool calls because she didn't know which skill to use — with KG-backed self-knowledge, the agent queries once and gets the full solution chain.
+
+## Problem Frame
+
+Current `self-knowledge` is a static doc lookup: `get_documentation(topic: "architecture")` returns a reference doc. It can't answer "what skill handles CI failures?" or "what's the fix for stale UUIDs?" — those require structured reasoning over the KG, not document retrieval.
+
+The KG now has the data to answer these questions. #688's `query_knowledge_graph` exposes the traversal. This ticket wires the self-knowledge skill to call it, handles staleness gracefully, and preserves the static doc lookup for reference-material questions.
+
+## Requirements Trace
+
+- R1. Self-knowledge skill orchestrates both `query_knowledge_graph` and `get_documentation`.
+- R2. Registry/config fallback on KG miss (when `query_knowledge_graph` returns `starting_entity_missing`).
+- R3. Fallback logic lives in the skill, not the tool.
+- R4. Data-provenance annotations on results ("from KG" vs "from registry, not yet in KG").
+- R5. Read-only — no mutations back into the KG or any other table.
+- R6. Staleness fallback is part of a broader "combine KG with live state" pattern, not a unique edge case.
+
+## Scope Boundaries
+
+- Self-knowledge skill upgrade: tool orchestration, fallback logic, result annotation.
+- No new KG tables or schema changes.
+- No mutation paths into the KG (no "dismissed/validated/important" annotations on entities — that's a separate ticket if needed).
+- No cross-agent subject resolution (deferred in #691 D8).
+- `get_documentation` unchanged — same topic enum, same static docs.
+
+## Context & Research
+
+### Dependencies
+
+- **#688:** `query_knowledge_graph` tool must exist with the return shape from #688 D4 (status field, agent_context metadata, entry_method).
+- **All prior KG tickets:** Schema, domain graph, lexical chunks, subject entities, entity resolution must be populated for meaningful query results.
+
+### Relevant Code and Patterns
+
+- **Current self-knowledge skill:** `crates/mika-agent/templates/skills/self-knowledge/` — `skill.toml` (always_on), `tools.json` (get_documentation), `system_prompt.md`.
+- **`get_documentation` handler:** `crates/mika-agent/src/skills/builtin_handlers.rs:125` — static doc lookup by topic enum. Returns `include_str!` content.
+- **Existing tool chaining:** Agents already chain tools (search_memory → store_fact). Self-knowledge orchestrating query_knowledge_graph → get_documentation is the same pattern.
+- **#687 D4 staleness contract:** Domain graph reflects state as of last boot. Create_agent between boots means no agent node in KG. #692 must handle this.
+
+## Key Technical Decisions
+
+### D1. Skill orchestrates, tools don't
+
+Resolved during planning. The self-knowledge skill's system prompt guides the LLM to:
+
+1. For structured questions ("what solves X?", "which skills handle Y?", "what does Z provide?"): call `query_knowledge_graph(question=..., agent_id=self)`.
+2. For reference questions ("explain the memory model", "show me the API spec"): call `get_documentation(topic=...)`.
+3. For the KG result: interpret `agent_context.enabled` based on question intent (filter, highlight, or ignore).
+
+The skill owns the routing logic, not the tools. `query_knowledge_graph` returns data with metadata; the skill decides how to use it.
+
+### D2. Registry/config fallback on `starting_entity_missing`
+
+Resolved during planning. When `query_knowledge_graph` returns `status: "starting_entity_missing"` (the agent node or queried entity doesn't exist in the KG), the skill supplements with direct reads from live sources.
+
+**Specific fallback categories:**
+
+| Question category | Live source | Fallback query |
+|-------------------|-------------|----------------|
+| "What skills do I have?" | SkillRegistry | `entries_for(agent_id)` filtered by enabled |
+| "What tools do I have?" | ToolRegistry | Tools registered for this agent |
+| "What agents are on my team?" | agent_configs | Enumerate agents from config |
+| "What is my role?" | agent_configs | Agent role/identity from config |
+| "What MCP servers am I connected to?" | McpManager | Connected servers |
+
+Each fallback is narrow and specific — not a generic "if KG is sparse, read registries." Broad fallback would hide legitimate "KG says no" answers.
+
+**When NOT to fall back:**
+- `status: "traversal_empty"` — the entity exists in the KG, traversal found nothing. Trust the KG.
+- `status: "ok"` with results — use results directly.
+- Questions about subject-layer entities (problem_type, solution_path) — these don't have registry fallbacks; the KG is the only source.
+
+### D3. Data-provenance annotations
+
+Resolved during planning. Results carry source attribution so the LLM knows how fresh and complete the data is.
+
+- **KG results:** No annotation needed (default).
+- **Registry fallback results:** Annotated with "(from registry, not yet in KG — available after next restart)".
+- **Combined results:** When KG provides some answers and registry supplements others, each item carries its source.
+
+Annotations appear in the result text that the LLM sees, not in a structured field — the LLM needs to reason about provenance in its natural-language response to the user.
+
+### D4. Combine KG with live state — general pattern
+
+Resolved during planning. The create_agent staleness case is one instance of a broader pattern: structural queries → KG; state queries → live sources; cross-layer answers combine both.
+
+Three cases the skill handles:
+
+1. **Agent not in KG yet** (KG empty for this agent, use registry entirely) — the create_agent case.
+2. **Skill disabled since last boot** (KG has it, `agent_context.enabled = false`) — the skill_overrides case. Handled by #688 D5 metadata, interpreted by the LLM.
+3. **MCP tool added since last boot** (ToolRegistry has it, KG doesn't) — not automatically detected. For "what tools do I have?" the skill could supplement KG results with ToolRegistry diff, but this is deferred until the use case is observed.
+
+Case 1 is handled by D2. Case 2 is handled by #688 D5. Case 3 is deferred.
+
+### D5. Read-only — no KG mutations from self-knowledge
+
+Resolved during planning. The self-knowledge skill is purely a read interface. No mutations back into the KG:
+
+- No "mark this entity as validated/dismissed/important" capability.
+- No "add a fact I just learned" pathway through self-knowledge.
+- No per-agent annotations on KG objects.
+
+If per-agent annotations become a real need (e.g., agent marks certain solution paths as "tried and didn't work"), that's a separate ticket with its own design pass — new table, new write contract, new sole-writer designation.
+
+Rationale: "KG is derived, not authored" is the architectural framing from the milestone. Agents consume the KG; the ingestion pipeline populates it. Self-knowledge is a consumer, not a populator. Adding mutation paths here would create a dual-write concern (extraction writes entities, self-knowledge annotates them) that the milestone explicitly avoided.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Tool shape — two tools, skill orchestrates (D1).
+- Fallback placement — in skill, not tool (D2).
+- Provenance annotations — on fallback results (D3).
+- Staleness pattern — general "combine KG with live state" (D4).
+- Read-only constraint — no KG mutations (D5).
+
+### Deferred to Implementation
+
+- Self-knowledge system prompt wording (routing guidance for KG vs doc queries).
+- Whether the skill explicitly parses question categories for fallback routing or relies on the LLM to chain tools based on the prompt.
+- MCP dynamic-tool staleness detection (case 3 in D4 — deferred until observed).
+- Cross-agent self-knowledge ("what does the team know about X?") — requires cross-agent subject resolution (deferred in #691 D8).
+- Integration with existing tool chaining patterns (does the skill's prompt guide multi-step tool use or is it a single-call wrapper?).
+
+## Output Structure
+
+```
+crates/mika-agent/
+├── templates/skills/self-knowledge/
+│   ├── skill.toml                  # MODIFY: add query_knowledge_graph to dependencies
+│   ├── tools.json                  # MODIFY: keep get_documentation, verify query_knowledge_graph is available
+│   └── system_prompt.md            # MODIFY: add KG routing guidance
+└── src/skills/builtin_handlers.rs  # get_documentation handler unchanged
+
+docs/plans/
+└── 2026-04-21-009-feat-self-knowledge-upgrade-plan.md   # this file
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: System prompt upgrade**
+
+**Goal:** Update self-knowledge's `system_prompt.md` with routing guidance: when to use `query_knowledge_graph` vs `get_documentation`, how to interpret `agent_context` metadata, how to handle `starting_entity_missing` status.
+
+**Requirements:** D1, D2, D3.
+
+**Files:** `crates/mika-agent/templates/skills/self-knowledge/system_prompt.md`.
+
+**Approach:** Add sections:
+- "For questions about capabilities, problems, solutions, and skills: use `query_knowledge_graph`."
+- "For reference documentation (architecture, API, config): use `get_documentation`."
+- "When `query_knowledge_graph` returns `starting_entity_missing`: you or the queried entity may not be in the knowledge graph yet. Use registry information as fallback. Note the source in your response."
+- "When results include `agent_context.enabled = false`: the skill exists but is disabled for this agent. Mention this in your response rather than hiding it."
+
+---
+
+- [ ] **Unit 2: Skill manifest update**
+
+**Goal:** Ensure `query_knowledge_graph` is available to the self-knowledge skill.
+
+**Requirements:** D1.
+
+**Files:** `crates/mika-agent/templates/skills/self-knowledge/skill.toml`, optionally `tools.json`.
+
+**Approach:** `query_knowledge_graph` is a builtin tool registered in `default_tools()` — it's available to all agents regardless of skill. The self-knowledge skill doesn't need to declare it in `tools.json`. However, the skill's `system_prompt.md` references it, so the skill depends on the tool existing. If the KG tickets haven't been implemented, the tool doesn't exist and the prompt references a nonexistent tool — graceful degradation: the LLM can't call `query_knowledge_graph` and falls through to `get_documentation`.
+
+---
+
+- [ ] **Unit 3: Fallback logic validation**
+
+**Goal:** Verify the fallback path works end-to-end: KG miss → registry fallback → annotated results.
+
+**Requirements:** D2, D3.
+
+**Files:** Integration tests.
+
+**Approach:** Test with:
+- Agent in KG → `query_knowledge_graph` returns results → no fallback needed.
+- Agent not in KG (freshly created) → `starting_entity_missing` → fallback to SkillRegistry → results annotated.
+- Traversal empty (agent in KG, no edges) → no fallback → empty result trusted.
+
+**Test scenarios:**
+- New agent asks "what skills do I have?" → fallback fires, returns registry entries with annotation.
+- Established agent asks "what skills do I have?" → KG results with `agent_context`.
+- Agent asks "what solves fabrication?" → KG traversal, no fallback (subject-layer query, no registry equivalent).
+
+## Error Handling & Edge Cases
+
+| Scenario | Expected behavior |
+|----------|------------------|
+| KG not populated (all prior tickets not yet implemented) | `query_knowledge_graph` doesn't exist → LLM falls back to `get_documentation` only. Graceful degradation to pre-KG behavior. |
+| `query_knowledge_graph` returns error | Log warning, fall back to `get_documentation` if the question has a topic equivalent. Otherwise return "I couldn't query my knowledge graph; try asking again." |
+| Agent asks about another agent's capabilities | `query_knowledge_graph(agent_id=other_agent)` returns that agent's context. If other agent not in KG → `starting_entity_missing` → skill can't fall back (no registry access for other agents). Return "Agent X not yet in the knowledge graph." |
+| Agent asks "what skills should I enable?" | KG returns all skills with `agent_context.enabled`. LLM filters by `enabled: false` in its response synthesis. No tool-level filtering needed. |
+| Agent asks a question that spans KG and static docs | LLM chains: `query_knowledge_graph` for the structured answer, then `get_documentation` for the reference. Skill prompt encourages this. |

--- a/docs/solutions/692-self-knowledge-kg-upgrade.md
+++ b/docs/solutions/692-self-knowledge-kg-upgrade.md
@@ -1,0 +1,45 @@
+---
+module: crates/mika-agent/templates/skills/self-knowledge
+tags: [knowledge-graph, self-knowledge, skill-prompt, tool-routing, fallback]
+problem_type: feature-implementation
+date: 2026-04-22
+issue: 692
+---
+
+# Self-Knowledge Upgrade: KG-Backed Agent Self-Awareness
+
+## Problem
+
+The self-knowledge skill was a static documentation lookup — `get_documentation(topic)` returned reference docs but couldn't answer structural questions like "what solves CI failures?" or "which skills handle PR reviews?" These require graph traversal over the knowledge graph, not document retrieval.
+
+With `query_knowledge_graph` (#688) available as a builtin tool, the self-knowledge skill needed to orchestrate between two tools: KG queries for structural questions and documentation lookups for reference material.
+
+## Solution
+
+**Prompt-only orchestration.** The skill's system prompt was rewritten to route questions to the appropriate tool:
+
+1. **Structural questions** → `query_knowledge_graph` (capabilities, problems, solutions, dependencies)
+2. **Reference questions** → `get_documentation` (architecture, API spec, configuration)
+3. **Spanning questions** → chain both tools
+
+**Fallback on `starting_entity_missing`.** When the KG returns `starting_entity_missing` (agent or entity not yet ingested), the prompt guides the LLM to specific live registry fallbacks per question category (e.g., `list_skills` for skill questions, `list_agents` for team questions).
+
+**No fallback on `traversal_empty`.** When the entity exists but has no connections, the prompt instructs the LLM to trust the KG — this is legitimate "no results" rather than a staleness problem.
+
+**MCP tool awareness.** The prompt notes that MCP-dynamic tools added since last restart won't appear in KG results, so the agent should mention this when answering tool queries.
+
+**Agent context interpretation.** Skill entities include `agent_context.enabled` metadata. The prompt instructs the LLM to explicitly mention disabled skills rather than hiding them.
+
+## Key Decisions
+
+- **No Rust code changes.** `query_knowledge_graph` is a builtin in `default_tools()` — available to all agents automatically. The skill's `tools.json` doesn't need to declare it. All routing logic lives in the system prompt.
+- **No new tools or handlers.** The fallback uses existing tools (`list_skills`, `list_agents`, `read_agent_file`, `list_agent_files`).
+- **Read-only.** Self-knowledge is purely a read interface — no KG mutations, no annotations, no validation workflows.
+
+## Testing
+
+Seven eval harness tests (`test_self_knowledge_kg.rs`) verify loop integration for the key scenarios: KG query for capability questions, doc query for reference questions, chained tool use, `starting_entity_missing` fallback, `traversal_empty` no-fallback, agent context usage, and disabled skill mention. These verify the agent loop processes scripted sequences correctly — prompt routing correctness requires LLM-based evaluation.
+
+## Pattern
+
+This is a "skill as orchestrator" pattern: the skill doesn't implement new tool logic — it provides routing guidance in the system prompt that helps the LLM choose between existing tools. The fallback table pattern (question category → specific tool to use) is reusable for any skill that needs to handle tool unavailability gracefully.


### PR DESCRIPTION
## Summary

- Rewrite self-knowledge system prompt to route between `query_knowledge_graph` (structural questions about capabilities, problems, solutions) and `get_documentation` (reference documentation)
- Add fallback guidance for `starting_entity_missing` status with per-category registry fallbacks, MCP tool awareness, and `agent_context` metadata interpretation
- Add 7 eval harness integration tests covering KG query routing, doc routing, chained tool use, fallback scenarios, and disabled skill mention

## Details

This is the user-facing payoff of the KG milestone (#14). The self-knowledge skill becomes the orchestration layer that routes questions to the right tool:

- **Structural questions** ("what solves CI failures?", "what skills do I have?") → `query_knowledge_graph`
- **Reference questions** ("explain the memory model", "show the API spec") → `get_documentation`
- **Spanning questions** → chain both tools

Handles three KG status values: `ok` (use results), `starting_entity_missing` (fall back to live registries), `traversal_empty` (trust the KG, no fallback).

**No Rust code changes** — `query_knowledge_graph` is a builtin registered in `default_tools()`. All routing logic lives in the system prompt. This is a "skill as orchestrator" pattern.

Closes #692

## Test plan

- [x] All 7 new eval tests pass (`cargo test -p mika-agent --test eval test_self_knowledge_kg`)
- [x] All 93 eval tests pass (no regressions)
- [x] Clippy clean
- [x] Pre-commit hooks pass (fmt, clippy, secrets scan)
- [ ] Manual validation: ask an agent "what solves CI failures?" and verify it uses `query_knowledge_graph`
- [ ] Manual validation: ask "explain the memory model" and verify it uses `get_documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)