### PR TITLE
docs: institutionalize infra-fix compounding rule (#776)

### DIFF
--- a/docs/plans/2026-04-23-006-feat-institutionalize-infra-fix-compounding-plan.md
+++ b/docs/plans/2026-04-23-006-feat-institutionalize-infra-fix-compounding-plan.md
@@ -1,0 +1,90 @@
+---
+title: "feat: Institutionalize infra-fix compounding rule (case: release automation drift)"
+type: feat
+status: active
+date: 2026-04-23
+---
+
+# Institutionalize Infra-Fix Compounding Rule
+
+## Overview
+
+Land a compound doc that names the "infra-fix compounding" practice using release-automation chronic drift as the case study. The deliverable is the rule, not the artifact — the doc is case evidence; the rule is what future infra work inherits.
+
+## Problem Frame
+
+Release automation for this Rust workspace has accumulated 14+ fix commits across three tools over ~7 weeks with zero durable institutional memory. The rule "look back before shipping an infra fix; compound when you see >=3 prior fixes in the class" was identified and captured in session memory (`feedback_compound_infra_fixes.md`). This ticket lands the case-study doc that demonstrates the rule and cross-references the memory entry.
+
+## Requirements Trace
+
+- R1. `docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md` lands with appendix content from issue #776
+- R2. Frontmatter, cross-references, and Class A/B/C/D taxonomy preserved
+- R3. Cross-reference to `feedback_compound_infra_fixes.md` memory entry included
+- R4. No changes to `.github/workflows/release-plz.yml` or `release-plz.toml`
+- R5. `/ce:compound` output institutionalizes the rule, not the drift doc content
+
+## Scope Boundaries
+
+- No workflow file changes (scoped to mika#775)
+- No changes to the memory file (outside repo state)
+- No retroactive compound docs for the 14+ prior fixes
+- No code changes of any kind — this is purely documentation
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `docs/solutions/ci-cd/rust-workspace-release-plz-github-actions.md` — existing release-plz setup doc (cross-referenced from the new doc)
+- `docs/solutions/ci-cd/` — 5 existing docs following consistent frontmatter + problem/solution structure
+- All solution docs use YAML frontmatter with `title`, `date`, `category`, `tags`, `modules`, `severity`, `resolved`
+
+### Institutional Learnings
+
+- `feedback_compound_infra_fixes.md` (session memory) — the rule being institutionalized: grep git log before fixing, compound when >=3 prior fixes in the class
+
+## Key Technical Decisions
+
+- **Content is pre-drafted:** The issue appendix contains peer-reviewed content. `/ce:work` should refine, not rewrite.
+- **verify-pipeline.sh expects source changes:** The pipeline verification script checks for source code changes beyond plan/config. Since this is a docs-only ticket, the compound doc in `docs/solutions/` counts as both the deliverable AND satisfies the compound-doc check. The "source code changes" check may need the solution doc to satisfy it — if not, the verification failure is expected and documented.
+
+## Implementation Units
+
+- [ ] **Unit 1: Land the compound doc**
+
+**Goal:** Create `docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md` with the full content from issue #776's appendix.
+
+**Requirements:** R1, R2, R3
+
+**Files:**
+- Create: `docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md`
+
+**Approach:**
+- Copy the drafted content from the issue appendix verbatim
+- Verify frontmatter fields match the repo's solution doc conventions (compare with existing `ci-cd/` docs)
+- Ensure cross-reference to `feedback_compound_infra_fixes.md` is in the final section
+- Ensure cross-reference to `rust-workspace-release-plz-github-actions.md` uses relative path
+- Verify Class A/B/C/D structure is clean and the "failure classes that outlive tool choice" framing is preserved
+
+**Patterns to follow:**
+- `docs/solutions/ci-cd/rust-workspace-release-plz-github-actions.md` — frontmatter and structure conventions
+
+**Test expectation:** none — pure documentation artifact with no behavioral change
+
+**Verification:**
+- File exists with correct frontmatter fields
+- All four failure classes (A, B, C, D) are present with tables
+- Cross-references to related docs and memory entry are intact
+- `resolved: false` reflects the open Class C issue (mika#775)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `verify-pipeline.sh` fails on "source code changes" check for a docs-only ticket | The solution doc itself may satisfy the check; if not, the failure is a known limitation of the script for docs-only tickets |
+
+## Sources & References
+
+- Related issue: #776
+- Related issue: #775 (Class C fix, out of scope)
+- Related code: `docs/solutions/ci-cd/rust-workspace-release-plz-github-actions.md`
+- Memory: `feedback_compound_infra_fixes.md`

--- a/docs/solutions/best-practices/infra-fix-compounding-practice-2026-04-23.md
+++ b/docs/solutions/best-practices/infra-fix-compounding-practice-2026-04-23.md
@@ -1,0 +1,103 @@
+---
+module: development_workflow
+date: 2026-04-23
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Shipping a fix to CI, release automation, deploy scripts, or auth/token plumbing
+  - Investigating an infrastructure failure that feels familiar
+  - Reviewing a PR that touches workflow files or infrastructure config
+  - Starting work on any infra-scoped ticket
+tags:
+  - infra-fix
+  - compounding
+  - institutional-memory
+  - chronic-drift
+  - ci-cd
+  - release-automation
+related_components:
+  - tooling
+  - documentation
+---
+
+## Context
+
+Infrastructure fixes evaporate faster than product fixes. The urgency is always "unblock the next merge / deploy / auth flow," so fixes ship ad-hoc, context thins, and when the issue recurs — infra failures cluster — the next investigator starts from scratch.
+
+This practice was named after a concrete case: release automation on this repo produced 14+ fixes over ~7 weeks across three tools (semantic-release → release-plz → git-cliff), with zero compound-doc entries until the pattern was identified. The developer's own recall was "2 or 3 times." The gap between 2–3 and 14+ is the evaporation hazard.
+
+The case study is documented separately in [`release-automation-chronic-drift-2026-04-23.md`](../ci-cd/release-automation-chronic-drift-2026-04-23.md). This doc is about the **generalized rule** that emerged from that case.
+
+## Guidance
+
+**Core rule: look back before shipping an infra fix.**
+
+Before shipping any infrastructure fix — CI, release automation, deploy scripts, auth/token plumbing, observability, secrets management, networking — grep git log for prior related fixes first.
+
+```bash
+git log --oneline --grep=<area>
+# e.g., git log --oneline --grep=release
+#       git log --oneline --grep=ci
+#       git log --oneline --grep=deploy
+```
+
+Count related prior fixes:
+- **0–2 hits** → probably a one-off. Fix and move on.
+- **3+ hits** → chronic drift. Treat as a class, not an instance.
+
+**When 3+ hits: compound before shipping.** Either the fix addresses the underlying class (root cause, not symptom) — in which case the compound doc explains WHY it addresses the class — or the fix is explicitly logged as "Nth point-fix in this class, adding to the ledger" in an existing or new compound doc. Do not silently ship the Nth point-fix without that explicit framing.
+
+**Rename when naming lies.** If looking back surfaces a naming hazard (e.g., a workflow file named `release-plz.yml` that now runs git-cliff after a migration), fix the name as part of the current work. Future grep-based discovery fails when names lie.
+
+**Commit messages are evidence, not explanation.** `git log --grep` surfaces WHAT was fixed; it rarely surfaces WHY the fix was right or what alternatives were tried. The compound doc fills that gap.
+
+## Why This Matters
+
+The anti-pattern this practice prevents: silently shipping the Nth point-fix in a chronic-drift class, producing 14+ fix commits with zero institutional memory. Each fix is muscle-memory at the time and evaporates within a week.
+
+The compounding effect: the first time a class is identified costs research. Document it, and every subsequent occurrence in that class takes minutes instead of hours. The doc grows iteratively; the memory decays exponentially.
+
+This rule applies far beyond release automation — it generalizes to any infrastructure domain where:
+1. Failures manifest in environments you can't reproduce locally (CI runners, production deploy pipelines, cloud auth flows)
+2. The fix cycle is slow (one attempt per merge/deploy cycle, 15–60 min between iterations)
+3. The psychological path of least resistance is a point-fix rather than understanding the class
+
+## When to Apply
+
+- **CI/CD pipeline fixes** — workflow files, build scripts, release automation
+- **Deploy script fixes** — provisioning, Helm charts, Docker builds
+- **Auth/token plumbing** — OAuth flows, API key rotation, App installation tokens
+- **Observability fixes** — logging, tracing, metrics pipelines
+- **Secrets management** — env var propagation, scrubbing, injection patterns
+- **Networking/routing** — gateway config, webhook delivery, DNS
+
+## Examples
+
+**Before (anti-pattern):**
+```
+commit abc1234  fix: pin Rust toolchain in release workflow
+commit def5678  fix: add git identity for release tags
+commit ghi9012  fix: exclude release/* from pipeline checks
+commit jkl3456  fix: disable cargo package verification
+...
+# 14+ fixes, zero compound docs, each investigator starts from scratch
+```
+
+**After (with this practice):**
+```
+# Developer about to ship fix #4 for release automation
+$ git log --oneline --grep=release | wc -l
+7
+
+# 7 hits → chronic drift. Before shipping:
+# 1. Read/create compound doc for the class
+# 2. Classify the fix (Class A/B/C/D in the release automation case)
+# 3. Ship the fix WITH the compound doc update
+```
+
+## Cross-references
+
+- Case study: [`release-automation-chronic-drift-2026-04-23.md`](../ci-cd/release-automation-chronic-drift-2026-04-23.md) — the triggering case with Class A/B/C/D taxonomy
+- MEMORY: `feedback_compound_infra_fixes.md` — the operational rule in session memory (auto memory [claude])
+- Ticket: mika#776 — institutionalization ticket

--- a/docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md
+++ b/docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md
@@ -1,0 +1,172 @@
+---
+title: "Release automation chronic drift — failure classes that outlive tool choice"
+date: 2026-04-23
+category: ci-cd
+problem_type: operational-pattern
+severity: medium
+resolved: false
+tags:
+  - release-automation
+  - ci-cd
+  - chronic-drift
+  - institutional-memory
+  - rust-workspace
+modules:
+  - .github/workflows/release-plz.yml
+  - .github/workflows/release.yml
+related:
+  - docs/solutions/ci-cd/rust-workspace-release-plz-github-actions.md
+---
+
+## Problem statement
+
+Release automation for this Rust workspace has been chronically brittle across **three different tools** (semantic-release → release-plz → git-cliff) over ~7 weeks, producing **14+ fix commits with zero durable institutional memory** until this doc. Every tool landed with a working initial commit, accumulated 5–10 fixes, then either stabilized precariously or was replaced. Each fix was muscle-memory at the time and evaporated within a week.
+
+As of 2026-04-23, the current tool (git-cliff, since 2026-04-03) fails on every merge to `main` with:
+
+```
+! [rejected]        release/v0.6.0 -> release/v0.6.0 (non-fast-forward)
+error: failed to push some refs to 'https://github.com/senara-solutions/mika'
+hint: Updates were rejected because the tip of your current branch is behind
+      its remote counterpart.
+```
+
+Zero impact on the CI gate (`CI` workflow is green on the same commits). The `Release` workflow fails silently in parallel; real impact is noise plus the release PR never auto-updating. But the symptom isn't what this doc is about. **This doc is about why the same failure class keeps resurfacing under different tools**, so the next fix can address a class rather than an instance.
+
+## Failure classes that survive tool choice
+
+The 14+ historical fix commits cluster into **four root causes**. Each has outlasted at least one tool migration. Name these explicitly when diagnosing the next failure:
+
+### Class A — Workspace dep resolution with mixed publish-status crates
+
+This workspace has 4 crates: `mika-common` (publishes to crates.io), `mika-agent` / `mika-cli` / `mika-gateway` (`publish = false`). Tools that run `cargo package` or similar verification on all workspace members can't resolve inter-crate deps: the dependent crates were never published to crates.io, so `cargo package`'s metadata lookup fails.
+
+This is the class that **killed release-plz**. From commit `4825e7ae` (migration to git-cliff, 2026-04-03):
+
+> *"release-plz is fundamentally incompatible with publish = false workspace crates that have inter-dependencies: it always runs cargo package on all workspace members, and cargo package can't resolve workspace dep versions from crates.io (where they were never published). This caused 7+ failed fix attempts over April 1-3."*
+
+Historical fixes against Class A (all release-plz era):
+
+| Commit | Fix |
+|---|---|
+| `04c65428` | remove version from workspace dep specs for publish = false crates |
+| `3361bf53` | set `release = false` on all crates except mika-common |
+| `db341b6a` | declare only mika-common in `release-plz.toml` |
+| `3ae64459` | restore `publish = false` to match Cargo.toml declarations |
+| `8800d8e8` | exclude mika-agent from release-plz packaging |
+| `076150bd` | skip cargo package verification in release-plz |
+| `58e3dd8a` | disable cargo package verification in release-plz |
+
+Cumulative trajectory of this fix cluster: **each fix narrowed release-plz's responsibility until the tool was doing almost nothing**. The underlying mismatch was never resolved; the tool was scoped down until it stopped hitting it, then replaced.
+
+**For git-cliff and any successor:** verify the tool doesn't `cargo package` all workspace members by default, or configure it to skip. If it does and there's no opt-out, that's a hard stop for this workspace shape — do not spend fix commits narrowing scope; either find a different tool or change the `publish` strategy.
+
+### Class B — Comparison mode / changelog source of truth
+
+The tool needs to know "what's unreleased?" Answer sources: crates.io metadata (doesn't exist for our non-published crates), git tags, commit history, or a persisted changelog file. Tools default to the wrong one; fixes flip flags.
+
+Historical fixes against Class B (release-plz era):
+
+| Commit | Fix |
+|---|---|
+| `8b1e1f3f` | switch release-plz to `git_only = true` mode for tag-based comparison |
+| `621af062` | revert release-plz to crates.io comparison mode |
+| `04b66e7c` | add `git_only = true` to fix release PR creation |
+
+Cluster trajectory: **one flag flipped back and forth**, indicating neither mode worked cleanly. Root cause likely same as Class A — crates.io mode fails because crates aren't published; git-only mode fails because of some other mismatch.
+
+**For git-cliff:** the equivalent decision is "conventional commits since last tag" — tag is the source of truth. Confirm the last-tag resolution is correct before diagnosing any "nothing to release" or "everything looks unreleased" failure.
+
+### Class C — Release-branch state management
+
+The tool opens/updates a PR on a long-lived `release/vX.Y.Z` branch. Branch state divergence between runs (manual commits, failed prior runs, concurrent pushes) produces non-fast-forward rejections.
+
+Historical fixes against Class C:
+
+| Commit | Fix |
+|---|---|
+| `b3fc1f44` | exclude `release/*` branches from pipeline artifact checks (adjacent fix) |
+| **(open)** | **current symptom: `release/v0.6.0` non-fast-forward on every merge** |
+
+Cluster trajectory: **only one historical fix, and it's a scope-exclusion (keep the broken branch from blocking other workflows), not a root-cause fix**. The current failure is the same class: the release branch's state diverges from what the workflow expects to push.
+
+**For git-cliff (current open issue):** the fix needs to make the `release-pr` job's push **idempotent with respect to the branch's current state**. Three candidate approaches, each with different trade-offs:
+
+| Approach | Preserves branch history? | Survives concurrent runs? | Simplicity |
+|---|---|---|---|
+| Rebase onto origin/release before push | Yes, but rewrites | No — second concurrent run still sees stale local branch | Moderate |
+| Force-push-with-lease | Partial — only allows if lease matches | Better — lease check catches concurrent divergence | Moderate |
+| Recreate `release/vX.Y.Z` from main every run | No — history thrown away each run | Yes — every run is independent | High |
+
+The release PR branch has **no meaningful history worth preserving** — commits on it are regenerated by the tool every run. That tips toward **option 3 (recreate)**, but this is a judgment call for whoever works the fix ticket (mika#775).
+
+### Class D — Packaging / build / identity
+
+Ancillary failures in the build, packaging, or git identity surrounding the release run.
+
+Historical fixes against Class D:
+
+| Commit | Fix |
+|---|---|
+| `afd8ca24` | use pinned Rust toolchain in release-plz workflow (#394) |
+| `0c649c4f` | commit dashboard dist for embedded serving and release-plz |
+| `47374b9b` | fix YAML syntax in release workflow (git-cliff era) |
+| `e89dc7a3` | add git identity for release tag creation (git-cliff era) |
+
+Cluster trajectory: **one-off fixes, each distinct**. These are the kind of fixes that legitimately don't need root-cause analysis — the problem space is unbounded (every new tool has its own packaging/identity quirks) and each fix stands alone.
+
+**For future fixes:** anything in Class D is a one-off; anything in A/B/C is chronic-drift and needs compound-doc discipline.
+
+## Current failure (Class C, open)
+
+Symptom on every merge to `main` since at least 2026-04-23: `release/v0.6.0` non-fast-forward. Tracked as **mika#775**. Compound doc will get a "Stage 3 — resolution" section when that ticket lands, naming:
+
+- Which of the three candidate approaches was chosen
+- Why it survived 10+ consecutive merges without recurrence (validation gate)
+- What it closed and what it didn't (Class A/B vulnerabilities may remain)
+
+## Operational workaround (while Class C remains open)
+
+If a release is actually blocked by the non-fast-forward failure:
+
+```bash
+# 1. Inspect what's on release/v0.6.0 that shouldn't be
+git fetch origin release/v0.6.0
+git log --oneline origin/main..origin/release/v0.6.0
+
+# 2. Delete the remote branch — the tool recreates it on next run
+git push origin :release/v0.6.0
+
+# 3. Trigger the Release workflow manually via workflow_dispatch,
+#    or wait for the next merge to main
+```
+
+Until mika#775 lands, this is the reset.
+
+## Tool evolution (appendix — chronological index)
+
+Failure classes are the primary axis of this doc. Tool chronology is here as secondary, to help locate commits by tool-era when grep hits.
+
+- **Stage 0 — semantic-release** (pre-2026-03). No surviving config; replaced because of Rust-workspace integration issues. Primary failures were Class A.
+- **Stage 1 — release-plz** (2026-03-01 → 2026-04-03). Setup captured in [`rust-workspace-release-plz-github-actions.md`](./rust-workspace-release-plz-github-actions.md) (now historical). 10+ fixes, all in Classes A, B, D. Migration driven by Class A.
+- **Stage 2 — git-cliff** (2026-04-03 → present). Migration commit `4825e7ae`. Fixes so far in Classes C, D. Current open issue is Class C.
+
+The `release-plz.yml` filename is retained for backward compatibility with workflow references, but the tool is git-cliff. Renaming to `release-pr.yml` is in mika#775's AC.
+
+## Meta — why release automation drifts chronically
+
+Two feedback-loop hazards make release automation unusually evaporative:
+
+1. **Failures only manifest on next push to main** — not on PR CI, not on local tests. So the fix cycle is "merge a PR, observe the next merge, see if it passed" — ~1 fix per merge cycle, with 15–60 min between iterations.
+2. **No local reproduction.** The broken state lives in a GitHub Actions runner environment. Reproducing in-repo requires mocking the runner's auth context, network state, and timing.
+
+Combined effect: it's psychologically easier to apply a point-fix than to understand the class. Fourteen+ commits of point-fixes is the anti-pattern.
+
+**Rule going forward:** every release-automation fix that's more than a typo earns a compound-doc entry in THIS file, even if it's three sentences. The friction of writing is negligible compared to re-deriving context the next time. Rule operationalized in `feedback_compound_infra_fixes.md`.
+
+## Cross-references
+
+- [`rust-workspace-release-plz-github-actions.md`](./rust-workspace-release-plz-github-actions.md) — original release-plz setup (2026-03-01, now historical)
+- Commit `4825e7ae` — tool migration (release-plz → git-cliff)
+- Ticket mika#775 — fix Class C (`release/v0.6.0` non-fast-forward)
+- MEMORY: `feedback_compound_infra_fixes.md` — institutional rule about infra-fix evaporation


### PR DESCRIPTION
## Summary

This ticket institutionalizes a rule; the doc is the case evidence.

- Lands `docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md` — the full case study of release automation chronic drift (14+ fixes, 3 tools, 7 weeks, zero compound docs until now), organized by four failure classes (A: workspace dep resolution, B: comparison mode, C: release-branch state, D: packaging/build/identity)
- Lands `docs/solutions/best-practices/infra-fix-compounding-practice-2026-04-23.md` — the generalized rule: "look back before shipping an infra fix; compound when you see ≥3 prior fixes in the class." Applies beyond release automation to CI, deploy scripts, auth/token plumbing, observability, and secrets management
- No code changes, no workflow file changes (those are scoped to #775)

Closes #776

## Meta-pattern

The deliverable is the rule, not the artifact. The case-study doc demonstrates what chronic drift looks like (release automation as evidence). The best-practices doc names the practice that prevents it. The rule applies forward — no retroactive compound docs for the 14+ prior fixes.

## Test plan

- [x] `docs/solutions/ci-cd/release-automation-chronic-drift-2026-04-23.md` has correct frontmatter, Class A/B/C/D taxonomy, cross-references
- [x] `docs/solutions/best-practices/infra-fix-compounding-practice-2026-04-23.md` institutionalizes the rule, generalizes beyond release automation
- [x] Cross-reference to `feedback_compound_infra_fixes.md` memory entry included
- [x] No changes to `.github/workflows/release-plz.yml` or `release-plz.toml`
- [x] `verify-pipeline.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>