### PR TITLE
fix: ask.rs correlation branch uses unscoped task lookup

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -7118,7 +7118,13 @@ impl Database {
 
     // ===== Dashboard: Paginated Task Listing =====
 
-    /// Get a single task by ID without agent_id scoping (for dashboard).
+    /// Cross-agent task lookup — for correlation and observability only.
+    ///
+    /// Does NOT enforce agent ownership. For state-mutating agent tools that require
+    /// the caller own the task, use [`crate::tools::validate_task_exists`] instead.
+    ///
+    /// Current callers: `mika ask --task-id` correlation branch at
+    /// `crates/mika-cli/src/commands/ask.rs`, dashboard task detail endpoint.
     pub fn get_task_unscoped(&self, id: &str) -> Result<Option<Task>> {
         let sql = format!("SELECT {} FROM tasks WHERE id = ?1", Self::TASK_COLUMNS);
         self.conn

--- a/crates/mika-agent/src/tools/mod.rs
+++ b/crates/mika-agent/src/tools/mod.rs
@@ -294,9 +294,17 @@ pub(crate) fn validate_uuid(
     })
 }
 
-/// Validate that a UUID-typed task parameter references an existing task owned by
+/// Agent-scoped task lookup — for intra-agent state mutation only.
+///
+/// Validates that a UUID-typed task parameter references an existing task owned by
 /// the calling agent. Combines format validation ([`validate_uuid`]) with a DB
 /// existence + agent-scope check in a single call.
+///
+/// For correlation-only / observability existence checks that cross agent boundaries
+/// (e.g., `mika ask --task-id` from a relay agent referencing a task owned by another
+/// agent), use [`crate::db::Database::get_task_unscoped`] instead. This function will
+/// return `task_not_found` if the task exists but belongs to a different agent, which
+/// is the intended behavior for ownership checks and the wrong behavior for correlation.
 ///
 /// Returns `Ok(Task)` on success, or `Err(ToolOutput)` with structured JSON:
 /// - Format error: `{"error": "invalid_uuid", "field": ..., ...}` (from `validate_uuid`)

--- a/crates/mika-agent/tests/ask_correlation.rs
+++ b/crates/mika-agent/tests/ask_correlation.rs
@@ -1,0 +1,91 @@
+//! Regression tests for the `mika ask --task-id` correlation path (#752).
+//!
+//! The relay agent (`mika-relay`) issues `mika ask --task-id <uuid>` for tasks
+//! owned by a different agent (e.g. `mika-dev`). The correlation branch must
+//! use `get_task_unscoped` so the lookup succeeds across agent boundaries.
+//! The contrast test proves an agent-scoped lookup on the same task returns
+//! `None`, which is exactly the failure mode the fix eliminates.
+
+use mika_agent::async_db::AsyncDatabase;
+use mika_agent::db::{Database, NewTask};
+
+async fn open_shared_db(agent_a: &str, agent_b: &str) -> AsyncDatabase {
+    let db = AsyncDatabase::new_with_agent(Database::open_in_memory().unwrap(), agent_a);
+    db.register_agent(agent_a, agent_a, "").await.unwrap();
+    db.register_agent(agent_b, agent_b, "").await.unwrap();
+    db
+}
+
+fn new_task(agent_id: &str, label: &str) -> NewTask {
+    NewTask {
+        agent_id: agent_id.to_string(),
+        team_run_id: None,
+        parent_task_id: None,
+        depth: 0,
+        label: label.to_string(),
+        trigger_type: "callback".to_string(),
+        cron_expr: None,
+        event_source: None,
+        event_offset_secs: None,
+        condition_expr: None,
+        next_fire_at: None,
+        timeout_at: None,
+        action_type: "resume_agent".to_string(),
+        action_config: "{}".to_string(),
+        input_context: None,
+        created_by_session: None,
+        created_trace_id: None,
+        reference_url: None,
+        source: None,
+        metadata: None,
+        r#type: None,
+    }
+}
+
+#[tokio::test]
+async fn unscoped_lookup_finds_cross_agent_task() {
+    let db_a = open_shared_db("agent-a", "agent-b").await;
+    let task_id = db_a
+        .create_task(new_task("agent-a", "agent-a owned task"))
+        .await
+        .unwrap();
+
+    let db_b = db_a.with_agent("agent-b");
+    let task = db_b
+        .get_task_unscoped(&task_id)
+        .await
+        .expect("unscoped lookup must not error")
+        .expect("unscoped lookup must find cross-agent task");
+
+    assert_eq!(task.id, task_id);
+    assert_eq!(task.agent_id, "agent-a");
+    assert_eq!(task.label, "agent-a owned task");
+}
+
+#[tokio::test]
+async fn scoped_lookup_rejects_cross_agent_task() {
+    let db_a = open_shared_db("agent-a", "agent-b").await;
+    let task_id = db_a
+        .create_task(new_task("agent-a", "agent-a owned task"))
+        .await
+        .unwrap();
+
+    let db_b = db_a.with_agent("agent-b");
+    let task = db_b
+        .get_task(&task_id)
+        .await
+        .expect("scoped lookup must not error");
+
+    assert!(task.is_none(), "scoped lookup must reject cross-agent task");
+}
+
+#[tokio::test]
+async fn unscoped_lookup_returns_none_for_nonexistent_task() {
+    let db = AsyncDatabase::new_with_agent(Database::open_in_memory().unwrap(), "agent-a");
+    let task = db
+        .get_task_unscoped("00000000-0000-0000-0000-000000000000")
+        .await
+        .expect("unscoped lookup must not error");
+
+    assert!(task.is_none());
+}

