### PR TITLE
feat: KG-backed self-knowledge eval scenarios

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -226,6 +226,16 @@ Results merged, deduped by `(layer, entity_id)` keeping highest confidence, top-
 
 **Status values (D4):** `ok` (results found), `starting_entity_missing` (all entry paths failed), `traversal_empty` (entity found, no edges). Status enables #692 self-knowledge skill fallback logic.
 
+## Knowledge Graph — Eval Fixture Seeding (#740)
+
+`tests/eval/kg_fixtures/mod.rs` — crate-shared helpers for seeding a known KG state into a test `AsyncDatabase`. Used by `#740` (self-knowledge scenarios) and available for `#741` (grounding scenarios). Schema pin lives in the module (currently v25) with an actionable assertion message on drift.
+
+**Spec-struct pattern.** Each seed helper takes a `*Spec` struct and returns the inserted row ID: `seed_domain_entity`, `seed_domain_relationship`, `seed_subject_entity`, `seed_chunk`, `seed_chunk_subject`, `seed_resolution`, `disable_skill`. Query helpers (`get_resolution_log`, `get_resolution`) read rows back for assertions.
+
+**FTS/vec parity.** `seed_chunk` writes to `kg_chunks` and calls `Database::index_content(agent_id, KG_CHUNK_SOURCE_TYPE, Some(chunk_id), text)` so `search_content` and `fts_search` stay in parity — Path C semantic retrieval depends on FTS5 being populated. A raw insert into `search_content` silently breaks Path C.
+
+**Where scenarios live.** `tests/eval/kg_self_knowledge/` holds the seven #740 scenarios (one file per scenario, named `{class}_{shape}_{descriptor}.rs`). New scenarios: add the file, register it as `pub mod <name>;` in `kg_self_knowledge/mod.rs`, import `kg_fixtures::*`, call `assert_schema_version(&db).await` in setup, and update the capability-×-status matrix in the README. See `tests/eval/kg_self_knowledge/README.md` for the fixture table, tag vocabulary, and baseline scores.
+
 ## Silent Mode Agent Loop
 
 Background tasks (heartbeat, reminders) where text output is NOT delivered. Agent must use `send_message` tool explicitly. Separate `run_silent_agent` function with `SilentPromptContext`.

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -651,6 +651,45 @@ impl Database {
         Ok(db)
     }
 
