### PR TITLE
feat: dedicated mika-relay agent for claude-pilot permission decisions

### DIFF
--- a/.claude/claude-pilot.json
+++ b/.claude/claude-pilot.json
@@ -1,5 +1,5 @@
 {
   "command": "mika",
-  "args": ["--agent", "mika-dev", "ask"],
+  "args": ["--agent", "mika-relay", "ask"],
   "timeout": 120000
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Server mode additionally requires:
 - `MIKA_INTERNAL_TOKEN` — Shared secret for Bearer auth between gateway and agent
 
 Optional (startup behavior):
-- `MIKA_DEV_MODE` — Enable dev mode (default: false). When true, auto-provisions well-known development agents (`mika-dev`, `mika-qa`) on startup with role-specific identity, soul, and skill assignments. mika-dev gets self-dev family skills; mika-qa gets qa-review family skills. Idempotent — existing agents are never overwritten.
+- `MIKA_DEV_MODE` — Enable dev mode (default: false). When true, auto-provisions well-known development agents (`mika-dev`, `mika-qa`, `mika-relay`) on startup with role-specific identity, soul, and skill assignments. mika-dev gets self-dev family skills; mika-qa gets qa-review family skills; mika-relay gets only permission-policy (haiku model for cheap permission classification). Idempotent — existing agents are never overwritten.
 - `MIKA_DISABLE_BUNDLED_SKILLS` — Skip bundled skill re-sync on startup (default: false). WARNING: do not enable in production — prevents security updates to handler scripts.
 - `MIKA_DISABLE_AGENT_PROVISIONING` — Skip well-known agent auto-creation on startup (default: false). When true, prevents `dev_mode` from creating or updating agent identity files, allowing manual edits to persist across restarts/deploys. Same pattern as `MIKA_DISABLE_BUNDLED_SKILLS`.
 

--- a/crates/mika-agent/src/bundled_skills.rs
+++ b/crates/mika-agent/src/bundled_skills.rs
@@ -194,6 +194,15 @@ pub fn is_bundled_skill(name: &str) -> bool {
         || ENTRIES.iter().any(|s| s.name.eq_ignore_ascii_case(name))
 }
 
+/// Returns the names of all bundled skills (both legacy hardcoded and
+/// directory-sourced), deduplicated with ENTRIES-wins semantics.
+///
+/// Used by well-known agent tests to verify that mika-relay's `disabled_skills`
+/// list stays in sync with the full bundled skill set.
+pub fn all_bundled_skill_names() -> Vec<&'static str> {
+    all_bundled_skills().iter().map(|s| s.name).collect()
+}
+
 /// Trust-critical bundled skills whose prompts must NOT be reviewed or adapted.
 ///
 /// These skills govern the agent's self-awareness, security posture, or ability

--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -22,6 +22,10 @@ pub struct WellKnownAgent {
     pub soul: &'static str,
     /// Bundled skills to disable for this agent.
     pub disabled_skills: &'static [&'static str],
+    /// Optional config.toml content to write on first creation.
+    /// When `Some`, overwrites the default config.toml with agent-specific
+    /// LLM provider/model settings.
+    pub config_toml: Option<&'static str>,
 }
 
 /// mika-dev agent specification.
@@ -31,6 +35,7 @@ pub static MIKA_DEV: WellKnownAgent = WellKnownAgent {
     emoji: "🛠",
     soul: MIKA_DEV_SOUL,
     disabled_skills: &["qa-review", "qa-review-build-callback", "skill-review"],
+    config_toml: None,
 };
 
 /// mika-qa agent specification.
@@ -50,10 +55,53 @@ pub static MIKA_QA: WellKnownAgent = WellKnownAgent {
         "address-pr-comments",
         "resolve-pr-conflicts",
     ],
