### PR TITLE
fix(kg): extraction idempotency + budget guard + fan-out advisories (#757)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,12 +35,21 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_BRAVE_API_KEY=BSA...
 
 # ── Knowledge Graph LLM (optional) ──
-# Shared fallback model for KG extraction and resolution. Format: provider/model
-# MIKA_KG_INGESTION_MODEL=anthropic/claude-haiku-4-5-20251001
+# Shared fallback model for KG extraction and resolution. Format: provider/model.
+# OpenRouter is recommended — Anthropic direct is typically ~10× more expensive
+# for bulk NER and will trigger a WARN (kg_anthropic_provider) at startup.
+# MIKA_KG_INGESTION_MODEL=openrouter/deepseek/deepseek-v3
 # Model for NER + fact-triple extraction (#690). Falls back to KG_INGESTION_MODEL.
-# MIKA_KG_EXTRACTION_MODEL=anthropic/claude-haiku-4-5-20251001
+# MIKA_KG_EXTRACTION_MODEL=openrouter/deepseek/deepseek-v3
 # Model for entity resolution disambiguation (#691). Falls back to KG_INGESTION_MODEL.
-# MIKA_KG_RESOLUTION_MODEL=anthropic/claude-haiku-4-5-20251001
+# Mid-tier model recommended for better judgment on ambiguous matches.
+# MIKA_KG_RESOLUTION_MODEL=openrouter/anthropic/claude-haiku-4-5
+
+# Per-batch LLM call cap on KG startup extraction and resolution (#757). Default: 500.
+# Worst-case per-startup cost is 2 × N_agents × MIKA_KG_BATCH_BUDGET (extraction +
+# resolution batches, one each per agent). Overflow emits a WARN (kg_budget_exhausted)
+# and leaves remaining work for the next restart. `0` disables the phase entirely.
+# MIKA_KG_BATCH_BUDGET=500
 
 # ── Provider Selection ──
 # Set in config.toml (not here): llm_provider = "anthropic"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - **Grounding rule:** The system prompt prohibits the agent from claiming downstream system state unless a tool result confirms it. Reinforced in `format_callback_framing` and `SilentTrigger::Callback`.
 - **Confirmation before action:** The system prompt instructs the agent to answer informational questions directly without starting multi-step workflows.
 - **Context priority:** current user message > core memory > active skill context > conversation summary > conversation history > search results. See `docs/memory-classification.md`.
-- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v25. See `crates/mika-agent/CLAUDE.md` for schema details.
+- **Database:** Case-insensitive COLLATE NOCASE on unique text columns. Schema v26. See `crates/mika-agent/CLAUDE.md` for schema details.
 - **Secrets:** All API keys and tokens in `Settings` use `secrecy::SecretString` (`Option<SecretString>`) for compile-time exposure safety and zeroize-on-drop. Secrets are exposed at the `Settings` accessor boundary (e.g., `provider_fields()`, `agent_github_token()`) via `.expose_secret()` — downstream types use plain `String`/`&str`. `Settings` has manual `Debug` impl that redacts all secret fields. `get_effective_value()` returns `"[SET]"` for secret-flagged fields (never raw values). Exec handler executor scrubs all MIKA_* env vars from child processes. MCP child processes use `env_clear()` + allowlist. Git subprocesses scrub MIKA_* vars and set `GIT_TERMINAL_PROMPT=0`.
 - **Labels:** `.github/labels.yml` is the canonical label taxonomy (type, priority, component). All issue-creation paths reference it.
 - **Async DB:** `AsyncDatabase` wraps sync `Database` with dedicated OS thread + `sync_channel(512)` mpsc channel (closure-based dispatch). Clone-able, Send+Sync. `with_db` releases the mutex before calling `send()` to avoid deadlocks.
@@ -112,9 +112,19 @@ Optional (web search):
 - `MIKA_BRAVE_API_KEY` — Brave Search API key for `web_search` builtin skill (get free key at https://brave.com/search/api/)
 
 Optional (Knowledge Graph LLM):
-- `MIKA_KG_INGESTION_MODEL` — Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled.
+- `MIKA_KG_INGESTION_MODEL` — Shared fallback model for KG extraction and resolution. Format: `provider/model`. **OpenRouter is recommended** — Anthropic direct is ~10× more expensive for bulk NER and triggers a `kg_anthropic_provider` WARN at startup. Example: `openrouter/deepseek/deepseek-v3`. If unset, KG features requiring LLM calls are disabled.
 - `MIKA_KG_EXTRACTION_MODEL` — Model for NER + fact-triple extraction (#690). Falls back to `MIKA_KG_INGESTION_MODEL` if unset. Task is mechanical JSON extraction — cheap/fast tier recommended.
 - `MIKA_KG_RESOLUTION_MODEL` — Model for entity resolution disambiguation (#691). Falls back to `MIKA_KG_INGESTION_MODEL` if unset. Mid-tier model recommended for better judgment on ambiguous matches.
+- `MIKA_KG_BATCH_BUDGET` — Per-batch LLM call cap on KG startup extraction and resolution (#757). Default `500`. Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch, one of each per agent). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely. Extraction idempotency (see `crates/mika-agent/src/db/kg_schema.rs` → **Idempotency key**) keeps the second and subsequent restarts free of extraction calls once marker rows are populated.
+
+### Post-restart safety check (#757)
+
+After KG-related deploys, four signals tell you the fix is working. The second restart after deploy is the steady-state signal — the first restart backfills NULL `source_doc_hash` rows from v26 under the budget.
+
+- **Signal A — extraction not re-running.** `grep subject_extraction_start server.log | jq 'select(.pending_docs == 0)'` should list every agent by the second post-deploy restart. Note: does NOT imply resolver is caught up — see Signal C.
+- **Signal B — budget not exhausted.** `grep kg_budget_exhausted server.log` returns zero lines on a healthy restart.
+- **Signal C — resolver backlog drains over time.** `SELECT agent_id, COUNT(*) FROM kg_subject_entities se WHERE NOT EXISTS (SELECT 1 FROM kg_resolutions_log rl WHERE rl.agent_id = se.agent_id AND rl.subject_entity_id = se.id) GROUP BY agent_id;` → count trends to 0 across restarts (bounded by per-restart budget). May take multiple restart cycles for agents starting > 3,000 pending.
+- **Signal D — concrete cost prediction.** With OpenRouter configured, expect ~`N_agents × budget` resolution LLM calls on the first restart + ~0 extraction calls. At OpenRouter cheap-tier pricing (~\$0.0001/call) that's **\$0.05–\$0.50 per restart** until the backlog drains. Substantially more than \$1 per restart indicates budget-guard failure, stale idempotency, or provider routing regression.
 
 Optional (GitHub App — preferred over PAT for agent operations):
 - `MIKA_GITHUB_APP_ID` — GitHub App ID (u64). Required for GitHub App authentication.

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -186,7 +186,9 @@ See `tests/eval/golden/README.md` for author-facing guidance (fixture patterns, 
 
 **Re-extraction (D5):** Three-phase capture → reingest → reconcile. `IngestionOrchestrator` (`src/kg/ingestion_orchestrator.rs`) coordinates #689 and #690 — neither module calls the other directly. Scoped orphan sweep deletes entities/relationships that lost all provenance after doc change.
 
-**Pending-doc detection (D7):** `kg_extractions` tracking table — one row per (agent_id, source_doc_path) recording completed extraction. Pending query: docs with `kg_chunks` rows but no `kg_extractions` row.
+**Pending-doc detection (D7 + #757 hash check):** `kg_extractions` tracking table with `UNIQUE(agent_id, source_doc_path)` and a `source_doc_hash TEXT` column (nullable, added in v26). A doc is pending when it either has no `kg_extractions` row OR `kg_extractions.source_doc_hash != kg_chunks.source_doc_hash` — direct equality, no aggregation, because the lexical ingestor writes one identical per-doc hash across every chunk row. See `src/db/kg_schema.rs` for the full idempotency contract.
+
+**Budget guard (#757):** `extract_pending(budget: u32)` caps per-batch LLM calls. `budget == 0` short-circuits with zero calls. On overflow, emits `kg_budget_exhausted` WARN with `scope="extraction"` and leaves remaining docs pending. Stats carry `aborted_budget: bool` + `llm_calls: u32`. Default budget: `MIKA_KG_BATCH_BUDGET` (500).
 
 **LLM policy (C2):** Model from `MIKA_KG_EXTRACTION_MODEL` → `MIKA_KG_INGESTION_MODEL` fallback. Retry taxonomy per C2.2 (transport: 3 attempts with backoff; semantic: one retry with prompt reinforcement; config: no retry). Log-and-skip per C2.3. `llm_calls` rows per C2.4. Audit events per C3.3.
 
@@ -201,6 +203,8 @@ See `tests/eval/golden/README.md` for author-facing guidance (fixture patterns, 
 **Execution contexts (D5):** (1) Startup: background `tokio::spawn` per agent after extraction tasks, non-blocking. (2) Compound hook: `IngestionOrchestrator` spawns async resolution after extraction commits. (3) `resolve_pending()` catches entities missed by either path.
 
 **Pending-entity detection (D4):** `kg_resolutions_log` tracking table with `UNIQUE(agent_id, subject_entity_id)`. Pending query: subject entities with well-known types that have no log row, or whose `source_extraction_trace_id` differs from the latest `kg_chunk_subjects` extraction.
+
+**Budget guard (#757):** `resolve_pending(budget: u32)` caps per-batch **Stage-2** LLM disambiguation calls. Stage-1 exact matches cost no LLM calls and are NOT debited against the budget — even `budget=0` lets exact matches resolve. On overflow, emits `kg_budget_exhausted` WARN with `scope="resolution"` and the remaining entities stay pending (no `kg_resolutions_log` row written). Stats carry `aborted_budget: bool` + `llm_calls: u32`. Default budget: `MIKA_KG_BATCH_BUDGET` (500).
 
 **LLM policy (C2):** Model from `MIKA_KG_RESOLUTION_MODEL` → `MIKA_KG_INGESTION_MODEL` fallback. Mid-tier model recommended. Same C2.2 retry taxonomy as extraction. `no_match` is a first-class LLM response (not an error). `llm_calls` rows per C2.4. Per-batch audit events per C3.3.
 
@@ -228,7 +232,7 @@ Results merged, deduped by `(layer, entity_id)` keeping highest confidence, top-
 
 ## Knowledge Graph — Eval Fixture Seeding (#740)
 
-`tests/eval/kg_fixtures/mod.rs` — crate-shared helpers for seeding a known KG state into a test `AsyncDatabase`. Used by `#740` (self-knowledge scenarios) and available for `#741` (grounding scenarios). Schema pin lives in the module (currently v25) with an actionable assertion message on drift.
+`tests/eval/kg_fixtures/mod.rs` — crate-shared helpers for seeding a known KG state into a test `AsyncDatabase`. Used by `#740` (self-knowledge scenarios) and available for `#741` (grounding scenarios). Schema pin lives in the module (currently v26) with an actionable assertion message on drift.
 
 **Spec-struct pattern.** Each seed helper takes a `*Spec` struct and returns the inserted row ID: `seed_domain_entity`, `seed_domain_relationship`, `seed_subject_entity`, `seed_chunk`, `seed_chunk_subject`, `seed_resolution`, `disable_skill`. Query helpers (`get_resolution_log`, `get_resolution`) read rows back for assertions.
 
@@ -302,7 +306,7 @@ All SQLite timestamp columns use ISO 8601 TEXT format (`%Y-%m-%dT%H:%M:%SZ`). Th
 
 ## Schema Version
 
-**Current: v25.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides (with `enabled` column for DB-backed disable state), tasks (with manual/callback/a2a trigger types and a `type` column distinguishing `issue`/`milestone`/`project`), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs, kg_entities, kg_relationships, kg_chunks, kg_subject_entities, kg_subject_relationships, kg_chunk_subjects, kg_chunk_subject_relationships, kg_extractions, kg_subject_resolutions, kg_resolutions_log. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
+**Current: v26.** Tables: sessions, messages (with `internal` flag for agent-to-agent visibility), team_workspace, audit_events, skill_overrides (with `enabled` column for DB-backed disable state), tasks (with manual/callback/a2a trigger types and a `type` column distinguishing `issue`/`milestone`/`project`), a2a_task_map, a2a_artifacts, a2a_push_notification_configs, llm_calls, tool_calls, team_runs, kg_entities, kg_relationships, kg_chunks, kg_subject_entities, kg_subject_relationships, kg_chunk_subjects, kg_chunk_subject_relationships, kg_extractions (with `source_doc_hash` for content-aware idempotency), kg_subject_resolutions, kg_resolutions_log. `unified_timeline` VIEW for cross-subsystem queries. Session-based message storage with FK. System sessions (`system-{agent_id}`) for compaction.
 
 Recent migrations:
 - v18->v19: `sessions.task_id` column for reverse session->task lookups. `get_sessions_for_task_tree()`.
@@ -312,5 +316,6 @@ Recent migrations:
 - v22->v23: `tasks.type` column (`TEXT NOT NULL DEFAULT 'issue' CHECK (type IN ('issue', 'milestone', 'project'))`). Foundational for milestone/project dispatch (mika#595): `create_task` accepts an optional `type` parameter; `list_tasks` and `check_task` surface it. mika core stays a dumb task store — orchestration logic lives in self-dev (mika-skills#149). `NewTask.r#type: Option<String>` defaults to `'issue'` via SQL DEFAULT when `None`. Constants: `TASK_TYPE_ISSUE`/`TASK_TYPE_MILESTONE`/`TASK_TYPE_PROJECT`/`VALID_TASK_TYPES` in `db.rs`.
 - v23->v24: `skill_overrides.enabled` column (`INTEGER`, nullable tri-state). `NULL` = default (enabled), `0` = disabled, `1` = explicitly enabled. Replaces `.disabled` marker files (#629). `SkillOverride.enabled: Option<bool>`. `set_skill_enabled()` with default-equals-delete (row deleted when all columns are NULL). `apply_overrides()` evicts disabled skills from `SkillRegistry.entries` into `disabled: Vec<DisabledSkill>`. One-shot `migrate_disabled_markers()` converts legacy `.disabled` marker files to DB rows at startup (fail-open on marker removal).
 - v24->v25: Knowledge graph tables. Domain layer: `kg_entities`, `kg_relationships`. Lexical layer: `kg_chunks` + `search_content` integration. Subject layer: `kg_subject_entities`, `kg_subject_relationships`, provenance tables (`kg_chunk_subjects`, `kg_chunk_subject_relationships`), `kg_extractions` tracking. Resolution layer (#691): `kg_subject_resolutions` (subject → domain edges with confidence, UNIQUE on agent_id+subject_entity_id+domain_entity_id), `kg_resolutions_log` (resolution tracking with outcome CHECK constraint, UNIQUE on agent_id+subject_entity_id).
+- v25->v26: `kg_extractions.source_doc_hash TEXT` (nullable) for #757 extraction idempotency. Pending-doc query now compares the stored hash against `kg_chunks.source_doc_hash` directly; pre-v26 rows get NULL and re-extract once under the budget before populating. Additive-nullable; no backfill needed. See `src/db/kg_schema.rs` → **Idempotency key** for the full contract.
 
 Full migration history: see `docs/runtime-structure.md`.

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -348,8 +348,10 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `embedding_model` | `String` | `text-embedding-3-small` | `MIKA_EMBEDDING_MODEL` | OpenAI embedding model ID. |
 | `embedding_dimensions` | `u32` | `512` | `MIKA_EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `brave_api_key` | `Option<String>` | None | `MIKA_BRAVE_API_KEY` | Brave Search API key for `web_search` builtin skill. Get a free key at https://brave.com/search/api/. |
-| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled. |
+| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model`. OpenRouter recommended — Anthropic direct is ~10× more expensive for bulk NER and triggers a `kg_anthropic_provider` WARN at startup. If unset, KG features requiring LLM calls are disabled. |
 | `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
+| `kg_resolution_model` | `Option<String>` | None | `MIKA_KG_RESOLUTION_MODEL` | Model for entity resolution disambiguation (#691). Falls back to `kg_ingestion_model` if unset. Mid-tier model recommended for better judgment on ambiguous matches. |
+| `kg_batch_budget` | `Option<u32>` | None (effective default: 500) | `MIKA_KG_BATCH_BUDGET` | Per-batch LLM call cap on KG startup extraction and resolution (#757). Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely (no LLM calls). |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -530,8 +532,10 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |
 | `MIKA_OPENAI_API_KEY` | No | OpenAI API key (LLM + Layer 3 vector search) |
 | `MIKA_BRAVE_API_KEY` | No | Brave Search API key for web search skill |
-| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format) |
+| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format); OpenRouter recommended |
 | `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
+| `MIKA_KG_RESOLUTION_MODEL` | No | KG resolution model (falls back to `MIKA_KG_INGESTION_MODEL`) |
+| `MIKA_KG_BATCH_BUDGET` | No | Per-batch LLM call cap on KG extraction/resolution (#757; default: 500; `0` disables) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/crates/mika-agent/docs/runtime-structure.md
+++ b/crates/mika-agent/docs/runtime-structure.md
@@ -143,7 +143,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20), `enabled INTEGER` (v24). Per-agent overrides: LLM overrides resolve as DB > manifest `[llm]` > agent default (`mika skills llm <name> set <provider>/<model>`). Enabled state is tri-state: `NULL`=default (enabled), `0`=disabled, `1`=explicitly enabled. `enabled=false` evicts the skill from `SkillRegistry.entries` during `apply_overrides()`. Replaces `.disabled` marker files (#629). Default-equals-delete: rows where all columns are NULL are pruned.
 
-### Knowledge Graph Tables (v25)
+### Knowledge Graph Tables (v25; `kg_extractions.source_doc_hash` added v26)
 
 **kg_entities** — `id INTEGER PK AUTO`, `entity_key TEXT UNIQUE`, `type TEXT NOT NULL`, `name TEXT NOT NULL`, `properties_json TEXT`, `created_at TEXT`, `updated_at TEXT`. Domain-layer entities (skill, tool, agent, problem_type). No `agent_id` — global scope.
 
@@ -159,7 +159,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **kg_chunk_subject_relationships** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `chunk_id FK→kg_chunks`, `subject_relationship_id FK→kg_subject_relationships`, `extraction_trace_id TEXT`, `created_at TEXT`. Provenance: which chunk produced which relationship.
 
-**kg_extractions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `source_doc_path TEXT NOT NULL`, `entities_extracted INTEGER`, `relationships_extracted INTEGER`, `extraction_trace_id TEXT`, `model TEXT`, `duration_ms INTEGER`, `created_at TEXT`. Tracking: one row per completed extraction. UNIQUE on `(agent_id, source_doc_path)`.
+**kg_extractions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `source_doc_path TEXT NOT NULL`, `source_doc_hash TEXT` (added v26, #757), `extraction_model TEXT NOT NULL`, `entities_extracted INTEGER`, `relationships_extracted INTEGER`, `extraction_trace_id TEXT`, `created_at TEXT`. Tracking: one row per completed extraction. UNIQUE on `(agent_id, source_doc_path)`. The hash enables content-aware idempotency — the pending-doc query compares the stored hash against `kg_chunks.source_doc_hash` and only re-extracts when they diverge (including the NULL-hash case for pre-v26 rows). Written atomically inside the extraction transaction alongside entity/relationship upserts.
 
 **kg_subject_resolutions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `subject_entity_id FK→kg_subject_entities`, `domain_entity_id FK→kg_entities`, `confidence REAL NOT NULL CHECK(0.0..1.0)`, `trace_id TEXT`, `created_at TEXT`. Resolution edges bridging subject→domain. UNIQUE on `(agent_id, subject_entity_id, domain_entity_id)`. CASCADE on both FKs. Sole writer: `SubjectEntityResolver` (#691).
 

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -24,7 +24,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 25;
+pub const CURRENT_SCHEMA_VERSION: i64 = 26;
 
 /// SQL for the unified_timeline VIEW — cross-subsystem event correlation.
 /// Used in both clean-slate schema creation and incremental migration.
@@ -822,6 +822,10 @@ impl Database {
             self.migrate_v24_to_v25()?;
             info!(version = 25, "database migrated to v25");
         }
+        if (3..=25).contains(&version) {
+            self.migrate_v25_to_v26()?;
+            info!(version = 26, "database migrated to v26");
+        }
         Ok(())
     }
 
@@ -878,7 +882,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (25);
+            INSERT INTO schema_version (version) VALUES (26);
 
             CREATE TABLE agents (
                 id TEXT PRIMARY KEY,
@@ -1366,11 +1370,12 @@ impl Database {
             CREATE INDEX idx_kg_csr_chunk ON kg_chunk_subject_relationships(agent_id, chunk_id);
             CREATE INDEX idx_kg_csr_rel ON kg_chunk_subject_relationships(agent_id, subject_relationship_id);
 
-            -- KG extraction tracking
+            -- KG extraction tracking (source_doc_hash added in v26 — #757)
             CREATE TABLE kg_extractions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
                 source_doc_path TEXT NOT NULL,
+                source_doc_hash TEXT,
                 extraction_model TEXT NOT NULL,
                 entities_extracted INTEGER NOT NULL DEFAULT 0,
                 relationships_extracted INTEGER NOT NULL DEFAULT 0,
@@ -2897,11 +2902,12 @@ impl Database {
                 CREATE INDEX IF NOT EXISTS idx_kg_csr_chunk ON kg_chunk_subject_relationships(agent_id, chunk_id);
                 CREATE INDEX IF NOT EXISTS idx_kg_csr_rel ON kg_chunk_subject_relationships(agent_id, subject_relationship_id);
 
-                -- KG extraction tracking
+                -- KG extraction tracking (source_doc_hash added in v26 — #757)
                 CREATE TABLE IF NOT EXISTS kg_extractions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
                     source_doc_path TEXT NOT NULL,
+                    source_doc_hash TEXT,
                     extraction_model TEXT NOT NULL,
                     entities_extracted INTEGER NOT NULL DEFAULT 0,
                     relationships_extracted INTEGER NOT NULL DEFAULT 0,
@@ -2932,6 +2938,37 @@ impl Database {
                 COMMIT;",
             )
             .context("failed to migrate v24 -> v25 (knowledge graph tables)")?;
+
+        Ok(())
+    }
+
+    /// v25 -> v26: add nullable `source_doc_hash` column to `kg_extractions`
+    /// so the pending-doc query can skip re-extraction when chunk content is
+    /// unchanged (#757). Pre-existing rows get NULL and will re-extract once
+    /// on the next run (bounded by MIKA_KG_BATCH_BUDGET), then populate the
+    /// hash on success so subsequent runs are no-ops.
+    ///
+    /// Idempotent at the migration-chain level (the version gate in
+    /// `run_migrations` prevents re-run); `column_exists` guards the inner
+    /// ALTER against manual invocation.
+    fn migrate_v25_to_v26(&self) -> Result<()> {
+        info!("migrating database schema v25 -> v26 (kg_extractions.source_doc_hash)");
+
+        if !self.column_exists("kg_extractions", "source_doc_hash")? {
+            self.conn
+                .execute_batch(
+                    "BEGIN IMMEDIATE;
+                 ALTER TABLE kg_extractions ADD COLUMN source_doc_hash TEXT;
+                 INSERT INTO schema_version (version) VALUES (26);
+                 COMMIT;",
+                )
+                .context("failed to migrate v25 -> v26 (add kg_extractions.source_doc_hash)")?;
+        } else {
+            // Column already exists (manual re-run in a test / recovery scenario).
+            // Just record the version bump.
+            self.conn
+                .execute("INSERT INTO schema_version (version) VALUES (26)", [])?;
+        }
 
         Ok(())
     }
@@ -10982,14 +11019,14 @@ mod tests {
 
     #[test]
     fn test_v1_and_incremental_schemas_converge() {
-        // DB1: fresh install via migrate_v1 (reaches v25 directly)
+        // DB1: fresh install via migrate_v1 (reaches CURRENT_SCHEMA_VERSION directly).
         let db1 = Database::open_in_memory().unwrap();
         let snap1 = snapshot_schema(&db1.conn);
 
-        // DB2: simulate a v24 DB, then migrate incrementally to v25.
-        // Strategy: create a fresh v25 DB, extract all non-KG DDL from
-        // sqlite_master, replay it on a new connection to get a v24 DB,
-        // then run migrate_v24_to_v25 and compare schemas.
+        // DB2: simulate a v24 DB, then migrate incrementally through v25 and
+        // v26 (#757). Strategy: create a fresh DB, extract all non-KG DDL from
+        // sqlite_master, replay it on a new connection to get a v24 DB, then
+        // run migrate_v24_to_v25 and migrate_v25_to_v26 and compare schemas.
         let fresh = Database::open_in_memory().unwrap();
         let mut stmt = fresh
             .conn
@@ -11050,7 +11087,7 @@ mod tests {
         // Set version to 24 and insert default agent
         conn2
             .execute_batch(
-                "DELETE FROM schema_version WHERE version = 25;
+                "DELETE FROM schema_version WHERE version > 24;
                  INSERT OR IGNORE INTO schema_version (version) VALUES (24);
                  INSERT OR IGNORE INTO agents (id, name, home_dir) VALUES ('mika', 'Mika', '');",
             )
@@ -11069,17 +11106,25 @@ mod tests {
             "kg_entities should not exist at v24"
         );
 
-        // Run incremental migration
+        // Run incremental migrations: v24 -> v25 -> v26
         let db2 = Database { conn: conn2 };
         db2.migrate_v24_to_v25().unwrap();
+        db2.migrate_v25_to_v26().unwrap();
 
-        let v25_version: i64 = db2
+        let final_version: i64 = db2
             .conn
             .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
             .unwrap();
         assert_eq!(
-            v25_version, 25,
-            "DB2 should be at v25 after incremental migration"
+            final_version, CURRENT_SCHEMA_VERSION,
+            "DB2 should be at CURRENT_SCHEMA_VERSION after incremental migrations"
+        );
+
+        // #757: kg_extractions.source_doc_hash must exist after v26 migration.
+        assert!(
+            db2.column_exists("kg_extractions", "source_doc_hash")
+                .unwrap(),
+            "kg_extractions.source_doc_hash should exist after v26 migration"
         );
 
         let snap2 = snapshot_schema(&db2.conn);

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -2902,12 +2902,17 @@ impl Database {
                 CREATE INDEX IF NOT EXISTS idx_kg_csr_chunk ON kg_chunk_subject_relationships(agent_id, chunk_id);
                 CREATE INDEX IF NOT EXISTS idx_kg_csr_rel ON kg_chunk_subject_relationships(agent_id, subject_relationship_id);
 
-                -- KG extraction tracking (source_doc_hash added in v26 — #757)
+                -- KG extraction tracking.
+                -- Historical shape as shipped at v25. `source_doc_hash` is
+                -- added at v26 via ALTER TABLE in migrate_v25_to_v26 (#757);
+                -- keeping migrate_v24_to_v25 as the record of v25's actual
+                -- schema preserves migration immutability and means the
+                -- convergence test exercises the ALTER path rather than
+                -- skipping it.
                 CREATE TABLE IF NOT EXISTS kg_extractions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
                     source_doc_path TEXT NOT NULL,
-                    source_doc_hash TEXT,
                     extraction_model TEXT NOT NULL,
                     entities_extracted INTEGER NOT NULL DEFAULT 0,
                     relationships_extracted INTEGER NOT NULL DEFAULT 0,

--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -36,7 +36,10 @@
 //!   (see D7 in the plan) means re-ingesting the same chunk position uses
 //!   `INSERT OR REPLACE` or explicit UPSERT.
 //! - **Content-hash check:** `source_doc_hash` (SHA-256 of normalized content, D10)
-//!   allows the ingestor to skip re-ingestion when the doc hasn't changed.
+//!   allows the ingestor to skip re-ingestion when the doc hasn't changed. The
+//!   ingestor writes the **same hash on every chunk row of a given doc**, so a
+//!   consumer can read the per-doc hash with `SELECT DISTINCT source_doc_hash
+//!   FROM kg_chunks WHERE agent_id=? AND source_doc_path=?` (exactly one row).
 //! - **Embedding backfill:** Embeddings are generated asynchronously by the existing
 //!   startup backfill path (`embedding_json IS NULL` in `search_content`). The
 //!   `kg_chunk` source_type is automatically included.
@@ -48,6 +51,77 @@
 //! - Chunks (`kg_chunks`): lexical ingestor (#689)
 //! - Subject entities/relationships: subject extractor (#690)
 //! - Resolution edges (`kg_subject_resolutions`): entity resolver (#691)
+//!
+//! ## Idempotency key (extraction, #757)
+//!
+//! Extraction is **whole-doc**: one LLM call per source doc, with `[CHUNK N]`
+//! markers in the prompt (see `subject_extractor::extract_document`). The unit
+//! of idempotency is therefore the doc, not the chunk. This is the deliberate
+//! interpretation of AC #1 ("skip any `kg_chunks` row that already has rows in
+//! `kg_chunk_subjects`") — chunk-level markers would be structurally redundant
+//! given whole-doc extraction. `kg_chunk_subjects` stays what it has always
+//! been: provenance, not an idempotency marker.
+//!
+//! The idempotency contract is:
+//!
+//! - **Primary key:** `UNIQUE(agent_id, source_doc_path)` on `kg_extractions`.
+//! - **Staleness check (content hash):** `kg_extractions.source_doc_hash` stores
+//!   the per-doc hash the extractor consumed on its last successful run. A doc
+//!   is "pending" when it either has no `kg_extractions` row OR the row's hash
+//!   disagrees with the current `kg_chunks.source_doc_hash` for that doc:
+//!
+//!   ```sql
+//!   SELECT DISTINCT c.source_doc_path
+//!   FROM kg_chunks c
+//!   WHERE c.agent_id = ?1
+//!     AND NOT EXISTS (
+//!       SELECT 1 FROM kg_extractions e
+//!       WHERE e.agent_id        = c.agent_id
+//!         AND e.source_doc_path = c.source_doc_path
+//!         AND e.source_doc_hash = c.source_doc_hash
+//!     )
+//!   ```
+//!
+//!   The direct hash equality works because the lexical ingestor writes one
+//!   identical per-doc hash across every chunk row (#689). No aggregation
+//!   needed.
+//! - **NULL-hash first boot:** Pre-v26 rows (if any, from the v25 landing)
+//!   have `source_doc_hash IS NULL`. The equality fails, so the doc is treated
+//!   as pending exactly once. After that run, the hash is populated and
+//!   subsequent runs are no-ops. The first-run cost is bounded by
+//!   `MIKA_KG_BATCH_BUDGET` (default 500).
+//!
+//! ## Fan-out cost model (per-agent scaling, #757)
+//!
+//! Subject, chunk, and resolution tables are **agent-scoped by schema design**:
+//! `kg_chunks`, `kg_subject_entities`, `kg_subject_relationships`,
+//! `kg_chunk_subjects`, `kg_chunk_subject_relationships`, `kg_extractions`,
+//! `kg_subject_resolutions`, and `kg_resolutions_log` all carry an `agent_id`.
+//! Only the domain layer (`kg_entities`, `kg_relationships`) is shared.
+//!
+//! When multiple agents share the same `docs_root`, this intentional isolation
+//! multiplies cost: the same source doc is extracted N times (once per agent)
+//! and every extracted subject entity is resolved N times. With 11 agents and
+//! 283 docs, that is ~3,113 extraction LLM calls per full startup plus a
+//! per-entity resolution multiplier on top.
+//!
+//! Guidance:
+//!
+//! - **Separate agents** when their subject graphs should diverge (research
+//!   personas, customers with distinct knowledge bases). Accept the N× cost.
+//! - **One agent** when agents should see the same corpus identically
+//!   (workspace tooling, on-call helpers). Extract once; avoid the multiplier.
+//! - **Budget guard (`MIKA_KG_BATCH_BUDGET`, default 500).** Hard cap on LLM
+//!   calls per extraction batch and per resolution batch. Worst-case cost per
+//!   startup is `2 × N_agents × budget` (extraction + resolution).
+//! - **Provider choice matters.** Anthropic is typically ~10× more expensive
+//!   than OpenRouter equivalents for bulk NER. The server emits a
+//!   `kg_anthropic_provider` WARN at startup when KG resolves to Anthropic so
+//!   the cost is visible before it accrues.
+//!
+//! Option (a) from the #757 plan — shared extraction across agents with the
+//! same `docs_root` — is a schema-level redesign (subject/chunk tables would
+//! become per-docs_root with per-agent views) and is out of scope here.
 
 /// Column list for `kg_entities` queries. No `SELECT *`.
 pub const KG_ENTITY_COLUMNS: &str =
@@ -81,7 +155,10 @@ pub const KG_CHUNK_SUBJECT_RELATIONSHIP_COLUMNS: &str =
     "id, agent_id, chunk_id, subject_relationship_id, extraction_trace_id, created_at";
 
 /// Column list for `kg_extractions` queries. No `SELECT *`.
-pub const KG_EXTRACTION_COLUMNS: &str = "id, agent_id, source_doc_path, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id, created_at";
+///
+/// `source_doc_hash` was added in v26 (#757). NULL for pre-v26 rows; populated
+/// on subsequent successful extractions to enable hash-equality idempotency.
+pub const KG_EXTRACTION_COLUMNS: &str = "id, agent_id, source_doc_path, source_doc_hash, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id, created_at";
 
 /// Column list for `kg_resolutions_log` queries. No `SELECT *`.
 pub const KG_RESOLUTION_LOG_COLUMNS: &str = "id, agent_id, subject_entity_id, outcome, resolution_trace_id, source_extraction_trace_id, model, duration_ms, resolved_at";

--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -56,11 +56,11 @@
 //!
 //! Extraction is **whole-doc**: one LLM call per source doc, with `[CHUNK N]`
 //! markers in the prompt (see `subject_extractor::extract_document`). The unit
-//! of idempotency is therefore the doc, not the chunk. This is the deliberate
-//! interpretation of AC #1 ("skip any `kg_chunks` row that already has rows in
-//! `kg_chunk_subjects`") — chunk-level markers would be structurally redundant
-//! given whole-doc extraction. `kg_chunk_subjects` stays what it has always
-//! been: provenance, not an idempotency marker.
+//! of idempotency is therefore the doc, not the chunk. `kg_chunk_subjects`
+//! is provenance data (which chunks mentioned which subject entities), not an
+//! idempotency marker — per-chunk markers would be structurally redundant
+//! given whole-doc extraction. See the #757 plan for the alternatives
+//! considered.
 //!
 //! The idempotency contract is:
 //!

--- a/crates/mika-agent/src/kg/entity_resolver.rs
+++ b/crates/mika-agent/src/kg/entity_resolver.rs
@@ -289,8 +289,11 @@ impl SubjectEntityResolver {
         for (i, entity) in entities.iter().enumerate() {
             // Stage-2 budget guard: would we call the LLM if needed?
             // `llm_call_allowed = false` tells resolve_single_entity to
-            // short-circuit before a Stage-2 call. Pre-budget-exhaustion
-            // Stage-1 exact matches still process for free.
+            // short-circuit before a Stage-2 call with `SkippedBudget`.
+            // Stage-1 exact matches still process for free even when the
+            // budget is exhausted — they cost no LLM calls, so skipping
+            // remaining entities when one needs Stage-2 would defer free
+            // work (#757 review finding P1).
             let llm_call_allowed = stats.llm_calls < budget;
 
             let extraction_trace_id = trace_lookup(entity.id);
@@ -302,22 +305,25 @@ impl SubjectEntityResolver {
                 stats.llm_calls = stats.llm_calls.saturating_add(1);
             }
 
-            // If the entity was skipped because the budget prevented a
-            // Stage-2 call, stop the batch here — subsequent entities would
-            // also need LLM calls and we've committed to aborting cleanly.
+            // If the budget prevented a Stage-2 call, record the abort once
+            // and continue — remaining entities may still resolve via Stage-1
+            // exact match for free. Entities that return SkippedBudget leave
+            // no `kg_resolutions_log` row, so they stay pending for next run.
             if matches!(result, ResolutionResult::SkippedBudget) {
-                stats.aborted_budget = true;
-                warn!(
-                    trace_id = %self.trace_id,
-                    agent_id = %agent_id,
-                    scope = "resolution",
-                    calls_made = stats.llm_calls,
-                    budget = budget,
-                    remaining = entities.len() - i,
-                    event = "kg_budget_exhausted",
-                    "resolution hit per-batch LLM call cap — remaining entities stay pending for next run"
-                );
-                break;
+                if !stats.aborted_budget {
+                    stats.aborted_budget = true;
+                    warn!(
+                        trace_id = %self.trace_id,
+                        agent_id = %agent_id,
+                        scope = "resolution",
+                        calls_made = stats.llm_calls,
+                        budget = budget,
+                        remaining = entities.len() - i,
+                        event = "kg_budget_exhausted",
+                        "resolution hit per-batch LLM call cap — entities needing LLM disambiguation stay pending; Stage-1 exact matches still proceed"
+                    );
+                }
+                continue;
             }
 
             self.apply_result(

--- a/crates/mika-agent/src/kg/entity_resolver.rs
+++ b/crates/mika-agent/src/kg/entity_resolver.rs
@@ -108,6 +108,8 @@ enum ResolutionResult {
     SkippedDiscoveredType,
     /// No LLM configured and exact match failed.
     SkippedNoLlm,
+    /// Per-batch LLM budget exhausted — entity stays pending for next run (#757).
+    SkippedBudget,
     /// Error during resolution.
     Error(String),
 }
@@ -123,6 +125,12 @@ pub struct ResolutionStats {
     pub skipped_no_llm: usize,
     pub errors: usize,
     pub duration_ms: u64,
+    /// True when the batch stopped early because the LLM call budget was
+    /// exhausted (#757). Remaining entities stay pending for the next run.
+    pub aborted_budget: bool,
+    /// Number of LLM disambiguation calls made. Stage 1 exact matches do NOT
+    /// debit this counter — only Stage 2 LLM calls.
+    pub llm_calls: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -174,10 +182,16 @@ impl SubjectEntityResolver {
     /// Called as per-doc follow-on after `extract_document()`.
     /// `entity_ids` are the IDs of subject entities to resolve.
     /// `extraction_trace_id` is recorded for staleness tracking.
+    ///
+    /// `budget` caps Stage 2 LLM disambiguation calls (#757). The compound
+    /// hook path is bounded-by-construction (one doc's entities), so callers
+    /// typically pass the configured budget; the cap still defends against a
+    /// pathological single doc that produces thousands of entities.
     pub async fn resolve_doc_entities(
         &self,
         entity_ids: &[i64],
         extraction_trace_id: &str,
+        budget: u32,
     ) -> Result<ResolutionStats> {
         if entity_ids.is_empty() {
             return Ok(ResolutionStats::default());
@@ -186,7 +200,7 @@ impl SubjectEntityResolver {
         let entities = self.get_entities_by_ids(entity_ids).await?;
         let trace_lookup = |_id: i64| extraction_trace_id.to_owned();
         let stats = self
-            .resolve_entities(&entities, &trace_lookup, "resolution_doc_complete")
+            .resolve_entities(&entities, &trace_lookup, "resolution_doc_complete", budget)
             .await;
 
         // Emit audit event for the per-doc batch.
@@ -195,8 +209,15 @@ impl SubjectEntityResolver {
         Ok(stats)
     }
 
-    /// Resolve all pending entities for an agent (startup or re-resolution).
-    pub async fn resolve_pending(&self) -> Result<ResolutionStats> {
+    /// Resolve all pending entities for an agent (startup or re-resolution),
+    /// capped by `budget` Stage-2 LLM disambiguation calls (#757 R2).
+    ///
+    /// `budget == 0` short-circuits with no LLM calls. On overflow the method
+    /// aborts cleanly, emits a `kg_budget_exhausted` WARN, and leaves
+    /// remaining entities pending for the next run. Stage-1 exact matches do
+    /// not consume the budget, so entities that resolve without the LLM still
+    /// make progress even when `budget` is tight.
+    pub async fn resolve_pending(&self, budget: u32) -> Result<ResolutionStats> {
         let start = Instant::now();
         let agent_id = self.db.agent_id.clone();
 
@@ -206,6 +227,7 @@ impl SubjectEntityResolver {
             trace_id = %self.trace_id,
             agent_id = %agent_id,
             pending = pending.len(),
+            budget = budget,
             event = "resolution_pending_start",
         );
 
@@ -228,7 +250,12 @@ impl SubjectEntityResolver {
         };
 
         let mut stats = self
-            .resolve_entities(&pending, &trace_lookup, "resolution_pending_complete")
+            .resolve_entities(
+                &pending,
+                &trace_lookup,
+                "resolution_pending_complete",
+                budget,
+            )
             .await;
         stats.duration_ms = start.elapsed().as_millis() as u64;
 
@@ -238,11 +265,17 @@ impl SubjectEntityResolver {
     /// Shared resolution loop for both per-doc and batch paths.
     ///
     /// `trace_lookup` maps entity ID → extraction trace ID for staleness tracking.
+    /// `budget` caps Stage-2 LLM disambiguation calls (#757). Stage-1 exact
+    /// matches do not debit the budget. When the budget is hit, remaining
+    /// entities that would need Stage-2 are left unprocessed — they stay
+    /// pending via the absence of a `kg_resolutions_log` row — and
+    /// `aborted_budget` is set on the returned stats.
     async fn resolve_entities<F>(
         &self,
         entities: &[PendingEntity],
         trace_lookup: &F,
         completion_event: &str,
+        budget: u32,
     ) -> ResolutionStats
     where
         F: Fn(i64) -> String,
@@ -253,11 +286,39 @@ impl SubjectEntityResolver {
             ..Default::default()
         };
 
-        for entity in entities {
+        for (i, entity) in entities.iter().enumerate() {
+            // Stage-2 budget guard: would we call the LLM if needed?
+            // `llm_call_allowed = false` tells resolve_single_entity to
+            // short-circuit before a Stage-2 call. Pre-budget-exhaustion
+            // Stage-1 exact matches still process for free.
+            let llm_call_allowed = stats.llm_calls < budget;
+
             let extraction_trace_id = trace_lookup(entity.id);
             let entity_start = Instant::now();
-            let result = self.resolve_single_entity(entity).await;
+            let (result, used_llm) = self.resolve_single_entity(entity, llm_call_allowed).await;
             let duration_ms = entity_start.elapsed().as_millis() as i64;
+
+            if used_llm {
+                stats.llm_calls = stats.llm_calls.saturating_add(1);
+            }
+
+            // If the entity was skipped because the budget prevented a
+            // Stage-2 call, stop the batch here — subsequent entities would
+            // also need LLM calls and we've committed to aborting cleanly.
+            if matches!(result, ResolutionResult::SkippedBudget) {
+                stats.aborted_budget = true;
+                warn!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    scope = "resolution",
+                    calls_made = stats.llm_calls,
+                    budget = budget,
+                    remaining = entities.len() - i,
+                    event = "kg_budget_exhausted",
+                    "resolution hit per-batch LLM call cap — remaining entities stay pending for next run"
+                );
+                break;
+            }
 
             self.apply_result(
                 entity,
@@ -289,6 +350,8 @@ impl SubjectEntityResolver {
             skipped_discovered = stats.skipped_discovered,
             skipped_no_llm = stats.skipped_no_llm,
             errors = stats.errors,
+            llm_calls = stats.llm_calls,
+            aborted_budget = stats.aborted_budget,
             event = %completion_event,
         );
 
@@ -372,6 +435,11 @@ impl SubjectEntityResolver {
                 .await;
                 stats.skipped_no_llm += 1;
             }
+            ResolutionResult::SkippedBudget => {
+                // Entity stays pending — do NOT write a kg_resolutions_log row.
+                // The outer loop breaks as soon as it sees this variant and
+                // records aborted_budget=true in ResolutionStats (#757).
+            }
             ResolutionResult::Error(_) => {
                 self.write_log(
                     entity.id,
@@ -391,10 +459,24 @@ impl SubjectEntityResolver {
     // -----------------------------------------------------------------------
 
     /// Resolve a single entity through the two-stage pipeline.
-    async fn resolve_single_entity(&self, entity: &PendingEntity) -> ResolutionResult {
+    ///
+    /// Returns `(result, used_llm)`. `used_llm` is `true` iff a Stage-2 LLM
+    /// disambiguation call was actually issued. Stage-1 exact matches and all
+    /// early returns (discovered type, no-LLM mode, DB error) report `false`
+    /// so the caller can debit the per-batch budget correctly (#757).
+    ///
+    /// When `llm_call_allowed = false`, the function short-circuits before a
+    /// Stage-2 call and returns `SkippedBudget`. The caller treats this as
+    /// "entity stays pending; abort the batch." Stage-1 exact matches still
+    /// proceed under this flag — they cost nothing.
+    async fn resolve_single_entity(
+        &self,
+        entity: &PendingEntity,
+        llm_call_allowed: bool,
+    ) -> (ResolutionResult, bool) {
         // D8: Discovered types skip resolution entirely.
         if !KG_DOMAIN_ENTITY_TYPES.contains(&entity.entity_type.as_str()) {
-            return ResolutionResult::SkippedDiscoveredType;
+            return (ResolutionResult::SkippedDiscoveredType, false);
         }
 
         // Stage 1: Exact match (D1).
@@ -402,10 +484,13 @@ impl SubjectEntityResolver {
             Ok(Some(domain)) => {
                 // Exact match found. If extraction confidence > threshold, resolve.
                 if entity.confidence > EXACT_MATCH_CONFIDENCE_THRESHOLD {
-                    return ResolutionResult::ExactMatch {
-                        domain_entity_id: domain.id,
-                        confidence: entity.confidence,
-                    };
+                    return (
+                        ResolutionResult::ExactMatch {
+                            domain_entity_id: domain.id,
+                            confidence: entity.confidence,
+                        },
+                        false,
+                    );
                 }
                 // Low confidence — escalate to LLM for verification.
             }
@@ -413,26 +498,40 @@ impl SubjectEntityResolver {
                 // No exact match — escalate to LLM.
             }
             Err(e) => {
-                return ResolutionResult::Error(format!("exact match query failed: {e}"));
+                return (
+                    ResolutionResult::Error(format!("exact match query failed: {e}")),
+                    false,
+                );
             }
         }
 
         // Stage 2: LLM disambiguation (D1 stage 2).
         let Some(ref llm) = self.llm else {
-            return ResolutionResult::SkippedNoLlm;
+            return (ResolutionResult::SkippedNoLlm, false);
         };
+
+        // #757: respect per-batch budget before issuing the LLM call.
+        if !llm_call_allowed {
+            return (ResolutionResult::SkippedBudget, false);
+        }
 
         match self.disambiguate_with_llm(llm, entity).await {
             Ok(Some((domain_id, llm_confidence))) => {
                 // D2: confidence = min(extraction_confidence, llm_confidence).
                 let combined_confidence = entity.confidence.min(llm_confidence);
-                ResolutionResult::LlmMatch {
-                    domain_entity_id: domain_id,
-                    confidence: combined_confidence,
-                }
+                (
+                    ResolutionResult::LlmMatch {
+                        domain_entity_id: domain_id,
+                        confidence: combined_confidence,
+                    },
+                    true,
+                )
             }
-            Ok(None) => ResolutionResult::NoMatch,
-            Err(e) => ResolutionResult::Error(format!("LLM disambiguation failed: {e}")),
+            Ok(None) => (ResolutionResult::NoMatch, true),
+            Err(e) => (
+                ResolutionResult::Error(format!("LLM disambiguation failed: {e}")),
+                true,
+            ),
         }
     }
 

--- a/crates/mika-agent/src/kg/ingestion_orchestrator.rs
+++ b/crates/mika-agent/src/kg/ingestion_orchestrator.rs
@@ -46,6 +46,11 @@ pub struct IngestionOrchestrator {
     /// LLM provider for entity resolution disambiguation. `None` when
     /// resolution LLM is disabled (exact-match-only mode).
     resolution_llm: Option<Arc<dyn LlmProvider>>,
+    /// Per-batch LLM call budget for Stage-2 resolution (#757). The compound
+    /// hook path is already bounded-by-construction (one doc's entities); the
+    /// budget is defensive against a pathological doc that produces thousands
+    /// of subject entities at once.
+    resolution_budget: u32,
     trace_id: String,
     session_id: String,
 }
@@ -56,11 +61,14 @@ impl IngestionOrchestrator {
     /// - `extraction_llm`: `None` to disable extraction (lexical ingestion
     ///   still runs).
     /// - `resolution_llm`: `None` for exact-match-only resolution mode.
+    /// - `resolution_budget`: per-batch Stage-2 LLM call cap (#757). Callers
+    ///   typically pass `settings.effective_kg_batch_budget()`.
     pub fn new(
         db: AsyncDatabase,
         docs_root: PathBuf,
         extraction_llm: Option<Arc<dyn LlmProvider>>,
         resolution_llm: Option<Arc<dyn LlmProvider>>,
+        resolution_budget: u32,
         trace_id: Option<&str>,
         session_id: Option<&str>,
     ) -> Self {
@@ -72,6 +80,7 @@ impl IngestionOrchestrator {
             docs_root,
             extraction_llm,
             resolution_llm,
+            resolution_budget,
             trace_id,
             session_id: session_id.unwrap_or("compound").to_owned(),
         }
@@ -256,11 +265,12 @@ impl IngestionOrchestrator {
         let trace_id = self.trace_id.clone();
         let agent_id = self.db.agent_id.clone();
         let doc_path = doc_path.to_owned();
+        let budget = self.resolution_budget;
 
         tokio::spawn(async move {
             let resolver = SubjectEntityResolver::new(db, resolution_llm, Some(&trace_id));
 
-            match resolver.resolve_pending().await {
+            match resolver.resolve_pending(budget).await {
                 Ok(stats) => {
                     if stats.matched_exact > 0 || stats.matched_llm > 0 || stats.errors > 0 {
                         info!(

--- a/crates/mika-agent/src/kg/ingestion_orchestrator.rs
+++ b/crates/mika-agent/src/kg/ingestion_orchestrator.rs
@@ -130,15 +130,9 @@ impl IngestionOrchestrator {
 
             match extractor.extract_document(&rel_path, None).await {
                 Ok(stats) => {
-                    // Record extraction so it's not re-extracted at startup.
-                    extractor
-                        .record_extraction_public(
-                            &rel_path,
-                            llm.model_name(),
-                            stats.entities_upserted,
-                            stats.relationships_upserted,
-                        )
-                        .await;
+                    // extract_document writes the kg_extractions marker
+                    // atomically with the extraction results (#757 review P1),
+                    // so no separate record_extraction call is needed here.
 
                     // 3. Spawn async resolution for extracted entities (D5 in #691).
                     // The compound write returns immediately; resolutions appear shortly after.
@@ -215,14 +209,8 @@ impl IngestionOrchestrator {
 
                 match extractor.extract_document(&rel_path, Some(prev)).await {
                     Ok(stats) => {
-                        extractor
-                            .record_extraction_public(
-                                &rel_path,
-                                llm.model_name(),
-                                stats.entities_upserted,
-                                stats.relationships_upserted,
-                            )
-                            .await;
+                        // extract_document writes the kg_extractions marker
+                        // atomically with the extraction results (#757 review P1).
 
                         // Phase 4: Re-resolve entities touched by re-extraction (D6).
                         // Coarse re-resolution — all entities from this doc re-resolve.

--- a/crates/mika-agent/src/kg/subject_extractor.rs
+++ b/crates/mika-agent/src/kg/subject_extractor.rs
@@ -481,9 +481,33 @@ impl SubjectExtractor {
             self.store_llm_call(doc_path, latency_ms, raw_output).await;
         }
 
-        // 7. Write entities, relationships, provenance in single transaction.
+        // Read the per-doc source hash so the idempotency marker can be
+        // written atomically with the extraction results (#757 review P1).
+        // Missing hash is non-fatal — stored as NULL, doc re-extracts once
+        // next run (bounded by budget) and populates on the next success.
+        let source_doc_hash = self.get_doc_hash(doc_path).await.unwrap_or_else(|e| {
+            warn!(
+                trace_id = %self.trace_id,
+                agent_id = %agent_id,
+                doc = %doc_path,
+                error = %e,
+                event = "extraction_doc_hash_read_failed",
+            );
+            None
+        });
+        let model_name = self.llm.model_name().to_string();
+
+        // 7. Write entities, relationships, provenance, and idempotency
+        //    marker in a single transaction.
         let final_stats = self
-            .write_extraction_results(doc_path, &validated, &chunks, previous_state)
+            .write_extraction_results(
+                doc_path,
+                source_doc_hash.as_deref(),
+                &model_name,
+                &validated,
+                &chunks,
+                previous_state,
+            )
             .await
             .with_context(|| format!("failed to write extraction results for {doc_path}"))?;
 
@@ -521,7 +545,6 @@ impl SubjectExtractor {
     pub async fn extract_pending(&self, budget: u32) -> Result<BatchStats> {
         let start = Instant::now();
         let agent_id = self.db.agent_id.clone();
-        let model_name = self.llm.model_name().to_string();
 
         // Query pending docs via kg_extractions tracking table.
         let pending_docs = self.get_pending_docs().await?;
@@ -578,36 +601,15 @@ impl SubjectExtractor {
                 break;
             }
 
-            // Capture the per-doc hash before extraction so we can persist it
-            // alongside the kg_extractions row (#757 R1). If read fails we fall
-            // back to None — extraction still happens; the idempotency marker
-            // will simply re-fire next run (bounded by the budget).
-            let doc_hash = self.get_doc_hash(doc_path).await.unwrap_or_else(|e| {
-                warn!(
-                    trace_id = %self.trace_id,
-                    agent_id = %agent_id,
-                    doc = %doc_path,
-                    error = %e,
-                    event = "extraction_doc_hash_read_failed",
-                );
-                None
-            });
-
+            // extract_document writes the kg_extractions idempotency marker
+            // atomically with the extraction results (#757 review P1). No
+            // separate record_extraction call here — on Err, no marker is
+            // written and the doc stays pending (budget-bounded retry).
             match self.extract_document(doc_path, None).await {
                 Ok(doc_stats) => {
                     stats.docs_extracted += 1;
                     stats.total_entities += doc_stats.entities_upserted;
                     stats.total_relationships += doc_stats.relationships_upserted;
-
-                    // Write kg_extractions tracking row with the hash we consumed.
-                    self.record_extraction(
-                        doc_path,
-                        doc_hash.as_deref(),
-                        &model_name,
-                        doc_stats.entities_upserted,
-                        doc_stats.relationships_upserted,
-                    )
-                    .await;
                 }
                 Err(e) => {
                     stats.docs_failed += 1;
@@ -657,23 +659,6 @@ impl SubjectExtractor {
         );
 
         Ok(stats)
-    }
-
-    /// Public wrapper for `record_extraction` — used by the ingestion
-    /// orchestrator to mark a doc as extracted after compound hook extraction.
-    ///
-    /// Passes `source_doc_hash = None`; the orchestrator calls
-    /// [`Self::get_doc_hash_public`] separately if it needs hash persistence.
-    pub async fn record_extraction_public(
-        &self,
-        doc_path: &str,
-        model: &str,
-        entities: usize,
-        relationships: usize,
-    ) {
-        let hash = self.get_doc_hash(doc_path).await.unwrap_or(None);
-        self.record_extraction(doc_path, hash.as_deref(), model, entities, relationships)
-            .await;
     }
 
     /// Capture previous provenance state before re-ingestion (D5, Phase 1).
@@ -982,16 +967,32 @@ Rules:
         })
     }
 
-    /// Write extraction results to DB in a single transaction (D5).
+    /// Write extraction results to DB in a single transaction (D5 + #757).
+    ///
+    /// The `kg_extractions` idempotency marker is written inside the same
+    /// transaction as the entity/relationship UPSERTs. If any write fails,
+    /// the whole transaction rolls back and the doc remains pending —
+    /// preventing the "LLM paid but no marker written" cascade where a
+    /// pathological doc would burn budget on every restart (#757 review P1).
+    ///
+    /// `source_doc_hash` may be `None` if the chunk-hash read failed; the
+    /// column is nullable. The pending-doc query rejects NULL matches so the
+    /// doc will re-extract once (bounded by the budget) until a real hash is
+    /// written.
     async fn write_extraction_results(
         &self,
-        _doc_path: &str,
+        doc_path: &str,
+        source_doc_hash: Option<&str>,
+        model: &str,
         output: &ExtractionOutput,
         chunks: &[ChunkBoundary],
         previous_state: Option<PreviousState>,
     ) -> Result<ExtractionStats> {
         let agent_id = self.db.agent_id.clone();
         let trace_id = self.trace_id.clone();
+        let doc_path_owned = doc_path.to_owned();
+        let hash_owned = source_doc_hash.map(str::to_owned);
+        let model_owned = model.to_owned();
         let entities = output.entities.clone();
         let relationships = output.relationships.clone();
         let chunk_lookup: HashMap<usize, i64> =
@@ -1147,11 +1148,38 @@ Rules:
                             .iter()
                             .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
                             .collect();
-                        params.push(Box::new(agent_id));
+                        params.push(Box::new(agent_id.clone()));
                         stats.orphans_removed +=
                             stmt.execute(rusqlite::params_from_iter(params))? as usize;
                     }
                 }
+
+                // -- Idempotency marker (#757): written atomically with the
+                // extraction results. A crash or write failure between
+                // writing entities and writing the marker is the cascade
+                // path that burns budget forever; keeping both in one
+                // transaction eliminates that window.
+                tx.execute(
+                    "INSERT INTO kg_extractions
+                        (agent_id, source_doc_path, source_doc_hash, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(agent_id, source_doc_path) DO UPDATE SET
+                        source_doc_hash = excluded.source_doc_hash,
+                        extraction_model = excluded.extraction_model,
+                        entities_extracted = excluded.entities_extracted,
+                        relationships_extracted = excluded.relationships_extracted,
+                        extraction_trace_id = excluded.extraction_trace_id,
+                        created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+                    rusqlite::params![
+                        agent_id,
+                        doc_path_owned,
+                        hash_owned,
+                        model_owned,
+                        stats.entities_upserted as i64,
+                        stats.relationships_upserted as i64,
+                        trace_id,
+                    ],
+                )?;
 
                 tx.commit()?;
                 Ok(stats)
@@ -1219,49 +1247,6 @@ Rules:
                 Ok(hash)
             })
             .await
-    }
-
-    /// Record a successful extraction in kg_extractions (D7 + #757 hash).
-    async fn record_extraction(
-        &self,
-        doc_path: &str,
-        source_doc_hash: Option<&str>,
-        model: &str,
-        entities: usize,
-        relationships: usize,
-    ) {
-        let agent_id = self.db.agent_id.clone();
-        let doc_path_owned = doc_path.to_owned();
-        let hash_owned = source_doc_hash.map(str::to_owned);
-        let model = model.to_owned();
-        let trace_id = self.trace_id.clone();
-
-        if let Err(e) = self
-            .db
-            .with_db(move |db| {
-                db.conn.execute(
-                    "INSERT INTO kg_extractions
-                        (agent_id, source_doc_path, source_doc_hash, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-                     ON CONFLICT(agent_id, source_doc_path) DO UPDATE SET
-                        source_doc_hash = excluded.source_doc_hash,
-                        extraction_model = excluded.extraction_model,
-                        entities_extracted = excluded.entities_extracted,
-                        relationships_extracted = excluded.relationships_extracted,
-                        extraction_trace_id = excluded.extraction_trace_id,
-                        created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
-                    rusqlite::params![agent_id, doc_path_owned, hash_owned, model, entities as i64, relationships as i64, trace_id],
-                )?;
-                Ok(())
-            })
-            .await
-        {
-            warn!(
-                trace_id = %self.trace_id,
-                error = %e,
-                event = "extraction_record_failed",
-            );
-        }
     }
 
     /// Store an llm_calls row (C2.4).

--- a/crates/mika-agent/src/kg/subject_extractor.rs
+++ b/crates/mika-agent/src/kg/subject_extractor.rs
@@ -344,6 +344,13 @@ pub struct BatchStats {
     pub total_entities: usize,
     pub total_relationships: usize,
     pub duration_ms: u64,
+    /// True when the batch stopped early because the LLM call budget was
+    /// exhausted (#757). Remaining docs stay pending for the next run.
+    pub aborted_budget: bool,
+    /// Number of LLM calls made against the budget. A `call` here is one
+    /// `extract_document` invocation (whole-doc extraction). Retries inside
+    /// `call_llm_with_retry` count as the same call for budget purposes.
+    pub llm_calls: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -503,8 +510,15 @@ impl SubjectExtractor {
         })
     }
 
-    /// Enumerate and extract all pending docs for the agent (D7).
-    pub async fn extract_pending(&self) -> Result<BatchStats> {
+    /// Enumerate and extract all pending docs for the agent (D7), capped by
+    /// `budget` LLM calls.
+    ///
+    /// `budget == 0` returns immediately with no LLM calls — the extraction
+    /// phase is effectively disabled for this invocation. On overflow the
+    /// method aborts cleanly, emits a `kg_budget_exhausted` WARN, and leaves
+    /// remaining docs pending for the next run (#757 R2). The aborted flag is
+    /// surfaced via `BatchStats::aborted_budget`.
+    pub async fn extract_pending(&self, budget: u32) -> Result<BatchStats> {
         let start = Instant::now();
         let agent_id = self.db.agent_id.clone();
         let model_name = self.llm.model_name().to_string();
@@ -516,6 +530,7 @@ impl SubjectExtractor {
             trace_id = %self.trace_id,
             agent_id = %agent_id,
             pending_docs = pending_docs.len(),
+            budget = budget,
             event = "subject_extraction_start",
         );
 
@@ -531,16 +546,63 @@ impl SubjectExtractor {
             ..Default::default()
         };
 
+        if budget == 0 {
+            warn!(
+                trace_id = %self.trace_id,
+                agent_id = %agent_id,
+                scope = "extraction",
+                budget = 0,
+                pending_docs = pending_docs.len(),
+                event = "kg_budget_exhausted",
+                "MIKA_KG_BATCH_BUDGET=0 — skipping extraction (all docs stay pending)"
+            );
+            stats.aborted_budget = true;
+            stats.duration_ms = start.elapsed().as_millis() as u64;
+            return Ok(stats);
+        }
+
         for (i, doc_path) in pending_docs.iter().enumerate() {
+            // Budget guard: abort cleanly once we've made `budget` LLM calls.
+            if stats.llm_calls >= budget {
+                warn!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    scope = "extraction",
+                    calls_made = stats.llm_calls,
+                    budget = budget,
+                    remaining = pending_docs.len() - i,
+                    event = "kg_budget_exhausted",
+                    "extraction hit per-batch LLM call cap — remaining docs stay pending for next run"
+                );
+                stats.aborted_budget = true;
+                break;
+            }
+
+            // Capture the per-doc hash before extraction so we can persist it
+            // alongside the kg_extractions row (#757 R1). If read fails we fall
+            // back to None — extraction still happens; the idempotency marker
+            // will simply re-fire next run (bounded by the budget).
+            let doc_hash = self.get_doc_hash(doc_path).await.unwrap_or_else(|e| {
+                warn!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    doc = %doc_path,
+                    error = %e,
+                    event = "extraction_doc_hash_read_failed",
+                );
+                None
+            });
+
             match self.extract_document(doc_path, None).await {
                 Ok(doc_stats) => {
                     stats.docs_extracted += 1;
                     stats.total_entities += doc_stats.entities_upserted;
                     stats.total_relationships += doc_stats.relationships_upserted;
 
-                    // Write kg_extractions tracking row.
+                    // Write kg_extractions tracking row with the hash we consumed.
                     self.record_extraction(
                         doc_path,
+                        doc_hash.as_deref(),
                         &model_name,
                         doc_stats.entities_upserted,
                         doc_stats.relationships_upserted,
@@ -559,6 +621,11 @@ impl SubjectExtractor {
                     );
                 }
             }
+
+            // Every attempted doc debits the budget — a validated-as-empty
+            // extraction still spent an LLM call (C2 retry taxonomy runs
+            // inside extract_document regardless of outcome).
+            stats.llm_calls = stats.llm_calls.saturating_add(1);
 
             // Progress logging every 10 docs.
             if (i + 1) % 10 == 0 {
@@ -583,6 +650,8 @@ impl SubjectExtractor {
             failed = stats.docs_failed,
             entities = stats.total_entities,
             relationships = stats.total_relationships,
+            llm_calls = stats.llm_calls,
+            aborted_budget = stats.aborted_budget,
             duration_ms = stats.duration_ms,
             event = "subject_extraction_complete",
         );
@@ -592,6 +661,9 @@ impl SubjectExtractor {
 
     /// Public wrapper for `record_extraction` — used by the ingestion
     /// orchestrator to mark a doc as extracted after compound hook extraction.
+    ///
+    /// Passes `source_doc_hash = None`; the orchestrator calls
+    /// [`Self::get_doc_hash_public`] separately if it needs hash persistence.
     pub async fn record_extraction_public(
         &self,
         doc_path: &str,
@@ -599,7 +671,8 @@ impl SubjectExtractor {
         entities: usize,
         relationships: usize,
     ) {
-        self.record_extraction(doc_path, model, entities, relationships)
+        let hash = self.get_doc_hash(doc_path).await.unwrap_or(None);
+        self.record_extraction(doc_path, hash.as_deref(), model, entities, relationships)
             .await;
     }
 
@@ -1086,7 +1159,14 @@ Rules:
             .await
     }
 
-    /// Get pending docs (D7 — docs with chunks but no kg_extractions row).
+    /// Get pending docs (D7 + #757 content-hash check).
+    ///
+    /// A doc is pending when it has `kg_chunks` rows but either has no
+    /// `kg_extractions` row, or the row's `source_doc_hash` disagrees with
+    /// the chunk's current `source_doc_hash` (which is per-doc — all chunk
+    /// rows of a given doc share one hash, see `lexical_ingestor`). The
+    /// direct hash-equality predicate catches both the "never extracted"
+    /// and "extracted-but-stale" cases without aggregation.
     async fn get_pending_docs(&self) -> Result<Vec<String>> {
         let agent_id = self.db.agent_id.clone();
 
@@ -1098,7 +1178,9 @@ Rules:
                      WHERE c.agent_id = ?1
                        AND NOT EXISTS (
                          SELECT 1 FROM kg_extractions e
-                         WHERE e.agent_id = c.agent_id AND e.source_doc_path = c.source_doc_path
+                         WHERE e.agent_id        = c.agent_id
+                           AND e.source_doc_path = c.source_doc_path
+                           AND e.source_doc_hash = c.source_doc_hash
                        )
                      ORDER BY c.source_doc_path",
                 )?;
@@ -1111,16 +1193,46 @@ Rules:
             .await
     }
 
-    /// Record a successful extraction in kg_extractions (D7).
+    /// Read the per-doc `source_doc_hash` from `kg_chunks` (#757).
+    ///
+    /// Returns `Ok(None)` when no chunks exist for the doc. Callers treat
+    /// missing-hash as "write NULL into `kg_extractions.source_doc_hash`,"
+    /// which the pending query rejects → the doc re-extracts once next run.
+    async fn get_doc_hash(&self, doc_path: &str) -> Result<Option<String>> {
+        let agent_id = self.db.agent_id.clone();
+        let doc_path = doc_path.to_owned();
+
+        self.db
+            .with_db(move |db| {
+                use rusqlite::OptionalExtension;
+                let hash: Option<String> = db
+                    .conn
+                    .query_row(
+                        "SELECT source_doc_hash
+                         FROM kg_chunks
+                         WHERE agent_id = ?1 AND source_doc_path = ?2
+                         LIMIT 1",
+                        rusqlite::params![agent_id, doc_path],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                Ok(hash)
+            })
+            .await
+    }
+
+    /// Record a successful extraction in kg_extractions (D7 + #757 hash).
     async fn record_extraction(
         &self,
         doc_path: &str,
+        source_doc_hash: Option<&str>,
         model: &str,
         entities: usize,
         relationships: usize,
     ) {
         let agent_id = self.db.agent_id.clone();
         let doc_path_owned = doc_path.to_owned();
+        let hash_owned = source_doc_hash.map(str::to_owned);
         let model = model.to_owned();
         let trace_id = self.trace_id.clone();
 
@@ -1129,15 +1241,16 @@ Rules:
             .with_db(move |db| {
                 db.conn.execute(
                     "INSERT INTO kg_extractions
-                        (agent_id, source_doc_path, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                        (agent_id, source_doc_path, source_doc_hash, extraction_model, entities_extracted, relationships_extracted, extraction_trace_id)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                      ON CONFLICT(agent_id, source_doc_path) DO UPDATE SET
+                        source_doc_hash = excluded.source_doc_hash,
                         extraction_model = excluded.extraction_model,
                         entities_extracted = excluded.entities_extracted,
                         relationships_extracted = excluded.relationships_extracted,
                         extraction_trace_id = excluded.extraction_trace_id,
                         created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
-                    rusqlite::params![agent_id, doc_path_owned, model, entities as i64, relationships as i64, trace_id],
+                    rusqlite::params![agent_id, doc_path_owned, hash_owned, model, entities as i64, relationships as i64, trace_id],
                 )?;
                 Ok(())
             })

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -766,6 +766,22 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
             .unwrap_or_default()
             .join("docs")
             .join("solutions");
+
+        // Fan-out cost advisory (#757 R3). All agents use the same docs_root,
+        // so per-agent extraction/resolution scales N× with agent count.
+        // Only emit when there's actually a multiplier to warn about.
+        if docs_root.exists() && agents.len() >= 2 {
+            let shared_agents: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+            info!(
+                event = "kg_shared_docs_root",
+                docs_root = %docs_root.display(),
+                agents = ?shared_agents,
+                agent_count = agents.len(),
+                "KG extraction and resolution run per agent; sharing docs_root means cost scales N×. \
+                 See MIKA_KG_BATCH_BUDGET (default 500) for the per-batch cap."
+            );
+        }
+
         if docs_root.exists() {
             for (agent_name, agent_state) in &agents {
                 let ingestor = crate::kg::lexical_ingestor::LexicalIngestor::new(
@@ -805,6 +821,23 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         // Per D2: startup extraction spawns one background task per agent.
         match settings.make_kg_extraction_provider() {
             Some(Ok(extraction_llm)) => {
+                // #757 R4: advise operators when KG extraction resolves to
+                // Anthropic (expensive for bulk NER). Fires once per startup
+                // by virtue of the surrounding `match` arm running once.
+                if extraction_llm
+                    .provider_name()
+                    .eq_ignore_ascii_case("anthropic")
+                {
+                    warn!(
+                        event = "kg_anthropic_provider",
+                        role = "extraction",
+                        provider = "anthropic",
+                        model = %extraction_llm.model_name(),
+                        "KG extraction is using Anthropic — typically ~10× more expensive than \
+                         OpenRouter equivalents for bulk NER. Consider \
+                         MIKA_KG_EXTRACTION_MODEL=openrouter/<model> for cost-sensitive deployments."
+                    );
+                }
                 for (agent_name, agent_state) in &agents {
                     let db = agent_state.db.clone();
                     let llm = extraction_llm.clone();
@@ -864,7 +897,21 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         // agent. Resolution LLM is optional — without it, exact-match-only mode.
         {
             let resolution_llm = match settings.make_kg_resolution_provider() {
-                Some(Ok(llm)) => Some(llm),
+                Some(Ok(llm)) => {
+                    // #757 R4: advise when resolution resolves to Anthropic.
+                    // Fires at most once per startup.
+                    if llm.provider_name().eq_ignore_ascii_case("anthropic") {
+                        warn!(
+                            event = "kg_anthropic_provider",
+                            role = "resolution",
+                            provider = "anthropic",
+                            model = %llm.model_name(),
+                            "KG resolution is using Anthropic — consider \
+                             MIKA_KG_RESOLUTION_MODEL=openrouter/<model> for cost-sensitive deployments."
+                        );
+                    }
+                    Some(llm)
+                }
                 Some(Err(e)) => {
                     warn!(
                         error = %e,

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -929,6 +929,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 let db = agent_state.db.clone();
                 let llm = resolution_llm.clone();
                 let agent_name_clone = agent_name.clone();
+                let budget = kg_batch_budget;
 
                 tokio::spawn(async move {
                     // Small delay to let extraction tasks commit first.
@@ -936,7 +937,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
 
                     let resolver =
                         crate::kg::entity_resolver::SubjectEntityResolver::new(db, llm, None);
-                    match resolver.resolve_pending().await {
+                    match resolver.resolve_pending(budget).await {
                         Ok(stats) => {
                             if stats.matched_exact > 0 || stats.matched_llm > 0 || stats.errors > 0
                             {

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -819,6 +819,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         // previously-ingested chunks (#690). Runs asynchronously in the
         // background after lexical ingestion — does not block server readiness.
         // Per D2: startup extraction spawns one background task per agent.
+        let kg_batch_budget = settings.effective_kg_batch_budget();
         match settings.make_kg_extraction_provider() {
             Some(Ok(extraction_llm)) => {
                 // #757 R4: advise operators when KG extraction resolves to
@@ -843,6 +844,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                     let llm = extraction_llm.clone();
                     let docs_root_clone = docs_root.clone();
                     let agent_name_clone = agent_name.clone();
+                    let budget = kg_batch_budget;
 
                     tokio::spawn(async move {
                         let extractor = crate::kg::subject_extractor::SubjectExtractor::new(
@@ -851,7 +853,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                             docs_root_clone,
                             None,
                         );
-                        match extractor.extract_pending().await {
+                        match extractor.extract_pending(budget).await {
                             Ok(stats) => {
                                 if stats.docs_extracted > 0 || stats.docs_failed > 0 {
                                     info!(

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -831,7 +831,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 {
                     warn!(
                         event = "kg_anthropic_provider",
-                        role = "extraction",
+                        scope = "extraction",
                         provider = "anthropic",
                         model = %extraction_llm.model_name(),
                         "KG extraction is using Anthropic — typically ~10× more expensive than \
@@ -905,7 +905,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                     if llm.provider_name().eq_ignore_ascii_case("anthropic") {
                         warn!(
                             event = "kg_anthropic_provider",
-                            role = "resolution",
+                            scope = "resolution",
                             provider = "anthropic",
                             model = %llm.model_name(),
                             "KG resolution is using Anthropic — consider \

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -27,6 +27,7 @@ mod eval {
     mod test_error_handling;
     mod test_intent_precondition_guard;
     mod test_internal_tagging;
+    mod test_kg_budget_757;
     mod test_max_steps_continuation;
     mod test_multi_step;
     mod test_multi_turn_persistence;

--- a/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
@@ -10,15 +10,19 @@
 //!
 //! ## Schema Pin
 //!
-//! Fixtures are pinned to schema v25 (the KG schema version). If the schema advances,
+//! Fixtures are pinned to the current KG schema version. If the schema advances,
 //! the assertion below fails with an actionable message pointing here.
+//!
+//! v26 (#757) added `kg_extractions.source_doc_hash` — no fixture-helper signature
+//! change needed because `seed_*` helpers write via positional SQL that ignores
+//! the new column (it stays NULL for fixture rows, which is the correct default).
 
 use mika_agent::async_db::AsyncDatabase;
 use mika_agent::db::Database;
 
 /// Current schema version this fixture module is pinned to.
 /// Bump this when updating fixtures for a new schema version.
-const PINNED_SCHEMA_VERSION: i32 = 25;
+const PINNED_SCHEMA_VERSION: i32 = 26;
 
 // ---------------------------------------------------------------------------
 // Test DB Factory

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_1_exact_match.rs
@@ -46,7 +46,7 @@ async fn test_stage_1_exact_match_case_insensitive() {
 
     // Run resolver — no LLM needed for exact match
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-stage-1"));
-    let stats = resolver.resolve_pending().await.unwrap();
+    let stats = resolver.resolve_pending(u32::MAX).await.unwrap();
 
     // Hard assertions on stats
     assert_eq!(stats.total, 1, "Should process exactly one pending entity");
@@ -114,7 +114,7 @@ async fn test_stage_1_low_confidence_escalates_to_stage_2() {
     // Run resolver with no LLM — exact match found but low confidence,
     // escalates to Stage 2 which skips because no LLM.
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-stage-1-low"));
-    let stats = resolver.resolve_pending().await.unwrap();
+    let stats = resolver.resolve_pending(u32::MAX).await.unwrap();
 
     assert_eq!(stats.total, 1);
     assert_eq!(
@@ -153,7 +153,7 @@ async fn test_stage_1_discovered_type_skipped() {
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-discovered"));
     // Use resolve_doc_entities which takes explicit IDs (no SQL type filter)
     let stats = resolver
-        .resolve_doc_entities(&[subject_id], "test-extraction-trace")
+        .resolve_doc_entities(&[subject_id], "test-extraction-trace", u32::MAX)
         .await
         .unwrap();
 

--- a/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
+++ b/crates/mika-agent/tests/eval/kg_self_knowledge/stage_2_llm_disambiguation.rs
@@ -86,7 +86,7 @@ async fn test_stage_2_synonyms_disambiguation() {
     let llm = mock_disambiguation_llm("skill:qa-review", 0.9);
 
     let resolver = SubjectEntityResolver::new(db.clone(), Some(llm), Some("test-synonyms"));
-    let stats = resolver.resolve_pending().await.unwrap();
+    let stats = resolver.resolve_pending(u32::MAX).await.unwrap();
 
     assert_eq!(stats.total, 1);
     assert_eq!(
@@ -162,7 +162,7 @@ async fn test_stage_2_case_variant_low_confidence() {
     let llm = mock_disambiguation_llm("skill:self-dev", 0.95);
 
     let resolver = SubjectEntityResolver::new(db.clone(), Some(llm), Some("test-case-variants"));
-    let stats = resolver.resolve_pending().await.unwrap();
+    let stats = resolver.resolve_pending(u32::MAX).await.unwrap();
 
     assert_eq!(stats.total, 1);
     assert_eq!(
@@ -224,7 +224,7 @@ async fn test_stage_2_skipped_no_llm() {
 
     // No LLM configured
     let resolver = SubjectEntityResolver::new(db.clone(), None, Some("test-no-llm"));
-    let stats = resolver.resolve_pending().await.unwrap();
+    let stats = resolver.resolve_pending(u32::MAX).await.unwrap();
 
     assert_eq!(stats.total, 1);
     assert_eq!(

--- a/crates/mika-agent/tests/eval/test_kg_budget_757.rs
+++ b/crates/mika-agent/tests/eval/test_kg_budget_757.rs
@@ -1,0 +1,256 @@
+//! # KG extraction budget + idempotency (#757)
+//!
+//! Covers the Unit 2 acceptance criteria for the #757 rescue fix:
+//!
+//! - `extract_pending(budget)` honors the per-batch LLM call cap.
+//! - `budget == 0` short-circuits with zero LLM calls and `aborted_budget = true`.
+//! - The pending-doc query matches on `(agent_id, source_doc_path,
+//!   source_doc_hash)` so stale markers re-fire only on actual content drift.
+//! - `record_extraction` persists `source_doc_hash` so subsequent runs see a
+//!   populated marker.
+//!
+//! These tests use `MockLlmProvider` only — no real-provider traffic.
+
+use std::sync::Arc;
+
+use mika_agent::async_db::AsyncDatabase;
+use mika_agent::db::Database;
+use mika_agent::kg::subject_extractor::SubjectExtractor;
+use mika_common::llm::LlmProvider;
+use mika_common::llm::mock::MockLlmProvider;
+
+// ---------------------------------------------------------------------------
+// Test DB helpers — scoped to this test file, independent of kg_fixtures
+// (we want a clean agent_id and no FTS5 indexing overhead here).
+// ---------------------------------------------------------------------------
+
+fn test_db(agent_id: &str) -> AsyncDatabase {
+    let db = Database::open_in_memory().unwrap();
+    db.register_agent(agent_id, agent_id, "/tmp/mika-test-757")
+        .unwrap();
+    AsyncDatabase::new_with_agent(db, agent_id)
+}
+
+async fn insert_chunk(db: &AsyncDatabase, seq_id: i64, doc_path: &str, hash: &str) {
+    let agent_id = db.agent_id.clone();
+    let doc_path = doc_path.to_owned();
+    let hash = hash.to_owned();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_chunks (agent_id, seq_id, source_doc_path, source_doc_hash) \
+             VALUES (?1, ?2, ?3, ?4)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &seq_id,
+                &doc_path,
+                &hash,
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+async fn insert_extraction(db: &AsyncDatabase, doc_path: &str, hash: Option<&str>) {
+    let agent_id = db.agent_id.clone();
+    let doc_path = doc_path.to_owned();
+    let hash = hash.map(|s| s.to_owned());
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_extractions \
+               (agent_id, source_doc_path, source_doc_hash, extraction_model, \
+                entities_extracted, relationships_extracted, extraction_trace_id) \
+             VALUES (?1, ?2, ?3, ?4, 0, 0, 'trace-test')",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &doc_path,
+                &hash,
+                &"mock/test",
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+async fn count_pending(db: &AsyncDatabase) -> i64 {
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        Ok(db
+            .query_scalar::<i64>(
+                "SELECT COUNT(*) FROM (
+                   SELECT DISTINCT c.source_doc_path
+                   FROM kg_chunks c
+                   WHERE c.agent_id = ?1
+                     AND NOT EXISTS (
+                       SELECT 1 FROM kg_extractions e
+                       WHERE e.agent_id        = c.agent_id
+                         AND e.source_doc_path = c.source_doc_path
+                         AND e.source_doc_hash = c.source_doc_hash
+                     )
+                 )",
+                &[&agent_id as &dyn rusqlite::types::ToSql],
+            )?
+            .unwrap_or(0))
+    })
+    .await
+    .unwrap()
+}
+
+async fn read_extraction_hash(db: &AsyncDatabase, doc_path: &str) -> Option<String> {
+    let agent_id = db.agent_id.clone();
+    let doc_path = doc_path.to_owned();
+    db.with_db(move |db| {
+        db.query_scalar::<Option<String>>(
+            "SELECT source_doc_hash FROM kg_extractions \
+             WHERE agent_id = ?1 AND source_doc_path = ?2",
+            &[&agent_id as &dyn rusqlite::types::ToSql, &doc_path],
+        )
+        .map(|v| v.flatten())
+    })
+    .await
+    .unwrap()
+}
+
+fn mock_llm() -> Arc<MockLlmProvider> {
+    // Zero-response mock: safe for tests that should make zero LLM calls.
+    // If anything calls into it, MockLlmProvider panics — loud failure, good.
+    Arc::new(MockLlmProvider::builder().build())
+}
+
+fn extractor(db: AsyncDatabase) -> SubjectExtractor {
+    let llm: Arc<dyn LlmProvider> = mock_llm() as Arc<dyn LlmProvider>;
+    SubjectExtractor::new(db, llm, std::path::PathBuf::from("/tmp/docs"), None)
+}
+
+// ---------------------------------------------------------------------------
+// Pending-query idempotency semantics (#757 R1)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pending_query_treats_doc_without_extraction_row_as_pending() {
+    let db = test_db("agent-a");
+    insert_chunk(&db, 0, "docs/a.md", "HASH-A").await;
+    insert_chunk(&db, 1, "docs/a.md", "HASH-A").await;
+
+    assert_eq!(count_pending(&db).await, 1, "unextracted doc is pending");
+}
+
+#[tokio::test]
+async fn pending_query_skips_doc_when_hash_matches() {
+    let db = test_db("agent-b");
+    insert_chunk(&db, 0, "docs/b.md", "HASH-B").await;
+    insert_extraction(&db, "docs/b.md", Some("HASH-B")).await;
+
+    assert_eq!(
+        count_pending(&db).await,
+        0,
+        "doc with matching extraction hash is not pending"
+    );
+}
+
+#[tokio::test]
+async fn pending_query_treats_null_hash_as_stale() {
+    // First-boot-after-v26 scenario: pre-existing extraction row has NULL hash.
+    // The hash-equality predicate rejects NULL, so the doc re-extracts once.
+    let db = test_db("agent-c");
+    insert_chunk(&db, 0, "docs/c.md", "HASH-C").await;
+    insert_extraction(&db, "docs/c.md", None).await;
+
+    assert_eq!(
+        count_pending(&db).await,
+        1,
+        "NULL source_doc_hash must be treated as stale"
+    );
+}
+
+#[tokio::test]
+async fn pending_query_treats_drifted_hash_as_stale() {
+    // Lexical ingestor re-ingested the doc with new content; chunk hash is
+    // now different from the hash stored in kg_extractions.
+    let db = test_db("agent-d");
+    insert_chunk(&db, 0, "docs/d.md", "HASH-NEW").await;
+    insert_extraction(&db, "docs/d.md", Some("HASH-OLD")).await;
+
+    assert_eq!(
+        count_pending(&db).await,
+        1,
+        "drifted source_doc_hash must re-trigger extraction"
+    );
+}
+
+// Note on agent-scope: the pending query filters by `agent_id`, so agent
+// isolation is by construction. Not testing it here would require sharing a
+// single Database across two AsyncDatabase handles, which the current
+// AsyncDatabase API does not support (it takes ownership of the Database).
+// The filter is plainly correct by inspection and is exercised in practice by
+// every multi-agent test that touches KG tables.
+
+// ---------------------------------------------------------------------------
+// Budget guard (#757 R2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn extract_pending_with_zero_budget_short_circuits_cleanly() {
+    // 3 pending docs, but budget=0 → no LLM calls and aborted_budget=true.
+    let db = test_db("agent-f");
+    insert_chunk(&db, 0, "docs/f1.md", "HASH-F1").await;
+    insert_chunk(&db, 0, "docs/f2.md", "HASH-F2").await;
+    insert_chunk(&db, 0, "docs/f3.md", "HASH-F3").await;
+
+    let llm = mock_llm();
+    let extractor_ref = {
+        let llm_trait: Arc<dyn LlmProvider> = llm.clone();
+        SubjectExtractor::new(db, llm_trait, std::path::PathBuf::from("/tmp/docs"), None)
+    };
+
+    let stats = extractor_ref.extract_pending(0).await.unwrap();
+
+    assert!(stats.aborted_budget, "zero budget must set aborted_budget");
+    assert_eq!(stats.llm_calls, 0, "zero budget must not consume LLM calls");
+    assert_eq!(stats.docs_extracted, 0);
+    assert_eq!(
+        stats.docs_total, 3,
+        "docs_total still reflects the pending set"
+    );
+    assert_eq!(
+        llm.calls_made(),
+        0,
+        "MockLlmProvider must never be called when budget=0"
+    );
+}
+
+#[tokio::test]
+async fn extract_pending_with_no_pending_docs_makes_zero_calls() {
+    // No kg_chunks rows at all — pending query returns empty → early return.
+    let db = test_db("agent-g");
+    let llm = mock_llm();
+    let extractor_ref = {
+        let llm_trait: Arc<dyn LlmProvider> = llm.clone();
+        SubjectExtractor::new(db, llm_trait, std::path::PathBuf::from("/tmp/docs"), None)
+    };
+
+    let stats = extractor_ref.extract_pending(10).await.unwrap();
+
+    assert!(!stats.aborted_budget);
+    assert_eq!(stats.llm_calls, 0);
+    assert_eq!(stats.docs_total, 0);
+    assert_eq!(llm.calls_made(), 0);
+}
+
+// Note on happy-path extraction tests: `extract_document` reads the real
+// doc from disk via `std::fs::read_to_string`, so a full end-to-end test
+// requires tempfile setup. The pending-query, zero-budget, and hash-drift
+// tests above cover the load-bearing logic of the fix. End-to-end post-fix
+// behavior is verified by the post-deploy signals described in the #757
+// PR body (Signal A: extraction not re-running; Signal B: budget not
+// exhausted; Signal C: resolver drains; Signal D: concrete cost prediction).
+
+// Keep a dead-code silencer for `extractor` — it's useful future scaffolding
+// for a happy-path test once tempfile infra is wired up.
+#[allow(dead_code)]
+fn _unused_silencer(db: AsyncDatabase) -> SubjectExtractor {
+    extractor(db)
+}

--- a/crates/mika-agent/tests/eval/test_kg_budget_757.rs
+++ b/crates/mika-agent/tests/eval/test_kg_budget_757.rs
@@ -254,3 +254,186 @@ async fn extract_pending_with_no_pending_docs_makes_zero_calls() {
 fn _unused_silencer(db: AsyncDatabase) -> SubjectExtractor {
     extractor(db)
 }
+
+// ---------------------------------------------------------------------------
+// Resolver budget guard (#757 Unit 3)
+// ---------------------------------------------------------------------------
+
+use mika_agent::kg::entity_resolver::SubjectEntityResolver;
+
+/// Seed a domain entity + a case-matching subject entity so Stage-1 exact
+/// match succeeds (no LLM needed). Returns the subject entity row ID.
+async fn seed_exact_match_pair(
+    db: &AsyncDatabase,
+    entity_type: &str,
+    name: &str,
+    subject_confidence: f64,
+) -> i64 {
+    let agent_id = db.agent_id.clone();
+    let domain_key = format!("{entity_type}:{name}");
+    let subject_key = domain_key.clone();
+    let entity_type_owned = entity_type.to_owned();
+    let name_owned = name.to_owned();
+
+    db.with_db(move |db| {
+        // Domain entity
+        db.execute_sql(
+            "INSERT INTO kg_entities (entity_key, type, name) VALUES (?1, ?2, ?3)",
+            &[
+                &domain_key as &dyn rusqlite::types::ToSql,
+                &entity_type_owned,
+                &name_owned,
+            ],
+        )?;
+        // Matching subject entity with high confidence (above exact-match threshold)
+        db.execute_sql(
+            "INSERT INTO kg_subject_entities \
+                (agent_id, entity_key, type, name, confidence) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &subject_key,
+                &entity_type_owned,
+                &name_owned,
+                &subject_confidence,
+            ],
+        )?;
+        Ok(db.last_insert_rowid())
+    })
+    .await
+    .unwrap()
+}
+
+async fn count_resolution_log(db: &AsyncDatabase) -> i64 {
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        Ok(db
+            .query_scalar::<i64>(
+                "SELECT COUNT(*) FROM kg_resolutions_log WHERE agent_id = ?1",
+                &[&agent_id as &dyn rusqlite::types::ToSql],
+            )?
+            .unwrap_or(0))
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn resolve_pending_with_zero_budget_still_processes_exact_matches() {
+    // Stage-1 exact matches do NOT consume the budget. Even with budget=0,
+    // entities whose name matches a domain entity exactly should resolve.
+    let db = test_db("agent-rx1");
+    seed_exact_match_pair(&db, "skill", "self-dev", 0.95).await;
+    seed_exact_match_pair(&db, "tool", "run_gh", 0.92).await;
+
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("trace-rx1"));
+    let stats = resolver.resolve_pending(0).await.unwrap();
+
+    assert_eq!(stats.matched_exact, 2, "two exact matches should resolve");
+    assert_eq!(stats.llm_calls, 0, "exact matches do not debit the budget");
+    assert!(
+        !stats.aborted_budget,
+        "budget=0 with all exact matches should not abort"
+    );
+    assert_eq!(
+        count_resolution_log(&db).await,
+        2,
+        "both resolution log rows should be written"
+    );
+}
+
+#[tokio::test]
+async fn resolve_pending_with_no_llm_and_no_exact_match_skips_cleanly() {
+    // With no LLM configured and no exact match, entities get SkippedNoLlm
+    // (not SkippedBudget). The budget does not fire because the code path
+    // exits at Stage-2-entry with SkippedNoLlm before the budget guard.
+    let db = test_db("agent-rx2");
+    // Subject entity with no matching domain entity
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_subject_entities \
+                (agent_id, entity_key, type, name, confidence) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &"skill:does-not-exist",
+                &"skill",
+                &"does-not-exist",
+                &0.7f64,
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("trace-rx2"));
+    let stats = resolver.resolve_pending(10).await.unwrap();
+
+    assert_eq!(stats.skipped_no_llm, 1);
+    assert_eq!(stats.llm_calls, 0);
+    assert!(!stats.aborted_budget);
+}
+
+#[tokio::test]
+async fn resolve_pending_empty_set_returns_zero_calls() {
+    // No kg_subject_entities → pending query returns empty → early return.
+    let db = test_db("agent-rx3");
+
+    let resolver = SubjectEntityResolver::new(db, None, Some("trace-rx3"));
+    let stats = resolver.resolve_pending(10).await.unwrap();
+
+    assert_eq!(stats.total, 0);
+    assert_eq!(stats.llm_calls, 0);
+    assert!(!stats.aborted_budget);
+}
+
+#[tokio::test]
+async fn resolve_pending_zero_budget_with_exact_match_mix_still_logs_exact() {
+    // Mix exact-match (budget-free) and potential LLM-entity (budget-gated).
+    // budget=0 → exact matches resolve; LLM-entity never gets to Stage-2
+    // because there's no LLM configured (SubjectEntityResolver built with
+    // None). So SkippedNoLlm fires, not SkippedBudget. Budget is orthogonal
+    // here — the test documents the composition.
+    let db = test_db("agent-rx4");
+    seed_exact_match_pair(&db, "skill", "self-dev", 0.95).await;
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_subject_entities \
+                (agent_id, entity_key, type, name, confidence) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &"skill:unknown-skill",
+                &"skill",
+                &"unknown-skill",
+                &0.7f64,
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    let resolver = SubjectEntityResolver::new(db, None, Some("trace-rx4"));
+    let stats = resolver.resolve_pending(0).await.unwrap();
+
+    assert_eq!(stats.matched_exact, 1);
+    assert_eq!(stats.skipped_no_llm, 1);
+    assert_eq!(stats.llm_calls, 0);
+    assert!(
+        !stats.aborted_budget,
+        "no LLM configured → SkippedNoLlm never triggers budget abort"
+    );
+}
+
+// Note: we do not test Stage-2 budget exhaustion with a mock LLM here because
+// the resolver's LLM prompt interface expects a specific JSON response shape
+// (validated in `entity_resolver::tests`). Stage-2 budget behavior is covered
+// by the structural contract of `resolve_single_entity(entity, llm_call_allowed=false)`
+// returning `SkippedBudget` without touching `self.llm` — this contract is
+// verified at the module boundary in entity_resolver.rs unit tests. Post-deploy
+// Signal B (kg_budget_exhausted WARN does not appear on healthy restarts)
+// covers the real-world integration path.

--- a/crates/mika-agent/tests/eval/test_kg_budget_757.rs
+++ b/crates/mika-agent/tests/eval/test_kg_budget_757.rs
@@ -120,11 +120,6 @@ fn mock_llm() -> Arc<MockLlmProvider> {
     Arc::new(MockLlmProvider::builder().build())
 }
 
-fn extractor(db: AsyncDatabase) -> SubjectExtractor {
-    let llm: Arc<dyn LlmProvider> = mock_llm() as Arc<dyn LlmProvider>;
-    SubjectExtractor::new(db, llm, std::path::PathBuf::from("/tmp/docs"), None)
-}
-
 // ---------------------------------------------------------------------------
 // Pending-query idempotency semantics (#757 R1)
 // ---------------------------------------------------------------------------
@@ -247,13 +242,6 @@ async fn extract_pending_with_no_pending_docs_makes_zero_calls() {
 // behavior is verified by the post-deploy signals described in the #757
 // PR body (Signal A: extraction not re-running; Signal B: budget not
 // exhausted; Signal C: resolver drains; Signal D: concrete cost prediction).
-
-// Keep a dead-code silencer for `extractor` — it's useful future scaffolding
-// for a happy-path test once tempfile infra is wired up.
-#[allow(dead_code)]
-fn _unused_silencer(db: AsyncDatabase) -> SubjectExtractor {
-    extractor(db)
-}
 
 // ---------------------------------------------------------------------------
 // Resolver budget guard (#757 Unit 3)
@@ -387,6 +375,110 @@ async fn resolve_pending_empty_set_returns_zero_calls() {
     assert_eq!(stats.total, 0);
     assert_eq!(stats.llm_calls, 0);
     assert!(!stats.aborted_budget);
+}
+
+#[tokio::test]
+async fn resolve_pending_budget_exhaustion_does_not_starve_later_exact_matches() {
+    // Regression test for the #757 code review P1 finding: the resolver
+    // must continue past a SkippedBudget entity so that later Stage-1
+    // exact matches still resolve for free. The previous `break`-on-first
+    // SkippedBudget contradicted the contract stated in CLAUDE.md
+    // ("even budget=0 lets exact matches resolve"). This test seeds a
+    // 3-entity batch where the MIDDLE entity would need Stage-2 (no
+    // matching domain) and the bookending entities are exact matches.
+    // With no LLM configured (so Stage-2 returns SkippedNoLlm not
+    // SkippedBudget), budget=0 is irrelevant — but this structure
+    // documents the contract for the resolver-with-LLM path too, where
+    // the middle entity returns SkippedBudget instead of SkippedNoLlm.
+    let db = test_db("agent-rx5");
+    seed_exact_match_pair(&db, "skill", "self-dev", 0.95).await;
+
+    // A low-confidence subject entity with no matching domain entity —
+    // Stage-1 fails, Stage-2 would fire but the resolver has no LLM
+    // configured, producing SkippedNoLlm. The test's value is not in
+    // this particular variant but in the ordering: the 3rd entity below
+    // (an exact match) MUST still resolve.
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "INSERT INTO kg_subject_entities \
+                (agent_id, entity_key, type, name, confidence) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            &[
+                &agent_id as &dyn rusqlite::types::ToSql,
+                &"skill:mystery-skill",
+                &"skill",
+                &"mystery-skill",
+                &0.7f64,
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    seed_exact_match_pair(&db, "tool", "run_gh", 0.92).await;
+
+    let resolver = SubjectEntityResolver::new(db.clone(), None, Some("trace-rx5"));
+    let stats = resolver.resolve_pending(0).await.unwrap();
+
+    // Both exact matches must resolve — the middle SkippedNoLlm entity
+    // does not starve the third entity.
+    assert_eq!(stats.matched_exact, 2);
+    assert_eq!(stats.skipped_no_llm, 1);
+    assert_eq!(stats.llm_calls, 0);
+    assert_eq!(
+        count_resolution_log(&db).await,
+        3,
+        "all 3 entities should have kg_resolutions_log rows (2 MATCHED_EXACT + 1 SKIPPED_NO_LLM)"
+    );
+}
+
+#[tokio::test]
+async fn null_hash_populates_on_successful_extraction() {
+    // The #757 plan claims the first post-v26 boot re-extracts NULL-hash
+    // rows once, then the hash is populated so subsequent runs are no-ops.
+    // This test verifies the two-phase contract WITHOUT invoking
+    // extract_document (which reads from disk): we simulate a successful
+    // extraction by writing the kg_extractions row directly with the
+    // hash, then assert the pending count drops to 0.
+    let db = test_db("agent-nh1");
+    insert_chunk(&db, 0, "docs/nh.md", "HASH-NH").await;
+    insert_extraction(&db, "docs/nh.md", None).await;
+
+    // Phase 1: pre-extraction state — NULL hash, pending=1.
+    assert_eq!(count_pending(&db).await, 1);
+    assert_eq!(read_extraction_hash(&db, "docs/nh.md").await, None);
+
+    // Phase 2: simulate a successful extraction by writing the hash.
+    // This is the UPSERT the production extract_document runs inside
+    // its transaction (#757 atomic marker write).
+    let agent_id = db.agent_id.clone();
+    db.with_db(move |db| {
+        db.execute_sql(
+            "UPDATE kg_extractions SET source_doc_hash = ?1 \
+             WHERE agent_id = ?2 AND source_doc_path = ?3",
+            &[
+                &"HASH-NH" as &dyn rusqlite::types::ToSql,
+                &agent_id,
+                &"docs/nh.md",
+            ],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    // Phase 3: post-extraction — hash populated, pending=0.
+    assert_eq!(
+        read_extraction_hash(&db, "docs/nh.md").await,
+        Some("HASH-NH".to_string())
+    );
+    assert_eq!(
+        count_pending(&db).await,
+        0,
+        "after hash is populated, doc must not be pending again"
+    );
 }
 
 #[tokio::test]

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -764,10 +764,23 @@ pub struct Settings {
     #[serde(default)]
     pub kg_resolution_model: Option<String>,
 
+    /// KG per-batch LLM call budget — structural cap on startup extraction and
+    /// resolution batches (#757). Unset = default of [`DEFAULT_KG_BATCH_BUDGET`].
+    /// `0` disables the phase entirely (no LLM calls).
+    ///
+    /// Worst-case per-startup cost is `2 × N_agents × budget` — extraction batch
+    /// plus resolution batch, one of each per agent. See `kg_schema.rs` for the
+    /// fan-out cost model.
+    #[serde(default)]
+    pub kg_batch_budget: Option<u32>,
+
     /// Resolved home directory path (populated after load, not from config file)
     #[serde(skip)]
     pub home_dir: PathBuf,
 }
+
+/// Default per-batch LLM call budget for KG extraction and resolution (#757).
+pub const DEFAULT_KG_BATCH_BUDGET: u32 = 500;
 
 fn default_true() -> bool {
     true
@@ -1038,6 +1051,15 @@ impl Settings {
         Some(self.make_provider_from_model_string(model_str))
     }
 
+    /// Effective KG per-batch LLM call budget (#757).
+    ///
+    /// Returns the configured value or [`DEFAULT_KG_BATCH_BUDGET`] when unset.
+    /// A return value of `0` means "disabled — the extraction or resolution
+    /// phase makes zero LLM calls per batch and returns immediately."
+    pub fn effective_kg_batch_budget(&self) -> u32 {
+        self.kg_batch_budget.unwrap_or(DEFAULT_KG_BATCH_BUDGET)
+    }
+
     /// Parse a `provider/model` string and create an LLM provider.
     ///
     /// Reusable by `make_kg_extraction_provider` and `make_kg_resolution_provider`.
@@ -1237,6 +1259,7 @@ impl Settings {
             kg_ingestion_model: None,
             kg_extraction_model: None,
             kg_resolution_model: None,
+            kg_batch_budget: None,
         }
     }
 }
@@ -1734,5 +1757,58 @@ mod tests {
 
         assert_eq!(model, Some("claude-sonnet-4-20250514"));
         assert_eq!(api_key, Some("sk-ant-provider-test"));
+    }
+
+    // -- KG batch budget (#757) --
+
+    #[test]
+    #[serial]
+    fn kg_batch_budget_defaults_to_500() {
+        clean_env();
+        unsafe { std::env::remove_var("MIKA_KG_BATCH_BUDGET") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(settings.kg_batch_budget, None);
+        assert_eq!(
+            settings.effective_kg_batch_budget(),
+            DEFAULT_KG_BATCH_BUDGET
+        );
+        assert_eq!(settings.effective_kg_batch_budget(), 500);
+    }
+
+    #[test]
+    #[serial]
+    fn kg_batch_budget_env_override() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_KG_BATCH_BUDGET", "100") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(settings.kg_batch_budget, Some(100));
+        assert_eq!(settings.effective_kg_batch_budget(), 100);
+
+        unsafe { std::env::remove_var("MIKA_KG_BATCH_BUDGET") };
+    }
+
+    #[test]
+    #[serial]
+    fn kg_batch_budget_zero_disables_phase() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_KG_BATCH_BUDGET", "0") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        // 0 is a valid configured value meaning "disable" — extractor/resolver
+        // honor this as an immediate-return signal (verified in their own tests).
+        assert_eq!(settings.kg_batch_budget, Some(0));
+        assert_eq!(settings.effective_kg_batch_budget(), 0);
+
+        unsafe { std::env::remove_var("MIKA_KG_BATCH_BUDGET") };
     }
 }

--- a/docs/architecture/kg-implementation-conventions.md
+++ b/docs/architecture/kg-implementation-conventions.md
@@ -57,9 +57,19 @@ Two environment variables cover the two distinct ingestion call types:
 
 Both fall back to a shared `MIKA_KG_INGESTION_MODEL` if only that is set, so operators who want one knob can set one and move on.
 
+**Provider recommendation (#757).** OpenRouter is the recommended default for KG models. Anthropic direct is typically ~10× more expensive than equivalent OpenRouter routes for bulk NER; a startup `kg_anthropic_provider` WARN fires when extraction or resolution resolves to `anthropic/*` so the cost is visible before it accrues.
+
 **Do not** route ingestion calls through the agent's primary conversational model (`MIKA_PROVIDER` / `MIKA_MODEL`). Interactive reasoning and bulk extraction have different quality, latency, and cost profiles; coupling them means every model upgrade for conversational quality drags ingestion cost along, and every ingestion cost optimization risks degrading conversational quality.
 
 **Do not** use per-skill `skill_overrides` as the default for ingestion category selection. Per-skill overrides are the right escape hatch if one specific skill needs a different model, but they scatter global ingestion policy across skill manifests — the "which model does ingestion use in this container" question should be answerable by reading one env var, not N files.
+
+### C2.5 Per-batch LLM call budget (#757)
+
+`MIKA_KG_BATCH_BUDGET` (default 500) caps the number of LLM calls per extraction batch and per resolution batch. Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely. Worst-case per-startup cost is `2 × N_agents × budget` — extraction batch plus resolution batch, one of each per agent.
+
+Stage-1 exact-match resolutions do not debit the budget (they cost no LLM calls), so entities that resolve via exact match still make progress even when the budget is exhausted. The budget guard is a structural caller-side counter, not a prompt-level instruction — LLMs rationalize crossing prompt-level budgets; structural constraints don't.
+
+**Idempotency pairs with the budget guard.** `kg_extractions.source_doc_hash` (added at schema v26) is compared against `kg_chunks.source_doc_hash` in the pending-doc query, so content-unchanged docs are skipped entirely. Pre-v26 rows have NULL hash and re-extract exactly once under the budget, then populate. The idempotency marker is written atomically with the extraction results — a write failure or crash between the LLM call and the marker would otherwise burn budget on the same doc every restart.
 
 ### C2.2 Retry taxonomy — four failure categories
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,8 +348,10 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `embedding_model` | `String` | `text-embedding-3-small` | `MIKA_EMBEDDING_MODEL` | OpenAI embedding model ID. |
 | `embedding_dimensions` | `u32` | `512` | `MIKA_EMBEDDING_DIMENSIONS` | Embedding vector dimensions. |
 | `brave_api_key` | `Option<String>` | None | `MIKA_BRAVE_API_KEY` | Brave Search API key for `web_search` builtin skill. Get a free key at https://brave.com/search/api/. |
-| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model` (e.g., `anthropic/claude-haiku-4-5-20251001`). If unset, KG features requiring LLM calls are disabled. |
+| `kg_ingestion_model` | `Option<String>` | None | `MIKA_KG_INGESTION_MODEL` | Shared fallback model for KG extraction and resolution. Format: `provider/model`. OpenRouter recommended — Anthropic direct is ~10× more expensive for bulk NER and triggers a `kg_anthropic_provider` WARN at startup. If unset, KG features requiring LLM calls are disabled. |
 | `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
+| `kg_resolution_model` | `Option<String>` | None | `MIKA_KG_RESOLUTION_MODEL` | Model for entity resolution disambiguation (#691). Falls back to `kg_ingestion_model` if unset. Mid-tier model recommended for better judgment on ambiguous matches. |
+| `kg_batch_budget` | `Option<u32>` | None (effective default: 500) | `MIKA_KG_BATCH_BUDGET` | Per-batch LLM call cap on KG startup extraction and resolution (#757). Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely (no LLM calls). |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -530,8 +532,10 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |
 | `MIKA_OPENAI_API_KEY` | No | OpenAI API key (LLM + Layer 3 vector search) |
 | `MIKA_BRAVE_API_KEY` | No | Brave Search API key for web search skill |
-| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format) |
+| `MIKA_KG_INGESTION_MODEL` | No | Shared fallback KG model (`provider/model` format); OpenRouter recommended |
 | `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
+| `MIKA_KG_RESOLUTION_MODEL` | No | KG resolution model (falls back to `MIKA_KG_INGESTION_MODEL`) |
+| `MIKA_KG_BATCH_BUDGET` | No | Per-batch LLM call cap on KG extraction/resolution (#757; default: 500; `0` disables) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/docs/plans/757-kg-extraction-idempotency-fanout.md
+++ b/docs/plans/757-kg-extraction-idempotency-fanout.md
@@ -1,0 +1,422 @@
+---
+title: "fix: KG extraction idempotency + startup budget guard + per-agent fan-out"
+type: fix
+status: active
+date: 2026-04-23
+origin: senara-solutions/mika#757
+---
+
+# fix: KG extraction idempotency + startup budget guard + per-agent fan-out
+
+## Overview
+
+On a normal server restart (2026-04-23 09:08 UTC), KG startup extraction + resolution fired ~30,400 LLM calls over 38 minutes against `claude-haiku-4-5`, exhausting Anthropic credit. Root cause is two-pronged: schema v25 landed the KG tracking tables, so the *first* restart after v25 saw every agent's doc set as "pending" (no `kg_extractions` rows); and 11 agents share the same `docs_root` (`.../mika/docs/solutions`), giving an 11× multiplier on every doc. The resolver then amplifies further because every newly-extracted entity drives a disambiguation call.
+
+This plan adds three layered safeguards — structural idempotency hardening, a hard budget cap per batch, and documented / warned-about fan-out — plus safer provider defaults and a post-deploy verification signal. The budget guard is the primary defense: even if every prior mitigation fails, a single batch cannot exceed its configured cap without aborting and surfacing a loud WARN.
+
+### AC #1 interpretation — **explicit approval needed**
+
+AC #1 as written says *"skip any `kg_chunks` row that already has rows in `kg_chunk_subjects`."* That framing assumes **chunk-level** extraction. Current implementation is **whole-doc** extraction (per #690 D1 — one LLM call per doc with `[CHUNK N]` markers), so chunk-level idempotency markers are structurally redundant: the doc is the unit of work, not the chunk.
+
+**This plan interprets AC #1 as "harden the doc-level `kg_extractions` marker with a content-hash check"** and documents the distinction explicitly in `crates/mika-agent/src/db/kg_schema.rs`. Moving to chunk-level extraction would be a larger refactor and is out of scope for this rescue fix. Reviewers must approve this interpretation before `/ce:work` starts — the ACs themselves are the contract, and quietly reinterpreting them is the drift class this milestone has been disciplined about avoiding elsewhere.
+
+Explicit non-goal: per-chunk refactoring of the extractor. In scope: a schema v26 bump that adds `kg_extractions.source_doc_hash TEXT NULL` so idempotency can compare against the per-doc hash already stored on `kg_chunks` rows.
+
+## Problem Frame
+
+**Incident (2026-04-23 09:08 UTC):** `sudo rc-service mika-server restart` triggered 30,400 LLM calls in 38 min (~800/min) across 11 agents on `claude-haiku-4-5`. 1,044 `credit balance too low` 400s logged. Default `mika` chat responses silently degraded for ~3h until Vincent noticed. Estimated cost: $40–60. KG resolution state left half-drained (50–92% pending per agent).
+
+**Structural issues:**
+
+1. **Idempotency fragility.** Extraction has a doc-level marker (`kg_extractions`), but after schema v25 landed, every agent's entire doc set was "pending" on first boot — no prior tracking rows existed. Subsequent restarts are guarded, but there is no second-line defense if the marker is ever invalidated (schema migration, agent rename, docs_root change, etc.).
+2. **No batch budget.** `extract_pending()` and `resolve_pending()` iterate until exhaustion with no maximum-call guard. A single misconfiguration silently burns an order of magnitude more than expected before anyone notices.
+3. **Undocumented 1:N cost.** Subject/chunk/resolution tables are agent-scoped by design. When N agents share `docs_root`, the cost is N×. This is intentional at the schema level but was never surfaced in `kg_schema.rs` or operator docs, so it caught the operator by surprise.
+4. **Expensive provider by default.** `MIKA_KG_INGESTION_MODEL=anthropic/claude-haiku-4-5` was in the live `.env`. There is no code-level signal that OpenRouter or another cheap provider is the recommended default for bulk NER.
+5. **No post-deploy verification.** After this fix merges, there is no one-line signal Vincent can read to confirm that the next restart was safe.
+
+**Constraints carried in from the prompt:**
+
+- No live env edits (`~/.mika/.env` is operator-owned).
+- No `make deploy`, no `rc-service`, no server restart during implementation.
+- No unguarded live-provider integration tests (`#[ignore]` + env gate required).
+- GitHub App webhooks are DISABLED for this rescue window; PR will not round-trip through mika-dev/mika-qa. Vincent merges manually.
+- Schema migration **is** in scope: v25 → v26 adds one nullable column to `kg_extractions`. Reviewer pushback on "avoid the migration" was accepted — the migration is ~30 minutes of code, convergence-tested (forward harness from #686), and avoids both the anti-pattern of out-of-band schema drift and the cost of perpetual query-time aggregation on every startup.
+
+## Requirements Trace
+
+- **R1 (AC #1).** Extraction idempotency hardened at the **doc level** (see AC interpretation in Overview): schema v26 adds `kg_extractions.source_doc_hash TEXT NULL`; pending query compares against the per-doc hash already stored on `kg_chunks` rows (which the lexical ingestor writes identically across all chunks of a single doc — verified in `lexical_ingestor.rs:318`). Idempotency key + AC interpretation documented in `crates/mika-agent/src/db/kg_schema.rs`.
+- **R2 (AC #2).** Startup budget guard: configurable cap (`MIKA_KG_BATCH_BUDGET`, default 500) on LLM calls per extraction batch and per resolution batch. Overflow logs WARN with exact count + remaining work and aborts the batch cleanly (pending work stays for next run).
+- **R3 (AC #3).** Per-agent fan-out decision: option (b) — **document** the 1:N cost in `kg_schema.rs` with operator guidance, and emit a startup INFO log when multiple agents share a `docs_root` so the cost is visible.
+- **R4 (AC #4).** Default provider safety: `.env.example` recommends an OpenRouter model for KG, `CLAUDE.md` KG section updated, and a startup WARN fires when extraction or resolution resolves to an `anthropic/*` model (non-fatal advisory).
+- **R5 (AC #5).** Resolver drain validation: plan doc + PR body describe the exact observable signals (log events, DB query) Vincent can read to confirm a post-deploy restart is safe.
+
+## Scope Boundaries
+
+- **In scope:** Code changes in `crates/mika-agent/src/kg/`, `crates/mika-agent/src/db.rs` (schema v26), `crates/mika-agent/src/db/kg_schema.rs`, `crates/mika-common/src/config.rs`, `crates/mika-agent/src/server/mod.rs`; documentation in `kg_schema.rs` doc comments, `CLAUDE.md`, `.env.example`; unit + migration tests using `#[cfg(test)]` with `MockLlmProvider`.
+- **Out of scope:** Chunk-level extraction refactor (whole-doc extraction stays); live-provider integration tests; rebalancing or backfilling the half-drained resolver state (Vincent handles post-deploy via a controlled restart); changing the Anthropic KG settings in `~/.mika/.env` (operator action, not code); schema changes beyond the one additive-nullable column on `kg_extractions`.
+
+### Deferred to Separate Tasks
+
+- **Chunk-level extraction.** Moving `extract_document` from whole-doc to per-chunk LLM calls would be a larger rewrite and is not required to meet AC #1 (see interpretation in Overview). Track as a follow-up if the observed cost profile warrants it.
+- **Shared-extraction short-circuit across agents.** Option (a) from AC #3 is a schema-touching redesign (subject/chunk tables are agent-scoped); opt for option (b) here and capture the redesign as a separate milestone item if operators want to run 10+ agents off one docs_root.
+- **Resolver drain rebalancing.** The 50–92% backlog per agent will drain on the next safe restarts with a cheap provider under budget; no code change needed here. May take multiple restart cycles for agents starting >3,000 pending — see Signal D in Unit 5.
+- **Milestone retrospective note (reviewer observation).** "First-boot cost spike after a tracking-table migration" is a pattern worth naming for future milestone planning reviews. This plan flags it here so the retrospective for milestone #14 + this rescue can capture it; actually writing the retrospective doc belongs to the retrospective pass, not to this fix PR.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/kg/subject_extractor.rs` — `extract_pending()` (line 507), `extract_document()` (line 404), `get_pending_docs()` (line 1090), `record_extraction()` (line 1115). Extraction is doc-level: one LLM call per doc with `[CHUNK N]` markers, then a single transaction writes entities/relationships/provenance.
+- `crates/mika-agent/src/kg/entity_resolver.rs` — `resolve_pending()` (line 199). Per-entity resolution via two-stage pipeline (exact match → LLM disambiguation).
+- `crates/mika-agent/src/kg/ingestion_orchestrator.rs` — compound hook (sync inline) and re-extraction on doc change. Does not need to honor the batch budget in the same way — single-doc path, bounded by construction.
+- `crates/mika-agent/src/server/mod.rs` — startup dispatch at lines 806–916 spawns per-agent extraction and resolution tasks after lexical ingestion. This is where fan-out multiplies: one `tokio::spawn` per agent × N agents.
+- `crates/mika-common/src/config.rs` — `kg_ingestion_model`, `kg_extraction_model`, `kg_resolution_model` fields (lines 754–765); `make_kg_extraction_provider` / `make_kg_resolution_provider` factories (lines 1014–1039). All currently default to `None` (feature disabled when unset), so "safer default" means operator guidance + startup advisory, not a hardcoded fallback.
+- `crates/mika-agent/src/db/kg_schema.rs` — central place for KG schema doc comments + column lists. The idempotency contract doc belongs here.
+- `crates/mika-agent/src/async_db.rs` + `crates/mika-agent/src/db.rs` — `AsyncDatabase` pattern for DB queries.
+- `.env.example` — referenced by `CLAUDE.md` as the source of truth for operator-facing env config.
+
+### Institutional Learnings
+
+- `docs/solutions/kg/` (if present) — check for KG-specific lessons from #689–#692.
+- Memory `feedback_transport_vs_workflow.md` — "Transport config shouldn't compensate for workflow concerns; prefer async decomposition." The batch budget is a workflow concern (per-batch ceiling), not a transport concern (per-request timeout). Aligns with that guidance.
+- Memory `feedback_prompt_enforcement_fragile.md` — "Don't use prompt-level budgets/limits; LLMs rationalize crossing them. Use structural constraints." The budget guard is structural (caller-side counter + early return), not prompted — correct pattern.
+- Memory `project_knowledge_graph.md` — milestone #14 layer overview; schema v25 landed the KG tracking tables.
+
+### External References
+
+None required — the fix is entirely within the existing KG module boundaries and uses established Rust/SQLite patterns already in the repo.
+
+## Key Technical Decisions
+
+- **Doc-level idempotency with content-hash verification (AC #1).** Schema v26 adds `kg_extractions.source_doc_hash TEXT NULL`. The pending query compares the stored hash against `kg_chunks.source_doc_hash` directly — no aggregation, no concatenation — because the lexical ingestor already stores one identical per-doc hash across all of a doc's chunk rows (confirmed by inspection of `lexical_ingestor.rs:260` which uses `SELECT DISTINCT source_doc_hash` and treats `len == 1` as "unchanged," and `lexical_ingestor.rs:318` which inserts the same `new_hash_owned` for every chunk). Rationale for v26 over out-of-band ALTER or query-time aggregation: (a) repo convention is versioned migrations with forward-test convergence (`migrate_v24_to_v25` pattern, convergence test at `db.rs:10992`), (b) one-shot additive nullable column is exactly the class of migration that pattern exists for, (c) query-time aggregation would pay SHA over N chunks per doc per startup forever.
+- **Budget guard is per-batch, not per-agent-process, and not shared across extraction/resolution.** Each call to `extract_pending()` or `resolve_pending()` receives its own budget (default 500). *Rationale:* simplest structural cap, composable, no shared counter between parallel per-agent tasks. *Tradeoff named honestly:* worst-case **per-startup cap** is `2 × N × budget` (extraction batch **plus** resolution batch). With N=11 agents and budget=500, that is up to ~11,000 LLM calls per startup — still roughly three × lower than the 30,400 incident, and in practice far lower once idempotency skips extraction entirely on the second restart. A shared pool would cap the total more tightly but would couple the two phases and is deferred unless the observed cost justifies it.
+- **Option (b) for AC #3 — document the fan-out.** Per-agent subject tables are agent-scoped by schema design; moving to shared extraction would require a substantial redesign (subject tables → cross-agent with per-agent views) and is out of scope for a rescue fix. *Rationale:* ship-before-next-restart mandate. Add a startup INFO log listing agents that share `docs_root` so operators see the multiplier. Document the 1:N cost in `kg_schema.rs` with guidance on when to share vs. separate agents.
+- **Safer provider default = guidance, not hardcoded default.** The code already defaults to `None` (disabled). The fix is (i) `.env.example` now shows an OpenRouter model, (ii) `CLAUDE.md` KG section recommends OpenRouter with cost rationale, (iii) a one-line startup WARN fires when extraction or resolution resolves to `anthropic/*`. *Rationale:* we cannot change the live operator `.env` per constraint; this is the safest in-code change set.
+- **Budget config lives alongside KG model config in `Settings`.** New field `kg_batch_budget: Option<u32>` with env key `MIKA_KG_BATCH_BUDGET`. Default when unset: `500`. Shared by extraction and resolution to keep the mental model simple.
+- **Tests use `MockLlmProvider` only.** No live-provider tests added. Integration-style tests stay under `#[cfg(test)]` in-module.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Should the budget guard be global (shared across all per-agent tasks) or per-batch?* **Per-batch.** Simpler, composable, and 11 × 500 = 5,500 is still safe by two orders of magnitude compared to the incident.
+- *Should we attempt to drain the current 50–92% resolver backlog in this PR?* **No.** Vincent will do a controlled restart with a cheap provider after merge. The fix is about preventing recurrence, not retroactively fixing state.
+- *Should we hard-default the KG model to openrouter if unset?* **No.** `None` means disabled, which is the safest default. A hardcoded fallback could silently turn on LLM calls for operators who deliberately left it off.
+- *Is the AC #1 literal "skip chunks with `kg_chunk_subjects`" incompatible with the existing whole-doc extractor?* **Yes — interpreted as doc-level idempotency hardening.** Elevated to Overview; documented in `kg_schema.rs`.
+- *Path A (v26 migration) vs Path B (query-time aggregation)?* **Path A.** Accepted reviewer pushback — leaving the choice to the implementer was the worst option. Schema bump is additive-nullable, convergence-tested, ~30 minutes.
+- *Should the anthropic warning be a general "expensive provider" warning or anthropic-specific?* **Anthropic-specific.** Event is `kg_anthropic_provider`; message explicitly names Anthropic. Future incidents can add other providers case by case; keeping the list general requires ongoing maintenance for no current benefit.
+- *Can the hash check query be simplified (reviewer's hypothesis)?* **Yes.** `kg_chunks.source_doc_hash` is per-doc, not per-chunk. Query becomes a direct `ke.source_doc_hash = kc.source_doc_hash` comparison.
+
+### Deferred to Implementation
+
+- Exact field name and default-constant location for the budget config — choose during implementation to match existing `config.rs` conventions.
+- Whether the WARN on `anthropic/*` should be info-level — tune during implementation to avoid noise in normal dev workflows.
+- Whether to include the hash in the `kg_extractions` row at migration time or populate it lazily on next successful extraction. Lazy is simpler; verify no regression.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+Startup dispatch (server/mod.rs):
+    group agents by docs_root; info!(kg_shared_docs_root) when group size >= 2
+    warn once per role if resolved provider is anthropic (kg_anthropic_provider)
+    for each agent:
+        tokio::spawn(extract_pending(agent, budget=N))
+    for each agent:
+        tokio::spawn(resolve_pending(agent, budget=N))   // N = effective_kg_batch_budget()
+
+extract_pending(budget):
+    // Pending query (simplified — hash is per-doc in kg_chunks):
+    //   SELECT DISTINCT c.source_doc_path FROM kg_chunks c
+    //   WHERE c.agent_id = ?1
+    //     AND NOT EXISTS (
+    //       SELECT 1 FROM kg_extractions e
+    //       WHERE e.agent_id=c.agent_id AND e.source_doc_path=c.source_doc_path
+    //         AND e.source_doc_hash = c.source_doc_hash
+    //     )
+    pending_docs = query(above)
+    calls_made = 0
+    for doc in pending_docs:
+        if calls_made >= budget:
+            warn!(event="kg_budget_exhausted", scope="extraction",
+                  calls_made, remaining=pending_docs.len()-i, budget)
+            return Ok(BatchStats { aborted: true, ... })
+        extract_document(doc)     // one LLM call per doc
+        calls_made += 1
+        record_extraction(doc, source_doc_hash=hash_from_chunks)
+
+resolve_pending(budget):
+    pending_entities = query: subject entities missing or stale resolution log row
+    llm_calls = 0
+    for entity in pending_entities:
+        if exact_match_hits(entity):
+            resolve via exact     // no LLM call, no budget debit
+            continue
+        if llm_calls >= budget:
+            warn!(event="kg_budget_exhausted", scope="resolution",
+                  llm_calls, remaining=..., budget)
+            return Ok(ResolutionStats { aborted: true, ... })
+        disambiguate_via_llm(entity)
+        llm_calls += 1
+```
+
+Per-startup cap (worst case, honest number):
+
+```text
+    extraction_cap  = N_agents × budget           (e.g., 11 × 500 = 5,500)
+    resolution_cap  = N_agents × budget           (e.g., 11 × 500 = 5,500)
+    total_per_boot  = extraction_cap + resolution_cap = 2 × N × budget
+                    = 11,000 calls per startup under worst-case fan-out
+
+    Expected steady state (after first successful boot):
+    extraction_calls = 0   (idempotency skips everything)
+    resolution_calls ≈ (new subject entities drained this boot), bounded by budget
+```
+
+Fan-out advisory (server/mod.rs startup):
+
+```text
+After collecting `agents` map, group by docs_root:
+    docs_root_groups = HashMap<PathBuf, Vec<agent_id>>
+    for group with len > 1:
+        info!(event="kg_shared_docs_root",
+              docs_root, agents=group,
+              note="each agent extracts independently; cost scales N×")
+```
+
+Anthropic provider advisory (one-shot, per role, anthropic-specific event):
+
+```text
+After make_kg_extraction_provider() returns Some(Ok(llm)):
+    if llm.provider_name() == "anthropic":
+        warn!(event="kg_anthropic_provider",
+              role="extraction", provider="anthropic",
+              note="Anthropic pricing is ~10× typical OpenRouter equivalents \
+                    for these models; consider MIKA_KG_EXTRACTION_MODEL=openrouter/...")
+// Same one-shot pattern for the resolution provider with role="resolution".
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add budget config + startup logging for shared docs_root / expensive provider**
+
+**Goal:** Wire the new `kg_batch_budget` config field, surface fan-out cost at startup, and warn when KG resolves to an expensive provider. All user-visible observability for R2/R3/R4 lands here first so the later units have structured log events to reference.
+
+**Requirements:** R2, R3, R4.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `crates/mika-common/src/config.rs` (add `kg_batch_budget: Option<u32>` field, default 500, documented alongside the other KG fields; expose via `effective_kg_batch_budget(&self) -> u32`).
+- Modify: `crates/mika-agent/src/server/mod.rs` (after `agents` collection and before per-agent extraction/resolution spawns: (a) group agents by `docs_root` and emit `kg_shared_docs_root` INFO when a group has ≥ 2 agents, (b) after each `make_kg_*_provider` call, check resolved provider and emit `kg_anthropic_provider` WARN — at most once per role per startup — when it resolves to an `anthropic/*` model).
+- Modify: `.env.example` — add `MIKA_KG_BATCH_BUDGET=500` with a comment; change commented example `MIKA_KG_*_MODEL` lines to reference an `openrouter/*` model rather than `anthropic/*`.
+- Test: `crates/mika-common/src/config.rs` (in-module `#[cfg(test)] mod tests`) — round-trip test for the new field default + env override.
+
+**Approach:**
+- Follow the existing `kg_ingestion_model` / `kg_extraction_model` pattern (serde default, `#[serde(default)]`, `Option<u32>`).
+- Provide `effective_kg_batch_budget()` helper returning `self.kg_batch_budget.unwrap_or(500)` so the callsite is explicit about the default.
+- For the shared-docs_root detection, docs_root is currently computed once per server (`std::env::current_dir().join("docs/solutions")`) — so the shared case is "all agents with extraction enabled share the same root." Emit once at INFO with the full agent list only when the group size is ≥ 2. Single-agent case stays silent.
+- For the anthropic-specific warning, use the `provider_name()` method on the resolved `LlmProvider`. Event name is `kg_anthropic_provider` (not a generic `kg_expensive_provider`). Message explicitly names Anthropic and points at the env var to change (`MIKA_KG_EXTRACTION_MODEL=openrouter/...`). Do NOT widen the check to other providers in this PR — that's a separate call when and if new incidents surface.
+- Do NOT add runtime providers or fallbacks — provider selection stays as-is.
+
+**Patterns to follow:**
+- `crates/mika-common/src/config.rs` field declarations + `Default::default()` overrides.
+- `crates/mika-agent/src/server/mod.rs` existing KG dispatch logging style (`event="..."`, `agent_id = %...`).
+
+**Test scenarios:**
+- Happy path: `Settings::default()` produces `kg_batch_budget = None` and `effective_budget()` returns 500.
+- Edge case: `MIKA_KG_BATCH_BUDGET=100` in env overrides to 100.
+- Edge case: `MIKA_KG_BATCH_BUDGET=0` is accepted and treated as "disable entirely" by the extractor/resolver (no calls made, immediate return — verified in Units 2 and 3).
+- Error path: `MIKA_KG_BATCH_BUDGET=-1` or non-numeric value fails to deserialize — captured as a config-load error, server logs it.
+
+**Verification:**
+- `cargo test -p mika-common config::` passes.
+- Manual: starting mika-server with multiple agents configured + `MIKA_KG_INGESTION_MODEL=openrouter/...` emits exactly one `kg_shared_docs_root` INFO with the full agent list; no `kg_anthropic_provider` WARN.
+- Manual: swapping to `anthropic/*` emits one `kg_anthropic_provider` WARN per role (extraction + resolution).
+
+- [ ] **Unit 2: Schema v26 migration + budget-guarded `extract_pending` with doc-hash idempotency marker**
+
+**Goal:** Schema v26 adds `kg_extractions.source_doc_hash TEXT NULL`. `extract_pending()` honors the budget cap and its pending query does a direct per-doc hash comparison against `kg_chunks.source_doc_hash`, so stale markers only re-trigger extraction when chunk content actually changed.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** Unit 1 (needs `kg_batch_budget` config and `effective_kg_batch_budget()`).
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs` — bump `CURRENT_SCHEMA_VERSION` to 26; add `migrate_v25_to_v26()` following the established pattern (see `migrate_v24_to_v25` at line 2783). Migration is a single `ALTER TABLE kg_extractions ADD COLUMN source_doc_hash TEXT` + `INSERT INTO schema_version (version) VALUES (26)`. Additive-nullable, fully idempotent on re-run (SQLite's `ALTER` is not, so guard with `pragma_table_info` check or rely on the version gate at line 622 which already prevents re-run). Update the `fresh schema` branch (line 877 area) to create the column on v26 installs. Extend the v24→v25 convergence test (`db.rs:10992`) to also assert v26 convergence from a fresh v26 install vs. a migrated v25→v26 install.
+- Modify: `crates/mika-agent/src/db/kg_schema.rs` — add `source_doc_hash` to `KG_EXTRACTION_COLUMNS`. Extend the module doc with a new **Idempotency key (extraction)** section documenting: (a) primary key is `(agent_id, source_doc_path)` in `kg_extractions`; (b) staleness triggers re-extraction when `kg_extractions.source_doc_hash != kg_chunks.source_doc_hash` for any of the doc's chunk rows (the hash is per-doc, so any chunk row for the doc has the same value — see `lexical_ingestor.rs:260,318`); (c) per-chunk `kg_chunk_subjects` rows are provenance, not idempotency markers — AC #1's literal "skip chunks with `kg_chunk_subjects`" is interpreted as doc-level marker hardening given whole-doc extraction.
+- Modify: `crates/mika-agent/src/kg/subject_extractor.rs` — `extract_pending(budget: u32)`; inner loop tracks `calls_made`, emits `kg_budget_exhausted` WARN and returns early with `BatchStats { aborted: true, ... }` when reached. `get_pending_docs()` rewritten (see Approach). `record_extraction()` persists the `source_doc_hash` it just consumed by reading one chunk row per doc before extraction (the hash is already in memory from the ingestor; we just need it back here).
+- Modify: `crates/mika-agent/src/server/mod.rs` — spawn site passes `settings.effective_kg_batch_budget()` into the constructor call chain.
+- Test: `crates/mika-agent/src/kg/subject_extractor.rs` `#[cfg(test)] mod tests` — scenarios below, using `MockLlmProvider`.
+- Test: `crates/mika-agent/src/db.rs` — convergence test covers v26.
+
+**Approach:**
+- **Migration.** Single nullable column, no backfill. Pre-existing `kg_extractions` rows from the first-run-after-v25 boot will have `source_doc_hash IS NULL`. The pending query treats NULL as stale (see SQL below), which correctly forces one re-extraction of those rows on the next boot — but only if chunks still exist and only within budget, so total cost is bounded. On the second post-deploy boot, all rows have a hash and the query returns empty.
+- **Pending query (simplified per reviewer).** The lexical ingestor stores one identical hash across all chunk rows of a doc (`lexical_ingestor.rs:318` writes `new_hash_owned` on every chunk). So a direct comparison suffices — no aggregation, no concatenation:
+  ```sql
+  SELECT DISTINCT c.source_doc_path
+  FROM kg_chunks c
+  WHERE c.agent_id = ?1
+    AND NOT EXISTS (
+      SELECT 1 FROM kg_extractions e
+      WHERE e.agent_id      = c.agent_id
+        AND e.source_doc_path = c.source_doc_path
+        AND e.source_doc_hash = c.source_doc_hash
+    )
+  ORDER BY c.source_doc_path
+  ```
+  `source_doc_hash IS NULL` on an old row fails the equality predicate, matching the NOT EXISTS → the doc is pending, as desired. On the next boot after a successful run, the row has a non-NULL hash matching current chunks → NOT EXISTS is false → doc is not pending.
+- **Budget.** `extract_pending(budget: u32)` — `budget == 0` returns immediately with zero calls. For every doc, check `calls_made >= budget` before `extract_document`; on trigger, emit `warn!(event="kg_budget_exhausted", scope="extraction", calls_made, remaining=pending.len()-i, budget)` and return `Ok(BatchStats { aborted: true, ..stats })`.
+- **Hash provenance on write.** Before extracting, read one `kg_chunks.source_doc_hash` for the doc; on success, pass that hash to `record_extraction()` which writes it into `kg_extractions.source_doc_hash` via the existing ON CONFLICT UPSERT.
+- **Mock LLM** from `mika-common::llm::mock` (already `test-utils` gated and used in eval tests).
+
+**Patterns to follow:**
+- `migrate_v24_to_v25` at `crates/mika-agent/src/db.rs:2783` for migration shape.
+- Convergence test at `crates/mika-agent/src/db.rs:10992` for fresh-vs-migrated parity.
+- Existing `for (i, doc_path) in pending_docs.iter().enumerate()` loop at `subject_extractor.rs:534`.
+- Existing `warn!` event style with `trace_id`, `agent_id`, `event=...`.
+
+**Test scenarios:**
+- Happy path: 3 pending docs (no `kg_extractions` rows), budget=10, mock LLM returns valid output → all 3 extracted, `calls_made=3`, `aborted=false`, 3 rows in `kg_extractions` each with a non-NULL `source_doc_hash` matching the corresponding `kg_chunks.source_doc_hash`.
+- Edge case: 3 pending docs, budget=2 → first 2 extracted, `aborted=true`, third doc has no `kg_extractions` row.
+- Edge case: `budget=0` → immediate return with `calls_made=0`, no LLM calls issued (`MockLlmProvider` verifies).
+- Integration (primary idempotency check): doc extracted once → `kg_extractions.source_doc_hash` populated → second `extract_pending` run with identical chunks sees **zero** pending → no LLM calls.
+- Integration (hash drift): doc extracted → chunks mutated (simulate re-ingestion writing a new hash on all chunk rows) → next `extract_pending` sees the doc pending again → one LLM call → `kg_extractions` updated to new hash.
+- Integration (NULL-hash reprocessing): pre-existing `kg_extractions` row with `source_doc_hash IS NULL` (simulating the post-v26-migration state) → first `extract_pending` treats doc as pending, re-extracts, writes non-NULL hash → second run is a no-op.
+- Error path: LLM returns malformed JSON after retries → C2.3 log-and-skip; budget is consumed for the attempt; remaining docs continue within the remaining budget.
+- Migration: v25 DB → run v25→v26 migration → `kg_extractions.source_doc_hash` column exists and is NULL for all pre-existing rows. Fresh v26 install + v25-then-migrated install converge schema.
+
+**Verification:**
+- `cargo test -p mika-agent --lib kg::subject_extractor` passes.
+- `cargo test -p mika-agent --lib db::` passes (includes migration + convergence).
+- `cargo clippy -p mika-agent` clean.
+- `kg_schema.rs` doc section covers idempotency key, hash-equality check, AC #1 interpretation, and non-idempotency role of `kg_chunk_subjects`.
+
+- [ ] **Unit 3: Budget-guarded `resolve_pending`**
+
+**Goal:** `resolve_pending()` honors the same budget cap. LLM-disambiguation calls count against the budget; exact-match resolutions do not (zero-cost). On exhaustion, remaining entities stay pending for the next run.
+
+**Requirements:** R2.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` — `resolve_pending(budget: u32)`; count LLM calls made in Stage 2 (disambiguation) against the budget; Stage 1 exact-match resolutions are free. Emit `kg_budget_exhausted` WARN with `scope = "resolution"`, return cleanly.
+- Modify: `crates/mika-agent/src/server/mod.rs` — pass budget into the resolver spawn at line 884.
+- Modify: `crates/mika-agent/src/kg/ingestion_orchestrator.rs` — `spawn_resolution()` also honors the budget (pass from `IngestionOrchestrator` constructor — thread through a `budget: u32` field).
+- Test: `crates/mika-agent/src/kg/entity_resolver.rs` `#[cfg(test)] mod tests` — add scenarios below.
+
+**Approach:**
+- Thread `budget: u32` through the resolver constructor and `resolve_pending`. Keep the existing mode-split (exact-match-only when no LLM) — `budget = 0` in exact-match-only mode is a no-op as before.
+- Emit budget-exhaustion WARN with structured fields matching Unit 2 for easy log correlation.
+- Ingestion orchestrator also needs the budget; default it through `Settings::effective_kg_batch_budget()` at the call site in `server/mod.rs`.
+
+**Patterns to follow:**
+- Existing resolver two-stage dispatch.
+- Same log event shape as Unit 2.
+
+**Test scenarios:**
+- Happy path: 5 pending entities, 3 exact-match, 2 LLM-disambiguated, budget = 10 → all resolved, `llm_calls = 2`, not aborted.
+- Edge case: 5 pending, all require LLM disambiguation, budget = 2 → first 2 resolved, remaining 3 stay pending (`kg_resolutions_log` has 2 rows, not 5).
+- Edge case: exact-match-only mode (`resolution_llm = None`) with budget = 0 → no-op; exact matches still happen for Stage 1 entities.
+- Edge case: 5 pending entities all exact-match with budget = 0 → all resolved via exact match, no LLM calls, no budget debit.
+- Error path: LLM disambiguation fails mid-batch → C2.3 log-and-skip; budget consumed for the failed attempt; remaining entities continue under remaining budget.
+
+**Verification:**
+- `cargo test -p mika-agent --lib kg::entity_resolver` passes.
+- `kg_resolutions_log` shows the cut-off cleanly (`outcome = 'matched_exact' | 'matched_llm' | 'skipped_no_llm' | 'no_match'`).
+
+- [ ] **Unit 4: Documentation + operator guidance (AC #3, AC #4)**
+
+**Goal:** Operators understand the per-agent fan-out cost, the recommended provider, and the new budget knob without reading the source.
+
+**Requirements:** R3, R4.
+
+**Dependencies:** Units 1–3 (references their log event names and new env var).
+
+**Files:**
+- Modify: `crates/mika-agent/src/db/kg_schema.rs` — extend the top-of-file module doc with a new **Fan-out cost model** section: documents the per-agent isolation decision, the N× multiplier when `docs_root` is shared, guidance on when to share vs. separate agents (examples: research agents that should diverge = separate; workspace tooling agents that should see the same library = shared with understood cost), and a forward pointer to `MIKA_KG_BATCH_BUDGET` as the safety net.
+- Modify: `CLAUDE.md` (project root) — KG section update: recommend OpenRouter for `MIKA_KG_*_MODEL`, mention `MIKA_KG_BATCH_BUDGET` default + override, reference `kg_shared_docs_root` and `kg_budget_exhausted` log events for observability.
+- Modify: `crates/mika-agent/CLAUDE.md` — subject-extractor / entity-resolver subsections: note budget guard, idempotency hash check, `kg_extractions` marker semantics, and pointer to `kg_schema.rs` for the full contract.
+- Modify: `.env.example` — replace any commented `MIKA_KG_*_MODEL=anthropic/...` examples with `openrouter/...` examples; add `MIKA_KG_BATCH_BUDGET=500` with a one-line comment on intent.
+
+**Approach:**
+- Keep `CLAUDE.md` edits concise — one paragraph per change, not full specs.
+- `kg_schema.rs` is the canonical place; other docs forward-point to it.
+- The fan-out section should include an example cost calc so operators can predict the bill (e.g., "11 agents × 283 docs × 1 LLM call ≈ 3,113 calls per full extraction").
+
+**Test scenarios:**
+- Test expectation: none — documentation-only unit. Covered indirectly by the `/mika-doc-audit` pipeline step, which verifies docs match code behavior.
+
+**Verification:**
+- `/mika-doc-audit` passes (no stale KG claims).
+- `rg 'anthropic/claude' .env.example` returns zero hits outside of "was" / historical mentions.
+- `kg_schema.rs` top-of-file doc visibly covers: write contract (existing), idempotency key (Unit 2), fan-out cost model (this unit).
+
+- [ ] **Unit 5: PR-body verification signal (AC #5)**
+
+**Goal:** The PR body for this change explicitly tells Vincent the three observable signals that prove the fix works, so post-deploy verification is a 30-second check, not an investigation.
+
+**Requirements:** R5.
+
+**Dependencies:** Units 1–4 merged in PR body references.
+
+**Files:**
+- Create: (none — signal description is in the PR body and plan, not a committed file).
+- Modify: `crates/mika-agent/CLAUDE.md` Knowledge Graph section — a short **Post-restart safety check** subsection that operators can re-read later, describing the expected log events and a SQL query.
+
+**Approach:**
+The PR body must include a **Post-deploy verification** section with four signals. Framing is deliberately tight — reviewer flagged that Signal A alone could be misread as "fully caught up" while Signal C still shows backlog.
+
+1. **Log signal A — extraction not re-running (narrowly scoped):** On the **second** post-deploy restart (the first one backfills NULL hashes per the v26 migration note), `event="subject_extraction_start"` should show `pending_docs=0` for every agent that previously had `kg_extractions` rows. Does **not** prove resolver is caught up — that's Signal C. `grep 'subject_extraction_start' server.log | jq -c 'select(.pending_docs == 0) | {agent_id}'` should list every agent.
+2. **Log signal B — budget not exhausted:** `grep 'kg_budget_exhausted' server.log` returns zero lines on a healthy second+ restart. A hit indicates either the budget is too tight, an unexpected re-extraction cascade, or the resolver needs more budget windows to catch up (in which case it'll drain over a few restarts — see Signal D).
+3. **SQL signal C — resolver backlog drains over time:** `SELECT agent_id, COUNT(*) FROM kg_subject_entities se WHERE NOT EXISTS (SELECT 1 FROM kg_resolutions_log rl WHERE rl.agent_id = se.agent_id AND rl.subject_entity_id = se.id) GROUP BY agent_id;` — count trends toward 0 across restarts (bounded by the per-restart budget). May take multiple restart cycles to reach 0 for agents starting at >3,000 pending. **This is the resolver-caught-up signal; Signal A does not imply it.**
+4. **Cost signal D — concrete prediction for first post-fix restart:** With `openrouter/...` configured and the current 50–92% resolver backlog, expect roughly `N_agents × budget = ~5,500` LLM calls for resolution on the first restart, plus ~0 for extraction (idempotency skips once hashes are backfilled). At typical OpenRouter cheap-tier pricing (~\$0.0001 per call average), total cost ≈ **\$0.05–\$0.50 per restart** until the backlog drains. If the first post-fix restart shows substantially more than `N × budget` calls or substantially more than \$1 of spend, something is wrong — budget guard failure, stale idempotency, or provider routing regression.
+
+The plan captures these signals; the PR body restates them concretely with copy-pasteable commands.
+
+**Test scenarios:**
+- Test expectation: none — verification signal is a documentation artifact. Its correctness is verified manually by Vincent post-deploy.
+
+**Verification:**
+- PR body contains all three signals with concrete commands/queries.
+- `CLAUDE.md` KG section has the matching **Post-restart safety check** subsection.
+
+## System-Wide Impact
+
+- **Interaction graph:** Startup spawn sites in `crates/mika-agent/src/server/mod.rs` are the only callers affected. Compound hook in `ingestion_orchestrator.rs` is per-doc and naturally bounded; threading budget through is defensive, not load-bearing.
+- **Error propagation:** Budget exhaustion is not an error — it returns `Ok(BatchStats { aborted: true, ... })` with a WARN log. Callers in `server/mod.rs` already log the returned stats; no behavior change downstream.
+- **State lifecycle risks:** A budget abort partway through extraction leaves some docs marked `kg_extractions` and others pending. This is correct behavior — the next run picks up where it left off. No partial-row state (extraction writes are transactional per-doc already).
+- **API surface parity:** `ingest_and_extract` and `reingest_and_reextract` in `IngestionOrchestrator` are compound-hook paths that extract one doc at a time — threading `budget` through them is a small refactor. For correctness, these paths should either honor the budget or explicitly skip the check because they're bounded-by-construction; pick "skip with comment" to avoid accidental compound-hook failures.
+- **Integration coverage:** Startup-triggered extraction + resolution is exercised by the server's init path. Unit tests cover extract/resolve in isolation using `MockLlmProvider`. A full end-to-end startup test would require instantiating the server with multiple agents — deliberately out of scope; Vincent's post-deploy verification signal covers the integration side.
+- **Unchanged invariants:** Sole-writer contracts (extractor, resolver, chunks), schema version (stays at v25), compound hook semantics, exact-match-only resolution mode, and the `kg_subject_resolutions` / `kg_resolutions_log` tables are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Pre-existing `kg_extractions` rows have `source_doc_hash=NULL` after v26 migration; first post-deploy boot treats every one of those docs as pending and re-extracts. | Accepted and bounded: the first post-deploy boot runs one extraction batch per agent capped at `budget`. Worst case ~N × budget extraction calls, which is exactly what the budget guard exists for. From the second boot onward, all rows have a hash and extraction is a no-op. This is the same first-boot behavior as the original v25 landing — only this time it's bounded and loud. Post-deploy verification Signal A is explicitly worded to test on the *second* restart for that reason. |
+| Convergence-test drift: fresh v26 install vs. migrated v25→v26 install produce different schemas. | Extend the existing v24→v25 convergence test at `db.rs:10992` to also cover v26. This is the forward-test harness pattern from #686 doing the job it was designed for. |
+| Budget default (500) is too tight for a fresh install with many docs_root-sharing agents. | Per-startup worst case is `2 × N × budget` (extraction + resolution). With N=11, default=500 → ~11,000 calls, still ~3× below the incident. Operators who legitimately need a bigger bound override via `MIKA_KG_BATCH_BUDGET`. Document default + tradeoff in `CLAUDE.md`. |
+| Budget exhaustion silently accrues partial state if operators never notice the WARN. | Mitigation is structural: partial state is valid (pending work resumes next run, per-doc transactions). Log signal B in Unit 5 makes "budget exhausted" a first-class observability event operators check post-deploy. |
+| Anthropic provider WARN fires on every restart, creating log noise. | Emit at most once per startup per role (extraction / resolution) via a `OnceLock` / `AtomicBool` at the call site in `server/mod.rs`. |
+| Fan-out INFO log is noisy when run with 1 agent (no multiplier). | Only emit `kg_shared_docs_root` when the group size is ≥ 2. Single-agent case is silent. |
+| Test coverage using `MockLlmProvider` could drift from real provider behavior. | Real-provider tests are gated behind `#[ignore]` + `MIKA_EVAL_REAL_PROVIDERS` per repo convention — not added in this PR. Vincent's post-deploy verification covers the real-world integration path. |
+| Per-startup cap under pathological fan-out (20+ agents sharing docs_root) could still exceed operator tolerance. | Out of scope for this rescue. Cap is `2 × N × budget`; if N grows that much, operators should either share extraction across agents (AC #3 option (a), deferred) or lower the budget. Documented in `CLAUDE.md` alongside the per-agent fan-out guidance. |
+
+## Documentation / Operational Notes
+
+- **CLAUDE.md (root)** — KG section gets the new env var + provider guidance.
+- **CLAUDE.md (`crates/mika-agent`)** — subject-extractor / entity-resolver sections reference the budget and idempotency hash.
+- **`kg_schema.rs`** — canonical idempotency key doc + fan-out cost model doc.
+- **`.env.example`** — new `MIKA_KG_BATCH_BUDGET`, reworded provider example.
+- **PR body** — must include the three post-deploy verification signals (Unit 5).
+- **Post-deploy ops (Vincent, not this PR):** swap `MIKA_KG_*_MODEL` to an openrouter/* model before the next restart to drain the half-done resolver backlog cheaply, then confirm the three signals.
+
+## Sources & References
+
+- **Origin document:** GitHub issue senara-solutions/mika#757.
+- **Related code:** `crates/mika-agent/src/kg/{subject_extractor.rs,entity_resolver.rs,ingestion_orchestrator.rs}`, `crates/mika-agent/src/db/kg_schema.rs`, `crates/mika-agent/src/server/mod.rs`, `crates/mika-common/src/config.rs`.
+- **Related PRs/issues:** #689 (lexical ingestor), #690 (subject extractor), #691 (entity resolver), #692 (self-knowledge upgrade), #740 (KG self-knowledge eval, merged today), #758 (companion eval PR).
+- **Memory references:** `project_knowledge_graph.md`, `feedback_transport_vs_workflow.md`, `feedback_prompt_enforcement_fragile.md`.

--- a/docs/runtime-structure.md
+++ b/docs/runtime-structure.md
@@ -143,7 +143,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **skill_overrides** — `(agent_id NOCASE, skill_name NOCASE) PK`, `always_on INTEGER`, `llm_provider TEXT`, `llm_model TEXT` (v20), `enabled INTEGER` (v24). Per-agent overrides: LLM overrides resolve as DB > manifest `[llm]` > agent default (`mika skills llm <name> set <provider>/<model>`). Enabled state is tri-state: `NULL`=default (enabled), `0`=disabled, `1`=explicitly enabled. `enabled=false` evicts the skill from `SkillRegistry.entries` during `apply_overrides()`. Replaces `.disabled` marker files (#629). Default-equals-delete: rows where all columns are NULL are pruned.
 
-### Knowledge Graph Tables (v25)
+### Knowledge Graph Tables (v25; `kg_extractions.source_doc_hash` added v26)
 
 **kg_entities** — `id INTEGER PK AUTO`, `entity_key TEXT UNIQUE`, `type TEXT NOT NULL`, `name TEXT NOT NULL`, `properties_json TEXT`, `created_at TEXT`, `updated_at TEXT`. Domain-layer entities (skill, tool, agent, problem_type). No `agent_id` — global scope.
 
@@ -159,7 +159,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 
 **kg_chunk_subject_relationships** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `chunk_id FK→kg_chunks`, `subject_relationship_id FK→kg_subject_relationships`, `extraction_trace_id TEXT`, `created_at TEXT`. Provenance: which chunk produced which relationship.
 
-**kg_extractions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `source_doc_path TEXT NOT NULL`, `entities_extracted INTEGER`, `relationships_extracted INTEGER`, `extraction_trace_id TEXT`, `model TEXT`, `duration_ms INTEGER`, `created_at TEXT`. Tracking: one row per completed extraction. UNIQUE on `(agent_id, source_doc_path)`.
+**kg_extractions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `source_doc_path TEXT NOT NULL`, `source_doc_hash TEXT` (added v26, #757), `extraction_model TEXT NOT NULL`, `entities_extracted INTEGER`, `relationships_extracted INTEGER`, `extraction_trace_id TEXT`, `created_at TEXT`. Tracking: one row per completed extraction. UNIQUE on `(agent_id, source_doc_path)`. The hash enables content-aware idempotency — the pending-doc query compares the stored hash against `kg_chunks.source_doc_hash` and only re-extracts when they diverge (including the NULL-hash case for pre-v26 rows). Written atomically inside the extraction transaction alongside entity/relationship upserts.
 
 **kg_subject_resolutions** — `id INTEGER PK AUTO`, `agent_id FK→agents`, `subject_entity_id FK→kg_subject_entities`, `domain_entity_id FK→kg_entities`, `confidence REAL NOT NULL CHECK(0.0..1.0)`, `trace_id TEXT`, `created_at TEXT`. Resolution edges bridging subject→domain. UNIQUE on `(agent_id, subject_entity_id, domain_entity_id)`. CASCADE on both FKs. Sole writer: `SubjectEntityResolver` (#691).
 

--- a/docs/solutions/best-practices/first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md
+++ b/docs/solutions/best-practices/first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md
@@ -1,0 +1,292 @@
+---
+title: "First-boot cost spike after a tracking-table migration"
+module: kg
+date: 2026-04-23
+problem_type: best_practice
+component: database
+severity: high
+applies_when:
+  - "A schema migration creates a new tracking table that records 'seen before' / 'already processed' state"
+  - "A non-interactive LLM or other expensive-per-unit pipeline reads from that table to decide what work to do"
+  - "The consumer runs against already-populated source data on first boot after the migration"
+  - "Per-agent or per-tenant fan-out multiplies the cost when the upstream source is shared"
+tags:
+  - knowledge-graph
+  - schema-migration
+  - idempotency
+  - llm-budget
+  - cost-control
+  - first-boot
+  - fan-out
+---
+
+## Context
+
+On 2026-04-23 09:08 UTC, a routine `mika-server` restart burned ~30,400 Haiku LLM calls over 38 minutes (~\$40–60) against `claude-haiku-4-5`, exhausting Anthropic Console API credit. Tracked as mika#757.
+
+The fault was structural, not a bug in any single line of code:
+
+1. Schema v25 landed the Knowledge Graph (KG) tables including `kg_extractions` — a tracking table that records one row per successfully extracted doc to prevent re-extraction on subsequent boots.
+2. The first boot after v25 saw an empty `kg_extractions` table — there were no prior "already extracted" rows because the table didn't exist before.
+3. The pending-doc query (`docs with chunks but no extraction row`) therefore returned every doc across every agent.
+4. 11 agents × 283 shared docs → ~3,113 extractions + per-entity resolution fan-out → ~30K LLM calls.
+5. No per-batch cap existed to bound the cost.
+
+**The general pattern:** any schema migration that introduces a tracking or "seen-before" table creates a first-boot cost spike the moment the consumer runs against populated source data. The spike scales with `source-units × consumer-multiplier × per-unit-cost`. If any of those factors is non-trivial — and they usually are for LLM-heavy consumers — the first boot after such a migration is a financial event waiting to happen.
+
+This pattern generalizes well beyond KG. Think: a new `email_processed` table added to an already-populated mailbox. A new `vector_embedded` column added after embeddings already exist. A new `consent_recorded` flag added after every user has already implicitly opted in. Any time "we'll track it going forward" meets "we have a backlog" on first boot, the cost is an open question that must be answered at planning time, not discovered at runtime.
+
+## Guidance
+
+### Ask the first-boot question during planning
+
+When a plan adds a tracking table for a consumer that does non-trivial per-unit work (LLM calls, external API calls, heavy compute), add this checklist item to the requirements trace:
+
+> **Q: On the first boot after this migration, how many units of work does the pending query return, and what does that cost?**
+
+Acceptable answers include:
+
+- "Zero, because the consumer doesn't run at startup."
+- "Bounded at N, because we cap the batch."
+- "All of them, but each unit costs \$X and total is acceptable."
+
+What is **not** an acceptable answer: "We don't know" or silence. If the answer is "we don't know," derive it — count source rows, model per-unit cost, multiply by consumer multipliers, and if the result is uncomfortable, build a safeguard before shipping.
+
+**Multiplier awareness** (both `docs_root` fan-out and resolver fan-out hit this):
+
+- Per-agent × per-tenant × per-customer → multiply every cost by the worst-case container count.
+- Per-entity downstream consumers (like resolution after extraction) compound further — one extracted entity may produce one disambiguation call.
+- Retry loops multiply again. A transient failure category that retries 3× with backoff scales by 3 on top of everything else.
+
+### Ship tracking-table migrations with a structural budget cap
+
+A migration that might trigger a first-boot spike should ship with a **caller-side structural budget** — not a prompt-level "be mindful" — capped on the consumer's batch. In Mika's case:
+
+```rust
+pub async fn extract_pending(&self, budget: u32) -> Result<BatchStats> {
+    for doc in pending_docs {
+        if stats.llm_calls >= budget {
+            warn!(event = "kg_budget_exhausted", scope = "extraction", ...);
+            stats.aborted_budget = true;
+            break;
+        }
+        extract_document(doc).await?;
+        stats.llm_calls += 1;
+    }
+}
+```
+
+Three properties matter:
+
+1. **Structural, not prompted.** LLMs rationalize crossing prompt-level budgets ("this one is important"); a caller-side counter that refuses to issue a request past the cap cannot be rationalized around. See `feedback_prompt_enforcement_fragile.md`.
+2. **Leaves remaining work pending.** A budget abort is not an error — it writes `aborted_budget = true` and logs `kg_budget_exhausted` with enough structured fields for operators to grep (scope, calls_made, budget, remaining). Remaining work drains over subsequent restarts.
+3. **Exempts free paths from the debit.** Stage-1 exact matches in the KG resolver cost no LLM calls; debiting the budget for them would starve free work. The resolver **continues** past budget-skipped entities rather than breaking, so later free-path entities still make progress.
+
+Default: pick a budget that is an order of magnitude below the worst-case steady-state volume. Mika defaults `MIKA_KG_BATCH_BUDGET` to 500 — high enough for healthy operation, low enough that a misconfiguration caps loss at roughly \$0.50 per restart at cheap-tier pricing instead of \$60.
+
+### Pair hash-based idempotency with atomic marker writes
+
+A tracking row is useless if the consumer can pay for the work and then fail to write the marker. On the next restart the same work repeats and the cost is paid again — unbounded if the failure is persistent.
+
+**Two properties are required**:
+
+1. **Content-aware idempotency.** Row-exists idempotency is fragile: if the source changes, the consumer still skips. Hash-based idempotency (`kg_extractions.source_doc_hash = kg_chunks.source_doc_hash`) compares the marker's recorded hash against the current source hash, so content drift triggers re-work and content-equivalence skips it. The pending query becomes a direct equality predicate:
+
+   ```sql
+   WHERE NOT EXISTS (
+     SELECT 1 FROM kg_extractions e
+     WHERE e.agent_id = c.agent_id
+       AND e.source_doc_path = c.source_doc_path
+       AND e.source_doc_hash = c.source_doc_hash
+   )
+   ```
+
+   This only works if the upstream writes one identical hash across all chunk rows of a source doc (which the lexical ingestor does — confirmed at `crates/mika-agent/src/kg/lexical_ingestor.rs:260`). If the upstream ever changed to per-chunk hashes, a `GROUP BY ... HAVING` aggregation would be needed instead.
+
+2. **Atomic marker write.** The marker must be written **inside the same transaction** as the extracted rows, not after them:
+
+   ```rust
+   tx.execute("INSERT ... kg_subject_entities ...", ...)?;
+   tx.execute("INSERT ... kg_subject_relationships ...", ...)?;
+   tx.execute("INSERT ... kg_extractions (..., source_doc_hash, ...) ...", ...)?;
+   tx.commit()?;
+   ```
+
+   A crash, SIGKILL, disk-full, or FK-violation between the entity write and the marker write would otherwise leave "LLM paid but no marker" — the doc re-extracts on every restart, burning budget on the same item forever. Wrap them, or accept unbounded-on-failure cost.
+
+### NULL-hash backfill is a one-shot: accept it and bound it
+
+When the migration is `ALTER TABLE ... ADD COLUMN source_doc_hash TEXT` (nullable), every pre-existing row gets `NULL`. The pending query rejects `NULL = anything`, so each pre-existing row is "pending" once. The first post-deploy boot re-extracts them — **once** — and populates the hash. From the second boot onward the rows compare equal and stay skipped.
+
+Two implications:
+
+- **Document this explicitly.** Operators reading the logs on the first post-deploy boot will see activity and need to know it's the one-shot backfill, not a regression.
+- **Bound it with the budget.** Don't assume "it's just a one-shot." If the backlog is large and the budget is tight, the one-shot becomes a multi-restart drain. That is still fine — it's deterministic and structural — but it needs to be named in the plan so operators don't panic-tune when they see `kg_budget_exhausted` WARN on the first few restarts.
+
+### Provider choice is a structural cost lever — surface it in code
+
+The same model family routed through different providers can be an order of magnitude apart in price. Anthropic direct vs. OpenRouter for `claude-haiku-4-5` is ~10× for bulk NER. An operator mis-setting `MIKA_KG_EXTRACTION_MODEL=anthropic/...` when `openrouter/anthropic/...` would work is a single-line choice that becomes a monthly bill difference.
+
+Pattern: when the code resolves to an expensive provider for a high-volume internal path, emit a one-shot startup advisory naming both the current choice and the cheaper alternative:
+
+```rust
+if llm.provider_name().eq_ignore_ascii_case("anthropic") {
+    warn!(
+        event = "kg_anthropic_provider",
+        scope = "extraction",
+        model = %llm.model_name(),
+        "KG extraction is using Anthropic — typically ~10× more expensive than \
+         OpenRouter equivalents for bulk NER. Consider MIKA_KG_EXTRACTION_MODEL=openrouter/<model>."
+    );
+}
+```
+
+One-shot, not per-call — a log flood is worse than a silent cost. The advisory should fire once per role (extraction / resolution / ingestion) per startup.
+
+Keep the check narrow and specific (`provider_name == "anthropic"`). A generic `kg_expensive_provider` event that tries to classify every provider's pricing becomes a maintenance tax — when OpenAI pricing changes, when a new provider is added, when OpenRouter's routing changes. Name the specific provider the specific incident involved, and add new providers case-by-case as new incidents surface.
+
+### Fan-out on shared source data: document it or share the extraction
+
+Per-tenant isolation is a deliberate schema decision — Mika's subject/chunk tables are agent-scoped so each agent has its own view of the subject graph. The cost consequence: when N agents point at the same `docs_root`, every doc is processed N times.
+
+Two options, pick one at planning time and commit:
+
+- **Option A (share extraction):** subject tables become per-docs_root with per-agent views. Larger redesign; schema-level.
+- **Option B (document the cost):** per-agent tables stay, and the cost multiplier is explicitly documented. Add a startup INFO log when multiple agents share a `docs_root` so operators see the multiplier before it bites.
+
+Mika picked Option B in the rescue fix because Option A is a schema redesign that doesn't belong in an incident response. The INFO log (`kg_shared_docs_root`) surfaces the fan-out at boot:
+
+```
+{"event":"kg_shared_docs_root","agents":["mika","mika-dev","mika-qa",...],"agent_count":11}
+```
+
+If operators running 10+ agents on one `docs_root` become common, that's the signal to revisit Option A.
+
+### Migration immutability — historical migrations are frozen
+
+An early version of this fix retroactively edited `migrate_v24_to_v25` to include the new column. This seems harmless (both paths converge to the same schema) but breaks two invariants:
+
+1. **Audit trail.** `migrate_v24_to_v25` should record what actually shipped at v25, not what we later wish had shipped. Editing historical migrations makes them unreliable as a rollback/forensic reference.
+2. **Test coverage.** The convergence test (fresh-install vs incremental-migrate) now skips the `ALTER TABLE` code path in `migrate_v25_to_v26`, because the retro-edited `migrate_v24_to_v25` already creates the column. The production v25→v26 migration path runs unexercised by tests.
+
+Rule: once a migration has shipped, it is frozen. New changes go in new migrations. The fresh-install path (`migrate_v1` clean-slate) gets updated to include the latest schema, but per-version migrations stay as they were.
+
+### AC interpretation discipline
+
+The original AC for #757 said "skip any `kg_chunks` row that already has rows in `kg_chunk_subjects`." That wording assumed chunk-level extraction. The actual implementation is whole-doc extraction, making chunk-level markers structurally redundant — the same information lives on the parent doc.
+
+The planner's job isn't to follow AC wording literally when the wording contradicts the code's shape. It's to call out the mismatch, propose an interpretation, and require explicit reviewer sign-off before `/ce:work` starts. Don't silently reinterpret; don't refuse to ship. Elevate the interpretation to the plan's Overview so approval is explicit.
+
+## Why This Matters
+
+Mika burned \$40–60 on one restart. The rescue fix caps the blast radius to ~\$0.50 per restart at equivalent pricing. But the deeper win is pattern recognition: a similar incident will happen the next time any tracking-table migration ships without someone asking the first-boot question.
+
+The budget guard is a 50-line safeguard. The hash-idempotency plumbing is a 100-line addition. Each of those, shipped as part of the original #690 feature, would have prevented the incident entirely — and cost less than the incident response.
+
+The expensive lesson is the **structural awareness**. The cheap lesson is the ~150 lines of code. Document the structural awareness first; the code pattern second.
+
+## When to Apply
+
+Invoke this pattern during planning for any feature that ships:
+
+- A new tracking table (`*_processed`, `*_ingested`, `*_seen`, `*_logged`)
+- A hash column added to an existing table for idempotency
+- A consumer that runs non-trivial per-unit work at startup
+- Per-tenant or per-agent fan-out that multiplies the work
+- Any combination of LLM calls, external API calls, or heavy compute tied to a schema change
+
+Skip the full pattern review for:
+
+- Purely cosmetic migrations (renaming a column, adding a comment)
+- Tracking tables that feed only interactive-request-path work (no startup scan)
+- Consumers with already-bounded cost (<\$1/month worst case)
+
+## Examples
+
+### The failing shape (what #757 was before the fix)
+
+```rust
+// Pending-doc query, row-exists only
+"SELECT DISTINCT source_doc_path FROM kg_chunks c
+ WHERE c.agent_id = ?1
+   AND NOT EXISTS (
+     SELECT 1 FROM kg_extractions e
+     WHERE e.agent_id = c.agent_id AND e.source_doc_path = c.source_doc_path
+   )"
+
+// Per-agent spawn, no budget
+for agent in agents {
+    tokio::spawn(async move {
+        let extractor = SubjectExtractor::new(...);
+        extractor.extract_pending().await  // loops through every pending doc
+    });
+}
+
+// Non-atomic marker write
+extract_document(doc).await?;         // LLM call #1
+write_extraction_results(doc).await?; // DB write #1
+record_extraction(doc).await;         // DB write #2 — separate transaction
+```
+
+Three amplifiers: row-exists idempotency invalidated by the v25 migration, no budget, non-atomic marker. The intersection produces the \$60 incident.
+
+### The safe shape
+
+```rust
+// Pending-doc query, hash-aware
+"SELECT DISTINCT c.source_doc_path FROM kg_chunks c
+ WHERE c.agent_id = ?1
+   AND NOT EXISTS (
+     SELECT 1 FROM kg_extractions e
+     WHERE e.agent_id = c.agent_id
+       AND e.source_doc_path = c.source_doc_path
+       AND e.source_doc_hash = c.source_doc_hash  // content-aware
+   )"
+
+// Per-agent spawn, budget-capped
+let budget = settings.effective_kg_batch_budget();  // default 500
+for agent in agents {
+    tokio::spawn(async move {
+        let extractor = SubjectExtractor::new(...);
+        extractor.extract_pending(budget).await  // aborts at cap, leaves work pending
+    });
+}
+
+// Atomic marker write — same transaction as entity rows
+let tx = db.conn.unchecked_transaction()?;
+tx.execute("INSERT ... kg_subject_entities ...", ...)?;
+tx.execute("INSERT ... kg_subject_relationships ...", ...)?;
+tx.execute("INSERT ... kg_extractions (..., source_doc_hash, ...) ...", ...)?;
+tx.commit()?;
+```
+
+### Post-deploy verification signals
+
+The rescue fix added four observable signals in `CLAUDE.md` so operators can confirm the fix is working after a restart:
+
+- **Signal A** (extraction not re-running): `grep subject_extraction_start server.log | jq 'select(.pending_docs == 0)'` should list every agent by the second post-deploy restart.
+- **Signal B** (budget not exhausted): `grep kg_budget_exhausted server.log` returns zero lines on a healthy restart.
+- **Signal C** (resolver backlog drains over time): `SELECT agent_id, COUNT(*) FROM kg_subject_entities WHERE NOT EXISTS (...)` trends to 0 across restarts.
+- **Signal D** (concrete cost prediction): with OpenRouter, expect ~\$0.05–\$0.50 per restart until the backlog drains.
+
+Signal D is the one most often missed. Giving operators a concrete cost prediction lets them verify the fix in the first minute post-deploy, instead of waiting for a monthly bill to surface a regression.
+
+## Related
+
+- **Incident ticket:** [mika#757](https://github.com/senara-solutions/mika/issues/757)
+- **Implementation plan:** `docs/plans/757-kg-extraction-idempotency-fanout.md`
+- **Prior idempotency precedent:** `docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md` (#689) — the hash-based idempotency pattern that #690 should have inherited but didn't.
+- **Constrained NER lineage:** `docs/solutions/best-practices/kg-subject-extraction-constrained-ner-2026-04-22.md` (#690) — the feature whose first-boot spike caused the incident.
+- **KG conventions:** `docs/architecture/kg-implementation-conventions.md` — C2.5 (per-batch budget guard) added in this fix; pairs with pre-existing C2.1–C2.4.
+- **Related memory entries:** `feedback_prompt_enforcement_fragile.md` (structural vs. prompt constraints), `feedback_transport_vs_workflow.md` (async decomposition over timeout tuning), `project_knowledge_graph.md` (KG milestone overview).
+
+## Follow-ups (captured during review, deferred out of rescue scope)
+
+These are real risks identified by the multi-reviewer `/ce:review` pass. They didn't block the rescue fix but warrant dedicated tickets:
+
+- **Cross-agent global semaphore** — per-agent budget caps volume but not concurrent rate. 11 agents × `tokio::spawn` hammers one provider simultaneously.
+- **N+1 on `get_doc_hash`** — the marker write now reads the chunk hash before the LLM call; partially mitigated by colocating both inside `extract_document`, but the query could be folded into `get_pending_docs`.
+- **Resolver correlated-subquery indexing** — `get_pending_entities` does a per-entity `ORDER BY created_at DESC LIMIT 1` subquery with no `created_at` index.
+- **Agent-native observability** — `get_config` reads only customer_config; agents can't see effective `kg_batch_budget` or correlate `kg_budget_exhausted` events (`tracing::warn!` only, not `audit_events`).
+- **Graceful-shutdown `JoinHandle`s** — background spawns have no handles stored, so a SIGTERM mid-batch cancels at the next `.await` and may lose the in-flight doc's marker.
+- **Invalid env-value fail-closed test** — `MIKA_KG_BATCH_BUDGET=-1` fails server startup (correct); no test locks this contract.


### PR DESCRIPTION
## Summary

Rescue fix for the KG extraction cost incident (mika#757). After schema v25 landed the KG tables on 2026-04-23, a routine `mika-server` restart fired ~30,400 Haiku LLM calls in 38 min (~\$40–60) because pre-existing `kg_chunks` rows had no `kg_extractions` markers — every doc was "pending" and 11 agents × 283 docs re-extracted in parallel.

This PR ships three layered safeguards so the next restart stays cheap:

- **Content-aware idempotency (schema v26).** `kg_extractions.source_doc_hash` compared against `kg_chunks.source_doc_hash`. Pre-v26 rows get NULL and re-extract exactly once under the budget, then populate. Second and subsequent restarts are no-ops.
- **Per-batch LLM call budget.** `MIKA_KG_BATCH_BUDGET` (default 500) caps extraction and resolution batches independently. Overflow emits `kg_budget_exhausted` WARN and leaves remaining work for next run. Stage-1 exact matches do not debit the budget (they cost no LLM calls).
- **Atomic marker write.** The `kg_extractions` UPSERT is inside the same transaction as the entity/relationship UPSERTs. Eliminates the "LLM paid but no marker" cascade that would otherwise burn budget on the same doc every restart.

Plus operator advisories:

- `kg_shared_docs_root` INFO at startup when ≥2 agents share a `docs_root` — surfaces the N× fan-out cost multiplier.
- `kg_anthropic_provider` WARN (once per role per startup) when KG resolves to `anthropic/*` — Anthropic direct is ~10× more expensive than equivalent OpenRouter routes for bulk NER.

AC #1 interpretation: "skip chunks with `kg_chunk_subjects` rows" assumes chunk-level extraction. Current implementation is whole-doc (per #690), so chunk-level markers are structurally redundant. This PR interprets AC #1 as hardening the doc-level `kg_extractions` marker with content-hash comparison and documents the interpretation in `kg_schema.rs`.

## Post-deploy verification

Four signals to confirm the fix works on the next restart (full docs in `CLAUDE.md` → **Post-restart safety check**, crate CLAUDE.md, and the compound doc):

- **Signal A (extraction not re-running):** by the **second** post-deploy restart, `grep subject_extraction_start server.log | jq 'select(.pending_docs == 0)'` lists every agent. The **first** post-deploy restart backfills NULL hashes — extraction activity is expected, bounded by the budget.
- **Signal B (budget not exhausted on healthy restart):** `grep kg_budget_exhausted server.log` returns zero lines on steady-state restarts. A hit on the first post-deploy restart is expected if the resolver backlog is large; should disappear after 1–2 cycles.
- **Signal C (resolver backlog drains):** `SELECT agent_id, COUNT(*) FROM kg_subject_entities se WHERE NOT EXISTS (SELECT 1 FROM kg_resolutions_log rl WHERE rl.agent_id = se.agent_id AND rl.subject_entity_id = se.id) GROUP BY agent_id;` trends to 0 across restarts. Agents starting >3,000 pending will take multiple cycles.
- **Signal D (concrete cost prediction):** with `MIKA_KG_*_MODEL=openrouter/...` configured, first-restart resolution cost ≈ `N_agents × budget × \$0.0001` ≈ **\$0.05–\$0.50 per restart** until the backlog drains. Substantially more than \$1/restart indicates a regression (budget-guard failure, stale idempotency, or provider routing issue).

## Operator action required before next restart

- Set `MIKA_KG_*_MODEL` to an OpenRouter model (e.g. `openrouter/deepseek/deepseek-v3`) in `~/.mika/.env`. The code defaults to `None` (disabled); there is no code-level OpenRouter fallback — the choice is config-tier.
- Optionally set `MIKA_KG_BATCH_BUDGET` if the default (500) needs tuning.
- Restart `mika-server` once and verify Signals A–D.

## Scope

**In scope:**
- Schema v26 migration (additive-nullable `kg_extractions.source_doc_hash`)
- `extract_pending(budget)` and `resolve_pending(budget)` signature changes
- `IngestionOrchestrator::new(..., resolution_budget: u32, ...)` signature change
- New `MIKA_KG_BATCH_BUDGET` config (`Option<u32>`, default 500)
- Documentation updates: root CLAUDE.md, crate CLAUDE.md, `docs/configuration.md`, `docs/runtime-structure.md`, `docs/architecture/kg-implementation-conventions.md` (new C2.5 section)
- 12 new tests in `crates/mika-agent/tests/eval/test_kg_budget_757.rs`; convergence test at `db.rs:~11020` extended to v26

**Out of scope** (tracked as follow-ups in the compound doc):
- Per-chunk extraction refactor — whole-doc extraction stays
- Backfilling the half-drained resolver state — Vincent handles via a post-deploy restart cycle
- Cross-agent global semaphore for startup fan-out rate-limiting
- N+1 optimization on `get_doc_hash`
- Agent-native observability: `get_config` exposing Settings, `audit_events` rows for budget exhaustion
- Graceful-shutdown JoinHandles for background spawns

## Artifacts

- **Plan:** `docs/plans/757-kg-extraction-idempotency-fanout.md`
- **Compound doc:** `docs/solutions/best-practices/first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md` — institutional-knowledge artifact capturing the failure pattern for future tracking-table migrations

## Test plan

- [x] `cargo test -p mika-agent --lib` — 2035 tests pass
- [x] `cargo test -p mika-agent --test eval` — 193 tests pass (12 new in `test_kg_budget_757`)
- [x] `cargo test -p mika-common` — KG batch budget config tests pass
- [x] `cargo clippy -p mika-agent -p mika-common --all-targets -- -D warnings` — clean
- [x] Convergence test (`test_v1_and_incremental_schemas_converge`) — exercises v25→v26 ALTER path
- [x] `bash scripts/verify-pipeline.sh` — pipeline artifacts verified
- [ ] **Post-deploy (Vincent):** restart mika-server with OpenRouter KG model configured, verify Signals A–D

## Review notes

The multi-reviewer `/ce:review` pass (10 reviewers) surfaced 4 P1 + 2 P2 + 4 P3 findings. All resolved in commit `8fab006a`:
- **P1** Atomic marker write (adversarial + reliability)
- **P1** Resolver `continue` not `break` on `SkippedBudget` (preserves Stage-1 exact-match processing)
- **P1** Reverted retroactive edit of `migrate_v24_to_v25` — restored migration immutability and ensures the convergence test exercises the v25→v26 ALTER path
- **P1** Removed stale `record_extraction_public` doc (now gone entirely)
- **P2** New tests: `resolve_pending_budget_exhaustion_does_not_starve_later_exact_matches` and `null_hash_populates_on_successful_extraction`
- **P3** Cleanups (naming consistency, dead-code removal, AC-ref removal from schema doc)

Closes #757