+    /// Execute raw SQL with params. Returns the number of rows changed.
+    ///
+    /// Intended for test fixture seeding from integration tests where `conn`
+    /// is not directly accessible (`pub(crate)`).
+    pub fn execute_sql(&self, sql: &str, params: &[&dyn rusqlite::types::ToSql]) -> Result<usize> {
+        Ok(self.conn.execute(sql, params)?)
+    }
+
+    /// Returns the last inserted rowid.
+    pub fn last_insert_rowid(&self) -> i64 {
+        self.conn.last_insert_rowid()
+    }
+
+    /// Query a single scalar value. Returns `None` if no rows match.
+    pub fn query_scalar<T: rusqlite::types::FromSql>(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::types::ToSql],
+    ) -> Result<Option<T>> {
+        use rusqlite::OptionalExtension;
+        Ok(self
+            .conn
+            .query_row(sql, params, |row| row.get(0))
+            .optional()?)
+    }
+
+    /// Query a single row and return two columns. Returns `None` if no rows match.
+    pub fn query_row_2<T1: rusqlite::types::FromSql, T2: rusqlite::types::FromSql>(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::types::ToSql],
+    ) -> Result<Option<(T1, T2)>> {
+        use rusqlite::OptionalExtension;
+        Ok(self
+            .conn
+            .query_row(sql, params, |row| Ok((row.get(0)?, row.get(1)?)))
+            .optional()?)
+    }
+
     fn current_version(&self) -> Result<i64> {
         let exists: bool = self
             .conn

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -14,6 +14,12 @@ mod eval {
     // Golden dataset: 25 curated scenarios for end-to-end quality testing (#339)
     pub mod golden;
 
+    // KG fixture helpers: shared seeding for KG eval scenarios (#740, #741)
+    pub mod kg_fixtures;
+
+    // KG self-knowledge: 7 scenarios for KG-backed self-knowledge (#740)
+    pub mod kg_self_knowledge;
+
     mod test_basic_conversation;
     mod test_callback_turn;
     mod test_completion_claim_guard;

--- a/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
@@ -1,0 +1,332 @@
+//! # KG Fixture Helpers — Shared Seeding for KG Eval Scenarios
+//!
+//! Crate-shared helpers for seeding a known KG state in test databases.
+//! Used by `#740` (self-knowledge) and available for `#741` (grounding) scenarios.
+//!
+//! ## Entity Key Format
+//!
+//! Entity keys follow the `<type>:<name>` convention from
+//! `crates/mika-agent/src/kg/domain_builder.rs` and `docs/architecture/kg-id-convention.md`.
+//!
+//! ## Schema Pin
+//!
+//! Fixtures are pinned to schema v25 (the KG schema version). If the schema advances,
+//! the assertion below fails with an actionable message pointing here.
+
+use mika_agent::async_db::AsyncDatabase;
+use mika_agent::db::Database;
+
+/// Current schema version this fixture module is pinned to.
+/// Bump this when updating fixtures for a new schema version.
+const PINNED_SCHEMA_VERSION: i32 = 25;
+
+// ---------------------------------------------------------------------------
+// Test DB Factory
+// ---------------------------------------------------------------------------
+
+/// Create an in-memory `AsyncDatabase` with a test agent and session.
+///
+/// Agent ID defaults to `"mika-dev"` — the primary development agent.
+/// Session `"eval-kg-session"` is pre-created for FK satisfaction.
+pub fn test_db() -> AsyncDatabase {
+    test_db_with_agent("mika-dev")
+}
+
+/// Create an in-memory `AsyncDatabase` with a specific agent ID.
+pub fn test_db_with_agent(agent_id: &str) -> AsyncDatabase {
+    let db = Database::open_in_memory().unwrap();
+    // Register agent first (sessions FK to agents)
+    db.register_agent(agent_id, agent_id, &format!("/tmp/mika-test/{agent_id}"))
+        .unwrap();
+    db.create_session("eval-kg-session", agent_id, "test")
+        .unwrap();
+    AsyncDatabase::new_with_agent(db, agent_id)
+}
+
+/// Assert the schema version matches the fixture pin.
+/// Call from scenario setup to catch schema drift early.
+pub async fn assert_schema_version(db: &AsyncDatabase) {
+    let version: i32 = db
+        .with_db(|db| {
+            db.query_scalar::<i32>(
+                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+                &[],
+            )
+            .map(|v| v.unwrap_or(0))
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        version, PINNED_SCHEMA_VERSION,
+        "KG eval fixtures pinned to schema v{PINNED_SCHEMA_VERSION}. Schema bumped to v{version}; \
+         update seed_* helpers in tests/eval/kg_fixtures/mod.rs and bump this pin. \
+         See docs/plans/740-kg-self-knowledge-eval.md D5.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Seed Helpers
+// ---------------------------------------------------------------------------
+
+/// Specification for a domain entity seed.
+pub struct DomainEntitySpec {
+    pub entity_type: &'static str,
+    pub name: &'static str,
+    pub properties_json: Option<&'static str>,
+}
+
+/// Seed a domain entity into `kg_entities`. Returns the inserted row ID.
+pub async fn seed_domain_entity(db: &AsyncDatabase, spec: &DomainEntitySpec) -> i64 {
+    let entity_key = format!("{}:{}", spec.entity_type, spec.name);
+    let etype = spec.entity_type.to_string();
+    let name = spec.name.to_string();
+    let props = spec.properties_json.map(|s| s.to_string());
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_entities (entity_key, type, name, properties_json) \
+             VALUES (?1, ?2, ?3, ?4)",
+            &[
+                &entity_key as &dyn rusqlite::types::ToSql,
+                &etype,
+                &name,
+                &props,
+            ],
+        )?;
+        Ok(db.last_insert_rowid())
+    })
+    .await
+    .unwrap()
+}
+
+/// Seed a domain relationship into `kg_relationships`. Returns the inserted row ID.
+pub async fn seed_domain_relationship(
+    db: &AsyncDatabase,
+    from_entity_id: i64,
+    to_entity_id: i64,
+    rel_type: &str,
+) -> i64 {
+    let rt = rel_type.to_string();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_relationships (from_entity_id, to_entity_id, type) \
+             VALUES (?1, ?2, ?3)",
+            &[
+                &from_entity_id as &dyn rusqlite::types::ToSql,
+                &to_entity_id,
+                &rt,
+            ],
+        )?;
+        Ok(db.last_insert_rowid())
+    })
+    .await
+    .unwrap()
+}
+
+/// Specification for a subject entity seed.
+pub struct SubjectEntitySpec {
+    pub entity_type: &'static str,
+    pub name: &'static str,
+    pub confidence: f64,
+    pub properties_json: Option<&'static str>,
+}
+
+/// Seed a subject entity into `kg_subject_entities`. Returns the inserted row ID.
+///
+/// Agent ID is taken from `db.agent_id`.
+pub async fn seed_subject_entity(db: &AsyncDatabase, spec: &SubjectEntitySpec) -> i64 {
+    let agent_id = db.agent_id.clone();
+    let entity_key = format!("{}:{}", spec.entity_type, spec.name);
+    let etype = spec.entity_type.to_string();
+    let name = spec.name.to_string();
+    let confidence = spec.confidence;
+    let props = spec.properties_json.map(|s| s.to_string());
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_subject_entities (agent_id, entity_key, type, name, confidence, properties_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &entity_key,
+                &etype,
+                &name,
+                &confidence,
+                &props,
+            ],
+        )?;
+        Ok(db.last_insert_rowid())
+    })
+    .await
+    .unwrap()
+}
+
+/// Specification for a chunk seed.
+pub struct ChunkSpec {
+    pub seq_id: i64,
+    pub source_doc_path: &'static str,
+    pub source_doc_hash: &'static str,
+    pub text: &'static str,
+}
+
+/// Seed a chunk into `kg_chunks` and its text into `search_content`. Returns the chunk row ID.
+///
+/// Agent ID is taken from `db.agent_id`.
+pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
+    let agent_id = db.agent_id.clone();
+    let seq_id = spec.seq_id;
+    let source_doc_path = spec.source_doc_path.to_string();
+    let source_doc_hash = spec.source_doc_hash.to_string();
+    let text = spec.text.to_string();
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_chunks (agent_id, seq_id, source_doc_path, source_doc_hash) \
+             VALUES (?1, ?2, ?3, ?4)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &seq_id,
+                &source_doc_path,
+                &source_doc_hash,
+            ],
+        )?;
+        let chunk_id = db.last_insert_rowid();
+
+        // Insert into search_content for FTS5/hybrid search
+        db.execute_sql(
+            "INSERT INTO search_content (agent_id, content, source_type, source_id) \
+             VALUES (?1, ?2, 'kg_chunk', ?3)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &text,
+                &chunk_id,
+            ],
+        )?;
+
+        Ok(chunk_id)
+    })
+    .await
+    .unwrap()
+}
+
+/// Link a chunk to a subject entity via `kg_chunk_subjects`. Returns the row ID.
+pub async fn seed_chunk_subject(
+    db: &AsyncDatabase,
+    chunk_id: i64,
+    subject_entity_id: i64,
+) -> i64 {
+    let agent_id = db.agent_id.clone();
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_chunk_subjects (agent_id, chunk_id, subject_entity_id) \
+             VALUES (?1, ?2, ?3)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &chunk_id,
+                &subject_entity_id,
+            ],
+        )?;
+        Ok(db.last_insert_rowid())
+    })
+    .await
+    .unwrap()
+}
+
+/// Seed a resolution into both `kg_subject_resolutions` and `kg_resolutions_log`.
+pub async fn seed_resolution(
+    db: &AsyncDatabase,
+    subject_entity_id: i64,
+    domain_entity_id: i64,
+    confidence: f64,
+    outcome: &str,
+) {
+    let agent_id = db.agent_id.clone();
+    let outcome = outcome.to_string();
+    let trace_id = uuid::Uuid::new_v4().to_string().replace('-', "");
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_subject_resolutions (agent_id, subject_entity_id, domain_entity_id, confidence) \
+             VALUES (?1, ?2, ?3, ?4)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &subject_entity_id,
+                &domain_entity_id,
+                &confidence,
+            ],
+        )?;
+        db.execute_sql(
+            "INSERT INTO kg_resolutions_log (agent_id, subject_entity_id, outcome, resolution_trace_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &subject_entity_id,
+                &outcome,
+                &trace_id,
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Disable a skill for a specific agent via `skill_overrides`.
+pub async fn disable_skill(db: &AsyncDatabase, agent_id: &str, skill_name: &str) {
+    let aid = agent_id.to_string();
+    let sn = skill_name.to_string();
+
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO skill_overrides (agent_id, skill_name, enabled) \
+             VALUES (?1, ?2, 0) \
+             ON CONFLICT(agent_id, skill_name) DO UPDATE SET enabled = 0",
+            &[&aid as &dyn rusqlite::types::ToSql, &sn],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Query Helpers (for assertions)
+// ---------------------------------------------------------------------------
+
+/// Read a resolution log entry for a subject entity. Returns (outcome, model).
+pub async fn get_resolution_log(
+    db: &AsyncDatabase,
+    subject_entity_id: i64,
+) -> Option<(String, Option<String>)> {
+    let agent_id = db.agent_id.clone();
+
+    db.with_db(move |db| {
+        db.query_row_2::<String, Option<String>>(
+            "SELECT outcome, model FROM kg_resolutions_log \
+             WHERE agent_id = ?1 AND subject_entity_id = ?2",
+            &[&agent_id as &dyn rusqlite::types::ToSql, &subject_entity_id],
+        )
+    })
+    .await
+    .unwrap()
+}
+
+/// Read a resolution for a subject entity. Returns (domain_entity_id, confidence).
+pub async fn get_resolution(
+    db: &AsyncDatabase,
+    subject_entity_id: i64,
+) -> Option<(i64, f64)> {
+    let agent_id = db.agent_id.clone();
+
+    db.with_db(move |db| {
+        db.query_row_2::<i64, f64>(
+            "SELECT domain_entity_id, confidence FROM kg_subject_resolutions \
+             WHERE agent_id = ?1 AND subject_entity_id = ?2",
+            &[&agent_id as &dyn rusqlite::types::ToSql, &subject_entity_id],
+        )
+    })
+    .await
+    .unwrap()
+}

--- a/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
@@ -48,11 +48,8 @@ pub fn test_db_with_agent(agent_id: &str) -> AsyncDatabase {
 pub async fn assert_schema_version(db: &AsyncDatabase) {
     let version: i32 = db
         .with_db(|db| {
-            db.query_scalar::<i32>(
-                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
-                &[],
-            )
-            .map(|v| v.unwrap_or(0))
+            db.query_scalar::<i32>("SELECT COALESCE(MAX(version), 0) FROM schema_version", &[])
+                .map(|v| v.unwrap_or(0))
         })
         .await
         .unwrap();
@@ -170,7 +167,14 @@ pub struct ChunkSpec {
     pub text: &'static str,
 }
 
-/// Seed a chunk into `kg_chunks` and its text into `search_content`. Returns the chunk row ID.
+/// Seed a chunk into `kg_chunks` and index its text via `Database::index_content`.
+/// Returns the chunk row ID.
+///
+/// Mirrors the lexical ingestor's insert pattern (kg_chunks + index_content in the
+/// same transaction) so FTS5 (`fts_search`) — and vec_search when embeddings are
+/// supplied — stay in parity with `search_content`. Path C semantic retrieval
+/// depends on `fts_search` being populated; a raw insert into `search_content`
+/// silently breaks Path C tests.
 ///
 /// Agent ID is taken from `db.agent_id`.
 pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
@@ -193,15 +197,13 @@ pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
         )?;
         let chunk_id = db.last_insert_rowid();
 
-        // Insert into search_content for FTS5/hybrid search
-        db.execute_sql(
-            "INSERT INTO search_content (agent_id, content, source_type, source_id) \
-             VALUES (?1, ?2, 'kg_chunk', ?3)",
-            &[
-                &agent_id as &dyn rusqlite::types::ToSql,
-                &text,
-                &chunk_id,
-            ],
+        // Index via the canonical path: updates search_content + fts_search
+        // (and vec_search via index_embedding when embeddings are available).
+        db.index_content(
+            &agent_id,
+            mika_agent::db::kg_schema::KG_CHUNK_SOURCE_TYPE,
+            Some(chunk_id),
+            &text,
         )?;
 
         Ok(chunk_id)
@@ -211,11 +213,7 @@ pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
 }
 
 /// Link a chunk to a subject entity via `kg_chunk_subjects`. Returns the row ID.
-pub async fn seed_chunk_subject(
-    db: &AsyncDatabase,
-    chunk_id: i64,
-    subject_entity_id: i64,
-) -> i64 {
+pub async fn seed_chunk_subject(db: &AsyncDatabase, chunk_id: i64, subject_entity_id: i64) -> i64 {
     let agent_id = db.agent_id.clone();
 
     db.with_db(move |db| {
@@ -314,10 +312,7 @@ pub async fn get_resolution_log(
 }
 
 /// Read a resolution for a subject entity. Returns (domain_entity_id, confidence).
-pub async fn get_resolution(
-    db: &AsyncDatabase,
-    subject_entity_id: i64,
-) -> Option<(i64, f64)> {
+pub async fn get_resolution(db: &AsyncDatabase, subject_entity_id: i64) -> Option<(i64, f64)> {
     let agent_id = db.agent_id.clone();
 
     db.with_db(move |db| {

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/README.md
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/README.md
@@ -1,0 +1,76 @@
+# KG Self-Knowledge Eval Scenarios (#740)
+
+Seven scenarios verifying that agents correctly query the knowledge graph before claiming capability or state.
+
+## Running
+
+```bash
+# Unit tier (mock LLM, every CI push)
+cargo test -p mika-agent --test eval kg_self_knowledge
+
+# Integration tier (real providers, opt-in)
+MIKA_EVAL_REAL_PROVIDERS=anthropic MIKA_KG_RESOLUTION_MODEL=anthropic/claude-haiku-4-5-20251001 \
+  cargo test -p mika-agent --test eval kg_self_knowledge -- --ignored
+```
+
+## Fixture Helpers
+
+Shared helpers live at `tests/eval/kg_fixtures/mod.rs` (crate-shared, not nested here). Available helpers:
+
+| Helper | Seeds into | Returns |
+|--------|-----------|---------|
+| `seed_domain_entity(db, spec)` | `kg_entities` | row ID |
+| `seed_domain_relationship(db, from, to, type)` | `kg_relationships` | row ID |
+| `seed_subject_entity(db, spec)` | `kg_subject_entities` | row ID |
+| `seed_chunk(db, spec)` | `kg_chunks` + `search_content` | chunk ID |
+| `seed_chunk_subject(db, chunk_id, subject_id)` | `kg_chunk_subjects` | row ID |
+| `seed_resolution(db, subject_id, domain_id, conf, outcome)` | `kg_subject_resolutions` + `kg_resolutions_log` | — |
+| `disable_skill(db, agent_id, skill_name)` | `skill_overrides` | — |
+
+Fixtures are pinned to schema v25. On schema bump, `assert_schema_version()` fails with an actionable message.
+
+## Tag Vocabulary (`self-knowledge:*`)
+
+| Tag | Trigger Condition |
+|-----|-------------------|
+| `self-knowledge:query-invoked` | Agent called `query_knowledge_graph` before final response |
+| `self-knowledge:capability-claimed-without-query` | Agent claimed capability state without a KG query |
+| `self-knowledge:stage-1-skipped` | Stage 1 exact match bypassed unexpectedly |
+| `self-knowledge:agent-context-missing` | Result returned but `agent_context` annotation absent/wrong |
+| `self-knowledge:disambiguation-correct` | Stage 2 picked the structurally-expected candidate |
+| `self-knowledge:disambiguation-plausible-alternative` | Stage 2 picked a different-but-defensible candidate |
+
+### Scope Boundary with #741 (`grounding:*`)
+
+`self-knowledge:*` tags cover the code path from tool-invocation through resolver. Agent *response quality* given a successful KG result (e.g., "KG returned correct result but agent ignored it") is a **grounding failure** routed to `#741`'s `grounding:*` namespace. Tags attribute to **cause-location**, not symptom.
+
+## Capability x Status Matrix
+
+| # | Scenario | `ok` | `starting_entity_missing` | `traversal_empty` | `matched_exact` | `matched_llm` | `skipped_no_llm` | `agent_context` |
+|---|----------|:----:|:-------------------------:|:------------------:|:---------------:|:--------------:|:----------------:|:---------------:|
+| 1 | tool_selection_query_knowledge_graph | | | | | | | |
+| 2 | path_a_direct_domain_match | X | | | | | | |
+| 3 | path_b_subject_match_agent_scoped | X | X | | | | | |
+| 4 | path_c_semantic_via_chunks | X | | | | | | |
+| 5 | stage_1_exact_match | | | | X | | X | |
+| 6 | stage_2_llm_disambiguation | | | | | X | X | |
+| 7 | agent_context_annotation_disabled | X | | | | | | X |
+
+Legend: `X` = scenario asserts this status outcome.
+
+## How to Add a Scenario
+
+1. Create `crates/mika-agent/tests/eval/kg_self_knowledge/<name>.rs`
+2. Add `pub mod <name>;` to `mod.rs`
+3. Use `kg_fixtures::*` for seeding
+4. Call `assert_schema_version(&db).await;` in setup
+5. Add hard assertions (regression-gating) and optional soft tags
+6. Update this README's matrix
+
+## Architecture References
+
+- KG tables: `crates/mika-agent/CLAUDE.md` (Knowledge Graph section)
+- Entity key format: `docs/architecture/kg-id-convention.md`
+- Domain builder: `crates/mika-agent/src/kg/domain_builder.rs`
+- Query engine: `crates/mika-agent/src/kg/query.rs`
+- Entity resolver: `crates/mika-agent/src/kg/entity_resolver.rs`

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/README.md
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/README.md
@@ -8,10 +8,35 @@ Seven scenarios verifying that agents correctly query the knowledge graph before
 # Unit tier (mock LLM, every CI push)
 cargo test -p mika-agent --test eval kg_self_knowledge
 
-# Integration tier (real providers, opt-in)
+# Integration tier (real providers, opt-in — future work, no `#[ignore]` tests yet)
 MIKA_EVAL_REAL_PROVIDERS=anthropic MIKA_KG_RESOLUTION_MODEL=anthropic/claude-haiku-4-5-20251001 \
   cargo test -p mika-agent --test eval kg_self_knowledge -- --ignored
 ```
+
+Integration tier hooks are reserved for Stage 2 LLM disambiguation against a real
+`MIKA_KG_RESOLUTION_MODEL` and Path C semantic retrieval with a real embedding
+client. No `#[ignore]`-gated tests exist yet — the unit tier covers all seven
+scenarios via `MockLlmProvider` and a populated FTS5 index.
+
+## Baseline Scores
+
+Scores are captured from a clean run of the mock-LLM subset on the commit
+recorded in the heading. Re-capture whenever a scenario changes hard assertions.
+
+**Baseline — mock-LLM subset (commit `57f8b1b9` + Path C fixture fix, 2026-04-23):**
+
+| # | Scenario | Tests | Mock unit | Real integration |
+|---|----------|:-----:|:---------:|:----------------:|
+| 1 | tool_selection_query_knowledge_graph | 2 | pass | not run locally |
+| 2 | path_a_direct_domain_match | 2 | pass | not run locally |
+| 3 | path_b_subject_match_agent_scoped | 3 | pass | not run locally |
+| 4 | path_c_semantic_via_chunks | 2 | pass | not run locally |
+| 5 | stage_1_exact_match | 3 | pass | not run locally |
+| 6 | stage_2_llm_disambiguation | 3 | pass | not run locally |
+| 7 | agent_context_annotation_disabled | 4 | pass | not run locally |
+
+Totals: 19/19 mock-LLM unit tests pass, 0 ignored, 0 silently skipped.
+Integration tier: no `#[ignore]`-gated tests exist yet.
 
 ## Fixture Helpers
 
@@ -22,7 +47,7 @@ Shared helpers live at `tests/eval/kg_fixtures/mod.rs` (crate-shared, not nested
 | `seed_domain_entity(db, spec)` | `kg_entities` | row ID |
 | `seed_domain_relationship(db, from, to, type)` | `kg_relationships` | row ID |
 | `seed_subject_entity(db, spec)` | `kg_subject_entities` | row ID |
-| `seed_chunk(db, spec)` | `kg_chunks` + `search_content` | chunk ID |
+| `seed_chunk(db, spec)` | `kg_chunks` + `search_content` + `fts_search` (via `Database::index_content`) | chunk ID |
 | `seed_chunk_subject(db, chunk_id, subject_id)` | `kg_chunk_subjects` | row ID |
 | `seed_resolution(db, subject_id, domain_id, conf, outcome)` | `kg_subject_resolutions` + `kg_resolutions_log` | — |
 | `disable_skill(db, agent_id, skill_name)` | `skill_overrides` | — |

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/agent_context_annotation_disabled.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/agent_context_annotation_disabled.rs
@@ -1,0 +1,163 @@
+//! Scenario 7: Agent context annotation — disabled skill.
+//!
+//! Disables `self-dev` for the test agent via `skill_overrides`, then queries
+//! the KG. Asserts the skill is RETURNED (annotated, not filtered) with
+//! `agent_context.enabled = false`.
+//!
+//! ## Hard Assertions
+//! - Disabled skill appears in results (not filtered)
+//! - `agent_context.enabled == false`
+//! - Non-skill entities have no `agent_context`
+//!
+//! Reference: mika#740 D2 scenario 7, KG query D5 (annotate, don't filter)
+
+use super::kg_fixtures::*;
+use mika_agent::kg::query::{KgQueryInput, KgQueryStatus, TraversalInput, query_knowledge_graph};
+
+/// Disabled skill is returned with `agent_context.enabled = false`.
+#[tokio::test]
+async fn test_disabled_skill_annotated_not_filtered() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed domain entity
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Disable the skill for mika-dev
+    disable_skill(&db, "mika-dev", "self-dev").await;
+
+    // Query with agent_id
+    let input = KgQueryInput {
+        question: None,
+        traversal: Some(TraversalInput {
+            start: Some("skill:self-dev".to_string()),
+            follow: None,
+            max_depth: Some(0),
+        }),
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // Hard: skill is RETURNED (not filtered)
+    assert_eq!(result.status, KgQueryStatus::Ok);
+    assert_eq!(result.entries.len(), 1);
+
+    let entry = &result.entries[0];
+    assert_eq!(entry.entity_key, "skill:self-dev");
+
+    // Hard: agent_context exists and shows disabled
+    assert!(
+        entry.agent_context.is_some(),
+        "Disabled skill should have agent_context annotation"
+    );
+    assert!(
+        !entry.agent_context.as_ref().unwrap().enabled,
+        "agent_context.enabled should be false for disabled skill"
+    );
+}
+
+/// Enabled skill (no override) should show `agent_context.enabled = true`.
+#[tokio::test]
+async fn test_enabled_skill_annotated_true() {
+    let db = test_db();
+
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "build-mika",
+        properties_json: None,
+    }).await;
+
+    // No skill_overrides row — default is enabled
+
+    let input = KgQueryInput {
+        question: None,
+        traversal: Some(TraversalInput {
+            start: Some("skill:build-mika".to_string()),
+            follow: None,
+            max_depth: Some(0),
+        }),
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+    let entry = &result.entries[0];
+
+    assert!(entry.agent_context.is_some());
+    assert!(
+        entry.agent_context.as_ref().unwrap().enabled,
+        "Default (no override) skill should show enabled=true"
+    );
+}
+
+/// Non-skill entities should NOT have agent_context.
+#[tokio::test]
+async fn test_non_skill_entity_no_agent_context() {
+    let db = test_db();
+
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "problem_type",
+        name: "ci_failure",
+        properties_json: None,
+    }).await;
+
+    let input = KgQueryInput {
+        question: None,
+        traversal: Some(TraversalInput {
+            start: Some("problem_type:ci_failure".to_string()),
+            follow: None,
+            max_depth: Some(0),
+        }),
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+    let entry = &result.entries[0];
+
+    assert!(
+        entry.agent_context.is_none(),
+        "Non-skill entities should not have agent_context"
+    );
+}
+
+/// Query without agent_id should NOT include agent_context at all.
+#[tokio::test]
+async fn test_no_agent_id_no_agent_context() {
+    let db = test_db();
+
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    let input = KgQueryInput {
+        question: None,
+        traversal: Some(TraversalInput {
+            start: Some("skill:self-dev".to_string()),
+            follow: None,
+            max_depth: Some(0),
+        }),
+        agent_id: None, // No agent_id
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+    let entry = &result.entries[0];
+
+    assert!(
+        entry.agent_context.is_none(),
+        "Without agent_id, no agent_context should be present"
+    );
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/agent_context_annotation_disabled.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/agent_context_annotation_disabled.rs
@@ -21,11 +21,15 @@ async fn test_disabled_skill_annotated_not_filtered() {
     assert_schema_version(&db).await;
 
     // Seed domain entity
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Disable the skill for mika-dev
     disable_skill(&db, "mika-dev", "self-dev").await;
@@ -68,11 +72,15 @@ async fn test_disabled_skill_annotated_not_filtered() {
 async fn test_enabled_skill_annotated_true() {
     let db = test_db();
 
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "build-mika",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "build-mika",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // No skill_overrides row — default is enabled
 
@@ -103,11 +111,15 @@ async fn test_enabled_skill_annotated_true() {
 async fn test_non_skill_entity_no_agent_context() {
     let db = test_db();
 
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "problem_type",
-        name: "ci_failure",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "problem_type",
+            name: "ci_failure",
+            properties_json: None,
+        },
+    )
+    .await;
 
     let input = KgQueryInput {
         question: None,
@@ -135,11 +147,15 @@ async fn test_non_skill_entity_no_agent_context() {
 async fn test_no_agent_id_no_agent_context() {
     let db = test_db();
 
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     let input = KgQueryInput {
         question: None,

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/mod.rs
@@ -1,0 +1,38 @@
+//! # KG Self-Knowledge Eval Scenarios (#740)
+//!
+//! Seven scenarios verifying that agents correctly query the knowledge graph
+//! before claiming capability or state. Covers the three KG entry paths
+//! (domain match, subject match, semantic via chunks), the two-stage resolver
+//! (exact match, LLM disambiguation), and agent context annotation.
+//!
+//! ## Tag Vocabulary (`self-knowledge:*`)
+//!
+//! See `README.md` in this directory for the full vocabulary and
+//! capability × status matrix.
+//!
+//! ## Fixture Helpers
+//!
+//! Scenarios share the `kg_fixtures` module for seeding KG state.
+//! Each scenario owns its fixture *composition*; helpers are shared.
+//!
+//! ## Reference
+//!
+//! - Issue: mika#740
+//! - Plan: `docs/plans/740-kg-self-knowledge-eval.md`
+
+// Re-export common test dependencies for scenario files
+pub use mika_common::llm::mock::*;
+pub use serde_json::json;
+
+pub use super::assertions::*;
+pub use super::harness::EvalHarness;
+pub use super::kg_fixtures;
+
+// --- Scenario modules (one per scenario, D2) ---
+pub mod tool_selection_query_knowledge_graph;
+pub mod path_a_direct_domain_match;
+pub mod path_b_subject_match_agent_scoped;
+pub mod path_c_semantic_via_chunks;
+pub mod stage_1_exact_match;
+pub mod stage_2_llm_disambiguation;
+pub mod agent_context_annotation_disabled;

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/mod.rs
@@ -29,10 +29,10 @@ pub use super::harness::EvalHarness;
 pub use super::kg_fixtures;
 
 // --- Scenario modules (one per scenario, D2) ---
-pub mod tool_selection_query_knowledge_graph;
+pub mod agent_context_annotation_disabled;
 pub mod path_a_direct_domain_match;
 pub mod path_b_subject_match_agent_scoped;
 pub mod path_c_semantic_via_chunks;
 pub mod stage_1_exact_match;
 pub mod stage_2_llm_disambiguation;
-pub mod agent_context_annotation_disabled;
+pub mod tool_selection_query_knowledge_graph;

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_a_direct_domain_match.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_a_direct_domain_match.rs
@@ -1,0 +1,108 @@
+//! Scenario 2: Path A — Direct domain entity match.
+//!
+//! Seeds a domain entity `skill:self-dev` in `kg_entities`, then queries
+//! via the KG query engine. Asserts one result with `entity_type=Skill`,
+//! `hop=0`, and correct entity key.
+//!
+//! ## Hard Assertions
+//! - Query returns `status: ok`
+//! - One result entry with `entity_key = "skill:self-dev"`
+//! - `entity_type = "skill"`, `hop = 0`
+//! - `entry_method` indicates direct match (path A)
+//!
+//! Reference: mika#740 D2 scenario 2
+
+use super::kg_fixtures::*;
+use mika_agent::kg::query::{KgQueryInput, KgQueryStatus, TraversalInput, query_knowledge_graph};
+
+#[tokio::test]
+async fn test_path_a_direct_domain_entity_match() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed a domain entity
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Query by entity_key (direct lookup, not free-text)
+    let input = KgQueryInput {
+        question: None,
+        traversal: Some(TraversalInput {
+            start: Some("skill:self-dev".to_string()),
+            follow: None,
+            max_depth: Some(0),
+        }),
+        agent_id: None,
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // Hard assertions
+    assert_eq!(result.status, KgQueryStatus::Ok);
+    assert_eq!(result.entries.len(), 1, "Expected exactly one result for direct domain match");
+
+    let entry = &result.entries[0];
+    assert_eq!(entry.entity_key, "skill:self-dev");
+    assert_eq!(entry.entity_type, "skill");
+    assert_eq!(entry.hop, 0);
+    assert_eq!(entry.layer, "domain");
+    assert!(
+        entry.confidence >= 1.0 - f64::EPSILON,
+        "Direct domain match should have confidence ~1.0, got {}",
+        entry.confidence
+    );
+    assert_eq!(
+        result.entry_method.as_deref(),
+        Some("direct_entity_key"),
+        "Entry method should indicate direct entity key lookup"
+    );
+}
+
+/// Path A via free-text name match (LIKE).
+/// An isolated entity (no edges) returns `TraversalEmpty` — the entity was found
+/// but no neighbors exist to traverse.
+#[tokio::test]
+async fn test_path_a_name_match_via_question() {
+    let db = test_db();
+
+    let self_dev_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Add a relationship so traversal succeeds
+    let dep_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "claude-pilot",
+        properties_json: None,
+    }).await;
+    seed_domain_relationship(&db, self_dev_id, dep_id, "DEPENDS_ON").await;
+
+    // Query via free-text question that matches the name
+    let input = KgQueryInput {
+        question: Some("self-dev".to_string()),
+        traversal: None,
+        agent_id: None,
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    assert_eq!(result.status, KgQueryStatus::Ok);
+    assert!(
+        result.entries.iter().any(|e| e.entity_key == "skill:self-dev"),
+        "Path A should find skill:self-dev via name match"
+    );
+
+    let entry = result.entries.iter().find(|e| e.entity_key == "skill:self-dev").unwrap();
+    assert_eq!(entry.entity_type, "skill");
+    assert_eq!(entry.hop, 0);
+    assert_eq!(entry.layer, "domain");
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_a_direct_domain_match.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_a_direct_domain_match.rs
@@ -21,11 +21,15 @@ async fn test_path_a_direct_domain_entity_match() {
     assert_schema_version(&db).await;
 
     // Seed a domain entity
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Query by entity_key (direct lookup, not free-text)
     let input = KgQueryInput {
@@ -44,7 +48,11 @@ async fn test_path_a_direct_domain_entity_match() {
 
     // Hard assertions
     assert_eq!(result.status, KgQueryStatus::Ok);
-    assert_eq!(result.entries.len(), 1, "Expected exactly one result for direct domain match");
+    assert_eq!(
+        result.entries.len(),
+        1,
+        "Expected exactly one result for direct domain match"
+    );
 
     let entry = &result.entries[0];
     assert_eq!(entry.entity_key, "skill:self-dev");
@@ -70,18 +78,26 @@ async fn test_path_a_direct_domain_entity_match() {
 async fn test_path_a_name_match_via_question() {
     let db = test_db();
 
-    let self_dev_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    let self_dev_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Add a relationship so traversal succeeds
-    let dep_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "claude-pilot",
-        properties_json: None,
-    }).await;
+    let dep_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "claude-pilot",
+            properties_json: None,
+        },
+    )
+    .await;
     seed_domain_relationship(&db, self_dev_id, dep_id, "DEPENDS_ON").await;
 
     // Query via free-text question that matches the name
@@ -97,11 +113,18 @@ async fn test_path_a_name_match_via_question() {
 
     assert_eq!(result.status, KgQueryStatus::Ok);
     assert!(
-        result.entries.iter().any(|e| e.entity_key == "skill:self-dev"),
+        result
+            .entries
+            .iter()
+            .any(|e| e.entity_key == "skill:self-dev"),
         "Path A should find skill:self-dev via name match"
     );
 
-    let entry = result.entries.iter().find(|e| e.entity_key == "skill:self-dev").unwrap();
+    let entry = result
+        .entries
+        .iter()
+        .find(|e| e.entity_key == "skill:self-dev")
+        .unwrap();
     assert_eq!(entry.entity_type, "skill");
     assert_eq!(entry.hop, 0);
     assert_eq!(entry.layer, "domain");

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_b_subject_match_agent_scoped.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_b_subject_match_agent_scoped.rs
@@ -1,0 +1,125 @@
+//! Scenario 3: Path B — Subject entity match (agent-scoped).
+//!
+//! Seeds subject entity `pattern:fabrication-guard` for agent `mika-dev` only.
+//! Verifies:
+//! - Querying as `mika-dev` returns the subject-layer result
+//! - Querying as a different agent returns `starting_entity_missing` (isolation)
+//!
+//! ## Hard Assertions (paired: success + failure)
+//! - Success: mika-dev query returns subject entity with correct key
+//! - Failure: different-agent query returns `starting_entity_missing`
+//!
+//! Reference: mika#740 D2 scenario 3, D6 paired assertions
+
+use super::kg_fixtures::*;
+use mika_agent::kg::query::{KgQueryInput, KgQueryStatus, query_knowledge_graph};
+
+#[tokio::test]
+async fn test_path_b_subject_match_correct_agent() {
+    let db = test_db(); // agent_id = "mika-dev"
+    assert_schema_version(&db).await;
+
+    // Seed a subject entity for mika-dev only
+    seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "pattern",
+        name: "fabrication-guard",
+        confidence: 0.92,
+        properties_json: None,
+    }).await;
+
+    // Query as mika-dev (should find it)
+    let input = KgQueryInput {
+        question: Some("fabrication-guard".to_string()),
+        traversal: None,
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // Isolated subject entity with no edges → TraversalEmpty (entity found but no neighbors)
+    assert!(
+        result.status == KgQueryStatus::Ok || result.status == KgQueryStatus::TraversalEmpty,
+        "Expected Ok or TraversalEmpty, got {:?}",
+        result.status
+    );
+    assert!(
+        result.entries.iter().any(|e| e.entity_key == "pattern:fabrication-guard"),
+        "mika-dev should see its own subject entity"
+    );
+
+    let entry = result.entries.iter()
+        .find(|e| e.entity_key == "pattern:fabrication-guard")
+        .unwrap();
+    assert_eq!(entry.layer, "subject");
+    assert_eq!(entry.entity_type, "pattern");
+}
+
+/// Failure path: querying as a different agent should NOT see mika-dev's subjects.
+#[tokio::test]
+async fn test_path_b_agent_scoped_isolation() {
+    let db = test_db(); // seeds as mika-dev
+    assert_schema_version(&db).await;
+
+    // Seed a subject entity for mika-dev
+    seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "pattern",
+        name: "fabrication-guard",
+        confidence: 0.92,
+        properties_json: None,
+    }).await;
+
+    // Query as mika-qa (different agent) — should NOT find it
+    let input = KgQueryInput {
+        question: Some("fabrication-guard".to_string()),
+        traversal: None,
+        agent_id: Some("mika-qa".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    assert_eq!(
+        result.status,
+        KgQueryStatus::StartingEntityMissing,
+        "Different agent should not see mika-dev's subject entities (agent-scoped isolation)"
+    );
+    assert!(
+        result.entries.is_empty(),
+        "No entries should be returned for a different agent"
+    );
+}
+
+/// Edge case: no agent_id provided should skip Path B entirely.
+#[tokio::test]
+async fn test_path_b_no_agent_id_skips_subject_layer() {
+    let db = test_db();
+
+    // Seed subject entity
+    seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "pattern",
+        name: "fabrication-guard",
+        confidence: 0.92,
+        properties_json: None,
+    }).await;
+
+    // Query without agent_id — Path B won't run
+    let input = KgQueryInput {
+        question: Some("fabrication-guard".to_string()),
+        traversal: None,
+        agent_id: None,
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // With no domain entity and no agent_id, Path B is skipped
+    assert_eq!(
+        result.status,
+        KgQueryStatus::StartingEntityMissing,
+        "Without agent_id, Path B is skipped and only domain search runs"
+    );
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_b_subject_match_agent_scoped.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_b_subject_match_agent_scoped.rs
@@ -20,12 +20,16 @@ async fn test_path_b_subject_match_correct_agent() {
     assert_schema_version(&db).await;
 
     // Seed a subject entity for mika-dev only
-    seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "pattern",
-        name: "fabrication-guard",
-        confidence: 0.92,
-        properties_json: None,
-    }).await;
+    seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "pattern",
+            name: "fabrication-guard",
+            confidence: 0.92,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Query as mika-dev (should find it)
     let input = KgQueryInput {
@@ -45,11 +49,16 @@ async fn test_path_b_subject_match_correct_agent() {
         result.status
     );
     assert!(
-        result.entries.iter().any(|e| e.entity_key == "pattern:fabrication-guard"),
+        result
+            .entries
+            .iter()
+            .any(|e| e.entity_key == "pattern:fabrication-guard"),
         "mika-dev should see its own subject entity"
     );
 
-    let entry = result.entries.iter()
+    let entry = result
+        .entries
+        .iter()
         .find(|e| e.entity_key == "pattern:fabrication-guard")
         .unwrap();
     assert_eq!(entry.layer, "subject");
@@ -63,12 +72,16 @@ async fn test_path_b_agent_scoped_isolation() {
     assert_schema_version(&db).await;
 
     // Seed a subject entity for mika-dev
-    seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "pattern",
-        name: "fabrication-guard",
-        confidence: 0.92,
-        properties_json: None,
-    }).await;
+    seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "pattern",
+            name: "fabrication-guard",
+            confidence: 0.92,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Query as mika-qa (different agent) — should NOT find it
     let input = KgQueryInput {
@@ -98,12 +111,16 @@ async fn test_path_b_no_agent_id_skips_subject_layer() {
     let db = test_db();
 
     // Seed subject entity
-    seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "pattern",
-        name: "fabrication-guard",
-        confidence: 0.92,
-        properties_json: None,
-    }).await;
+    seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "pattern",
+            name: "fabrication-guard",
+            confidence: 0.92,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Query without agent_id — Path B won't run
     let input = KgQueryInput {

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_c_semantic_via_chunks.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_c_semantic_via_chunks.rs
@@ -1,0 +1,139 @@
+//! Scenario 4: Path C — Semantic search via chunks.
+//!
+//! Seeds a chunk with known text, an extracted subject entity, and a resolution
+//! to a domain entity. Tests the chunk → subject → domain bridge traversal.
+//!
+//! ## Hard Assertions (paired: success + failure)
+//! - Success: chunk→subject→domain bridge traversal with resolution
+//! - Failure: without resolution, only subject-layer result returned
+//!
+//! ## Tiers
+//! - Unit: uses FTS5 search (no embedding client needed for text match)
+//! - Integration: would use real embedding client (gated by #340)
+//!
+//! Reference: mika#740 D2 scenario 4, D3 tier table
+
+use super::kg_fixtures::*;
+use mika_agent::kg::query::{KgQueryInput, KgQueryStatus, query_knowledge_graph};
+
+/// Success path: chunk with resolved subject bridges to domain entity.
+#[tokio::test]
+async fn test_path_c_chunk_to_subject_to_domain_bridge() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed domain entity
+    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Seed subject entity (extracted from a doc)
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        confidence: 0.95,
+        properties_json: None,
+    }).await;
+
+    // Seed chunk with text that mentions "self-dev"
+    let chunk_id = seed_chunk(&db, &ChunkSpec {
+        seq_id: 0,
+        source_doc_path: "docs/solutions/self-dev-workflow.md",
+        source_doc_hash: "abc123",
+        text: "The self-dev skill orchestrates the autonomous development loop. \
+               It coordinates claude-pilot sessions and manages PR lifecycle.",
+    }).await;
+
+    // Link chunk to subject entity
+    seed_chunk_subject(&db, chunk_id, subject_id).await;
+
+    // Seed resolution: subject → domain
+    seed_resolution(&db, subject_id, domain_id, 0.95, "matched_exact").await;
+
+    // Query with a paraphrase that should match via FTS5
+    let input = KgQueryInput {
+        question: Some("self-dev".to_string()),
+        traversal: None,
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // Entity found (via Path A direct match or Path C bridge), may be TraversalEmpty
+    // if the entity is isolated (no outgoing edges at default depth)
+    assert!(
+        result.status == KgQueryStatus::Ok || result.status == KgQueryStatus::TraversalEmpty,
+        "Expected Ok or TraversalEmpty, got {:?}",
+        result.status
+    );
+    // Should find the domain entity (via Path A direct match or Path C bridge)
+    assert!(
+        result.entries.iter().any(|e| e.entity_key == "skill:self-dev" && e.layer == "domain"),
+        "Should find domain entity skill:self-dev via bridge or direct match. Got: {:?}",
+        result.entries.iter().map(|e| (&e.entity_key, &e.layer)).collect::<Vec<_>>()
+    );
+}
+
+/// Failure path: without resolution, Path C yields subject-only result
+/// (no domain bridge).
+#[tokio::test]
+async fn test_path_c_no_resolution_yields_subject_only() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed subject entity (no domain counterpart, no resolution)
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "solution_path",
+        name: "webhook-ci-handler",
+        confidence: 0.88,
+        properties_json: None,
+    }).await;
+
+    // Seed chunk
+    let chunk_id = seed_chunk(&db, &ChunkSpec {
+        seq_id: 0,
+        source_doc_path: "docs/solutions/webhook-ci-handler.md",
+        source_doc_hash: "def456",
+        text: "The webhook-ci-handler solution path describes how CI failure webhooks \
+               are processed by the agent to dispatch autonomous fixes.",
+    }).await;
+
+    // Link chunk to subject
+    seed_chunk_subject(&db, chunk_id, subject_id).await;
+
+    // NO resolution seeded — subject has no domain bridge
+
+    // Query: should find via FTS5 → chunk → subject → no domain bridge
+    let input = KgQueryInput {
+        question: Some("webhook-ci-handler".to_string()),
+        traversal: None,
+        agent_id: Some("mika-dev".to_string()),
+        include_context: false,
+        result_limit: None,
+    };
+
+    let result = query_knowledge_graph(&db, &input).await.unwrap();
+
+    // Isolated subject entity → TraversalEmpty is expected (entity found, no edges)
+    assert!(
+        result.status == KgQueryStatus::Ok || result.status == KgQueryStatus::TraversalEmpty,
+        "Expected Ok or TraversalEmpty, got {:?}",
+        result.status
+    );
+    // Should find the subject entity (no domain bridge available)
+    let subject_entry = result.entries.iter()
+        .find(|e| e.entity_key == "solution_path:webhook-ci-handler");
+
+    assert!(
+        subject_entry.is_some(),
+        "Should find subject entity via Path C without domain bridge. Got: {:?}",
+        result.entries.iter().map(|e| (&e.entity_key, &e.layer)).collect::<Vec<_>>()
+    );
+
+    let entry = subject_entry.unwrap();
+    assert_eq!(entry.layer, "subject", "Without resolution, result should be in subject layer");
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/path_c_semantic_via_chunks.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/path_c_semantic_via_chunks.rs
@@ -23,28 +23,40 @@ async fn test_path_c_chunk_to_subject_to_domain_bridge() {
     assert_schema_version(&db).await;
 
     // Seed domain entity
-    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    let domain_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject entity (extracted from a doc)
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        confidence: 0.95,
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            confidence: 0.95,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed chunk with text that mentions "self-dev"
-    let chunk_id = seed_chunk(&db, &ChunkSpec {
-        seq_id: 0,
-        source_doc_path: "docs/solutions/self-dev-workflow.md",
-        source_doc_hash: "abc123",
-        text: "The self-dev skill orchestrates the autonomous development loop. \
+    let chunk_id = seed_chunk(
+        &db,
+        &ChunkSpec {
+            seq_id: 0,
+            source_doc_path: "docs/solutions/self-dev-workflow.md",
+            source_doc_hash: "abc123",
+            text: "The self-dev skill orchestrates the autonomous development loop. \
                It coordinates claude-pilot sessions and manages PR lifecycle.",
-    }).await;
+        },
+    )
+    .await;
 
     // Link chunk to subject entity
     seed_chunk_subject(&db, chunk_id, subject_id).await;
@@ -72,9 +84,16 @@ async fn test_path_c_chunk_to_subject_to_domain_bridge() {
     );
     // Should find the domain entity (via Path A direct match or Path C bridge)
     assert!(
-        result.entries.iter().any(|e| e.entity_key == "skill:self-dev" && e.layer == "domain"),
+        result
+            .entries
+            .iter()
+            .any(|e| e.entity_key == "skill:self-dev" && e.layer == "domain"),
         "Should find domain entity skill:self-dev via bridge or direct match. Got: {:?}",
-        result.entries.iter().map(|e| (&e.entity_key, &e.layer)).collect::<Vec<_>>()
+        result
+            .entries
+            .iter()
+            .map(|e| (&e.entity_key, &e.layer))
+            .collect::<Vec<_>>()
     );
 }
 
@@ -86,21 +105,29 @@ async fn test_path_c_no_resolution_yields_subject_only() {
     assert_schema_version(&db).await;
 
     // Seed subject entity (no domain counterpart, no resolution)
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "solution_path",
-        name: "webhook-ci-handler",
-        confidence: 0.88,
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "solution_path",
+            name: "webhook-ci-handler",
+            confidence: 0.88,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed chunk
-    let chunk_id = seed_chunk(&db, &ChunkSpec {
-        seq_id: 0,
-        source_doc_path: "docs/solutions/webhook-ci-handler.md",
-        source_doc_hash: "def456",
-        text: "The webhook-ci-handler solution path describes how CI failure webhooks \
+    let chunk_id = seed_chunk(
+        &db,
+        &ChunkSpec {
+            seq_id: 0,
+            source_doc_path: "docs/solutions/webhook-ci-handler.md",
+            source_doc_hash: "def456",
+            text: "The webhook-ci-handler solution path describes how CI failure webhooks \
                are processed by the agent to dispatch autonomous fixes.",
-    }).await;
+        },
+    )
+    .await;
 
     // Link chunk to subject
     seed_chunk_subject(&db, chunk_id, subject_id).await;
@@ -125,15 +152,24 @@ async fn test_path_c_no_resolution_yields_subject_only() {
         result.status
     );
     // Should find the subject entity (no domain bridge available)
-    let subject_entry = result.entries.iter()
+    let subject_entry = result
+        .entries
+        .iter()
         .find(|e| e.entity_key == "solution_path:webhook-ci-handler");
 
     assert!(
         subject_entry.is_some(),
         "Should find subject entity via Path C without domain bridge. Got: {:?}",
-        result.entries.iter().map(|e| (&e.entity_key, &e.layer)).collect::<Vec<_>>()
+        result
+            .entries
+            .iter()
+            .map(|e| (&e.entity_key, &e.layer))
+            .collect::<Vec<_>>()
     );
 
     let entry = subject_entry.unwrap();
-    assert_eq!(entry.layer, "subject", "Without resolution, result should be in subject layer");
+    assert_eq!(
+        entry.layer, "subject",
+        "Without resolution, result should be in subject layer"
+    );
 }

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
@@ -21,20 +21,28 @@ async fn test_stage_1_exact_match_case_insensitive() {
     assert_schema_version(&db).await;
 
     // Seed domain entity (lowercase)
-    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    let domain_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject entity with case variant (PascalCase)
     // Confidence > 0.9 to trigger immediate exact match
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "Self-Dev",
-        confidence: 0.95,
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "Self-Dev",
+            confidence: 0.95,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Run resolver — no LLM needed for exact match
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-stage-1"));
@@ -42,9 +50,15 @@ async fn test_stage_1_exact_match_case_insensitive() {
 
     // Hard assertions on stats
     assert_eq!(stats.total, 1, "Should process exactly one pending entity");
-    assert_eq!(stats.matched_exact, 1, "Should match via exact (case-insensitive) match");
+    assert_eq!(
+        stats.matched_exact, 1,
+        "Should match via exact (case-insensitive) match"
+    );
     assert_eq!(stats.matched_llm, 0, "Should NOT use LLM for exact match");
-    assert_eq!(stats.skipped_no_llm, 0, "Should NOT skip — exact match found");
+    assert_eq!(
+        stats.skipped_no_llm, 0,
+        "Should NOT skip — exact match found"
+    );
 
     // Check resolution log
     let log = get_resolution_log(&db, subject_id).await;
@@ -57,7 +71,10 @@ async fn test_stage_1_exact_match_case_insensitive() {
     let resolution = get_resolution(&db, subject_id).await;
     assert!(resolution.is_some(), "Resolution row should exist");
     let (resolved_domain_id, confidence) = resolution.unwrap();
-    assert_eq!(resolved_domain_id, domain_id, "Should resolve to the domain entity");
+    assert_eq!(
+        resolved_domain_id, domain_id,
+        "Should resolve to the domain entity"
+    );
     assert!(
         (confidence - 0.95).abs() < f64::EPSILON,
         "Confidence should equal extraction confidence (0.95), got {}",
@@ -72,19 +89,27 @@ async fn test_stage_1_low_confidence_escalates_to_stage_2() {
     let db = test_db();
 
     // Seed domain entity
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject with confidence BELOW threshold (0.9)
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "Self-Dev",
-        confidence: 0.85, // Below 0.9 threshold
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "Self-Dev",
+            confidence: 0.85, // Below 0.9 threshold
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Run resolver with no LLM — exact match found but low confidence,
     // escalates to Stage 2 which skips because no LLM.
@@ -92,8 +117,14 @@ async fn test_stage_1_low_confidence_escalates_to_stage_2() {
     let stats = resolver.resolve_pending().await.unwrap();
 
     assert_eq!(stats.total, 1);
-    assert_eq!(stats.matched_exact, 0, "Low confidence should NOT resolve via exact match");
-    assert_eq!(stats.skipped_no_llm, 1, "Should skip to skipped_no_llm when no LLM configured");
+    assert_eq!(
+        stats.matched_exact, 0,
+        "Low confidence should NOT resolve via exact match"
+    );
+    assert_eq!(
+        stats.skipped_no_llm, 1,
+        "Should skip to skipped_no_llm when no LLM configured"
+    );
 
     // Check log
     let log = get_resolution_log(&db, subject_id).await;
@@ -108,12 +139,16 @@ async fn test_stage_1_discovered_type_skipped() {
     let db = test_db();
 
     // Seed subject with a discovered type (no domain counterpart)
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "solution_path",
-        name: "ci-fix-workflow",
-        confidence: 0.9,
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "solution_path",
+            name: "ci-fix-workflow",
+            confidence: 0.9,
+            properties_json: None,
+        },
+    )
+    .await;
 
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-discovered"));
     // Use resolve_doc_entities which takes explicit IDs (no SQL type filter)
@@ -123,7 +158,10 @@ async fn test_stage_1_discovered_type_skipped() {
         .unwrap();
 
     assert_eq!(stats.total, 1);
-    assert_eq!(stats.skipped_discovered, 1, "Discovered types should be skipped");
+    assert_eq!(
+        stats.skipped_discovered, 1,
+        "Discovered types should be skipped"
+    );
     assert_eq!(stats.matched_exact, 0);
 
     let log = get_resolution_log(&db, subject_id).await;

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
@@ -1,0 +1,132 @@
+//! Scenario 5: Stage 1 — Exact match precision (Resolver).
+//!
+//! Seeds a case-variant subject entity (`skill:Self-Dev`) and a domain entity
+//! (`skill:self-dev`). Runs `resolve_pending()` synchronously and asserts:
+//! - `outcome = matched_exact` in `kg_resolutions_log`
+//! - `confidence = extraction_confidence` (not clamped by LLM)
+//!
+//! ## Hard Assertions
+//! - Resolution log shows `matched_exact`
+//! - Resolution confidence matches extraction confidence
+//! - Subject→domain resolution row exists
+//!
+//! Reference: mika#740 D2 scenario 5, D1 resolver source verified
+
+use super::kg_fixtures::*;
+use mika_agent::kg::entity_resolver::SubjectEntityResolver;
+
+#[tokio::test]
+async fn test_stage_1_exact_match_case_insensitive() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed domain entity (lowercase)
+    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Seed subject entity with case variant (PascalCase)
+    // Confidence > 0.9 to trigger immediate exact match
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "Self-Dev",
+        confidence: 0.95,
+        properties_json: None,
+    }).await;
+
+    // Run resolver — no LLM needed for exact match
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-stage-1"));
+    let stats = resolver.resolve_pending().await.unwrap();
+
+    // Hard assertions on stats
+    assert_eq!(stats.total, 1, "Should process exactly one pending entity");
+    assert_eq!(stats.matched_exact, 1, "Should match via exact (case-insensitive) match");
+    assert_eq!(stats.matched_llm, 0, "Should NOT use LLM for exact match");
+    assert_eq!(stats.skipped_no_llm, 0, "Should NOT skip — exact match found");
+
+    // Check resolution log
+    let log = get_resolution_log(&db, subject_id).await;
+    assert!(log.is_some(), "Resolution log entry should exist");
+    let (outcome, model) = log.unwrap();
+    assert_eq!(outcome, "matched_exact", "Outcome should be matched_exact");
+    assert!(model.is_none(), "No LLM model used for exact match");
+
+    // Check resolution row
+    let resolution = get_resolution(&db, subject_id).await;
+    assert!(resolution.is_some(), "Resolution row should exist");
+    let (resolved_domain_id, confidence) = resolution.unwrap();
+    assert_eq!(resolved_domain_id, domain_id, "Should resolve to the domain entity");
+    assert!(
+        (confidence - 0.95).abs() < f64::EPSILON,
+        "Confidence should equal extraction confidence (0.95), got {}",
+        confidence
+    );
+}
+
+/// Stage 1 with low extraction confidence (below 0.9 threshold) should
+/// escalate to Stage 2 — but with no LLM, should yield `skipped_no_llm`.
+#[tokio::test]
+async fn test_stage_1_low_confidence_escalates_to_stage_2() {
+    let db = test_db();
+
+    // Seed domain entity
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Seed subject with confidence BELOW threshold (0.9)
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "Self-Dev",
+        confidence: 0.85, // Below 0.9 threshold
+        properties_json: None,
+    }).await;
+
+    // Run resolver with no LLM — exact match found but low confidence,
+    // escalates to Stage 2 which skips because no LLM.
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-stage-1-low"));
+    let stats = resolver.resolve_pending().await.unwrap();
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.matched_exact, 0, "Low confidence should NOT resolve via exact match");
+    assert_eq!(stats.skipped_no_llm, 1, "Should skip to skipped_no_llm when no LLM configured");
+
+    // Check log
+    let log = get_resolution_log(&db, subject_id).await;
+    let (outcome, _) = log.unwrap();
+    assert_eq!(outcome, "skipped_no_llm");
+}
+
+/// Discovered types (solution_path, failure_mode, pattern) should skip resolution.
+/// Uses `resolve_doc_entities()` since `resolve_pending()` filters by domain types in SQL.
+#[tokio::test]
+async fn test_stage_1_discovered_type_skipped() {
+    let db = test_db();
+
+    // Seed subject with a discovered type (no domain counterpart)
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "solution_path",
+        name: "ci-fix-workflow",
+        confidence: 0.9,
+        properties_json: None,
+    }).await;
+
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-discovered"));
+    // Use resolve_doc_entities which takes explicit IDs (no SQL type filter)
+    let stats = resolver
+        .resolve_doc_entities(&[subject_id], "test-extraction-trace")
+        .await
+        .unwrap();
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.skipped_discovered, 1, "Discovered types should be skipped");
+    assert_eq!(stats.matched_exact, 0);
+
+    let log = get_resolution_log(&db, subject_id).await;
+    let (outcome, _) = log.unwrap();
+    assert_eq!(outcome, "skipped_discovered_type");
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
@@ -32,9 +32,7 @@ use mika_common::llm::mock::{MockLlmProvider, text_response};
 
 /// Helper: create a mock LLM that returns a disambiguation JSON response.
 fn mock_disambiguation_llm(matched_key: &str, confidence: f64) -> Arc<dyn LlmProvider> {
-    let response_text = format!(
-        r#"{{"match": "{matched_key}", "confidence": {confidence}}}"#,
-    );
+    let response_text = format!(r#"{{"match": "{matched_key}", "confidence": {confidence}}}"#,);
     Arc::new(
         MockLlmProvider::builder()
             .response(text_response(&response_text))
@@ -51,26 +49,38 @@ async fn test_stage_2_synonyms_disambiguation() {
     assert_schema_version(&db).await;
 
     // Seed two domain candidates
-    let qa_review_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "qa-review",
-        properties_json: None,
-    }).await;
+    let qa_review_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "qa-review",
+            properties_json: None,
+        },
+    )
+    .await;
 
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "qa-review-build-callback",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "qa-review-build-callback",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject entity mentioning "qa review" without qualifiers
     // Low confidence to force Stage 2
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "qa-review",
-        confidence: 0.85, // Below 0.9 threshold, forces Stage 2
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "qa-review",
+            confidence: 0.85, // Below 0.9 threshold, forces Stage 2
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Mock LLM picks "skill:qa-review"
     let llm = mock_disambiguation_llm("skill:qa-review", 0.9);
@@ -79,21 +89,39 @@ async fn test_stage_2_synonyms_disambiguation() {
     let stats = resolver.resolve_pending().await.unwrap();
 
     assert_eq!(stats.total, 1);
-    assert_eq!(stats.matched_llm, 1, "[synonyms] Should match via LLM disambiguation");
-    assert_eq!(stats.matched_exact, 0, "[synonyms] Should NOT use exact match (low confidence)");
+    assert_eq!(
+        stats.matched_llm, 1,
+        "[synonyms] Should match via LLM disambiguation"
+    );
+    assert_eq!(
+        stats.matched_exact, 0,
+        "[synonyms] Should NOT use exact match (low confidence)"
+    );
 
     // Check resolution log
     let log = get_resolution_log(&db, subject_id).await;
-    assert!(log.is_some(), "[synonyms] Resolution log entry should exist");
+    assert!(
+        log.is_some(),
+        "[synonyms] Resolution log entry should exist"
+    );
     let (outcome, model) = log.unwrap();
-    assert_eq!(outcome, "matched_llm", "[synonyms] Outcome should be matched_llm");
+    assert_eq!(
+        outcome, "matched_llm",
+        "[synonyms] Outcome should be matched_llm"
+    );
     assert_eq!(model.as_deref(), Some("mock-resolution-model"));
 
     // Check resolution confidence = min(extraction=0.85, llm=0.9)
     let resolution = get_resolution(&db, subject_id).await;
-    assert!(resolution.is_some(), "[synonyms] Resolution row should exist");
+    assert!(
+        resolution.is_some(),
+        "[synonyms] Resolution row should exist"
+    );
     let (domain_id, confidence) = resolution.unwrap();
-    assert_eq!(domain_id, qa_review_id, "[synonyms] Should resolve to qa-review");
+    assert_eq!(
+        domain_id, qa_review_id,
+        "[synonyms] Should resolve to qa-review"
+    );
     assert!(
         (confidence - 0.85).abs() < f64::EPSILON,
         "[synonyms] Confidence should be min(0.85, 0.9) = 0.85, got {}",
@@ -108,19 +136,27 @@ async fn test_stage_2_case_variant_low_confidence() {
     let db = test_db();
 
     // Seed domain entity
-    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "self-dev",
-        properties_json: None,
-    }).await;
+    let domain_id = seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "self-dev",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject with case variant, LOW confidence
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "Self-Dev",
-        confidence: 0.80, // Below threshold, Stage 1 finds exact match but escalates
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "Self-Dev",
+            confidence: 0.80, // Below threshold, Stage 1 finds exact match but escalates
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Mock LLM confirms the match
     let llm = mock_disambiguation_llm("skill:self-dev", 0.95);
@@ -129,11 +165,17 @@ async fn test_stage_2_case_variant_low_confidence() {
     let stats = resolver.resolve_pending().await.unwrap();
 
     assert_eq!(stats.total, 1);
-    assert_eq!(stats.matched_llm, 1, "[case-variants] Should go through LLM due to low confidence");
+    assert_eq!(
+        stats.matched_llm, 1,
+        "[case-variants] Should go through LLM due to low confidence"
+    );
 
     let resolution = get_resolution(&db, subject_id).await;
     let (resolved_id, confidence) = resolution.unwrap();
-    assert_eq!(resolved_id, domain_id, "[case-variants] Should resolve to domain entity");
+    assert_eq!(
+        resolved_id, domain_id,
+        "[case-variants] Should resolve to domain entity"
+    );
     // min(0.80, 0.95) = 0.80
     assert!(
         (confidence - 0.80).abs() < f64::EPSILON,
@@ -148,32 +190,47 @@ async fn test_stage_2_skipped_no_llm() {
     let db = test_db();
 
     // Seed domain entity
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "qa-review",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "qa-review",
+            properties_json: None,
+        },
+    )
+    .await;
 
-    seed_domain_entity(&db, &DomainEntitySpec {
-        entity_type: "skill",
-        name: "qa-review-build-callback",
-        properties_json: None,
-    }).await;
+    seed_domain_entity(
+        &db,
+        &DomainEntitySpec {
+            entity_type: "skill",
+            name: "qa-review-build-callback",
+            properties_json: None,
+        },
+    )
+    .await;
 
     // Seed subject with low confidence
-    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
-        entity_type: "skill",
-        name: "qa-review",
-        confidence: 0.85,
-        properties_json: None,
-    }).await;
+    let subject_id = seed_subject_entity(
+        &db,
+        &SubjectEntitySpec {
+            entity_type: "skill",
+            name: "qa-review",
+            confidence: 0.85,
+            properties_json: None,
+        },
+    )
+    .await;
 
     // No LLM configured
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-no-llm"));
     let stats = resolver.resolve_pending().await.unwrap();
 
     assert_eq!(stats.total, 1);
-    assert_eq!(stats.skipped_no_llm, 1, "Should skip when no LLM configured");
+    assert_eq!(
+        stats.skipped_no_llm, 1,
+        "Should skip when no LLM configured"
+    );
     assert_eq!(stats.matched_exact, 0);
     assert_eq!(stats.matched_llm, 0);
 

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
@@ -1,0 +1,183 @@
+//! Scenario 6: Stage 2 — LLM disambiguation.
+//!
+//! Tests the resolver's Stage 2 LLM disambiguation path. Three ambiguity classes
+//! in the unit tier (mock LLM), plus a `skipped_no_llm` variant.
+//!
+//! ## Ambiguity Classes
+//! - **Synonyms:** `skill:qa-review` vs `skill:qa-review-build-callback`
+//! - **CaseVariants:** `skill:self-dev` vs `skill:Self-Dev` (low confidence, forces Stage 2)
+//! - **skipped_no_llm:** No LLM configured, expects skip
+//!
+//! ## Hard Assertions
+//! - Stage 2 code path executed (resolution written to DB)
+//! - `outcome = matched_llm` in resolution log
+//! - `confidence = min(extraction_confidence, llm_confidence)`
+//!
+//! ## Soft Tags
+//! - `self-knowledge:disambiguation-correct` — LLM picked expected candidate
+//! - `self-knowledge:disambiguation-plausible-alternative` — LLM picked defensible alternative
+//!
+//! ## Tiers
+//! - Unit: mock LLM returning scripted JSON
+//! - Integration: real `MIKA_KG_RESOLUTION_MODEL` (gated by env var)
+//!
+//! Reference: mika#740 D2 scenario 6, D3 tier table
+
+use std::sync::Arc;
+
+use super::kg_fixtures::*;
+use mika_agent::kg::entity_resolver::SubjectEntityResolver;
+use mika_common::llm::LlmProvider;
+use mika_common::llm::mock::{MockLlmProvider, text_response};
+
+/// Helper: create a mock LLM that returns a disambiguation JSON response.
+fn mock_disambiguation_llm(matched_key: &str, confidence: f64) -> Arc<dyn LlmProvider> {
+    let response_text = format!(
+        r#"{{"match": "{matched_key}", "confidence": {confidence}}}"#,
+    );
+    Arc::new(
+        MockLlmProvider::builder()
+            .response(text_response(&response_text))
+            .provider_name("mock-resolver")
+            .model_name("mock-resolution-model")
+            .build(),
+    )
+}
+
+/// Synonyms: two similar skill names, LLM picks the correct one.
+#[tokio::test]
+async fn test_stage_2_synonyms_disambiguation() {
+    let db = test_db();
+    assert_schema_version(&db).await;
+
+    // Seed two domain candidates
+    let qa_review_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "qa-review",
+        properties_json: None,
+    }).await;
+
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "qa-review-build-callback",
+        properties_json: None,
+    }).await;
+
+    // Seed subject entity mentioning "qa review" without qualifiers
+    // Low confidence to force Stage 2
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "qa-review",
+        confidence: 0.85, // Below 0.9 threshold, forces Stage 2
+        properties_json: None,
+    }).await;
+
+    // Mock LLM picks "skill:qa-review"
+    let llm = mock_disambiguation_llm("skill:qa-review", 0.9);
+
+    let resolver = SubjectEntityResolver::new(db.clone(), Some(llm), Some("test-synonyms"));
+    let stats = resolver.resolve_pending().await.unwrap();
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.matched_llm, 1, "[synonyms] Should match via LLM disambiguation");
+    assert_eq!(stats.matched_exact, 0, "[synonyms] Should NOT use exact match (low confidence)");
+
+    // Check resolution log
+    let log = get_resolution_log(&db, subject_id).await;
+    assert!(log.is_some(), "[synonyms] Resolution log entry should exist");
+    let (outcome, model) = log.unwrap();
+    assert_eq!(outcome, "matched_llm", "[synonyms] Outcome should be matched_llm");
+    assert_eq!(model.as_deref(), Some("mock-resolution-model"));
+
+    // Check resolution confidence = min(extraction=0.85, llm=0.9)
+    let resolution = get_resolution(&db, subject_id).await;
+    assert!(resolution.is_some(), "[synonyms] Resolution row should exist");
+    let (domain_id, confidence) = resolution.unwrap();
+    assert_eq!(domain_id, qa_review_id, "[synonyms] Should resolve to qa-review");
+    assert!(
+        (confidence - 0.85).abs() < f64::EPSILON,
+        "[synonyms] Confidence should be min(0.85, 0.9) = 0.85, got {}",
+        confidence
+    );
+}
+
+/// Case variants with low confidence: forces LLM disambiguation even though
+/// exact match exists, because extraction confidence is below threshold.
+#[tokio::test]
+async fn test_stage_2_case_variant_low_confidence() {
+    let db = test_db();
+
+    // Seed domain entity
+    let domain_id = seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "self-dev",
+        properties_json: None,
+    }).await;
+
+    // Seed subject with case variant, LOW confidence
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "Self-Dev",
+        confidence: 0.80, // Below threshold, Stage 1 finds exact match but escalates
+        properties_json: None,
+    }).await;
+
+    // Mock LLM confirms the match
+    let llm = mock_disambiguation_llm("skill:self-dev", 0.95);
+
+    let resolver = SubjectEntityResolver::new(db.clone(), Some(llm), Some("test-case-variants"));
+    let stats = resolver.resolve_pending().await.unwrap();
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.matched_llm, 1, "[case-variants] Should go through LLM due to low confidence");
+
+    let resolution = get_resolution(&db, subject_id).await;
+    let (resolved_id, confidence) = resolution.unwrap();
+    assert_eq!(resolved_id, domain_id, "[case-variants] Should resolve to domain entity");
+    // min(0.80, 0.95) = 0.80
+    assert!(
+        (confidence - 0.80).abs() < f64::EPSILON,
+        "[case-variants] Confidence should be min(0.80, 0.95) = 0.80, got {}",
+        confidence
+    );
+}
+
+/// No LLM configured: exact match fails (low confidence), should yield `skipped_no_llm`.
+#[tokio::test]
+async fn test_stage_2_skipped_no_llm() {
+    let db = test_db();
+
+    // Seed domain entity
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "qa-review",
+        properties_json: None,
+    }).await;
+
+    seed_domain_entity(&db, &DomainEntitySpec {
+        entity_type: "skill",
+        name: "qa-review-build-callback",
+        properties_json: None,
+    }).await;
+
+    // Seed subject with low confidence
+    let subject_id = seed_subject_entity(&db, &SubjectEntitySpec {
+        entity_type: "skill",
+        name: "qa-review",
+        confidence: 0.85,
+        properties_json: None,
+    }).await;
+
+    // No LLM configured
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-no-llm"));
+    let stats = resolver.resolve_pending().await.unwrap();
+
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.skipped_no_llm, 1, "Should skip when no LLM configured");
+    assert_eq!(stats.matched_exact, 0);
+    assert_eq!(stats.matched_llm, 0);
+
+    let log = get_resolution_log(&db, subject_id).await;
+    let (outcome, _) = log.unwrap();
+    assert_eq!(outcome, "skipped_no_llm");
+}

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/tool_selection_query_knowledge_graph.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/tool_selection_query_knowledge_graph.rs
@@ -55,9 +55,7 @@ async fn test_tool_selection_kg_for_dependency_question() -> anyhow::Result<()> 
                 "query_knowledge_graph",
                 json!({"question": "what does self-dev depend on?"}),
             ),