+    config_toml: None,
+};
+
+/// mika-relay agent specification.
+///
+/// Lightweight agent for handling claude-pilot `can_use_tool` permission
+/// relay events. Only the `permission-policy` skill is enabled; all other
+/// bundled skills are disabled. Uses haiku for cheap, fast JSON classification.
+pub static MIKA_RELAY: WellKnownAgent = WellKnownAgent {
+    name: "mika-relay",
+    display_name: "Relay",
+    emoji: "🔑",
+    soul: MIKA_RELAY_SOUL,
+    disabled_skills: &[
+        // Disable all bundled skills except permission-policy.
+        // Engine-coupled (skills/bundled/):
+        "self-dev",
+        "self-dev-iterate",
+        "self-dev-webhook-qa",
+        "self-dev-webhook-ci",
+        "qa-review",
+        "qa-review-build-callback",
+        "skill-review",
+        "claude-pilot",
+        "build-mika",
+        "deploy-mika",
+        "agents-teams",
+        "address-pr-comments",
+        "resolve-pr-conflicts",
+        "self-check",
+        // Community (hardcoded BUNDLED_SKILLS):
+        "tmux",
+        "shell-exec",
+        "web-search",
+        "file-reader",
+        "self-knowledge",
+        "git-ops",
+        "google-workspace",
+        "github",
+        "mcp",
+        "browser-control",
+    ],
+    config_toml: Some(MIKA_RELAY_CONFIG),
 };
 
 /// All well-known agents.
-pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA];
+pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA, &MIKA_RELAY];
 
 /// Look up a well-known agent by name.
 pub fn find_well_known_agent(name: &str) -> Option<&'static WellKnownAgent> {
@@ -113,6 +161,18 @@ pub fn provision_well_known_agents(home_dir: &Path, disabled: bool) {
                         agent = spec.name,
                         error = %e,
                         "failed to write soul.md for well-known agent"
+                    );
+                    continue;
+                }
+
+                // Overwrite config.toml if the spec provides custom content
+                if let Some(config_content) = spec.config_toml
+                    && let Err(e) = std::fs::write(agent_home.join("config.toml"), config_content)
+                {
+                    warn!(
+                        agent = spec.name,
+                        error = %e,
+                        "failed to write config.toml for well-known agent"
                     );
                     continue;
                 }
@@ -220,6 +280,34 @@ verify implementations against requirements, and ensure code quality standards.
 - Flag security, performance, and maintainability concerns
 "#;
 
+const MIKA_RELAY_SOUL: &str = r#"# Mika Relay — Permission Relay Agent
+
+## Role
+You are Mika Relay, a permission relay agent. Your sole job is handling
+claude-pilot `can_use_tool` permission events — classifying tool calls
+into allow/deny/answer/escalate tiers and returning structured JSON.
+
+## Communication style
+- Respond only with structured JSON as specified by the permission-policy skill
+- Never engage in conversation or prose when handling `[claude-pilot]` events
+- Be fast and decisive — permission decisions should not require deliberation
+
+## Behaviors
+- Apply the permission-policy skill's tier classification strictly
+- When in doubt, escalate (Tier 3) rather than allow
+- Never initiate workflows, create tasks, or manage development lifecycle
+- You exist only to make permission decisions efficiently
+"#;
+
+const MIKA_RELAY_CONFIG: &str = r#"# Mika Relay — lightweight permission relay agent.
+# Uses haiku for cheap, fast JSON classification of permission events.
+
+llm_provider = "anthropic"
+anthropic_model = "claude-haiku-4-5-20251001"
+llm_max_tokens = 1024
+log_level = "info"
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,6 +319,11 @@ mod tests {
         assert_eq!(find_well_known_agent("mika-dev").unwrap().name, "mika-dev");
         assert!(find_well_known_agent("mika-qa").is_some());
         assert_eq!(find_well_known_agent("mika-qa").unwrap().name, "mika-qa");
+        assert!(find_well_known_agent("mika-relay").is_some());
+        assert_eq!(
+            find_well_known_agent("mika-relay").unwrap().name,
+            "mika-relay"
+        );
     }
 
     #[test]
@@ -241,7 +334,7 @@ mod tests {
     }
 
     #[test]