--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -179,8 +179,10 @@ pub async fn run(
             return Ok(());
         }
 
-        // Correlation-only path: validate task exists, emit deprecation warning if needed
-        match ctx.async_db.get_task(tid).await {
+        // Correlation-only path: validate task exists, emit deprecation warning if needed.
+        // Uses unscoped lookup because the caller (e.g., mika-relay) may not own the task.
+        // See Database::get_task_unscoped for the ownership-vs-correlation distinction.
+        match ctx.async_db.get_task_unscoped(tid).await {
             Ok(Some(task)) => {
                 // Deprecation bridge: warn if this looks like an old-style completion call
                 if task.trigger_type == "callback"

--- a/docs/plans/2026-04-23-003-fix-ask-rs-correlation-unscoped-plan.md
+++ b/docs/plans/2026-04-23-003-fix-ask-rs-correlation-unscoped-plan.md
@@ -1,0 +1,130 @@
+---
+title: "fix: Swap ask.rs correlation branch from agent-scoped to unscoped task lookup"
+type: fix
+status: active
+date: 2026-04-23
+issue: 752
+---
+
+# fix: Swap ask.rs correlation branch from agent-scoped to unscoped task lookup
+
+## Overview
+
+The `mika ask --task-id` correlation-only path uses `get_task()` (agent-scoped) when it should use `get_task_unscoped()`. This causes cross-agent relay failures when mika-relay correlates tasks owned by mika-dev. One-line swap plus bidirectional doc comments and a regression test.
+
+## Problem Frame
+
+`ask.rs:183` calls `ctx.async_db.get_task(tid)` inside a code path explicitly labeled "correlation-only." The intent is an existence check for observability metadata — not ownership validation. `get_task()` enforces `WHERE agent_id = ?`, so when mika-relay (the caller) differs from the task owner (mika-dev), the lookup returns `None` and bails with "Task not found."
+
+Exposed by the claude-pilot routing fix (commit `8b6df69`) that correctly routed relay to mika-relay per #721's intent. 65+ relay denials in production logs. Milestone #16 is blocked.
+
+## Requirements Trace
+
+- R1. Correlation path at `ask.rs:183` must use unscoped task lookup
+- R2. Doc comment on `validate_task_exists` must cross-link `get_task_unscoped` with ownership-vs-correlation distinction
+- R3. Reciprocal doc comment on `get_task_unscoped` must name `validate_task_exists` and list callers
+- R4. Regression test: task owned by agent A, correlation path invoked as agent B, must succeed
+
+## Scope Boundaries
+
+- The `--task-complete` path at line 129 correctly uses agent-scoped `get_task()` — it mutates task state and ownership check is correct there
+- `validate_task_exists` in `tools/mod.rs` is correctly agent-scoped for its consumers — no change
+- No architectural changes, no new helpers, no enum parameters
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-cli/src/commands/ask.rs:183` — the one-line fix site
+- `crates/mika-agent/src/async_db.rs:1624` — `get_task_unscoped()` already exists on `AsyncDatabase`
+- `crates/mika-agent/src/db.rs:7122` — `Database::get_task_unscoped()` — no agent_id parameter
+- `crates/mika-agent/src/tools/mod.rs:311` — `validate_task_exists()` — agent-scoped, correct for its callers
+- Existing test patterns: `TestHarness::with_agent("agent-a")` for cross-agent test setup (see `tools/mod.rs:914`)
+
+### Institutional Learnings
+
+- Cross-agent correlation is a known pattern — `get_task_unscoped` was introduced for the dashboard and is documented as "without agent_id scoping"
+
+## Key Technical Decisions
+
+- **Use `get_task_unscoped` not a new helper:** The primitive already exists and has the exact semantics needed — no agent_id filter, returns `Option<Task>`
+- **Keep completion path agent-scoped:** Line 129's `get_task()` is correct — completing a task is a state mutation that requires ownership
+
+## Implementation Units
+
+- [ ] **Unit 1: Swap to unscoped lookup + doc comments**
+
+**Goal:** Fix the correlation path and add bidirectional documentation
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-cli/src/commands/ask.rs`
+- Modify: `crates/mika-agent/src/tools/mod.rs`
+- Modify: `crates/mika-agent/src/db.rs`
+
+**Approach:**
+- Replace `ctx.async_db.get_task(tid)` with `ctx.async_db.get_task_unscoped(tid)` at line 183
+- Add doc comment above `validate_task_exists` (~line 310 in tools/mod.rs) naming the ownership-vs-correlation distinction and pointing to `Database::get_task_unscoped`
+- Add reciprocal doc comment above `get_task_unscoped` (~line 7122 in db.rs) pointing back to `validate_task_exists` and listing current callers
+
+**Patterns to follow:**
+- Existing doc comment style in `tools/mod.rs` (see lines 300-310)
+- `get_task_unscoped` already has a one-line doc comment — extend it
+
+**Test expectation:** none — behavioral verification is in Unit 2
+
+**Verification:**
+- `cargo clippy -p mika-cli -p mika-agent` clean
+- `cargo build -p mika-cli` succeeds
+
+- [ ] **Unit 2: Cross-agent correlation regression test**
+
+**Goal:** Prove the correlation path works across agent boundaries
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-cli/src/commands/ask.rs` (test module)
+
+**Approach:**
+- Create an `AsyncDatabase` with agent "agent-a", seed a callback task
+- Create a second `AsyncDatabase` with agent "agent-b"
+- Call `get_task_unscoped(tid)` on the agent-b database — assert `Ok(Some(task))` and task fields match
+- Verify agent-scoped `get_task(tid)` on agent-b returns `Ok(None)` — proves the distinction
+
+**Patterns to follow:**
+- `TestHarness::with_agent("agent-a")` pattern from `tools/mod.rs:916`
+- Existing async test pattern in `tools/mod.rs` tests
+- Note: ask.rs tests currently only test serialization (non-async `#[test]`). The new test will be the first `#[tokio::test]` in this module — may need to add `use mika_agent::...` imports
+
+**Test scenarios:**
+- Happy path: task owned by agent-a, `get_task_unscoped` from agent-b context returns `Ok(Some(task))` with correct label and id
+- Contrast: same task, agent-scoped `get_task` from agent-b context returns `Ok(None)` — confirms the fix is necessary
+- Edge case: `get_task_unscoped` with non-existent UUID returns `Ok(None)` (not an error)
+
+**Verification:**
+- `cargo test -p mika-cli` passes including the new test
+- `cargo test -p mika-agent` passes (no regressions)
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the correlation path in `ask.rs` is affected. The completion path (line 129) and all `validate_task_exists` callers in tools remain agent-scoped
+- **Error propagation:** The `Ok(None)` bail at line 200-202 still fires for genuinely non-existent tasks — unscoped lookup doesn't suppress real errors
+- **Unchanged invariants:** All agent-scoped task operations (`update_task_status`, `cancel_task`, `complete_task`) continue to enforce ownership via `validate_task_exists`
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Unscoped lookup reveals task existence across agents | Correlation path only logs/warns — no task data returned to external callers. Same exposure as dashboard endpoint which already uses `get_task_unscoped` |
+
+## Sources & References
+
+- Related issue: #752
+- Related PRs: #751 (shipped despite relay denials), #721 (introduced mika-relay)
+- Related commits: `8b6df69` (claude-pilot routing fix that exposed the latent bug)

--- a/docs/solutions/752-ask-rs-correlation-branch-uses-unscoped-task-lookup.md
+++ b/docs/solutions/752-ask-rs-correlation-branch-uses-unscoped-task-lookup.md
@@ -1,0 +1,88 @@
+---
+module: crates/mika-cli/src/commands/ask.rs
+tags: [validation, agent-scope, correlation, ownership, relay, latent-bug, task-lookup]
+problem_type: correctness-bug
+date: 2026-04-23
+issue: 752
+---
+
+# ask.rs correlation branch uses unscoped task lookup
+
+## Problem
+
+`mika ask --task-id <uuid>` has two branches: `--task-complete` (mutates the task: marks a callback complete) and the correlation-only path (existence check for observability, then falls through to the normal agent loop with the task ID in session metadata). The correlation path validated the task via `ctx.async_db.get_task(tid)` — the **agent-scoped** primitive whose SQL is `WHERE id = ? AND agent_id = ?`.
+
+That worked for months only because the caller of `mika ask --task-id` was always the task owner. Claude-pilot's permission relay routed through `mika-dev`, which owned every task it dispatched, so the agent filter was a no-op. Commit `8b6df69` (the fix for mika#721) correctly rerouted permission forwarding to `mika-relay` — and from that moment forward, the caller was no longer the owner. The agent filter started rejecting real cross-agent correlation attempts with `Error: Task 'X' not found`. Production observed 65+ denials across the golden-dataset dispatch under milestone #16; tier-1 auto-approval covered enough safe Bash patterns that the PR still shipped, but non-tier-1 commands were silently auto-denied for 42 minutes. Milestone #16 blocked.
+
+The call site even had a comment directly above it — `// Correlation-only path` — contradicting the primitive it called. The comment was right, the call was wrong, and nothing in the type system, linter, or review process could tell them apart because both primitives return `Result<Option<Task>>` with identical shapes. See `docs/solutions/best-practices/correlation-vs-ownership-validator-bug-class-2026-04-23.md` for the bug-class writeup that derives the prevention principles.
+
+## Solution
+
+One-line swap plus bidirectional documentation, no new abstractions.
+
+**Fix:** `crates/mika-cli/src/commands/ask.rs:185` now calls `ctx.async_db.get_task_unscoped(tid)` — the existing unscoped primitive on `AsyncDatabase` that delegates to `Database::get_task_unscoped` (SQL: `WHERE id = ?`, no agent filter). The `--task-complete` branch at line 129 continues to use agent-scoped `get_task` — completion is a state mutation and ownership is load-bearing there.
+
+**Bidirectional doc comments** on `Database::get_task_unscoped` (`crates/mika-agent/src/db.rs`) and `validate_task_exists` (`crates/mika-agent/src/tools/mod.rs`) cross-link the two and spell out the ownership-vs-correlation distinction, including the constraint that tool-path consumers must use the scoped validator while CLI correlation/observability sites must use the unscoped primitive. The doc comments are a tripwire for the next reviewer facing this same choice.
+
+**Regression tests** in `crates/mika-agent/tests/ask_correlation.rs` — placed in `mika-agent` because `mika_agent::test_utils` is `#[cfg(test)]`-gated and not reachable from `mika-cli`'s dev build. The tests use one shared in-memory `Database` wrapped by two `AsyncDatabase` handles (`new_with_agent("agent-a")` plus `.with_agent("agent-b")`) to exercise the actual cross-agent condition, not two disjoint in-memory DBs (which was the semantic bug in the original test draft — same agent on both sides would have trivially returned `Ok(None)` and hidden the real behavior). Three scenarios: unscoped lookup finds the cross-agent task (happy path, proves the fix), scoped lookup rejects it (contrast, proves the fix was necessary), unscoped lookup of a non-existent UUID returns `Ok(None)` (edge, confirms unscoped doesn't suppress real misses).
+
+## Key Decisions
+
+- **Use the existing `get_task_unscoped` primitive; do not introduce a new helper or an `enum AgentScope { Scoped(AgentId), Unscoped }` parameter.** Both alternatives were tempting. Both expand the surface area of the fix from 1 line to ~30 lines and introduce a fresh abstraction for a bug that is structurally about *which primitive to call*, not about *how the primitive is shaped*. The better structural answer (a type-level `AgentScopedTaskId` newtype so correlation call sites can't construct it) is filed as mika#755 and deliberately not in scope here — the relay was live when this was diagnosed and the shipping goal was unblock-first.
+
+- **Keep the completion branch agent-scoped.** Line 129's `get_task` is correct: completing a callback task is a privileged state mutation, and callers from other agents should not be able to complete tasks they don't own. The fix is targeted at the correlation path alone.
+
+- **Place regression tests in `mika-agent/tests/`, not `mika-cli`.** `mika-agent::test_utils::test_helpers` is `#[cfg(test)]`-gated so it's invisible to mika-cli's dev build and invisible to mika-agent's integration-test build. Pulling it into a `test-utils` cargo feature would touch the dependency graph for a two-file fix and contradict "no new abstractions, no new features." A self-contained integration test in `mika-agent/tests/ask_correlation.rs` using only public API is the minimum-blast-radius placement.
+
+- **Amend the fix commit, do not split into fix + test-move.** The original commit message already describes "fix + regression test" as one logical change; the broken test code was never meant to land independently. The local branch had not been pushed, so amend was safe.
+
+## Testing
+
+```
+$ cargo test -p mika-agent --test ask_correlation
+running 3 tests
+test unscoped_lookup_returns_none_for_nonexistent_task ... ok
+test scoped_lookup_rejects_cross_agent_task ... ok
+test unscoped_lookup_finds_cross_agent_task ... ok
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+$ cargo test -p mika-cli
+test result: ok. 252 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
+
+$ cargo clippy -p mika-cli -p mika-agent --all-targets -- -D warnings
+(clean)
+
+$ cargo fmt --all -- --check
+(clean)
+```
+
+## Generalizable Lesson
+
+Any codebase that exposes both a scoped and an unscoped variant of the same lookup (tasks, sessions, messages, facts, audit events) is one routing change away from a latent-bug incident at every call site that didn't document which variant it needed and why. Two practical rules:
+
+1. **Each caller must carry an explicit rationale tied to state-mutation-vs-observation.** Tools and handlers that change state: scoped. CLI correlation, observability, dashboard lookups, external-webhook correlation: unscoped. The rationale belongs in a comment at the call site *or* — stronger — encoded in the primitive's name so a reviewer can't miss it.
+
+2. **Bidirectional doc-comment cross-links on the primitives are structural, not decorative.** Prompt-level conventions ("always use the scoped variant by default") rot; docstrings that name each other by fully qualified path survive renames, moves, and IDE search because they show up in both directions of navigation. This is the same seam as the `feedback_prompt_enforcement_fragile` pattern: structural beats prompt-level when the cost of getting it wrong is asymmetric.
+
+The strongest fix (not taken in this PR) is a type-level newtype — `AgentScopedTaskId` constructible only from within a `ToolContext` — that turns wrong-primitive-selection into a compile-time error. Filed as mika#755. Doc-comment cross-links are the tripwire; the newtype is the guard.
+
+## Follow-up Audit
+
+Grep for other `async_db.get_task(` (and `db.get_task(`) call sites and for each one confirm whether the path mutates state (scoped is correct) or merely observes / correlates (scoped is wrong). Not in scope for this PR. Starting pointers from the existing codebase, to be triaged in a separate ticket:
+
+- `crates/mika-cli/src/commands/ask.rs:129` — `--task-complete` branch. **State-mutating, scoped is correct.**
+- `crates/mika-agent/src/tools/mod.rs:328` — `validate_task_exists`, consumed by state-mutating tools. **Scoped is correct for its consumers.**
+- `crates/mika-agent/src/skills/executor.rs:570` — skill executor lookup path. Review whether the caller is always the owning agent or whether this is reachable from a relay-style dispatch.
+- `crates/mika-agent/src/server/mod.rs:1744` — server handler. Review whether webhook-driven paths ever reach this with non-owner callers.
+- `crates/mika-agent/src/task_engine/{engine,dispatcher}.rs` — task engine callers. Review the callback/resume path, which is the most likely second instance of this class.
+
+Test-only call sites (`*_tests`, `#[cfg(test)]` modules) can be ignored for the audit — they construct their own task owner and aren't reachable from relay routing.
+
+## Related
+
+- **`docs/solutions/best-practices/correlation-vs-ownership-validator-bug-class-2026-04-23.md`** — the bug-class knowledge-track doc derived from this incident, with the three prevention principles (name the semantic, bidirectional docstrings, integration test at the pipeline layer) and the `AgentScopedTaskId` newtype proposal.
+- **mika#721** — introduced the `mika-relay` agent and rerouted claude-pilot permission forwarding. The routing change was correct but did not exercise the cross-agent task-id correlation path before merge, so this bug activated on production dispatch rather than in review.
+- **mika#753** — pipeline-level integration test that exercises relay → task-id correlation end-to-end on the mika#721 surface. Operational-layer prevention.
+- **mika#754** — mika-qa produced zero tool calls on a `#751` PR-opened webhook during the same incident window. Investigation ticket; unclear whether same class or different failure mode.
+- **mika#755** — the structural tripwire (newtype `AgentScopedTaskId` or rename `validate_task_exists` to match its enforced semantic). Not active work; fires if this class recurs.
+- Commit `8b6df69` (claude-pilot routing fix for mika#721) — the caller-context change that activated the latent bug.


### PR DESCRIPTION
Closes #752

## Problem

The `mika ask --task-id` correlation-only branch in `crates/mika-cli/src/commands/ask.rs` validated the referenced task via `get_task` (agent-scoped). When the caller agent differed from the task owner — the exact condition introduced when claude-pilot permission forwarding started routing through `mika-relay` while tasks remained owned by `mika-dev` — the lookup returned `None` and bailed with "Task not found," rejecting every forwarded permission request and stranding claude-pilot sessions in denied-tool loops. Production logs showed 65+ relay denials before this was caught, blocking milestone #16.

## What changed

- **One-line fix** in `crates/mika-cli/src/commands/ask.rs`: the correlation-only path (which is an existence check for observability, not an ownership gate) now calls `get_task_unscoped` instead of `get_task`. The `--task-complete` path at line 129 keeps agent-scoped `get_task` — completing a task is a state mutation and ownership is load-bearing there.
- **Bidirectional doc comments** on `Database::get_task_unscoped` (`crates/mika-agent/src/db.rs`) and `validate_task_exists` (`crates/mika-agent/src/tools/mod.rs`) cross-link the two and name the ownership-vs-correlation distinction so future callers pick the right primitive.
- **Three regression tests** in `crates/mika-agent/tests/ask_correlation.rs` — placed in `mika-agent` (not `mika-cli`) because `mika-agent::test_utils` is `#[cfg(test)]`-gated and not reachable from `mika-cli`'s dev build. Written against the public API only: one shared in-memory `Database` wrapped by two `AsyncDatabase` handles (`new_with_agent("agent-a")` + `.with_agent("agent-b")`), exercising the actual cross-agent condition rather than two disjoint in-memory DBs.
  - `unscoped_lookup_finds_cross_agent_task` — happy path, proves the fix works.
  - `scoped_lookup_rejects_cross_agent_task` — contrast, proves the fix was necessary (agent-scoped lookup still returns `None`).
  - `unscoped_lookup_returns_none_for_nonexistent_task` — edge case, unscoped lookup still returns `Ok(None)` for missing tasks.

## Verification

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy -p mika-cli -p mika-agent --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.69s
(no warnings)

$ cargo test -p mika-agent --test ask_correlation
running 3 tests
test unscoped_lookup_returns_none_for_nonexistent_task ... ok
test scoped_lookup_rejects_cross_agent_task ... ok
test unscoped_lookup_finds_cross_agent_task ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

$ cargo test -p mika-cli
test result: ok. 252 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
```

## Note

Rescued from a stalled claude-pilot session that could not run cargo, git, or gh because the bug it was fixing was live on the deployed relay — the autonomous session could produce the patch but not verify it. This PR carries the same fix plus the corrected regression tests and a clean local verification run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)