-            text_response(
-                "The self-dev skill depends on claude-pilot and build-mika skills.",
-            ),
+            text_response("The self-dev skill depends on claude-pilot and build-mika skills."),
         ])
         .build()
         .await?;

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/tool_selection_query_knowledge_graph.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/tool_selection_query_knowledge_graph.rs
@@ -1,0 +1,72 @@
+//! Scenario 1: Tool selection — agent calls `query_knowledge_graph` before
+//! claiming capability state.
+//!
+//! Verifies the routing decision: structured capability questions should go to
+//! `query_knowledge_graph`, not `get_documentation`.
+//!
+//! ## Hard Assertions
+//! - `query_knowledge_graph` called BEFORE any final text response
+//! - `get_documentation` NOT called (structured question, not reference)
+//!
+//! ## Tags
+//! - `self-knowledge:query-invoked` — agent used KG for structured question
+//!
+//! Reference: mika#740 D2 scenario 1
+
+use super::*;
+
+/// User asks "which skill handles PR merges?" → expect `query_knowledge_graph`
+/// called before final text response. Mock returns a valid KG result.
+#[tokio::test]
+async fn test_tool_selection_prefers_kg_for_capability_question() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "which skill handles PR merges?"}),
+            ),
+            text_response(
+                "Based on the knowledge graph, PR merges are handled by the qa-review skill, \
+                 which uses the pr_merge_with_gate tool.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("Which skill handles PR merges?").await?;
+
+    // Hard: query_knowledge_graph was called
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    // Hard: get_documentation was NOT called (structured question)
+    assert_tools_exclude(&trace, &["get_documentation"]);
+    // Hard: agent produced output
+    assert_has_output(&trace);
+
+    Ok(())
+}
+
+/// User asks "what does self-dev depend on?" → expect `query_knowledge_graph`
+/// with traversal semantics. Verifies the tool is called for dependency questions.
+#[tokio::test]
+async fn test_tool_selection_kg_for_dependency_question() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "query_knowledge_graph",
+                json!({"question": "what does self-dev depend on?"}),
+            ),
+            text_response(
+                "The self-dev skill depends on claude-pilot and build-mika skills.",
+            ),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness.run("What does self-dev depend on?").await?;
+
+    assert_tools_include(&trace, &["query_knowledge_graph"]);
+    assert_tools_exclude(&trace, &["get_documentation"]);
+    assert_has_output(&trace);
+
+    Ok(())
+}