-    fn test_provision_creates_both_agents() {
+    fn test_provision_creates_all_agents() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         // Create the agents directory
@@ -249,9 +342,10 @@ mod tests {
 
         provision_well_known_agents(home, false);
 
-        // Both agents should exist
+        // All well-known agents should exist
         assert!(mika_common::agent::agent_exists(home, "mika-dev"));
         assert!(mika_common::agent::agent_exists(home, "mika-qa"));
+        assert!(mika_common::agent::agent_exists(home, "mika-relay"));
     }
 
     #[test]
@@ -275,6 +369,13 @@ mod tests {
         .unwrap();
         assert!(qa_identity.contains("name = \"QA\""));
         assert!(qa_identity.contains("emoji = \"🔍\""));
+
+        let relay_identity = fs::read_to_string(
+            mika_common::agent::agent_dir(home, "mika-relay").join("identity.toml"),
+        )
+        .unwrap();
+        assert!(relay_identity.contains("name = \"Relay\""));
+        assert!(relay_identity.contains("emoji = \"🔑\""));
     }
 
     #[test]
@@ -296,6 +397,34 @@ mod tests {
                 .unwrap();
         assert!(qa_soul.contains("Mika QA"));
         assert!(qa_soul.contains("Quality Assurance"));
+
+        let relay_soul =
+            fs::read_to_string(mika_common::agent::agent_dir(home, "mika-relay").join("soul.md"))
+                .unwrap();
+        assert!(relay_soul.contains("Mika Relay"));
+        assert!(relay_soul.contains("Permission Relay Agent"));
+    }
+
+    #[test]
+    fn test_provision_relay_config_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        provision_well_known_agents(home, false);
+
+        let relay_config = fs::read_to_string(
+            mika_common::agent::agent_dir(home, "mika-relay").join("config.toml"),
+        )
+        .unwrap();
+        assert!(relay_config.contains("anthropic_model = \"claude-haiku-4-5-20251001\""));
+        assert!(relay_config.contains("llm_max_tokens = 1024"));
+
+        // mika-dev should have the default config.toml (not overwritten)
+        let dev_config =
+            fs::read_to_string(mika_common::agent::agent_dir(home, "mika-dev").join("config.toml"))
+                .unwrap();
+        assert!(!dev_config.contains("claude-haiku"));
     }
 
     #[test]
@@ -413,6 +542,80 @@ mod tests {
     }
 
     #[test]
