### PR TITLE
fix: self-heal stale-base + CONFLICTING PRs (#747)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - `docs/adr/` — Architecture Decision Records (numbered)
 - `docs/openapi/` — OpenAPI specs (mika-server.yaml, gateway.yaml)
 - `docs/solutions/` — Documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when debugging or implementing in documented areas.
-- `skills/bundled/` — Source tree for engine-coupled bundled skills discovered at build time via `crates/mika-agent/build.rs` (currently empty; migration of engine-coupled skills from `mika-skills/` is tracked separately — see `crates/mika-agent/CLAUDE.md` Skills System).
+- `skills/bundled/` — Source tree for engine-coupled bundled skills discovered at build time via `crates/mika-agent/build.rs`. See `crates/mika-agent/CLAUDE.md` Skills System for details.
 - `scripts/` — Utility scripts (sync-agent-docs.sh for crates.io publish prep)
 - `Makefile` — Development workflow targets: `make build`, `make deploy` (dashboard+build+stop+install), `make test`, `make lint`, `make fmt`, `make check`
 - `todos/` — Code review findings (tracked as markdown files)
@@ -207,14 +207,17 @@ Skills are bundled and discovered at build time via `crates/mika-agent/build.rs`
 
 ```
 skills/bundled/
-├── self-dev/              # Main self-development orchestration
-│   ├── skill.toml
-│   └── system_prompt.md   # Per-issue + milestone + project workflows
+├── self-dev/              # Main self-development orchestration (per-issue + milestone + project workflows)
+├── self-dev-iterate/      # PR iteration handler for self-dev
 ├── self-dev-webhook-qa/   # QA webhook handler for self-dev
 ├── self-dev-webhook-ci/   # CI webhook handler for self-dev
-├── claude-pilot/          # Claude Code integration
+├── claude-pilot/          # Claude Code integration (worktree setup, rebase-or-abort guard, claude-pilot dispatch)
 ├── qa-review/             # PR review skill
+├── qa-review-build-callback/ # Build callback handler for QA review
 ├── permission-policy/     # Permission handler for claude-pilot sessions
+├── resolve-pr-conflicts/  # Rebase + conflict resolution for CONFLICTING PRs
+├── address-pr-comments/   # Address PR review comments
+├── self-check/            # Self-check/health verification
 ├── build-mika/            # Build verification
 ├── deploy-mika/           # Deployment
 ├── agents-teams/          # Agent/team management

--- a/docs/plans/2026-04-23-001-fix-self-heal-stale-base-conflicting-prs-plan.md
+++ b/docs/plans/2026-04-23-001-fix-self-heal-stale-base-conflicting-prs-plan.md
@@ -1,0 +1,173 @@
+---
+title: "fix: Self-heal stale-base + CONFLICTING PRs"
+type: fix
+status: active
+date: 2026-04-23
+---
+
+# fix: Self-heal stale-base + CONFLICTING PRs
+
+## Overview
+
+Add a rebase-or-abort guard to the claude-pilot handler so branches pre-committed from a stale main are caught up before claude-pilot runs. Wire the existing `resolve-pr-conflicts` skill into self-dev so mika-dev can self-heal PRs that reach CONFLICTING state.
+
+## Problem Frame
+
+PR mika#746 sat in `mergeable=CONFLICTING` for 8+ hours because two structural gaps prevented self-healing:
+
+1. **Stale-base at dispatch:** When `run.sh` falls through to `git worktree add <WORKTREE> <branch>` (branch already exists from plan pre-commit), it checks out the branch without rebasing onto `origin/main`. Sequential tickets dispatched after upstream merges inherit stale bases, causing avoidable conflicts.
+
+2. **Capability not loaded:** The `resolve-pr-conflicts` bundled skill exists with a `resolve_pr_conflicts` tool, but self-dev doesn't declare it as a dependency (so the tool is never in mika-dev's inventory) and self-dev's prompt never checks mergeable state before merge attempts.
+
+## Requirements Trace
+
+- R1. `run.sh` must auto-rebase existing branches onto `origin/main` after worktree creation
+- R2. On rebase conflict, `run.sh` must capture conflicted files BEFORE aborting and exit with structured `STATUS=REBASE_CONFLICT` result
+- R3. `self-dev/skill.toml` must list `resolve-pr-conflicts` as a dependency
+- R4. `self-dev/system_prompt.md` must route to `resolve_pr_conflicts` when a PR is CONFLICTING — single sentence, no routing-table duplication
+
+## Scope Boundaries
+
+- NOT fixing PR #746's current conflict (manual resolution by Vincent)
+- NOT adding dashboard observability (tracked as #744)
+- NOT adding a webhook for `mergeable` state transitions (GitHub doesn't emit one)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/claude-pilot/handlers/run.sh` lines 233–247: fetch + worktree creation block
+- `skills/bundled/claude-pilot/handlers/run.sh` lines 36–93: EXIT trap uses `$RESULT` variable — structured result must populate RESULT before `exit 1`
+- `skills/bundled/self-dev/skill.toml` line 8–13: dependencies array
+- `skills/bundled/self-dev/system_prompt.md`: Callback Entry Point section covers pre-merge handling
+- `skills/bundled/resolve-pr-conflicts/system_prompt.md`: already documents routing decision table and tool contract
+
+### Institutional Learnings
+
+- `feedback_prompt_enforcement_fragile.md`: structural > prompt-level enforcement — fix 2 (dependency) and fix 3 (single-sentence routing) honor this principle
+
+## Key Technical Decisions
+
+- **Capture conflicts before abort:** `git diff --name-only --diff-filter=U` must run BEFORE `rebase --abort` because abort resets the index — the conflict markers are gone after abort
+- **Structured discriminator:** Use `STATUS=REBASE_CONFLICT` as first line of RESULT so the EXIT trap's callback delivery sends it verbatim — orthogonal to mika-dev's callback-rendering logic (it can pattern-match the prefix)
+- **Single-sentence delegation:** self-dev prompt gets one sentence pointing to `resolve_pr_conflicts` — the skill's own `system_prompt.md` already owns the routing table, input schema, and escalation criteria
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to insert rebase guard in run.sh?** After line 247 (the worktree add fallthrough block), before line 249 (config copy). At this point `origin/main` is already fresh (line 233 fetches it) and `$WORKTREE_DIR` is set.
+- **Should both the "reuse existing worktree" and "create new worktree" paths get the guard?** Yes — both paths can result in a branch behind `origin/main`. The reuse path (line 240–241) checks out the branch without rebasing; the create-new fallthrough path (line 245) also checks out without rebasing.
+
+### Deferred to Implementation
+
+- Exact stderr message wording — implementation can tune the diagnostic text
+
+## Implementation Units
+
+- [ ] **Unit 1: Add rebase-or-abort guard to run.sh**
+
+**Goal:** After worktree creation/reuse, detect if the branch is behind `origin/main` and auto-rebase. On conflict, capture file list and exit with structured result.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/claude-pilot/handlers/run.sh`
+
+**Approach:**
+- Insert the guard after the worktree creation block (after line 247) and also after the reuse path (line 241)
+- Use `git rev-list --count HEAD..origin/main` to detect commits behind
+- On `BEHIND > 0`, attempt `git rebase origin/main`
+- On rebase success, log to stderr
+- On rebase failure: capture `git diff --name-only --diff-filter=U` BEFORE calling `rebase --abort`, then populate `RESULT` with `STATUS=REBASE_CONFLICT` discriminator and `exit 1` (the EXIT trap delivers the callback)
+- The guard runs inside the `repo#number` block only — free-text mode has no worktree
+
+**Patterns to follow:**
+- EXIT trap at lines 36–93 already handles `$RESULT` — populate it before `exit 1`
+- Line 233 already fetches `origin main` — no additional fetch needed
+- Stderr logging pattern: `echo "..." >&2` (matches existing handler style)
+
+**Test scenarios:**
+- Happy path: branch 3 commits behind origin/main, no conflicts → rebase succeeds, stderr shows "Rebased <branch> onto origin/main (3 commits caught up)"
+- Happy path: branch already up-to-date (BEHIND=0) → guard is a no-op, proceeds normally
+- Error path: branch behind origin/main with conflicting files → captures conflict file list, RESULT starts with `STATUS=REBASE_CONFLICT`, exit 1 triggers callback delivery
+- Edge case: `git rev-list` fails (e.g., detached HEAD) → BEHIND defaults to 0, guard is a no-op
+
+**Verification:**
+- The rebase guard block exists after both worktree paths
+- RESULT format starts with `STATUS=REBASE_CONFLICT` on conflict
+- Conflict file list is captured before `rebase --abort`
+
+- [ ] **Unit 2: Add resolve-pr-conflicts dependency to self-dev**
+
+**Goal:** Make the `resolve_pr_conflicts` tool available in mika-dev's tool inventory when self-dev is active.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/self-dev/skill.toml`
+
+**Approach:**
+- Add `"resolve-pr-conflicts"` to the `dependencies` array (line 8–13)
+- The BFS dependency resolver loads it whenever self-dev activates
+
+**Patterns to follow:**
+- Existing dependency entries: `"build-mika"`, `"deploy-mika"`, `"claude-pilot"`, `"browser-control"`
+
+**Test scenarios:**
+- Happy path: self-dev activates → `resolve_pr_conflicts` tool appears in mika-dev's tool inventory (verified by `build.rs` bundling both skills and the dependency resolver loading transitively)
+
+**Verification:**
+- `skill.toml` dependencies array includes `"resolve-pr-conflicts"`
+
+- [ ] **Unit 3: Add mergeable-check routing to self-dev prompt**
+
+**Goal:** Insert a single sentence in self-dev's pre-merge path so mika-dev checks `mergeable` state and delegates to `resolve_pr_conflicts` when CONFLICTING.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 2 (tool must be available)
+
+**Files:**
+- Modify: `skills/bundled/self-dev/system_prompt.md`
+
+**Approach:**
+- Insert one sentence in the "On success" callback handling section (after metadata extraction, before merge/close-out) — this is the natural point where a PR is about to be acted on
+- The sentence directs: check `mergeable` via `gh pr view`, invoke `resolve_pr_conflicts` if CONFLICTING
+- No routing-table duplication — the `resolve-pr-conflicts` skill's own `system_prompt.md` documents the full routing table, input schema, and behavior
+
+**Patterns to follow:**
+- Existing delegation style in self-dev: single-sentence references to other skills (e.g., "Permission requests... intercepted automatically by the `permission-policy` skill")
+- `resolve-pr-conflicts/system_prompt.md` already documents the `resolve_pr_conflicts` tool contract
+
+**Test scenarios:**
+- Happy path: self-dev prompt contains a sentence about checking `mergeable` state and invoking `resolve_pr_conflicts`
+- Edge case: sentence does NOT duplicate the routing table from `resolve-pr-conflicts/system_prompt.md`
+
+**Verification:**
+- Exactly one sentence added referencing `mergeable` and `resolve_pr_conflicts`
+- No routing-table duplication from the resolve-pr-conflicts skill
+
+## System-Wide Impact
+
+- **Interaction graph:** The rebase guard runs before claude-pilot launches — on conflict, the EXIT trap delivers the RESULT callback to mika-dev. mika-dev sees `STATUS=REBASE_CONFLICT` and can act (escalate or invoke `resolve_pr_conflicts`)
+- **Error propagation:** Rebase conflicts exit via `exit 1` → EXIT trap → `deliver_callback` → mika callback. Standard path, no new failure modes
+- **Unchanged invariants:** Free-text mode in run.sh is not affected. The resolve-pr-conflicts tool contract is unchanged. The EXIT trap's callback delivery mechanism is unchanged
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Rebase guard adds latency to every dispatch | `git rev-list --count` is fast (~ms); rebase only runs when behind |
+| Rebase could introduce subtle merge artifacts | This is the same rebase any developer would do; conflicts are caught and reported |
+
+## Sources & References
+
+- Related issue: #747
+- Related PR: #746 (motivating case — CONFLICTING state)
+- Related issue: #744 (dashboard observability gap — separate concern)
+- Related doc: `feedback_prompt_enforcement_fragile.md`

--- a/docs/solutions/logic-errors/stale-base-conflicting-prs-no-self-heal-2026-04-23.md
+++ b/docs/solutions/logic-errors/stale-base-conflicting-prs-no-self-heal-2026-04-23.md
@@ -1,0 +1,95 @@
+---
+title: Stale-base branches cause CONFLICTING PRs with no self-heal path
+date: 2026-04-23
+category: logic-errors
+module: claude-pilot-handler
+problem_type: logic_error
+component: tooling
+symptoms:
+  - PR stuck in mergeable=CONFLICTING state for hours with no autonomous recovery
+  - Sequential tickets dispatched after upstream merge inherit stale base
+  - resolve-pr-conflicts skill exists but is never invoked by self-dev
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+tags:
+  - claude-pilot
+  - self-dev
+  - rebase
+  - merge-conflicts
+  - worktree
+  - stale-base
+  - resolve-pr-conflicts
+---
+
+# Stale-base branches cause CONFLICTING PRs with no self-heal path
+
+## Problem
+
+PRs created by the autonomous dev loop sit in `mergeable=CONFLICTING` state indefinitely because two structural gaps prevent self-healing: (1) the claude-pilot handler checks out pre-committed branches without rebasing onto the latest `origin/main`, and (2) the `resolve-pr-conflicts` skill is loaded nowhere and triggered by nothing in self-dev.
+
+## Symptoms
+
+- PR #746 sat in `mergeable=CONFLICTING, mergeState=DIRTY` for 8+ hours
+- Multiple pre-committed branches (`feat/338/...`, `feat/339/...`, `feat/740-742/...`) all branched from stale commit `6a0315be` while main had advanced to `65abe6f2`
+- `self-dev/skill.toml` dependencies array did not include `resolve-pr-conflicts`
+- `self-dev/system_prompt.md` had zero matches for `resolve_pr_conflicts`, `mergeable`, or `CONFLICTING`
+
+## What Didn't Work
+
+- The milestone grooming pattern pre-commits plan docs on feature branches before dispatch. When those branches are later checked out by the handler, they carry the stale base from grooming time — not from dispatch time.
+- The handler's worktree fallthrough path (`git worktree add <WORKTREE> <branch>`) was designed for branch reuse but did not account for the branch being behind `origin/main`.
+
+## Solution
+
+Three targeted fixes in one PR:
+
+**Fix 1 — Rebase-or-abort guard in `skills/bundled/claude-pilot/handlers/run.sh`:**
+
+After worktree creation/reuse (both paths converge), check if the branch is behind `origin/main` and auto-rebase. On conflict, capture the file list BEFORE `rebase --abort` (abort resets the index) and exit with a structured `STATUS=REBASE_CONFLICT` discriminator:
+
+```sh
+BEHIND=$(git -C "$WORKTREE_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+if [ "$BEHIND" -gt 0 ]; then
+    if git -C "$WORKTREE_DIR" rebase origin/main 2>/dev/null; then
+        echo "Rebased ${BRANCH} onto origin/main (${BEHIND} commits caught up)." >&2
+    else
+        CONFLICTS=$(git -C "$WORKTREE_DIR" diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ' ')
+        git -C "$WORKTREE_DIR" rebase --abort 2>/dev/null || true
+        RESULT="STATUS=REBASE_CONFLICT
+Branch ${BRANCH} is ${BEHIND} commits behind origin/main.
+Conflicted files: ${CONFLICTS:-<unable to capture>}
+Resolve manually before re-dispatching ${REPO}#${ISSUE_NUM}."
+        exit 1
+    fi
+fi
+```
+
+Key ordering: `diff --diff-filter=U` runs BEFORE `rebase --abort` because abort resets the index and the conflict markers are gone after.
+
+**Fix 2 — Dependency declaration in `skills/bundled/self-dev/skill.toml`:**
+
+Added `"resolve-pr-conflicts"` to the `dependencies` array. The BFS dependency resolver loads it whenever self-dev activates, making `resolve_pr_conflicts` available in mika-dev's tool inventory.
+
+**Fix 3 — Routing sentence in `skills/bundled/self-dev/system_prompt.md`:**
+
+Added one sentence in the "On success" callback path: check `mergeable` state via `gh pr view --json mergeable` before treating PR as ready; if `CONFLICTING`, invoke `resolve_pr_conflicts` per that skill's documented routing table. No routing-table duplication — the skill's own prompt owns the contract.
+
+## Why This Works
+
+**Root cause 1 (stale base):** The handler's worktree fallthrough path checked out existing branches at their current tip, which could be arbitrarily behind `origin/main`. The rebase guard catches this gap after both worktree paths converge — `origin/main` is already fresh from the fetch at line 233. For clean rebases (no conflicts), claude-pilot starts from a current base. For real conflicts, the structured `STATUS=REBASE_CONFLICT` exits early with diagnostic details instead of silently producing a CONFLICTING PR.
+
+**Root cause 2 (capability not loaded):** The `resolve-pr-conflicts` skill existed with a working `resolve_pr_conflicts` tool, but self-dev didn't declare the dependency (BFS resolver never loaded it) and the prompt never checked mergeable state. Adding the dependency makes the tool structurally available; adding the routing sentence makes the agent check for the condition. This follows the `feedback_prompt_enforcement_fragile.md` principle: structural dependency > prompt enforcement.
+
+## Prevention
+
+- When adding new skills that should be invoked by an orchestrator skill, always add both: (1) the dependency in `skill.toml` so the tool is in the inventory, and (2) the trigger condition in the orchestrator's system prompt. A skill that exists but isn't loaded is invisible.
+- When worktree reuse or branch checkout paths exist in handlers, always consider whether the branch may be behind the base. Fetch + rebase-or-abort is the standard pattern.
+- The EXIT trap in `run.sh` checks `[ -z "$RESULT" ]` — populate `RESULT` before `exit 1` to deliver a structured callback instead of a generic "HANDLER CRASH" message.
+
+## Related Issues
+
+- [#747](https://github.com/senara-solutions/mika/issues/747) — this fix
+- [#746](https://github.com/senara-solutions/mika/pull/746) — motivating PR (stuck CONFLICTING)
+- [#744](https://github.com/senara-solutions/mika/issues/744) — dashboard observability gap that let the stuck state stay hidden
+- `feedback_prompt_enforcement_fragile.md` — structural > prompt-level enforcement principle

--- a/skills/bundled/claude-pilot/handlers/run.sh
+++ b/skills/bundled/claude-pilot/handlers/run.sh
@@ -246,6 +246,26 @@ if [ -n "$REPO" ] && [ -n "$ISSUE_NUM" ]; then
         fi
     fi
 
+    # Rebase-or-abort guard: catch up branches pre-committed from stale main.
+    # At this point origin/main is fresh (line 233 fetched it) and WORKTREE_DIR is set.
+    # If the branch is behind origin/main, auto-rebase. On conflict, capture the
+    # conflicted-file list BEFORE abort (abort resets the index) and exit with a
+    # structured STATUS=REBASE_CONFLICT discriminator so the EXIT trap delivers it.
+    BEHIND=$(git -C "$WORKTREE_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    if [ "$BEHIND" -gt 0 ]; then
+        if git -C "$WORKTREE_DIR" rebase origin/main 2>/dev/null; then
+            echo "Rebased ${BRANCH} onto origin/main (${BEHIND} commits caught up)." >&2
+        else
+            CONFLICTS=$(git -C "$WORKTREE_DIR" diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ' ')
+            git -C "$WORKTREE_DIR" rebase --abort 2>/dev/null || true
+            RESULT="STATUS=REBASE_CONFLICT
+Branch ${BRANCH} is ${BEHIND} commits behind origin/main.
+Conflicted files: ${CONFLICTS:-<unable to capture>}
+Resolve manually before re-dispatching ${REPO}#${ISSUE_NUM}."
+            exit 1
+        fi
+    fi
+
     # Copy gitignored .claude/ config into worktree (relay + permissions only)
     # NOTE: Do NOT copy .claude/commands/ — Claude Code discovers commands from
     # the repo's own .claude/commands/. Copying the meta-repo's commands overwrites

--- a/skills/bundled/self-dev/skill.toml
+++ b/skills/bundled/self-dev/skill.toml
@@ -10,6 +10,7 @@ dependencies = [
     "deploy-mika",
     "claude-pilot",
     "browser-control",
+    "resolve-pr-conflicts",
 ]
 
 [constraints]

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -132,8 +132,9 @@ When you receive a callback result from a completed background task (`run_claude
 **On success (no "PIPELINE FAILURE:" prefix):**
 1. Extract metadata and persist immediately (see "Metadata extraction" above).
 2. If `pr_url` was not extracted from the callback text (no "PR: ..." line), discover it now: `run_gh("pr list --head <branch> --repo senara-solutions/<repo> --json url --jq '.[0].url'")`. Update metadata with the discovered URL.
-3. Notify Vincent: "claude-pilot completed for {repo}#{issue_number}. PR: {url}. QA will review automatically."
-4. Proceed to Step 6 (close-out) with status `in_progress` and note "PR open, awaiting QA review. PR: {url}". mika-qa will be triggered automatically by the GitHub webhook when the PR is created — no delegation needed.
+3. Before treating the PR as ready or attempting merge, check mergeable state via `run_gh("pr view <number> --repo senara-solutions/<repo> --json mergeable --jq '.mergeable'")` — if `CONFLICTING`, invoke `resolve_pr_conflicts` per that skill's documented routing table before proceeding.
+4. Notify Vincent: "claude-pilot completed for {repo}#{issue_number}. PR: {url}. QA will review automatically."
+5. Proceed to Step 6 (close-out) with status `in_progress` and note "PR open, awaiting QA review. PR: {url}". mika-qa will be triggered automatically by the GitHub webhook when the PR is created — no delegation needed.
 
 **On failure (non-zero exit, "FAILED", or "not structured JSON"):** Before blocking the task, **always check if a PR was created** by running `run_gh("pr list --head <branch> --json url,number,state,reviewDecision")`. If a PR exists (especially if already approved by mika-qa), the run succeeded regardless of what the callback text says — treat it as a success, merge the PR, and close out normally. Only proceed to Step 4.5 if no PR exists on the branch.
 


### PR DESCRIPTION
## Summary

- Add rebase-or-abort guard to `claude-pilot/handlers/run.sh` — after worktree creation, detect if the branch is behind `origin/main` and auto-rebase. On conflict, capture file list before abort and exit with structured `STATUS=REBASE_CONFLICT` result via the EXIT trap callback
- Wire `resolve-pr-conflicts` skill into self-dev: add dependency in `skill.toml` so the tool is in mika-dev's inventory, and add mergeable-check routing in `system_prompt.md` so mika-dev checks PR state before treating it as ready
- Update `CLAUDE.md` bundled skills directory listing (was missing 5 skills)

Closes #747

## Context

PR #746 sat in `mergeable=CONFLICTING` for 8+ hours because:
1. The handler's worktree fallthrough checked out pre-committed branches without rebasing onto the now-advanced `origin/main`
2. The `resolve-pr-conflicts` skill existed but wasn't wired into self-dev (dependency not declared, prompt never checked mergeable state)

## Test plan

- [ ] `cargo clippy` and `cargo test -p mika-agent` pass (skill changes are prompt-only, no Rust code affected)
- [ ] Verify rebase guard: dispatch a ticket on a branch that's behind main — should auto-rebase silently
- [ ] Verify conflict path: dispatch a ticket on a branch that conflicts with main — should exit with `STATUS=REBASE_CONFLICT` and deliver structured callback
- [ ] Verify `resolve-pr-conflicts` appears in mika-dev's tool inventory when self-dev is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>