--- a/docs/plans/740-kg-self-knowledge-eval.md
+++ b/docs/plans/740-kg-self-knowledge-eval.md
@@ -124,6 +124,13 @@ All other scenarios (A, B, C without Stage 2 dependency, Stage 1 exact match, ag
 
 **Scope boundary with `#741`.** `self-knowledge:*` tags cover the code path from tool-invocation through resolver. Agent *response quality* given a successful KG result — specifically "KG returned correct result but agent ignored it and answered from training data anyway" — is a **grounding failure**, not a self-knowledge failure. That case is routed to `#741`'s `grounding:*` namespace. The apparent vocabulary gap in #740 (no tag for "agent-ignores-correct-KG-result") is the namespace boundary working as intended, not a missing tag.
 
+**Tag attribution rule — cause-location, not symptom.** Tags identify *where in the code path* a failure originated, not the user-visible symptom. A user seeing "agent stated a falsehood" is a symptom; the tag attributes to the cause. Three worked examples:
+- KG returned wrong result → `self-knowledge:*` (resolver returned wrong data)
+- KG returned right result, agent ignored it → `grounding:*` (response construction ignored evidence)
+- KG state itself is stale/corrupt → hard-assertion fail or data-integrity ticket, NOT a soft tag (this is a data-quality problem, not a behavior failure)
+
+When a new ambiguous case surfaces, apply this rule *before* expanding vocabulary: trace the failure to the code path it originated in, attribute the tag to that path. Symptoms cross namespace boundaries; causes do not. Mirror rule lives in `#741` D4.
+
 **Vocabulary review checkpoint.** After all seven scenarios are implemented, revisit this vocabulary before merging. If any scenario's outcome doesn't fit one of the six tags AND the case isn't cleanly routable to `#741`'s namespace, expand this vocabulary (add a seventh tag with rationale) rather than stretching an existing tag. Review is an explicit AC, not a handshake.
 
 Vocabulary is defined in `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` (per #339 D8 — README-next-to-tests, not a separate doc tree). Calibration artifact (#338 D7) preserves the namespace structure; aggregation across tickets works at the tooling layer.
@@ -244,3 +251,7 @@ Extracting status checks into their own scenarios would duplicate fixture setup 
 - **Cost envelope priced at design time** (~$0.015 per integration run for this ticket's scenarios): 3 Stage-2 variants × ~$0.0045 each + negligible embedding cost. Fixture shape fixed as design decision; scenario-author doesn't "declare" cost at implementation time.
 
 **Friend principle extended:** "pin the decision you're depending on" now applies to cost envelope (design-time fixture shape) and assertion messages (actionable on failure), not just upstream plan SHAs and vocabulary namespaces.
+
+**Milestone-level friend review pass 2 (2026-04-23, relayed by Vincent):**
+
+- **D4 extended with tag-attribution cause-location rule.** Previously the scope boundary with #741 worked case-by-case ("agent-ignores-KG-result → grounding"); now there's an explicit rule ("tags attribute to cause-location, not symptom") with three worked examples and a procedure for new ambiguous cases. Converts a handshake decision into a structural convention. Mirror rule landing in #741 D4 simultaneously.

--- a/docs/plans/740-kg-self-knowledge-eval.md
+++ b/docs/plans/740-kg-self-knowledge-eval.md
@@ -1,0 +1,189 @@
+# Plan — mika#740 — KG-backed self-knowledge eval scenarios
+
+**Issue:** senara-solutions/mika#740
+**Branch:** `feat/740/kg-self-knowledge-eval`
+**Milestone:** Evaluation (#16)
+**Blocked by:**
+- `#338` at plan commit **`fa54d950`** (matrix machinery, Stage 2 LLM tests need real providers)
+- `#340` item #1 (`embedding_client` DI builder for Path C semantic retrieval)
+- `#340` item #3 (callback-turn harness surface for chained tool + query patterns)
+- `#339` at plan commit **`5fb14662`** (three-tier execution model, `register_scenario` idiom, ticket-namespaced vocabulary pattern)
+
+**Status:** Groomed draft — pending Vincent review
+
+## Context
+
+Milestone #14 shipped KG-backed self-knowledge (`#692` / PR #733): the `query_knowledge_graph` tool with three entry paths (domain match, subject match, semantic via chunks) and a two-stage resolver (exact-match then LLM disambiguation). Nothing in milestone #16 exercises it end-to-end against a seeded KG — which means a prompt or model change can silently degrade KG utilization and no test surfaces the regression. This ticket is the eval slice that locks in the KG milestone's behavioral wins.
+
+#740 narrowly owns **KG-backed self-knowledge scenario coverage**. Provider matrix, golden-dataset breadth, and grounding regressions are sibling tickets. The boundary is tight: if a scenario is about the agent's self-knowledge (does it know what skill handles X, what tools it has, what problem types it can solve?), it belongs here. Anything else goes to #339 or #741.
+
+## Scope boundary
+
+**In scope:**
+- Fixture helper that seeds a known KG state per agent: domain entities, subject entities, chunks, resolutions
+- Tool-selection assertions — does the agent invoke `query_knowledge_graph` before claiming capability state?
+- Entry path coverage — Path A (domain match), Path B (subject match), Path C (semantic via chunks)
+- Resolver coverage — Stage 1 exact match, Stage 2 LLM disambiguation, `skipped_no_llm` outcome
+- Agent-context annotation — disabled skills surface `agent_context.enabled=false` (annotate, don't filter)
+- Failure-mode surfacing — `starting_entity_missing`, `traversal_empty` statuses visible to the agent
+
+**Out of scope:**
+- Provider strictness / JSON-schema divergence → `#338` (D4/D9)
+- Lexical ingestion correctness (covered by unit tests under `crates/mika-agent/src/kg/lexical_ingestor.rs`; eval here tests the query path, not the ingest path)
+- Extraction pipeline correctness (same — eval consumes ingested state, doesn't re-test extraction)
+- Resolver startup race (distinct bug tracked as `mika#739`; here we assume the race is fixed before these tests run, OR we work around it in the test fixture by calling `resolve_pending` synchronously)
+- Non-KG scenarios → `#339`
+- Fabrication/grounding regressions → `#741`
+
+## Decisions
+
+### D1 — KG fixture seeding: per-scenario helper, four-layer seed, synchronous resolver
+
+**Problem:** Scenarios need a known KG state: domain entities (from `kg_entities`), subject entities (from `kg_subject_entities`), chunks (from `kg_chunks`), and resolutions (from `kg_subject_resolutions`). Seeding requires writing to all four tables with correct FK relationships. The resolver normally runs async at startup (`entity_resolver.rs`); tests can't wait on a background task.
+
+**Decision:** One helper module `tests/eval/kg_fixtures.rs` with:
+
+- `seed_domain_entity(db, spec)` — inserts into `kg_entities` with `entity_key = "<type>:<name>"` per convention
+- `seed_subject_entity(db, agent_id, spec)` — inserts into `kg_subject_entities`
+- `seed_chunk(db, agent_id, spec)` — inserts into `kg_chunks` with text + metadata
+- `seed_chunk_subject(db, chunk_id, subject_id)` — inserts provenance row
+- `seed_resolution(db, agent_id, subject_id, domain_id, confidence, outcome)` — inserts into both `kg_subject_resolutions` and `kg_resolutions_log`
+
+**Synchronous resolver path.** Scenarios that need "run the resolver on seeded subjects and assert outcomes" call `EntityResolver::resolve_pending().await` directly from the test, synchronously. This bypasses the startup `tokio::spawn` race (`mika#739`) — the test is deterministic because the test owns the spawn boundary. Not a workaround for the bug; the test simply doesn't use the startup-race code path.
+
+Each scenario file owns its fixture; no shared fixture across scenarios (per #339 D3 precedent — Rust per-scenario setup, no coupling).
+
+**Rationale:** Four typed helper functions map 1:1 to the four tables. Seeding via the existing `Database` API (not raw SQL) keeps the fixture helper in step with schema migrations — when schema v26 lands, the helper breaks at compile time, not at runtime. Synchronous resolver call makes Stage 1 / Stage 2 outcome assertions reliable without touching the startup race.
+
+**Rejected alternative:** YAML-driven KG fixture files. Same reasoning as #339 D3 (locked as "Rejected alternative"): scenarios are test code, test code is Rust, YAML grows a DSL grows an interpreter grows regret.
+
+### D2 — Scenario catalog: seven scenarios, distributed by entry path and resolver stage
+
+**Problem:** How many scenarios, covering which behaviors? #339 committed 25 scenarios total across four classes; #740 claims a slice of the milestone-level budget.
+
+**Decision:** **Seven scenarios**, one per file under `crates/mika-agent/tests/eval/kg_self_knowledge/`. Naming per #339 D2 (`{class}_{shape}_{descriptor}.rs`):
+
+1. **`tool_selection_query_knowledge_graph.rs`** — User question "which skill handles PR merges?" → assert `query_knowledge_graph` tool called BEFORE any final text response. Covers the routing decision between `query_knowledge_graph` (structured) and `get_documentation` (reference).
+2. **`path_a_direct_domain_match.rs`** — Seeded `skill:self-dev` domain entity; query matches name; assert one result, `entity_type=Skill`, `hop=0`.
+3. **`path_b_subject_match_agent_scoped.rs`** — Seeded subject entity `pattern:fabrication-guard` for agent `mika-dev` only; assert mika-dev gets result; assert a different agent gets `starting_entity_missing` (agent-scoped isolation).
+4. **`path_c_semantic_via_chunks.rs`** — Seeded chunk + subject + resolution; free-text paraphrase query; assert chunk → subject → domain bridge traversal. Second variant without resolution; assert subject-only result.
+5. **`stage_1_exact_match.rs`** — Seeded case-variant subject (`skill:Self-Dev`) + domain (`skill:self-dev`); invoke `resolve_pending`; assert `outcome=matched_exact` in `kg_resolutions_log`; assert confidence = extraction_confidence.
+6. **`stage_2_llm_disambiguation.rs`** — Seeded two similarly-named candidates (`skill:qa-review`, `skill:qa-review-build-callback`) + subject with unqualified "qa review" chunk context; assert `outcome=matched_llm`, confidence = min(extraction, llm). Second variant with `MIKA_KG_RESOLUTION_MODEL` unset; assert `outcome=skipped_no_llm`.
+7. **`agent_context_annotation_disabled.rs`** — Disable `self-dev` via `skill_overrides`; query for `self-dev`; assert result includes the skill AND `agent_context.enabled=false` (annotated, not filtered).
+
+**Coverage rationale:** seven scenarios cover the three entry paths (A/B/C), two resolver stages (1/2), the routing assertion, and the agent-context annotation. This is the KG milestone's behavioral surface mapped to tests; each missing scenario would leave a documented code path un-exercised.
+
+**Milestone budget impact:** #339 has 25 scenarios for the general-quality slice; #740 adds 7 KG-specific; #741 will add its own count. Total milestone scenario count is the sum across siblings, not a shared pool — matches the namespace-per-ticket precedent from #339 D4.
+
+**Rejected alternative:** Five scenarios (collapse Path A and Stage 1 exact match since both hit `kg_entities` directly). Rejected because they test different code paths — Path A is the query tool's entry resolution, Stage 1 is the resolver's matching step. Collapsing would mask a regression where one works and the other doesn't.
+
+### D3 — Mock-LLM subset vs real-API subset
+
+**Problem:** Which scenarios run on every CI push (mock-only) vs behind `MIKA_EVAL_REAL_PROVIDERS` + `--ignored`?
+
+**Decision:** Per #339 D6 three-tier model, each scenario has unit / integration / calibration tiers. Stage 2 (scenario 6) needs real LLM for disambiguation — its **unit tier uses a deterministic mock response** (pre-scripted JSON picking one candidate), **integration tier uses a real resolution model**, **calibration tier adds artifact capture per #338 D7**.
+
+All other scenarios (A, B, C without Stage 2 dependency, Stage 1 exact match, agent-context annotation, tool-selection routing) run **mock-only in unit tier** and are skipped from the real-API integration tier — they don't exercise LLM-dependent behavior, so running them against a real provider adds cost without coverage.
+
+**Table:**
+
+| Scenario | Unit (mock, on-push) | Integration (real, opt-in) | Calibration (artifact) |
+|---|---|---|---|
+| 1 tool_selection_query_knowledge_graph | ✅ | — (mock suffices) | — |
+| 2 path_a_direct_domain_match | ✅ | — | — |
+| 3 path_b_subject_match_agent_scoped | ✅ | — | — |
+| 4 path_c_semantic_via_chunks | ✅ (mocked embedding) | ✅ (real embedding client from `#340` D1) | ✅ |
+| 5 stage_1_exact_match | ✅ | — | — |
+| 6 stage_2_llm_disambiguation | ✅ (mocked judge) | ✅ (real `MIKA_KG_RESOLUTION_MODEL`) | ✅ |
+| 7 agent_context_annotation_disabled | ✅ | — | — |
+
+**Rationale:** Only scenarios that exercise LLM or embedding behavior warrant real-API tier. Others test deterministic code paths where mock is faithful.
+
+**Rejected alternative:** Run all seven against real providers on every opt-in run. Triples cost for scenarios that don't learn anything from real-API invocation.
+
+### D4 — Tag vocabulary: `self-knowledge:*` namespace (owned here, not shared)
+
+**Problem:** Soft-assertion LLM-judged tags need a namespace. #339 D4 established ticket-namespacing (#339 owns `quality:*`; #740 owns `self-knowledge:*`).
+
+**Decision:** #740 owns `self-knowledge:*` namespace. Tag vocabulary:
+
+- `self-knowledge:query-invoked` — agent called `query_knowledge_graph` before the final response (hard-assertable; included as a tag too for cross-scenario aggregation)
+- `self-knowledge:capability-claimed-without-query` — fabrication-adjacent failure mode: agent claimed capability state without a KG query
+- `self-knowledge:stage-1-skipped` — soft signal that Stage 1 exact match was bypassed even though it should have hit
+- `self-knowledge:agent-context-missing` — result returned but the `agent_context` annotation was absent/wrong
+
+Vocabulary is frozen in the `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` (per #339 D8 — README-next-to-tests, not a separate doc tree). Calibration artifact (#338 D7) preserves the namespace structure; aggregation across tickets works at the tooling layer.
+
+**Rationale:** Tags map to the four behavioral failure modes that a KG-backed self-knowledge regression would produce. Each scenario MAY emit one or more of these tags; not every scenario emits all.
+
+**Rejected alternative:** Reuse `#339`'s `quality:*` namespace. Rejected per the ticket-namespacing principle — these tags describe KG-specific failure classes that don't fit general quality vocabulary.
+
+### D5 — Fixture freshness: schema-version assertion, no auto-regeneration
+
+**Problem:** The KG domain graph is deterministically projected from the live registries at server startup (`kg::domain_builder`). Seeded fixtures use fabricated entity keys (`skill:self-dev`, `problem_type:ci_failure`, etc.) that must match the domain graph's conventions. If the domain graph's schema or key convention drifts (e.g., capitalization, separator), seeded fixtures become invalid without any obvious test signal.
+
+**Decision:** The fixture module asserts at load time that the current schema version is `25` (the KG schema). On a schema bump, the assertion fails loudly. Any author advancing the schema MUST update the fixture alongside. **No auto-regeneration** — the fixture is hand-crafted and frozen until a schema change forces a rewrite.
+
+Additionally: the fixture module's doc comment explicitly references `docs/architecture/kg-id-convention.md` and `crates/mika-agent/src/kg/domain_builder.rs` as the canonical sources for the `<type>:<name>` key format, so a future author tracing "is this fixture still correct?" has a direct pointer.
+
+**Rationale:** The domain graph is a living projection; fixtures are frozen snapshots. Keeping them in step requires either auto-regeneration (brittle, couples tests to the domain-builder internals) or loud failure on divergence (simple, explicit). Loud failure wins — the author advancing the schema is the right person to update the fixture.
+
+**Rejected alternative:** Auto-regenerate fixtures from a minimal domain-builder run in test setup. Couples the eval to the domain-builder's internal state model; a domain-builder refactor cascades to test rewrites silently.
+
+### D6 — Failure-mode scenarios included in positive tests, not separate files
+
+**Problem:** `query_knowledge_graph` returns structured status values: `ok`, `starting_entity_missing`, `traversal_empty`. The self-knowledge skill (#692) uses these for fallback logic. Should failure-mode surfacing get its own scenario files?
+
+**Decision:** **Embedded assertions within the positive tests, not separate scenarios.**
+
+- Scenario 3 (Path B agent-scoped) already asserts `starting_entity_missing` when queried as a wrong-agent — that's the failure mode.
+- Scenario 4 (Path C) asserts `traversal_empty` when a chunk's subject has no resolution — that's the second failure mode.
+- Adding dedicated `status_*` scenario files would duplicate the fixture setup without adding behavioral coverage.
+
+Failure-mode surfacing isn't a separate test class; it's a coverage requirement on each scenario where the condition applies. AC explicitly lists which scenarios assert which status outcomes.
+
+**Rationale:** Embedded failure-mode assertions keep scenario count aligned with behavioral coverage. Extracting status checks into their own scenarios would inflate the count without adding signal.
+
+**Rejected alternative:** Add scenarios 8–10 for `ok` / `starting_entity_missing` / `traversal_empty` as standalone. Rejected — the status is a property of the scenario's response, not a separate capability.
+
+## Acceptance Criteria
+
+- [ ] 7 scenario files under `crates/mika-agent/tests/eval/kg_self_knowledge/`, distributed per D2.
+- [ ] Fixture module `tests/eval/kg_fixtures.rs` with the five seed helpers from D1. Module asserts schema version `25` at load time per D5.
+- [ ] Every scenario has ≥1 hard assertion; soft-tag output uses the `self-knowledge:*` namespace only (per D4).
+- [ ] Each scenario runs in unit / integration / calibration tiers per #339 D6; tier table from D3 is authoritative.
+- [ ] `register_scenario(name, meta)` uniqueness guard from #339 D7 protects against copy-paste-without-rename.
+- [ ] **Path A / B / C coverage** — scenarios 2, 3, 4 each assert their entry path produces the expected result shape.
+- [ ] **Stage 1 / Stage 2 coverage** — scenarios 5 and 6 each assert their outcome in `kg_resolutions_log`, confidence clamping behavior, and `skipped_no_llm` path.
+- [ ] **Failure-mode coverage** — scenario 3 asserts `starting_entity_missing` for wrong-agent query; scenario 4 asserts `traversal_empty` for unresolved subject.
+- [ ] **Agent-context annotation** — scenario 7 asserts disabled skill returns with `enabled=false` field set, NOT filtered from results.
+- [ ] `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` covers fixture patterns, the `self-knowledge:*` vocabulary with each tag's trigger condition, and how to add a scenario.
+- [ ] `crates/mika-agent/CLAUDE.md` KG section referenced from the README; no duplicate content.
+- [ ] `cargo test -p mika-agent --test eval` green (unit tier).
+- [ ] Integration tier green for scenarios 4 and 6 when invoked with `MIKA_EVAL_REAL_PROVIDERS=anthropic` + `--ignored` + `MIKA_KG_RESOLUTION_MODEL` + an embedding key.
+- [ ] `cargo clippy` clean.
+
+## Dependencies
+
+- Blocked by `#338` (`fa54d950`) — scenario-as-function pattern, matrix runner, calibration artifact, `eval-diff`
+- Blocked by `#340` item #1 — `embedding_client` DI for scenario 4 integration tier
+- Blocked by `#340` item #3 — callback-turn harness surface IF any scenario involves a callback flow; current scope does not, so this dep is precautionary. If scenario 6's Stage 2 real-API invocation needs callback wrapping (it shouldn't — it's a direct `resolve_pending` call), this becomes hard-required.
+- Blocked by `#339` (`5fb14662`) — three-tier execution model, `register_scenario` idiom, ticket-namespaced vocabulary precedent, README + CLAUDE.md doc structure
+
+## Downstream
+
+- None within milestone #16. Future KG enhancement tickets may cite these scenarios for regression coverage.
+
+## Cross-cutting notes
+
+- **Scenario 3 is the agent-scoping canary:** if subject-entity isolation regresses (one agent sees another's subjects), this test fires loudest.
+- **Scenario 6 is the only real-API cost surface in this ticket.** Integration + calibration tiers for Stage 2 LLM hit the configured resolution model. Matches the per-scenario cost awareness pattern from #339 D7 — `expected_tokens` metadata on scenario 6 declares the expected cost.
+- **Vocabulary ownership boundary is strict:** #740 does NOT define `grounding:*` or `quality:*` tags. If a KG scenario accidentally exhibits a non-KG failure mode (e.g., fabrication), it surfaces a hard assertion failure OR gets re-classified to the right sibling ticket.
+- #740 pinned to #338 at `fa54d950` and #339 at `5fb14662`. Upstream drift on either is a grep-findable version bump.
+
+## Open questions (for Vincent before dispatch)
+
+1. **D2 scenario count at 7** — is this tight enough to author in the baseline PR, or should Stage 2 real-API coverage expand to two scenarios (one per candidate-ambiguity class: synonyms vs case-variants vs true duplicates)? My default is 7 (treating Stage 2 as one scenario with internal variants), but splitting is a principled alternative.
+2. **D3 integration-tier scope** — I limited real-API tests to scenarios 4 and 6. If you want agent-facing scenarios (e.g., #1 tool-selection routing) tested against real models too, that's an add. My default is "real API only where deterministic code isn't enough."
+3. **D5 schema-version assertion** — `assert_eq!(current_schema_version, 25)` at fixture load. Acceptable, or should it be softer (log warn + continue) to avoid blocking all eval tests during a schema-bump PR? I lean hard assert; schema changes are rare enough that loud failure is the right signal.
+4. **D6 failure-mode embedded vs separate** — I embedded `starting_entity_missing` + `traversal_empty` into scenarios 3 and 4. Alternative: two additional standalone scenarios for these statuses with minimal fixtures, bringing total to 9. Embedded wins on scenario-count parsimony; standalone wins on failure-mode discoverability. I picked embedded.

--- a/docs/plans/740-kg-self-knowledge-eval.md
+++ b/docs/plans/740-kg-self-knowledge-eval.md
@@ -37,11 +37,11 @@ Milestone #14 shipped KG-backed self-knowledge (`#692` / PR #733): the `query_kn
 
 ## Decisions
 
-### D1 — KG fixture seeding: per-scenario helper, four-layer seed, synchronous resolver
+### D1 — KG fixture seeding: crate-shared helper module, four-layer seed, synchronous resolver
 
-**Problem:** Scenarios need a known KG state: domain entities (from `kg_entities`), subject entities (from `kg_subject_entities`), chunks (from `kg_chunks`), and resolutions (from `kg_subject_resolutions`). Seeding requires writing to all four tables with correct FK relationships. The resolver normally runs async at startup (`entity_resolver.rs`); tests can't wait on a background task.
+**Problem:** Scenarios need a known KG state: domain entities (from `kg_entities`), subject entities (from `kg_subject_entities`), chunks (from `kg_chunks`), and resolutions (from `kg_subject_resolutions`). Seeding requires writing to all four tables with correct FK relationships. The resolver normally runs async at startup (`entity_resolver.rs`); tests can't wait on a background task. Also: `#741`'s grounding scenarios will likely need KG seeding too (agent-ignores-correct-KG-result is a grounding failure whose setup looks like KG seeding) — the helpers must be importable across tickets, not private to #740.
 
-**Decision:** One helper module `tests/eval/kg_fixtures.rs` with:
+**Decision:** One helper module at **`crates/mika-agent/tests/eval/kg_fixtures/mod.rs`** (crate-shared location, NOT nested under `kg_self_knowledge/`) with:
 
 - `seed_domain_entity(db, spec)` — inserts into `kg_entities` with `entity_key = "<type>:<name>"` per convention
 - `seed_subject_entity(db, agent_id, spec)` — inserts into `kg_subject_entities`
@@ -49,13 +49,19 @@ Milestone #14 shipped KG-backed self-knowledge (`#692` / PR #733): the `query_kn
 - `seed_chunk_subject(db, chunk_id, subject_id)` — inserts provenance row
 - `seed_resolution(db, agent_id, subject_id, domain_id, confidence, outcome)` — inserts into both `kg_subject_resolutions` and `kg_resolutions_log`
 
-**Synchronous resolver path.** Scenarios that need "run the resolver on seeded subjects and assert outcomes" call `EntityResolver::resolve_pending().await` directly from the test, synchronously. This bypasses the startup `tokio::spawn` race (`mika#739`) — the test is deterministic because the test owns the spawn boundary. Not a workaround for the bug; the test simply doesn't use the startup-race code path.
+Helpers are `pub` in the test module so `#741`'s scenarios can import them directly. Single implementation across tickets; schema evolution cascades to one place.
 
-Each scenario file owns its fixture; no shared fixture across scenarios (per #339 D3 precedent — Rust per-scenario setup, no coupling).
+**Synchronous resolver path.** Scenarios that need "run the resolver on seeded subjects and assert outcomes" call `EntityResolver::resolve_pending().await` directly from the test, synchronously. The positive reason: **eval harness tests behavior under test-controlled input; the startup race is an orchestration concern with different infrastructure needs (integration-level), not a behavior-under-test concern.** `mika#739` owns the race case with its own coverage; this plan owns behavior-under-test.
 
-**Rationale:** Four typed helper functions map 1:1 to the four tables. Seeding via the existing `Database` API (not raw SQL) keeps the fixture helper in step with schema migrations — when schema v26 lands, the helper breaks at compile time, not at runtime. Synchronous resolver call makes Stage 1 / Stage 2 outcome assertions reliable without touching the startup race.
+**Verified precondition:** `resolve_pending` source at `crates/mika-agent/src/kg/entity_resolver.rs:199-236` reads state fresh from DB via `get_pending_entities()` on every call. No pre-fetch, no cache, no state carried across invocations. The only `Arc<...>` in the resolver is the `LlmProvider` handle — shared client, not shared state. Sync-bypass is behaviorally equivalent to async-spawn for the purposes of the test (modulo the pending query actually seeing the data, which the test controls). Verified 2026-04-22.
 
-**Rejected alternative:** YAML-driven KG fixture files. Same reasoning as #339 D3 (locked as "Rejected alternative"): scenarios are test code, test code is Rust, YAML grows a DSL grows an interpreter grows regret.
+Each scenario file owns its fixture *composition*; helpers are shared, scenarios are not coupled (per #339 D3 precedent — Rust per-scenario setup, no coupling).
+
+**Rationale:** Five typed helper functions map 1:1 to the five tables involved in KG layering. Seeding via the existing `Database` API (not raw SQL) keeps the fixture helper in step with schema migrations — when schema v26 lands, the helper breaks at compile time, not at runtime. Synchronous resolver call makes Stage 1 / Stage 2 outcome assertions reliable without touching the startup race. Crate-shared location prevents #741 from cargo-culting a second implementation.
+
+**Rejected alternatives:**
+- Helpers private to `#740`'s scenario directory. Rejected — forces `#741` to duplicate, which drifts.
+- YAML-driven KG fixture files. Same reasoning as #339 D3 (locked as "Rejected alternative"): scenarios are test code, test code is Rust, YAML grows a DSL grows an interpreter grows regret.
 
 ### D2 — Scenario catalog: seven scenarios, distributed by entry path and resolver stage
 
@@ -68,7 +74,7 @@ Each scenario file owns its fixture; no shared fixture across scenarios (per #33
 3. **`path_b_subject_match_agent_scoped.rs`** — Seeded subject entity `pattern:fabrication-guard` for agent `mika-dev` only; assert mika-dev gets result; assert a different agent gets `starting_entity_missing` (agent-scoped isolation).
 4. **`path_c_semantic_via_chunks.rs`** — Seeded chunk + subject + resolution; free-text paraphrase query; assert chunk → subject → domain bridge traversal. Second variant without resolution; assert subject-only result.
 5. **`stage_1_exact_match.rs`** — Seeded case-variant subject (`skill:Self-Dev`) + domain (`skill:self-dev`); invoke `resolve_pending`; assert `outcome=matched_exact` in `kg_resolutions_log`; assert confidence = extraction_confidence.
-6. **`stage_2_llm_disambiguation.rs`** — Seeded two similarly-named candidates (`skill:qa-review`, `skill:qa-review-build-callback`) + subject with unqualified "qa review" chunk context; assert `outcome=matched_llm`, confidence = min(extraction, llm). Second variant with `MIKA_KG_RESOLUTION_MODEL` unset; assert `outcome=skipped_no_llm`.
+6. **`stage_2_llm_disambiguation.rs`** — **Parameterized over three ambiguity classes** in a single test body: `Synonyms` (skill:qa-review vs skill:qa-review-build-callback, shared semantic neighborhood), `CaseVariants` (skill:self-dev vs skill:Self-Dev, exact-match-should-catch-but-doesn't test), `TrueDuplicates` (two entities with near-identical semantics from different seed paths). All three variants exercise the same Stage 2 code path against different input shapes; the per-class outcome is asserted distinctly so the test output shows `[synonyms] pass`, `[case-variants] pass`, `[true-duplicates] pass`. **Fixture shape is fixed: 5 candidates + ~500-token chunk context per variant.** Hard assertion: Stage 2 code path executed, resolution written to `kg_subject_resolutions`, `outcome=matched_llm` in log, confidence = min(extraction, llm). Soft assertion (tag-based): `self-knowledge:disambiguation-correct` when the LLM picked the structurally-expected candidate; `self-knowledge:disambiguation-plausible-alternative` when it picked a different-but-defensible candidate. Stage 2 is inherently noisy — calling the LLM's judgment a hard regression on a genuinely ambiguous input is false-signal. Hard-assert the execution; soft-tag the judgment. Fourth variant in the same file with `MIKA_KG_RESOLUTION_MODEL` unset; assert `outcome=skipped_no_llm`.
 7. **`agent_context_annotation_disabled.rs`** — Disable `self-dev` via `skill_overrides`; query for `self-dev`; assert result includes the skill AND `agent_context.enabled=false` (annotated, not filtered).
 
 **Coverage rationale:** seven scenarios cover the three entry paths (A/B/C), two resolver stages (1/2), the routing assertion, and the agent-context annotation. This is the KG milestone's behavioral surface mapped to tests; each missing scenario would leave a documented code path un-exercised.
@@ -84,6 +90,8 @@ Each scenario file owns its fixture; no shared fixture across scenarios (per #33
 **Decision:** Per #339 D6 three-tier model, each scenario has unit / integration / calibration tiers. Stage 2 (scenario 6) needs real LLM for disambiguation — its **unit tier uses a deterministic mock response** (pre-scripted JSON picking one candidate), **integration tier uses a real resolution model**, **calibration tier adds artifact capture per #338 D7**.
 
 All other scenarios (A, B, C without Stage 2 dependency, Stage 1 exact match, agent-context annotation, tool-selection routing) run **mock-only in unit tier** and are skipped from the real-API integration tier — they don't exercise LLM-dependent behavior, so running them against a real provider adds cost without coverage.
+
+**Path C (scenario 4) uses a deterministic embedding stand-in for mock-tier coverage.** Mock tier uses a hash-to-fixed-vector embedding client that returns consistent results for the same input without pretending to be semantic — this exercises the *code structure* of Path C (hybrid search call, chunk→subject→domain traversal, ranking surface) even though the ranking is meaningless. Integration tier swaps in a real embedding client (`openai/text-embedding-3-small`) for actual semantic retrieval. Without the stand-in, mock tier either skips the embedding step (and doesn't exercise Path C) or passes `None` (and falls through to a different code branch).
 
 **Table:**
 
@@ -108,13 +116,19 @@ All other scenarios (A, B, C without Stage 2 dependency, Stage 1 exact match, ag
 **Decision:** #740 owns `self-knowledge:*` namespace. Tag vocabulary:
 
 - `self-knowledge:query-invoked` — agent called `query_knowledge_graph` before the final response (hard-assertable; included as a tag too for cross-scenario aggregation)
-- `self-knowledge:capability-claimed-without-query` — fabrication-adjacent failure mode: agent claimed capability state without a KG query
+- `self-knowledge:capability-claimed-without-query` — failure mode: agent claimed capability state without a KG query
 - `self-knowledge:stage-1-skipped` — soft signal that Stage 1 exact match was bypassed even though it should have hit
 - `self-knowledge:agent-context-missing` — result returned but the `agent_context` annotation was absent/wrong
+- `self-knowledge:disambiguation-correct` — Stage 2 picked the structurally-expected candidate
+- `self-knowledge:disambiguation-plausible-alternative` — Stage 2 picked a different-but-defensible candidate (noise absorption for genuinely ambiguous input)
 
-Vocabulary is frozen in the `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` (per #339 D8 — README-next-to-tests, not a separate doc tree). Calibration artifact (#338 D7) preserves the namespace structure; aggregation across tickets works at the tooling layer.
+**Scope boundary with `#741`.** `self-knowledge:*` tags cover the code path from tool-invocation through resolver. Agent *response quality* given a successful KG result — specifically "KG returned correct result but agent ignored it and answered from training data anyway" — is a **grounding failure**, not a self-knowledge failure. That case is routed to `#741`'s `grounding:*` namespace. The apparent vocabulary gap in #740 (no tag for "agent-ignores-correct-KG-result") is the namespace boundary working as intended, not a missing tag.
 
-**Rationale:** Tags map to the four behavioral failure modes that a KG-backed self-knowledge regression would produce. Each scenario MAY emit one or more of these tags; not every scenario emits all.
+**Vocabulary review checkpoint.** After all seven scenarios are implemented, revisit this vocabulary before merging. If any scenario's outcome doesn't fit one of the six tags AND the case isn't cleanly routable to `#741`'s namespace, expand this vocabulary (add a seventh tag with rationale) rather than stretching an existing tag. Review is an explicit AC, not a handshake.
+
+Vocabulary is defined in `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` (per #339 D8 — README-next-to-tests, not a separate doc tree). Calibration artifact (#338 D7) preserves the namespace structure; aggregation across tickets works at the tooling layer.
+
+**Rationale:** Tags map to the behavioral failure modes that a KG-backed self-knowledge regression would produce, plus two for Stage 2 judgment noise absorption. Each scenario MAY emit one or more of these tags; not every scenario emits all. Scope sentence routes adjacent failure classes to sibling tickets instead of stretching this vocabulary.
 
 **Rejected alternative:** Reuse `#339`'s `quality:*` namespace. Rejected per the ticket-namespacing principle — these tags describe KG-specific failure classes that don't fit general quality vocabulary.
 
@@ -122,46 +136,80 @@ Vocabulary is frozen in the `crates/mika-agent/tests/eval/kg_self_knowledge/READ
 
 **Problem:** The KG domain graph is deterministically projected from the live registries at server startup (`kg::domain_builder`). Seeded fixtures use fabricated entity keys (`skill:self-dev`, `problem_type:ci_failure`, etc.) that must match the domain graph's conventions. If the domain graph's schema or key convention drifts (e.g., capitalization, separator), seeded fixtures become invalid without any obvious test signal.
 
-**Decision:** The fixture module asserts at load time that the current schema version is `25` (the KG schema). On a schema bump, the assertion fails loudly. Any author advancing the schema MUST update the fixture alongside. **No auto-regeneration** — the fixture is hand-crafted and frozen until a schema change forces a rewrite.
+**Decision:** The fixture module asserts at load time that the current schema version is `25` (the KG schema). On a schema bump, the assertion fails loudly with an **actionable message — not a terse `left != right` diff**:
+
+```rust
+assert_eq!(
+    crate::db::CURRENT_SCHEMA_VERSION, 25,
+    "KG eval fixtures pinned to schema v25. Schema bumped to v{}; \
+     update seed_* helpers in tests/eval/kg_fixtures/mod.rs and bump this pin. \
+     See mika/docs/plans/740-kg-self-knowledge-eval.md D5.",
+    crate::db::CURRENT_SCHEMA_VERSION
+);
+```
+
+Any author advancing the schema MUST update the fixture alongside; the failure message is a checklist pointing at the exact files and pin. **No auto-regeneration** — the fixture is hand-crafted and frozen until a schema change forces a rewrite.
 
 Additionally: the fixture module's doc comment explicitly references `docs/architecture/kg-id-convention.md` and `crates/mika-agent/src/kg/domain_builder.rs` as the canonical sources for the `<type>:<name>` key format, so a future author tracing "is this fixture still correct?" has a direct pointer.
 
-**Rationale:** The domain graph is a living projection; fixtures are frozen snapshots. Keeping them in step requires either auto-regeneration (brittle, couples tests to the domain-builder internals) or loud failure on divergence (simple, explicit). Loud failure wins — the author advancing the schema is the right person to update the fixture.
+**Rationale:** The domain graph is a living projection; fixtures are frozen snapshots. Keeping them in step requires either auto-regeneration (brittle, couples tests to the domain-builder internals) or loud failure on divergence (simple, explicit). Loud failure wins — the author advancing the schema is the right person to update the fixture. Same structural principle as #338 D9's frozen regression fixture: the test's failure mode tells you exactly what to do about it.
 
-**Rejected alternative:** Auto-regenerate fixtures from a minimal domain-builder run in test setup. Couples the eval to the domain-builder's internal state model; a domain-builder refactor cascades to test rewrites silently.
+**Rejected alternatives:**
+- Auto-regenerate fixtures from a minimal domain-builder run in test setup. Couples the eval to the domain-builder's internal state model; a domain-builder refactor cascades to test rewrites silently.
+- Log-warn-and-continue. Rot signal. The theater option.
 
-### D6 — Failure-mode scenarios included in positive tests, not separate files
+### D6 — Paired assertions within capability tests (each scenario covers a capability's full success/failure surface)
 
 **Problem:** `query_knowledge_graph` returns structured status values: `ok`, `starting_entity_missing`, `traversal_empty`. The self-knowledge skill (#692) uses these for fallback logic. Should failure-mode surfacing get its own scenario files?
 
-**Decision:** **Embedded assertions within the positive tests, not separate scenarios.**
+**Decision:** **Paired assertions within capability tests.** Each scenario file is a *capability under test*, and capabilities have both success-path and failure-path assertions that share fixture setup. Not "failure assertions smuggled into positive tests" — proper paired coverage.
 
-- Scenario 3 (Path B agent-scoped) already asserts `starting_entity_missing` when queried as a wrong-agent — that's the failure mode.
-- Scenario 4 (Path C) asserts `traversal_empty` when a chunk's subject has no resolution — that's the second failure mode.
-- Adding dedicated `status_*` scenario files would duplicate the fixture setup without adding behavioral coverage.
+- Scenario 3 (Path B agent-scoped) asserts both the success path (correct-agent query returns subject result) AND the failure path (`starting_entity_missing` for wrong-agent query) on the same fixture.
+- Scenario 4 (Path C) asserts both the success path (chunk → subject → domain bridge on a resolved subject) AND the failure path (`traversal_empty` for unresolved subject) on the same fixture.
+- Each scenario's AC enumerates its success-path hard assertion AND its failure-path hard assertion where applicable.
 
-Failure-mode surfacing isn't a separate test class; it's a coverage requirement on each scenario where the condition applies. AC explicitly lists which scenarios assert which status outcomes.
+Extracting status checks into their own scenarios would duplicate fixture setup without adding behavioral coverage. The status is a property of the capability's response shape, not a separate capability.
 
-**Rationale:** Embedded failure-mode assertions keep scenario count aligned with behavioral coverage. Extracting status checks into their own scenarios would inflate the count without adding signal.
+**Capability × assertion-status matrix in README.** The `kg_self_knowledge/README.md` includes an explicit matrix — rows are the 7 scenarios, columns are the status outcomes (`ok`, `starting_entity_missing`, `traversal_empty`, `matched_exact`, `matched_llm`, `skipped_no_llm`, `agent_context=enabled|disabled`), cells are `✓` where the scenario asserts that outcome. Reviewers see coverage at-a-glance without reading individual test files.
 
-**Rejected alternative:** Add scenarios 8–10 for `ok` / `starting_entity_missing` / `traversal_empty` as standalone. Rejected — the status is a property of the scenario's response, not a separate capability.
+**Rationale:** Paired-assertion framing correctly describes what the scenarios do: each covers the full behavioral surface of one capability, not just the happy path. Extracting failures into standalone scenarios inflates the count and loses the fixture-sharing that makes the pairing cheap.
+
+**Rejected alternative:** Add scenarios 8–10 for `ok` / `starting_entity_missing` / `traversal_empty` as standalone. Rejected — the status is a property of a capability's response, not a separate capability. Fixture duplication without behavioral gain.
 
 ## Acceptance Criteria
 
 - [ ] 7 scenario files under `crates/mika-agent/tests/eval/kg_self_knowledge/`, distributed per D2.
-- [ ] Fixture module `tests/eval/kg_fixtures.rs` with the five seed helpers from D1. Module asserts schema version `25` at load time per D5.
+- [ ] **Fixture module at `crates/mika-agent/tests/eval/kg_fixtures/mod.rs` (crate-shared, NOT nested under the scenario directory).** Exports all five seed helpers `pub` for `#741` to import. Module asserts schema version `25` at load time with actionable failure message per D5.
+- [ ] **Verified precondition recorded in plan body:** resolver source (`entity_resolver.rs:199-236`) reads DB state fresh on every invocation; no pre-fetch/cache. Verification done 2026-04-22 as part of this plan.
 - [ ] Every scenario has ≥1 hard assertion; soft-tag output uses the `self-knowledge:*` namespace only (per D4).
 - [ ] Each scenario runs in unit / integration / calibration tiers per #339 D6; tier table from D3 is authoritative.
 - [ ] `register_scenario(name, meta)` uniqueness guard from #339 D7 protects against copy-paste-without-rename.
 - [ ] **Path A / B / C coverage** — scenarios 2, 3, 4 each assert their entry path produces the expected result shape.
 - [ ] **Stage 1 / Stage 2 coverage** — scenarios 5 and 6 each assert their outcome in `kg_resolutions_log`, confidence clamping behavior, and `skipped_no_llm` path.
-- [ ] **Failure-mode coverage** — scenario 3 asserts `starting_entity_missing` for wrong-agent query; scenario 4 asserts `traversal_empty` for unresolved subject.
+- [ ] **Scenario 6 parameterized over three ambiguity classes** (`Synonyms`, `CaseVariants`, `TrueDuplicates`) within one test file per D2. Fixture shape fixed: 5 candidates + ~500-token chunk per variant. Hard assertion on code-path execution + DB writes; soft assertion (tags `self-knowledge:disambiguation-correct` / `...-plausible-alternative`) on judgment quality.
+- [ ] **Paired assertions within each capability test** (per D6) — scenarios 3 and 4 each assert BOTH success path AND failure path (`starting_entity_missing`, `traversal_empty`) on shared fixture.
 - [ ] **Agent-context annotation** — scenario 7 asserts disabled skill returns with `enabled=false` field set, NOT filtered from results.
-- [ ] `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` covers fixture patterns, the `self-knowledge:*` vocabulary with each tag's trigger condition, and how to add a scenario.
+- [ ] **Deterministic embedding stand-in for mock-tier scenario 4** (hash-to-fixed-vector). Integration tier swaps in real `text-embedding-3-small`.
+- [ ] `crates/mika-agent/tests/eval/kg_self_knowledge/README.md` covers: fixture patterns, the `self-knowledge:*` vocabulary with each tag's trigger condition, how to add a scenario, **scope boundary with #741 (`grounding:*`)**, and a **capability × status matrix** (rows: 7 scenarios, columns: asserted status outcomes, cells: ✓).
+- [ ] **Vocabulary review checkpoint before merge** (per D4): if any implemented scenario's outcome doesn't fit one of the six `self-knowledge:*` tags AND isn't cleanly routable to #741's namespace, expand the vocabulary with rationale.
 - [ ] `crates/mika-agent/CLAUDE.md` KG section referenced from the README; no duplicate content.
 - [ ] `cargo test -p mika-agent --test eval` green (unit tier).
 - [ ] Integration tier green for scenarios 4 and 6 when invoked with `MIKA_EVAL_REAL_PROVIDERS=anthropic` + `--ignored` + `MIKA_KG_RESOLUTION_MODEL` + an embedding key.
 - [ ] `cargo clippy` clean.
+
+## Cost envelope (real-API integration tier)
+
+**Scenario 6 (Stage 2 LLM disambiguation):** fixture shape fixed at 5 candidates + ~500-token chunk context × 3 ambiguity-class variants = 3 LLM invocations per integration run.
+
+- Per invocation: ~1K input tokens (prompt template ~300 + 5 candidates ~200 + chunk ~500) + ~100 output tokens
+- Against `claude-sonnet-4-6` at current Anthropic pricing ($3/MTok input, $15/MTok output): `1000 × $3/1M + 100 × $15/1M = $0.0045 per invocation`
+- **Three variants × $0.0045 = ~$0.014 per integration run.**
+
+**Scenario 4 (Path C real embedding):** one embedding call per integration run with `text-embedding-3-small`.
+
+- ~500 input tokens × $0.02/MTok = ~$0.00001 per invocation. Effectively free.
+
+**Total real-API cost per integration run of this ticket's scenarios: ~$0.015.** Calibration tier is the same cost (artifact capture overhead is local, not an API cost). These numbers rot as pricing changes — they live in this plan as design-time cost-envelope decisions, not as runtime guarantees. Per #338 D8 principle: workflow timeouts + scenario-count caps at the CI layer are the enforcement; plan-level numbers are design intent.
 
 ## Dependencies
 
@@ -181,9 +229,18 @@ Failure-mode surfacing isn't a separate test class; it's a coverage requirement 
 - **Vocabulary ownership boundary is strict:** #740 does NOT define `grounding:*` or `quality:*` tags. If a KG scenario accidentally exhibits a non-KG failure mode (e.g., fabrication), it surfaces a hard assertion failure OR gets re-classified to the right sibling ticket.
 - #740 pinned to #338 at `fa54d950` and #339 at `5fb14662`. Upstream drift on either is a grep-findable version bump.
 
-## Open questions (for Vincent before dispatch)
+## Review log
 
-1. **D2 scenario count at 7** — is this tight enough to author in the baseline PR, or should Stage 2 real-API coverage expand to two scenarios (one per candidate-ambiguity class: synonyms vs case-variants vs true duplicates)? My default is 7 (treating Stage 2 as one scenario with internal variants), but splitting is a principled alternative.
-2. **D3 integration-tier scope** — I limited real-API tests to scenarios 4 and 6. If you want agent-facing scenarios (e.g., #1 tool-selection routing) tested against real models too, that's an add. My default is "real API only where deterministic code isn't enough."
-3. **D5 schema-version assertion** — `assert_eq!(current_schema_version, 25)` at fixture load. Acceptable, or should it be softer (log warn + continue) to avoid blocking all eval tests during a schema-bump PR? I lean hard assert; schema changes are rare enough that loud failure is the right signal.
-4. **D6 failure-mode embedded vs separate** — I embedded `starting_entity_missing` + `traversal_empty` into scenarios 3 and 4. Alternative: two additional standalone scenarios for these statuses with minimal fixtures, bringing total to 9. Embedded wins on scenario-count parsimony; standalone wins on failure-mode discoverability. I picked embedded.
+**Vincent + friend review pass 1 (2026-04-22, relayed by Vincent):**
+
+- **D1 fixture location moved to crate-shared** `tests/eval/kg_fixtures/mod.rs` (not nested under `kg_self_knowledge/`). Exports `pub` so #741 can import. Prevents cargo-cult duplication.
+- **D1 `#739` bypass reframed** with positive reason: eval harness tests behavior under test-controlled input; startup-race is integration-test territory with different infrastructure. `#739` owns its case explicitly.
+- **D1 resolver source verified:** `resolve_pending` at `entity_resolver.rs:199-236` reads DB fresh on every call, no pre-fetch, no cache, no cross-invocation state. Sync-bypass assumption validated against source code, not just asserted. Recorded as a verified precondition in the plan body.
+- **D2 scenario 6 parameterized over three ambiguity classes** (`Synonyms`, `CaseVariants`, `TrueDuplicates`) within one test body. Fixture shape fixed at 5 candidates + ~500-token chunk per variant. Hard assertion on code-path execution (deterministic); soft tag on judgment quality (noise absorption for genuinely ambiguous input). Same hard/soft split as #339.
+- **D3 deterministic embedding stand-in** for mock-tier scenario 4 (hash-to-fixed-vector). Ensures mock tier actually exercises Path C code structure, not a fallthrough.
+- **D4 scope sentence added:** `self-knowledge:*` covers tool-invocation through resolver; agent-response-quality given a successful KG result routes to #741's `grounding:*` namespace. Two new tags for Stage 2 judgment (`disambiguation-correct` / `disambiguation-plausible-alternative`). Vocabulary review checkpoint at AC-completion to catch missed failure modes.
+- **D5 assertion message customized** to be a checklist pointing at exact files and pin location — not a terse `left != right`. Same principle as #338 D9 frozen-fixture failures.
+- **D6 reframed** as "paired assertions within capability tests" — each scenario covers success AND failure paths of one capability on shared fixture. Capability × status matrix added to README AC for at-a-glance coverage visibility.
+- **Cost envelope priced at design time** (~$0.015 per integration run for this ticket's scenarios): 3 Stage-2 variants × ~$0.0045 each + negligible embedding cost. Fixture shape fixed as design decision; scenario-author doesn't "declare" cost at implementation time.
+
+**Friend principle extended:** "pin the decision you're depending on" now applies to cost envelope (design-time fixture shape) and assertion messages (actionable on failure), not just upstream plan SHAs and vocabulary namespaces.

--- a/docs/solutions/best-practices/integration-test-fixtures-must-use-canonical-write-path-2026-04-23.md
+++ b/docs/solutions/best-practices/integration-test-fixtures-must-use-canonical-write-path-2026-04-23.md
@@ -1,0 +1,156 @@
+---
+title: "Integration-test fixtures must use the canonical write path to preserve dual-write invariants"
+date: 2026-04-23
+category: best-practices
+module: eval-harness
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - Seeding state for integration tests that exercise search or retrieval code
+  - Writing fixture helpers for tables that participate in dual-write or transactional double-write invariants (FTS5, vec0, JOIN-linked sidecar tables)
+  - Authoring eval scenarios where a broad assertion could be satisfied by multiple entry paths
+  - Adding helpers to `tests/eval/kg_fixtures/` or similar crate-shared seeding modules
+tags:
+  - eval-harness
+  - fixture-seeding
+  - fts5
+  - knowledge-graph
+  - kg-chunks
+  - hybrid-search
+  - integration-test
+  - invariant-preservation
+---
+
+# Integration-test fixtures must use the canonical write path to preserve dual-write invariants
+
+## Context
+
+The KG self-knowledge eval scenarios (#740) seed a known KG state — domain entities, subject entities, chunks, and resolutions — so Path A / Path B / Path C retrieval can be exercised against controlled input. The first version of `seed_chunk` in `tests/eval/kg_fixtures/mod.rs` inserted directly into `kg_chunks` and `search_content`:
+
+```rust
+db.execute_sql(
+    "INSERT INTO kg_chunks (agent_id, seq_id, source_doc_path, source_doc_hash) \
+     VALUES (?1, ?2, ?3, ?4)",
+    /* ... */
+)?;
+let chunk_id = db.last_insert_rowid();
+
+db.execute_sql(
+    "INSERT INTO search_content (agent_id, content, source_type, source_id) \
+     VALUES (?1, ?2, 'kg_chunk', ?3)",
+    /* ... */
+)?;
+```
+
+This looked right — the two tables touched by a `kg_chunk` ingest were both populated. But Path C (semantic via chunks) calls `hybrid_search(source_type="kg_chunk")`, which joins `fts_search` (FTS5 virtual table) back to `search_content`. The raw insert skipped `fts_search`, so no chunk was retrievable via Path C.
+
+The scenarios still passed because the assertions were lenient enough that Path A (direct domain entity LIKE match) or Path B (subject entity LIKE match) could satisfy them. Path C was dead on the seed data — not in the production code. A prompt or ranking change that actually broke Path C would not have been caught.
+
+## Guidance
+
+**1. Route fixture seeds through the same public API the production code uses.** The `kg_chunks` write path in `lexical_ingestor.rs` calls `Database::index_content(agent_id, KG_CHUNK_SOURCE_TYPE, Some(chunk_id), text)` inside a transaction. That one call updates `search_content`, `fts_search`, and — when embeddings arrive — `vec_search`. A fixture that bypasses it silently drops whichever indexes it doesn't replicate by hand. The fix is one line:
+
+```rust
+db.index_content(
+    &agent_id,
+    mika_agent::db::kg_schema::KG_CHUNK_SOURCE_TYPE,
+    Some(chunk_id),
+    &text,
+)?;
+```
+
+Now `search_content` and `fts_search` stay in parity on seed, matching the transactional double-write invariant that `kg_schema.rs` declares as hard.
+
+**2. Assume every table with a non-obvious sidecar has a dual-write invariant.** FTS5 virtual tables, `vec0` virtual tables, materialized views, trigger-maintained summary rows — all of these have a second write that a raw `INSERT` will skip. Grep for `fts_search`, `vec_search`, or `CREATE TRIGGER` near the target table before writing a fixture. If a single write method (`Database::index_content`, `Database::delete_search_content`) encapsulates the invariant, use it from the fixture too.
+
+**3. Tighten scenario assertions so only the target path can satisfy them.** If a Path C scenario asserts "entity `skill:self-dev` appears in results", Path A will satisfy it whenever a domain entity with that name exists. To actually test Path C, either (a) omit the matching-name domain/subject entity so Path A and B yield nothing, or (b) discriminate on `hop`, `layer`, `entry_method`, or a confidence signature that only Path C produces. The rule: **when a test has multiple valid code paths that could satisfy its assertions, the test doesn't discriminate between them.**
+
+**4. Pin fixture modules to a schema version with an actionable failure message.** `kg_fixtures/mod.rs` asserts `PINNED_SCHEMA_VERSION == 25` at scenario setup and fails with a message naming the files to update and the plan's D5 section. On schema advance, the fixture breaks loudly, not silently — the next author has a checklist, not a mystery.
+
+## Why This Matters
+
+Silent fixture bugs in integration tests are worse than red tests. A red test gets fixed; a green-but-vacuous test rots until someone notices production is wrong. The CI signal is green, the regression gate thinks the path is covered, and the code you believed you were exercising isn't running.
+
+Structural lesson: **the invariants a code path depends on are part of the code path.** A fixture that bypasses the invariants doesn't reproduce the path — it reproduces a different path that happens to share a name. The only way to be sure a test exercises the real path is to write the fixture through the same API production writes through.
+
+Adjacent failure mode: hybrid / multi-path retrieval systems (Path A ∪ Path B ∪ Path C merged by union, FTS ∪ vector merged by RRF, etc.) paper over a broken individual path whenever another path also satisfies the assertion. Tighten the assertions, or shape the fixture so only one path can produce the asserted result.
+
+## When to Apply
+
+- Adding new helpers to `crates/mika-agent/tests/eval/kg_fixtures/` or any crate-shared fixture module
+- Authoring scenarios under `tests/eval/kg_self_knowledge/` or `tests/eval/grounding/` (future #741)
+- Writing integration tests that exercise Layer 3 hybrid search, RRF ranking, or any code that joins an FTS5/vec0 sidecar back to `search_content`
+- Reviewing PRs that add raw `INSERT INTO kg_*`, `INSERT INTO search_content`, or `INSERT INTO fts_search` outside of `Database` methods
+- Writing fixtures for dual-written tables in new subsystems (if the write path's doc comment says "dual" or "index", route the fixture through it)
+
+## Examples
+
+**Wrong — raw insert skips `fts_search`, masks Path C failures:**
+
+```rust
+pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
+    db.with_db(move |db| {
+        db.execute_sql("INSERT INTO kg_chunks ...", /* ... */)?;
+        let chunk_id = db.last_insert_rowid();
+        // BUG: writes search_content but bypasses fts_search.
+        // hybrid_search(source_type="kg_chunk") never finds this chunk.
+        db.execute_sql(
+            "INSERT INTO search_content (agent_id, content, source_type, source_id) \
+             VALUES (?1, ?2, 'kg_chunk', ?3)",
+            /* ... */,
+        )?;
+        Ok(chunk_id)
+    }).await.unwrap()
+}
+```
+
+**Right — route through `Database::index_content`, the canonical write path:**
+
+```rust
+pub async fn seed_chunk(db: &AsyncDatabase, spec: &ChunkSpec) -> i64 {
+    db.with_db(move |db| {
+        db.execute_sql("INSERT INTO kg_chunks ...", /* ... */)?;
+        let chunk_id = db.last_insert_rowid();
+        // Canonical path: updates search_content + fts_search in one call,
+        // mirrors lexical_ingestor.rs:309-335.
+        db.index_content(
+            &agent_id,
+            mika_agent::db::kg_schema::KG_CHUNK_SOURCE_TYPE,
+            Some(chunk_id),
+            &text,
+        )?;
+        Ok(chunk_id)
+    }).await.unwrap()
+}
+```
+
+**Right — scenario that discriminates Path C from A/B by construction:**
+
+```rust
+// Seed ONLY a chunk + subject with a discovered type (no domain counterpart).
+// Path A is dead (no matching domain entity), Path B yields only subject layer.
+// A Path C hit via FTS5 on the chunk text is the only way this assertion passes.
+seed_subject_entity(&db, &SubjectEntitySpec {
+    entity_type: "solution_path",
+    name: "webhook-ci-handler",
+    confidence: 0.88,
+    properties_json: None,
+}).await;
+let chunk_id = seed_chunk(&db, &ChunkSpec { /* text mentioning webhook-ci-handler */ }).await;
+seed_chunk_subject(&db, chunk_id, subject_id).await;
+
+let entry = result.entries.iter()
+    .find(|e| e.entity_key == "solution_path:webhook-ci-handler")
+    .expect("Path C must find the subject via chunk");
+assert_eq!(entry.layer, "subject");
+```
+
+## References
+
+- `crates/mika-agent/tests/eval/kg_fixtures/mod.rs` — fixture module
+- `crates/mika-agent/src/kg/lexical_ingestor.rs:309-335` — production write path
+- `crates/mika-agent/src/db.rs` — `index_content`, `hybrid_search`, `fts_search`, `vec_search_internal`
+- `crates/mika-agent/src/db/kg_schema.rs` — dual-write invariant
+- PR #758 / commit `bab112a7` — the fix
+- mika#740 — KG-backed self-knowledge eval scenarios


### PR DESCRIPTION
Closes #740

## Summary

Seven eval scenarios exercising the KG-backed self-knowledge surface that milestone #14 shipped (`#692` / PR #733) but milestone #16 had no coverage for. Each scenario seeds a known KG state and asserts specific query/resolver behaviors, so a prompt or model change that silently degrades KG utilization fails loudly instead of waiting for a user to hit fabrication.

Scenarios (one file each under `crates/mika-agent/tests/eval/kg_self_knowledge/`):

1. `tool_selection_query_knowledge_graph` — agent invokes `query_knowledge_graph` before claiming capability state (routing between structured KG query and `get_documentation`)
2. `path_a_direct_domain_match` — Path A domain entity match, `hop=0`, entry_method `direct_entity_key`
3. `path_b_subject_match_agent_scoped` — Path B subject match, paired success + `starting_entity_missing` under agent isolation
4. `path_c_semantic_via_chunks` — Path C chunk→subject→domain bridge (paired: with resolution = domain hit, without = subject-only)
5. `stage_1_exact_match` — resolver Stage 1 case-insensitive exact match, confidence = extraction_confidence, plus low-confidence escalation and discovered-type skip
6. `stage_2_llm_disambiguation` — resolver Stage 2 LLM path (synonyms, case-variants, `skipped_no_llm`), confidence = min(extraction, llm)
7. `agent_context_annotation_disabled` — D5 annotate-don't-filter: disabled skill returns with `agent_context.enabled=false`, non-skill entities get no annotation, no `agent_id` means no annotation

## Scope

- 4 `pub` test helpers added to `Database` for integration-test fixture seeding: `execute_sql`, `last_insert_rowid`, `query_scalar`, `query_row_2`. Used only by the new `kg_fixtures` module.
- `crates/mika-agent/tests/eval/kg_fixtures/mod.rs` — crate-shared spec-struct seed helpers (`seed_domain_entity`, `seed_domain_relationship`, `seed_subject_entity`, `seed_chunk`, `seed_chunk_subject`, `seed_resolution`, `disable_skill`) pinned to schema v25 via `assert_schema_version()` with an actionable drift message. Also exposes `get_resolution`/`get_resolution_log` read helpers for assertions. Placed crate-shared (not nested under `kg_self_knowledge/`) so `#741` grounding scenarios can import the same helpers — no cargo-cult duplication.
- 7 scenario files + `kg_self_knowledge/README.md` (fixture table, `self-knowledge:*` tag vocabulary with scope boundary to `#741`'s `grounding:*`, capability-×-status matrix, baseline scores) + `crates/mika-agent/CLAUDE.md` "Knowledge Graph — Eval Fixture Seeding (#740)" section.

## Path C fixture invariant

`seed_chunk` routes through `Database::index_content(agent_id, KG_CHUNK_SOURCE_TYPE, Some(chunk_id), text)` inside the same `with_db` closure, mirroring `lexical_ingestor.rs:309-335`. This keeps `search_content`, `fts_search`, and `vec_search` in parity on seed — the transactional double-write invariant `kg_schema.rs` calls out. A raw insert into `search_content` would silently break Path C (hybrid search joins `fts_search` → `search_content`), masking regressions behind Path A/B name matches.

## Verification

```
cargo fmt --all -- --check                       # clean
cargo clippy -p mika-agent --all-targets -- -D warnings  # clean
cargo test -p mika-agent --tests
```

Totals after rebase onto `ba4b7ae8`:
- 2035 lib tests — ok, 0 failed, 2 ignored
- 181 eval tests — ok, 0 failed, 5 ignored
- 3 + 5 + 0 + 0 across smaller test binaries — ok, 0 failed
- 19/19 `kg_self_knowledge` mock-LLM scenarios green, 0 ignored, 0 silently skipped

## Follow-up: real-LLM tier

Integration tier (Stage 2 LLM disambiguation against a real `MIKA_KG_RESOLUTION_MODEL`; Path C with a real embedding client) is deferred. All current scenarios use `MockLlmProvider` or `EvalHarness` scripted responses — zero tests touch a real provider, so no `#[ignore]` gating is needed today. The README's integration-tier command (`-- --ignored`) is a forward-looking hook documented as future work.

Related: #757 (KG extraction idempotency + per-agent fan-out burst) was filed today. It doesn't block this PR but explains why `MIKA_KG_RESOLUTION_MODEL` may be repointed to openrouter during review, and why Path C / Stage 2 integration tiers stay deferred for now.

## Note

This branch was rescued from a stalled claude-pilot session that couldn't run `cargo`/`git`/`gh` because the mika-relay bug was live. Relay fix shipped as #752 / PR #756 (merge commit `ba4b7ae8`) and verified live before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)