+    fn test_seed_skill_overrides_mika_relay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.register_agent("mika-relay", "Relay", "/tmp/mika-relay")
+            .unwrap();
+
+        seed_well_known_skill_overrides(&db, "mika-relay");
+
+        let overrides = db.get_skill_overrides("mika-relay").unwrap();
+        assert_eq!(overrides.len(), MIKA_RELAY.disabled_skills.len());
+        for ovr in &overrides {
+            assert_eq!(ovr.enabled, Some(false));
+            assert!(
+                MIKA_RELAY
+                    .disabled_skills
+                    .contains(&ovr.skill_name.as_str()),
+                "unexpected override: {}",
+                ovr.skill_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_relay_only_allows_permission_policy() {
+        // Verify that permission-policy is NOT in the disabled list
+        assert!(
+            !MIKA_RELAY.disabled_skills.contains(&"permission-policy"),
+            "permission-policy must not be disabled for mika-relay"
+        );
+    }
+
+    #[test]
+    fn test_relay_disables_all_bundled_skills_except_permission_policy() {
+        // Comprehensive check: every bundled skill except permission-policy
+        // must be in mika-relay's disabled list. This catches new skills
+        // added to the bundled set without updating mika-relay.
+        let all_names = crate::bundled_skills::all_bundled_skill_names();
+        for name in &all_names {
+            if name.eq_ignore_ascii_case("permission-policy") {
+                continue;
+            }
+            assert!(
+                MIKA_RELAY
+                    .disabled_skills
+                    .iter()
+                    .any(|d| d.eq_ignore_ascii_case(name)),
+                "bundled skill '{}' is not disabled for mika-relay — \
+                 add it to MIKA_RELAY.disabled_skills",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_relay_config_toml_is_valid_toml() {
+        // Verify the config string is valid TOML and contains expected fields
+        let config: toml::Table =
+            toml::from_str(MIKA_RELAY_CONFIG).expect("MIKA_RELAY_CONFIG must be valid TOML");
+        assert_eq!(
+            config.get("llm_provider").and_then(|v| v.as_str()),
+            Some("anthropic")
+        );
+        assert_eq!(
+            config.get("anthropic_model").and_then(|v| v.as_str()),
+            Some("claude-haiku-4-5-20251001")
+        );
+        assert_eq!(
+            config.get("llm_max_tokens").and_then(|v| v.as_integer()),
+            Some(1024)
+        );
+    }
+
+    #[test]
     fn test_seed_skill_overrides_non_well_known() {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
@@ -427,13 +630,38 @@ mod tests {
     }
 
     #[test]
-    fn test_well_known_agent_specs() {
-        // Verify the skill lists don't overlap
+    fn test_well_known_agent_specs_dev_qa_no_overlap() {
+        // Verify the dev and qa skill lists don't overlap (they have
+        // complementary roles — one builds, the other reviews)
         for dev_skill in MIKA_DEV.disabled_skills {
             assert!(
                 !MIKA_QA.disabled_skills.contains(dev_skill),
                 "skill '{}' is disabled for both mika-dev and mika-qa",
                 dev_skill
+            );
+        }
+    }
+
+    #[test]
+    fn test_relay_disables_superset_of_dev_and_qa() {
+        // mika-relay should disable everything that both dev and qa disable
+        // (plus more), since it only needs permission-policy.
+        // Exception: permission-policy itself — qa disables it, relay keeps it.
+        for dev_skill in MIKA_DEV.disabled_skills {
+            assert!(
+                MIKA_RELAY.disabled_skills.contains(dev_skill),
+                "mika-relay should also disable '{}' (disabled for mika-dev)",
+                dev_skill
+            );
+        }
+        for qa_skill in MIKA_QA.disabled_skills {
+            if *qa_skill == "permission-policy" {
+                continue; // relay's sole purpose is permission-policy
+            }
+            assert!(
+                MIKA_RELAY.disabled_skills.contains(qa_skill),
+                "mika-relay should also disable '{}' (disabled for mika-qa)",
+                qa_skill
             );
         }
     }

--- a/docs/plans/721-dedicated-mika-relay-agent.md
+++ b/docs/plans/721-dedicated-mika-relay-agent.md
@@ -1,0 +1,126 @@
+# Plan: Dedicated mika-relay Agent for Claude-Pilot Permission Decisions (#721)
+
+## Problem
+
+claude-pilot sends 50-150 permission events per session through `mika --agent mika-dev ask`. Each event is a simple allow/deny JSON classification, but mika-dev's full orchestration stack (skills, 30K+ token system prompt, mid-tier model) processes every one. This causes:
+
+- **Cost:** mid-tier model for trivial JSON classification
+- **Skill collision:** relay payloads contain keywords like "build" that match self-dev triggers
+- **Context bloat:** full mika-dev system prompt sent for each relay call
+
+## Solution
+
+A dedicated `mika-relay` well-known agent with minimal footprint: only the `permission-policy` skill, a cheap model (haiku-4.5), and a focused soul prompt. All other skills disabled.
+
+## Implementation Steps
+
+### Step 1: Add MIKA_RELAY to well_known_agents.rs
+
+Add a third `WellKnownAgent` static alongside `MIKA_DEV` and `MIKA_QA`:
+
+```rust
+pub static MIKA_RELAY: WellKnownAgent = WellKnownAgent {
+    name: "mika-relay",
+    display_name: "Relay",
+    emoji: "🔑",
+    soul: MIKA_RELAY_SOUL,
+    disabled_skills: &[
+        // Disable everything except permission-policy
+        "self-dev",
+        "self-dev-iterate",
+        "self-dev-webhook-qa",
+        "self-dev-webhook-ci",
+        "self-dev-sprint",
+        "qa-review",
+        "qa-review-build-callback",
+        "skill-review",
+        "claude-pilot",
+        "build-mika",
+        "deploy-mika",
+        "agents-teams",
+        "address-pr-comments",
+        "resolve-pr-conflicts",
+    ],
+};
+```
+
+Add `MIKA_RELAY_SOUL` const with relay-focused personality (direct, minimal, permission-decision-only).
+
+Add `&MIKA_RELAY` to `WELL_KNOWN_AGENTS` array.
+
+**File:** `crates/mika-agent/src/well_known_agents.rs`
+
+### Step 2: Add per-agent LLM model to WellKnownAgent spec
+
+The `WellKnownAgent` struct currently has no model field. Add an optional `model` field:
+
+```rust
+pub struct WellKnownAgent {
+    // ... existing fields
+    /// Optional LLM model override (provider/model format).
+    /// Written to the agent's config.toml on creation.
+    pub model: Option<&'static str>,
+}
+```
+
+For `MIKA_RELAY`, set `model: Some("anthropic/claude-haiku-4-5-20251001")`. For `MIKA_DEV` and `MIKA_QA`, set `model: None` (use default).
+
+In `provision_well_known_agents()`, after writing `identity.toml` and `soul.md`, if `spec.model` is `Some(m)`, write a `config.toml` with the model override:
+
+```toml
+[llm]
+model = "anthropic/claude-haiku-4-5-20251001"
+```
+
+**File:** `crates/mika-agent/src/well_known_agents.rs`
+
+**Research needed:** Check how per-agent `config.toml` is loaded and whether `[llm] model` field is already supported. If not, the model can be set via the existing per-skill LLM override mechanism on `permission-policy`.
+
+### Step 3: Update claude-pilot.json
+
+Change the relay target from `mika-dev` to `mika-relay`:
+
+```json
+{
+  "command": "mika",
+  "args": ["--agent", "mika-relay", "ask"],
+  "timeout": 120000
+}
+```
+
+**File:** `.claude/claude-pilot.json`
+
+### Step 4: Update tests
+
+- Add `MIKA_RELAY` to existing well-known agent tests (find, provision, identity, soul, seed overrides)
+- Test that `MIKA_RELAY.disabled_skills` covers all bundled skills except `permission-policy`
+- Update the skill-overlap test to include `mika-relay`
+- Verify the model field is written correctly to `config.toml`
+
+**File:** `crates/mika-agent/src/well_known_agents.rs` (test module)
+
+### Step 5: Update documentation
+
+- Update `docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md` to include mika-relay
+- Note in claude-pilot skill docs that relay now targets mika-relay
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/well_known_agents.rs` | Add MIKA_RELAY spec, model field, soul const, tests |
+| `.claude/claude-pilot.json` | Point relay to mika-relay |
+
+## Risks & Mitigations
+
+- **Risk:** Missing a bundled skill in the disabled list → new skills added later could activate on relay turns.
+  **Mitigation:** Test that disabled_skills covers all bundled skills except permission-policy. Use an allowlist approach in the test.
+
+- **Risk:** Per-agent config.toml model override not supported by config loading.
+  **Mitigation:** Research config loading first. Fallback: use skill_overrides DB for per-skill LLM override on permission-policy specifically for this agent.
+
+## Out of Scope
+
+- Updating `claude-pilot.json` in other repos (mika-cloud, mika-skills) — those are separate PRs
+- Changes to the permission-policy skill itself
+- Changes to the claude-pilot handler

--- a/docs/solutions/architecture-patterns/well-known-agent-config-toml-override.md
+++ b/docs/solutions/architecture-patterns/well-known-agent-config-toml-override.md
@@ -1,0 +1,72 @@
+---
+title: Per-agent config.toml override via WellKnownAgent spec
+date: 2026-04-22
+category: architecture-patterns
+module: startup, config
+problem_type: best_practice
+component: agent_provisioning
+severity: low
+applies_when:
+  - Adding a well-known agent that needs a different LLM model
+  - Controlling per-agent cost by assigning cheaper models to simple tasks
+tags:
+  - agent-provisioning
+  - config-override
+  - llm-model
+  - well-known-agents
+  - cost-optimization
+---
+
+# Per-agent config.toml override via WellKnownAgent spec
+
+## Context
+
+Well-known agents previously shared the same default `config.toml` (Anthropic, default model, 4096 max tokens). When mika-relay was added (#721) — a single-purpose agent handling only permission classification — it needed haiku instead of the default mid-tier model. The existing per-skill LLM override (`skill_overrides` table) was considered but rejected: it relies on keyword matching to activate, which is fragile for a single-skill agent where the activation keyword (`[claude-pilot]`) appears in every input.
+
+## Guidance
+
+The `WellKnownAgent` struct has an optional `config_toml: Option<&'static str>` field. When `Some`, `provision_well_known_agents()` overwrites the default `config.toml` after `bootstrap_agent()` creates it. The config string must be valid TOML compatible with the `Settings` deserializer.
+
+### When to use config_toml
+
+Use it when the agent's **entire** config profile differs from the default — different model, different max_tokens, different log level. This is a filesystem-level override written once at agent creation, not a runtime override.
+
+### When to use per-skill LLM override instead
+
+Use `skill_overrides.llm_provider/llm_model` when only specific skills should use a different model while the agent's default model serves other skills normally.
+
+### Key constraint
+
+`config_toml` is only written on first creation (when `!agent_exists()`). Existing agents are never overwritten. To update a deployed agent's config, either delete and re-provision, or edit `~/.mika/agents/<name>/config.toml` directly.
+
+## Examples
+
+```rust
+pub static MIKA_RELAY: WellKnownAgent = WellKnownAgent {
+    name: "mika-relay",
+    // ...
+    config_toml: Some(MIKA_RELAY_CONFIG),
+};
+
+const MIKA_RELAY_CONFIG: &str = r#"
+llm_provider = "anthropic"
+anthropic_model = "claude-haiku-4-5-20251001"
+llm_max_tokens = 1024
+log_level = "info"
+"#;
+```
+
+A test validates that the config string parses as valid TOML:
+```rust
+#[test]
+fn test_relay_config_toml_is_valid_toml() {
+    let config: toml::Table = toml::from_str(MIKA_RELAY_CONFIG).unwrap();
+    assert_eq!(config.get("anthropic_model").and_then(|v| v.as_str()),
+               Some("claude-haiku-4-5-20251001"));
+}
+```
+
+## Related
+
+- Issue #721 — mika-relay agent (first user of config_toml)
+- `docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md` — parent pattern

--- a/docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md
+++ b/docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md
@@ -22,7 +22,7 @@ tags:
 
 ## Context
 
-The autonomous dev loop requires `mika-dev` and `mika-qa` agents with specific configurations: identity files (soul.md), skill assignments, and per-agent env vars. Previously these had to be created manually. Missing agents caused silent degradation. Wrong skill assignments caused active interference (qa-review's run_gh allowlist blocked mika-dev's `gh pr create`).
+The autonomous dev loop requires `mika-dev`, `mika-qa`, and `mika-relay` agents with specific configurations: identity files (soul.md), skill assignments, model overrides, and per-agent env vars. Previously these had to be created manually. Missing agents caused silent degradation. Wrong skill assignments caused active interference (qa-review's run_gh allowlist blocked mika-dev's `gh pr create`).
 
 The provisioning system follows a two-phase design to work within the existing startup sequence where filesystem operations happen before the DB is available.
 
@@ -30,7 +30,7 @@ The provisioning system follows a two-phase design to work within the existing s
 
 ### Two-phase provisioning
 
-**Phase 1 (filesystem):** `provision_well_known_agents()` runs after `migrate_to_multi_agent()` but before `list_agents()` in server startup. For each well-known agent spec, it checks `agent_exists()`, calls `bootstrap_agent()` to create the directory structure, then overwrites `identity.toml` and `soul.md` with agent-specific content.
+**Phase 1 (filesystem):** `provision_well_known_agents()` runs after `migrate_to_multi_agent()` but before `list_agents()` in server startup. For each well-known agent spec, it checks `agent_exists()`, calls `bootstrap_agent()` to create the directory structure, then overwrites `identity.toml` and `soul.md` with agent-specific content. If the spec provides `config_toml`, the default `config.toml` is also overwritten with agent-specific LLM settings (e.g., mika-relay uses haiku for cheap permission classification).
 
 **Phase 2 (DB overrides):** `seed_well_known_skill_overrides()` runs inside `init_agent()` after the DB is opened and `seed_bundled_skills_if_needed()` has written all skill files. It writes `set_skill_enabled(false)` for skills the agent should not have. Both phases are gated on `settings.dev_mode`.
 
@@ -46,7 +46,7 @@ The provisioning system follows a two-phase design to work within the existing s
 
 ### Adding a new well-known agent
 
-1. Add a `WellKnownAgent` static spec in `crates/mika-agent/src/well_known_agents.rs` with name, display_name, emoji, soul content, and `disabled_skills` list
+1. Add a `WellKnownAgent` static spec in `crates/mika-agent/src/well_known_agents.rs` with name, display_name, emoji, soul content, `disabled_skills` list, and optional `config_toml`
 2. Add a reference to `WELL_KNOWN_AGENTS` static slice
 3. The agent is automatically provisioned on next startup with `dev_mode = true`
 
@@ -59,6 +59,17 @@ pub static MIKA_DEV: WellKnownAgent = WellKnownAgent {
     emoji: "...",
     soul: MIKA_DEV_SOUL,
     disabled_skills: &["qa-review", "qa-review-build-callback", "skill-review"],
+    config_toml: None,  // uses default config
+};
+```
+
+For agents needing a specific LLM model (e.g., mika-relay uses haiku for cheap permission classification):
+
+```rust
+pub static MIKA_RELAY: WellKnownAgent = WellKnownAgent {
+    name: "mika-relay",
+    // ...
+    config_toml: Some(MIKA_RELAY_CONFIG),  // overrides config.toml with haiku model
 };
 ```
 
@@ -100,5 +111,6 @@ for each agent:
 
 - Issue #254 -- original feature request
 - Issue #602 -- skill interference incident that motivated per-agent skill filtering
+- Issue #721 -- mika-relay agent for permission relay (first agent with `config_toml` override)
 - `docs/solutions/architecture-patterns/skill-enabled-state-db-eviction.md` -- how skill overrides work
 - `docs/solutions/architecture-patterns/per-agent-dotenv-config-injection.md` -- per-agent config loading


### PR DESCRIPTION
## Summary

Closes #721

Add a lightweight `mika-relay` well-known agent whose sole job is handling claude-pilot `can_use_tool` permission events. Previously these flowed through `mika-dev`, which meant every permission event (50-150 per session) triggered a full LLM turn with all of mika-dev's skills, context, and model cost.

- **New agent:** `mika-relay` — uses haiku (`claude-haiku-4-5-20251001`) for cheap, fast JSON classification
- **Single skill:** Only `permission-policy` is enabled; all 24 other bundled skills are disabled
- **Config override:** New `config_toml` field on `WellKnownAgent` struct for per-agent LLM settings
- **Relay redirect:** `.claude/claude-pilot.json` now points to `mika-relay` instead of `mika-dev`
- **Comprehensive tests:** 19 tests including sync guard that fails if new bundled skills aren't added to the disabled list

### Impact
- ~3x cost reduction on relay calls (haiku vs mid-tier models)
- Eliminates skill collision risk (relay payloads contain keywords like "build" that matched self-dev triggers)
- Faster relay latency (smaller prompt, faster model)

## Files changed

| File | Change |
|------|--------|
| `crates/mika-agent/src/well_known_agents.rs` | MIKA_RELAY spec, config_toml field, soul, config, tests |
| `crates/mika-agent/src/bundled_skills.rs` | `all_bundled_skill_names()` public helper for test sync |
| `.claude/claude-pilot.json` | Relay target: `mika-dev` → `mika-relay` |
| `CLAUDE.md` | Updated MIKA_DEV_MODE docs |
| `docs/solutions/...well-known-agent-provisioning-dev-mode.md` | Updated with config_toml pattern |
| `docs/solutions/...well-known-agent-config-toml-override.md` | New compound doc |
| `docs/plans/721-dedicated-mika-relay-agent.md` | Plan doc |

## Test plan

- [x] All 19 well_known_agents tests pass (provisioning, identity, soul, config, skill overrides, sync guards)
- [x] Clippy clean
- [x] Pre-commit hooks pass (fmt, clippy, no-secrets)
- [ ] Deploy with `MIKA_DEV_MODE=true` and verify mika-relay is auto-provisioned
- [ ] Run a claude-pilot session and verify permission events route to mika-relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)