### PR TITLE
fix(teams): consolidate team-run callbacks into single user notification

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -276,7 +276,7 @@ Background tasks (heartbeat, reminders) where text output is NOT delivered. Agen
 
 ## MessageSender Trait
 
-`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Returns `Result<SendOutcome>` where `SendOutcome` is `Delivered` (gateway 2xx), `Failed { reason }` (non-2xx after retry, saved to `failed_sends`), or `NoChannel` (`chat_id == 0` sentinel — no reply channel available, e.g. GitHub webhook sessions). `Err` is reserved for infrastructure failures (chat_id resolution, DB errors). Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender` (one retry after 2s, error classification: connection/timeout/HTTP status with body snippet). Team engine agents intentionally have `message_sender: None`.
+`#[async_trait]` with `Send + Sync` bounds for `Arc<dyn MessageSender>`. Returns `Result<SendOutcome>` where `SendOutcome` is `Delivered` (gateway 2xx), `Failed { reason }` (non-2xx after retry, saved to `failed_sends`), or `NoChannel` (`chat_id == 0` sentinel — no reply channel available, e.g. GitHub webhook sessions). `Err` is reserved for infrastructure failures (chat_id resolution, DB errors). Text-only outbound. CLI prints to stdout. Server uses `GatewayMessageSender` (one retry after 2s, error classification: connection/timeout/HTTP status with body snippet). Team engine agents intentionally have `message_sender: None`. `NoopSender` (pub in `messaging.rs`) silently returns `Ok(Delivered)` — used to suppress user-facing notifications in team-child callback turns (#287) where the consolidated team-run notification handles delivery.
 
 **`NoChannel` sentinel (#650):** `GatewayMessageSender::send()` detects `chat_id == 0` after `resolve_chat_id()` and returns `Ok(NoChannel)` before the HTTP POST — no retry, no `failed_sends` entry. `chat_id == 0` is the documented sentinel for sessions without a Telegram reply channel (GitHub webhooks, non-Telegram channels). The agent should use channel-appropriate tools (e.g., `run_gh`) instead of `send_message`.
 
@@ -298,7 +298,7 @@ Background tasks (heartbeat, reminders) where text output is NOT delivered. Agen
 
 **Engine-level callback metadata extraction (#376):** `try_extract_callback_metadata()` parses structured fields from callback results and persists to parent task.
 
-**Team task tree:** parent `invoke_orchestrator` task + child `resume_agent` tasks per delegation. Suspend/resume on pending grandchild callbacks.
+**Team task tree:** parent `invoke_orchestrator` task + child `resume_agent` tasks per delegation. Suspend/resume on pending grandchild callbacks. **Team-run user notification (#287):** fired once at terminal status from two symmetric callsites (`run_team` tool for sync completion, `dispatch_invoke_orchestrator` for async resume), both routing through `teams::notification::build_run_completion_message`. Per-child `resume_agent` callbacks have their user-facing `send_message` suppressed via `NoopSender`; the silent turn still runs (updates memory, records `llm_calls`) — only the user channel is gated. Deliverable text is UTF-8-safe truncated at 4000 chars (below Telegram's 4096 limit).
 
 ## HTTP Server (mika-server)
 

--- a/crates/mika-agent/src/messaging.rs
+++ b/crates/mika-agent/src/messaging.rs
@@ -191,6 +191,20 @@ impl MessageSender for GatewayMessageSender {
     }
 }
 
+/// A no-op message sender that silently accepts all messages.
+///
+/// Used to suppress user-facing notifications in contexts where the silent
+/// turn should still run but not produce outbound messages (e.g., team-child
+/// callback turns where the consolidated team notification handles delivery).
+pub struct NoopSender;
+
+#[async_trait]
+impl MessageSender for NoopSender {
+    async fn send(&self, _text: &str) -> Result<SendOutcome> {
+        Ok(SendOutcome::Delivered)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -373,6 +387,13 @@ mod tests {
             SendOutcome::NoChannel,
             "poisoned chat_id=0 from DB should return NoChannel"
         );
+    }
+
+    #[tokio::test]
+    async fn test_noop_sender_returns_delivered() {
+        let sender = NoopSender;
+        let outcome = sender.send("hello").await.unwrap();
+        assert_eq!(outcome, SendOutcome::Delivered);
     }
 
     /// resolve_chat_id() returning Err (no chat_id configured) still propagates

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use chrono::Timelike;
 use mika_common::config::Settings;
 use mika_common::embedding::EmbeddingClient;
@@ -534,55 +534,67 @@ impl TaskDispatcher {
             &self.db,
             self.github_app.clone(),
         )
-        .await?;
+        .await
+        .with_context(|| format!("resuming team_run_id={team_run_id}"))?;
 
         // Consolidated team-run notification (async path).
         // Paired with run_team tool (sync path); see
         // docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
         // for why this lives here and not in TeamEngine::finalize_and_shutdown
         // (keeps the team engine free of a user_message_sender field).
-        if let Some(run) = self.db.load_team_run_by_id(team_run_id).await?
-            && let Some(msg) =
+        if let Some(run) = self.db.load_team_run_by_id(team_run_id).await? {
+            if let Some(msg) =
                 crate::teams::notification::build_run_completion_message_from_row(&run)
-        {
-            if let Some(ref sender) = self.message_sender {
-                match sender.send(&msg.text).await {
-                    Ok(crate::messaging::SendOutcome::Delivered) => {
-                        info!(
-                            team_run_id = %run.id,
-                            team_name = %run.team_name,
-                            status = %run.status,
-                            notification_kind = %msg.notification_kind,
-                            deliverable_chars = msg.deliverable_chars,
-                            truncated = msg.truncated,
-                            path = "async",
-                            "team_run_notified"
-                        );
-                    }
-                    Ok(crate::messaging::SendOutcome::NoChannel) => {
-                        // NoChannel is permanent — silent per dispatcher policy.
-                    }
-                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
-                        warn!(
-                            team_run_id = %run.id,
-                            error = %reason,
-                            "team_run_notification_delivery_failed"
-                        );
-                    }
-                    Err(e) => {
-                        warn!(
-                            team_run_id = %run.id,
-                            error = %e,
-                            "team_run_notification_send_error"
-                        );
+            {
+                if let Some(ref sender) = self.message_sender {
+                    match sender.send(&msg.text).await {
+                        Ok(crate::messaging::SendOutcome::Delivered) => {
+                            info!(
+                                team_run_id = %run.id,
+                                team_name = %run.team_name,
+                                status = %run.status,
+                                notification_kind = %msg.notification_kind,
+                                deliverable_chars = msg.deliverable_chars,
+                                truncated = msg.truncated,
+                                path = "async",
+                                "team_run_notified"
+                            );
+                        }
+                        Ok(crate::messaging::SendOutcome::NoChannel) => {
+                            // NoChannel is permanent — silent per dispatcher policy.
+                        }
+                        Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                            warn!(
+                                team_run_id = %run.id,
+                                error = %reason,
+                                "team_run_notification_delivery_failed"
+                            );
+                        }
+                        Err(e) => {
+                            warn!(
+                                team_run_id = %run.id,
+                                error = %e,
+                                "team_run_notification_send_error"
+                            );
+                        }
                     }
                 }
-            }
-            // Log warning for completed-without-deliverable
-            if msg.notification_kind == "fallback" {
-                warn!(
+                // Log warning for completed-without-deliverable
+                if msg.notification_kind == "fallback" {
+                    warn!(
+                        team_run_id = %run.id,
+                        "team run completed without a deliverable"
+                    );
+                }
+            } else {
+                // Non-terminal status (running/suspended) after resume — team run
+                // re-suspended for another delegation cycle. Notification deferred
+                // to the next resume that reaches a terminal state.
+                debug!(
                     team_run_id = %run.id,
-                    "team run completed without a deliverable"
+                    team_name = %run.team_name,
+                    status = %run.status,
+                    "team run non-terminal after resume, deferring notification"
                 );
             }
         }
@@ -944,13 +956,6 @@ async fn try_extract_callback_metadata(db: &AsyncDatabase, task: &Task) {
     }
 }
 
-/// Parse structured fields from callback result text.
-///
-/// Expected format (lines from claude-pilot `run.sh`):
-/// ```text
-/// claude-pilot completed (status: done).
-/// Session: <session_id>
-/// Turns: <N>
 /// Returns `true` if the task is a team-child callback (per-delegation
 /// `resume_agent` created by the team engine). Both `team_run_id` and
 /// `parent_task_id` are set together at child-creation time in
@@ -959,6 +964,13 @@ fn is_team_child_callback(task: &Task) -> bool {
     task.team_run_id.is_some() && task.parent_task_id.is_some()
 }
 
+/// Parse structured fields from callback result text.
+///
+/// Expected format (lines from claude-pilot `run.sh`):
+/// ```text
+/// claude-pilot completed (status: done).
+/// Session: <session_id>
+/// Turns: <N>
 /// Cost: $<amount>
 /// Duration: <N>ms
 /// ```

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -382,6 +382,24 @@ impl TaskDispatcher {
             try_extract_callback_metadata(&self.db, task).await;
         }
 
+        // Suppress user-facing notifications for team-child callbacks.
+        // The consolidated team-run notification (from run_team tool or
+        // dispatch_invoke_orchestrator) handles user delivery — per-child
+        // silent turns should not independently call send_message on the
+        // user channel. The silent turn still runs for internal state updates.
+        let message_sender = if is_team_child_callback(task) {
+            info!(
+                task_id = %task.id,
+                team_run_id = ?task.team_run_id,
+                parent_task_id = ?task.parent_task_id,
+                agent_id = %task.agent_id,
+                "team_child_callback_notification_suppressed"
+            );
+            Some(Arc::new(crate::messaging::NoopSender) as Arc<dyn crate::messaging::MessageSender>)
+        } else {
+            self.message_sender.clone()
+        };
+
         let params = SilentAgentParams {
             db: &self.db,
             llm: self.llm.as_ref(),
@@ -390,7 +408,7 @@ impl TaskDispatcher {
             trigger,
             home_dir: &self.home_dir,
             session_id: &session_id,
-            message_sender: self.message_sender.clone(),
+            message_sender,
             embedding_client: self.embedding_client.as_ref(),
             brave_api_key: self.brave_api_key.as_deref(),
             github_token: self.github_token.as_deref(),
@@ -516,7 +534,60 @@ impl TaskDispatcher {
             &self.db,
             self.github_app.clone(),
         )
-        .await
+        .await?;
+
+        // Consolidated team-run notification (async path).
+        // Paired with run_team tool (sync path); see
+        // docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+        // for why this lives here and not in TeamEngine::finalize_and_shutdown
+        // (keeps the team engine free of a user_message_sender field).
+        if let Some(run) = self.db.load_team_run_by_id(team_run_id).await?
+            && let Some(msg) =
+                crate::teams::notification::build_run_completion_message_from_row(&run)
+        {
+            if let Some(ref sender) = self.message_sender {
+                match sender.send(&msg.text).await {
+                    Ok(crate::messaging::SendOutcome::Delivered) => {
+                        info!(
+                            team_run_id = %run.id,
+                            team_name = %run.team_name,
+                            status = %run.status,
+                            notification_kind = %msg.notification_kind,
+                            deliverable_chars = msg.deliverable_chars,
+                            truncated = msg.truncated,
+                            path = "async",
+                            "team_run_notified"
+                        );
+                    }
+                    Ok(crate::messaging::SendOutcome::NoChannel) => {
+                        // NoChannel is permanent — silent per dispatcher policy.
+                    }
+                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                        warn!(
+                            team_run_id = %run.id,
+                            error = %reason,
+                            "team_run_notification_delivery_failed"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            team_run_id = %run.id,
+                            error = %e,
+                            "team_run_notification_send_error"
+                        );
+                    }
+                }
+            }
+            // Log warning for completed-without-deliverable
+            if msg.notification_kind == "fallback" {
+                warn!(
+                    team_run_id = %run.id,
+                    "team run completed without a deliverable"
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Run the heartbeat silent agent with all pre-filter checks.
@@ -880,6 +951,14 @@ async fn try_extract_callback_metadata(db: &AsyncDatabase, task: &Task) {
 /// claude-pilot completed (status: done).
 /// Session: <session_id>
 /// Turns: <N>
+/// Returns `true` if the task is a team-child callback (per-delegation
+/// `resume_agent` created by the team engine). Both `team_run_id` and
+/// `parent_task_id` are set together at child-creation time in
+/// `engine.rs:874-912`.
+fn is_team_child_callback(task: &Task) -> bool {
+    task.team_run_id.is_some() && task.parent_task_id.is_some()
+}
+
 /// Cost: $<amount>
 /// Duration: <N>ms
 /// ```
@@ -1434,5 +1513,68 @@ mod tests {
         let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
         // Should not panic or error — just returns early
         try_extract_callback_metadata(&db, &task).await;
+    }
+
+    // ===== is_team_child_callback predicate tests =====
+
+    fn make_task_with_team_fields(team_run_id: Option<&str>, parent_task_id: Option<&str>) -> Task {
+        Task {
+            id: "test-task-1".to_string(),
+            agent_id: "mika".to_string(),
+            team_run_id: team_run_id.map(String::from),
+            parent_task_id: parent_task_id.map(String::from),
+            depth: 0,
+            label: "test".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            status: "completed".to_string(),
+            process_id: None,
+            input_context: None,
+            result: None,
+            created_by_session: None,
+            created_trace_id: None,
+            execution_trace_id: None,
+            created_at: "2026-04-24T12:00:00Z".to_string(),
+            updated_at: "2026-04-24T12:00:00Z".to_string(),
+            fired_at: None,
+            completed_at: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: "issue".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_is_team_child_callback_both_set() {
+        let task = make_task_with_team_fields(Some("run-1"), Some("parent-1"));
+        assert!(is_team_child_callback(&task));
+    }
+
+    #[test]
+    fn test_is_team_child_callback_no_team_run_id() {
+        // Regular skill callback with a parent but no team_run_id
+        let task = make_task_with_team_fields(None, Some("parent-1"));
+        assert!(!is_team_child_callback(&task));
+    }
+
+    #[test]
+    fn test_is_team_child_callback_no_parent() {
+        // team_run_id set but no parent — team root task (not a child callback)
+        let task = make_task_with_team_fields(Some("run-1"), None);
+        assert!(!is_team_child_callback(&task));
+    }
+
+    #[test]
+    fn test_is_team_child_callback_neither_set() {
+        let task = make_task_with_team_fields(None, None);
+        assert!(!is_team_child_callback(&task));
     }
 }

--- a/crates/mika-agent/src/teams/mod.rs
+++ b/crates/mika-agent/src/teams/mod.rs
@@ -1,4 +1,5 @@
 pub mod engine;
+pub(crate) mod notification;
 pub mod prompt;
 pub mod types;
 

--- a/crates/mika-agent/src/teams/notification.rs
+++ b/crates/mika-agent/src/teams/notification.rs
@@ -1,0 +1,302 @@
+//! Team-run completion notification formatting.
+//!
+//! Shared helper for building the single user-facing message at team-run
+//! terminal state. Used by both the sync path (`run_team` tool) and the
+//! async path (`dispatch_invoke_orchestrator`).
+
+use crate::db::TeamRunRow;
+use crate::teams::types::{RunStatus, TeamRun};
+
+/// Maximum character count for the deliverable text in a notification.
+/// 4000 is below the Telegram 4096-char text limit with headroom for the prefix.
+const MAX_DELIVERABLE_CHARS: usize = 4000;
+
+/// Result of building a completion message: the text and metadata for logging.
+pub(crate) struct CompletionMessage {
+    pub text: String,
+    pub notification_kind: &'static str,
+    pub deliverable_chars: usize,
+    pub truncated: bool,
+}
+
+/// Build a user-facing completion message from an in-memory `TeamRun`.
+///
+/// Returns `None` for non-terminal statuses (`Running`, `Suspended`).
+/// Used by the sync path (run_team tool).
+pub(crate) fn build_run_completion_message(run: &TeamRun) -> Option<CompletionMessage> {
+    match &run.status {
+        RunStatus::Completed => {
+            if let Some(ref deliverable) = run.deliverable {
+                let (text, truncated) = format_deliverable(&run.team_name, deliverable);
+                Some(CompletionMessage {
+                    deliverable_chars: deliverable.chars().count(),
+                    text,
+                    notification_kind: "deliverable",
+                    truncated,
+                })
+            } else {
+                Some(CompletionMessage {
+                    text: format!(
+                        "Team '{}' completed (no deliverable produced).",
+                        run.team_name
+                    ),
+                    notification_kind: "fallback",
+                    deliverable_chars: 0,
+                    truncated: false,
+                })
+            }
+        }
+        RunStatus::Failed(reason) => Some(CompletionMessage {
+            text: format!("Team '{}' failed: {}", run.team_name, reason),
+            notification_kind: "failure",
+            deliverable_chars: 0,
+            truncated: false,
+        }),
+        // Running and Suspended are non-terminal — no notification.
+        RunStatus::Running | RunStatus::Suspended => None,
+    }
+}
+
+/// Build a user-facing completion message from a `TeamRunRow` (DB row).
+///
+/// Returns `None` for non-terminal statuses.
+/// Used by the async path (dispatch_invoke_orchestrator).
+pub(crate) fn build_run_completion_message_from_row(run: &TeamRunRow) -> Option<CompletionMessage> {
+    match run.status.as_str() {
+        "completed" => {
+            if let Some(ref deliverable) = run.deliverable {
+                let (text, truncated) = format_deliverable(&run.team_name, deliverable);
+                Some(CompletionMessage {
+                    deliverable_chars: deliverable.chars().count(),
+                    text,
+                    notification_kind: "deliverable",
+                    truncated,
+                })
+            } else {
+                Some(CompletionMessage {
+                    text: format!(
+                        "Team '{}' completed (no deliverable produced).",
+                        run.team_name
+                    ),
+                    notification_kind: "fallback",
+                    deliverable_chars: 0,
+                    truncated: false,
+                })
+            }
+        }
+        "failed" => {
+            let reason = run.failure_reason.as_deref().unwrap_or("unknown error");
+            Some(CompletionMessage {
+                text: format!("Team '{}' failed: {}", run.team_name, reason),
+                notification_kind: "failure",
+                deliverable_chars: 0,
+                truncated: false,
+            })
+        }
+        "cancelled" => Some(CompletionMessage {
+            text: format!("Team '{}' was cancelled.", run.team_name),
+            notification_kind: "cancelled",
+            deliverable_chars: 0,
+            truncated: false,
+        }),
+        // "running", "suspended", or unexpected — no notification.
+        _ => None,
+    }
+}
+
+/// Format a deliverable with UTF-8-safe truncation.
+fn format_deliverable(team_name: &str, deliverable: &str) -> (String, bool) {
+    let char_count = deliverable.chars().count();
+    if char_count <= MAX_DELIVERABLE_CHARS {
+        (
+            format!(
+                "Team '{}' completed. Deliverable:\n\n{}",
+                team_name, deliverable
+            ),
+            false,
+        )
+    } else {
+        // UTF-8-safe truncation: find the char boundary at MAX_DELIVERABLE_CHARS chars
+        let truncation_byte_index = deliverable
+            .char_indices()
+            .nth(MAX_DELIVERABLE_CHARS)
+            .map(|(i, _)| i)
+            .unwrap_or(deliverable.len());
+        let truncated_text = &deliverable[..truncation_byte_index];
+        (
+            format!(
+                "Team '{}' completed. Deliverable:\n\n{}\n\n[…truncated after {} chars — full deliverable persisted on team_runs.deliverable]",
+                team_name, truncated_text, MAX_DELIVERABLE_CHARS
+            ),
+            true,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::teams::types::RunStatus;
+
+    fn make_run(status: RunStatus, deliverable: Option<String>) -> TeamRun {
+        TeamRun {
+            run_id: "test-run-1".to_string(),
+            team_name: "alpha".to_string(),
+            goal: "test goal".to_string(),
+            status,
+            iteration: 1,
+            max_iterations: 3,
+            tasks: vec![],
+            started_at: "2026-04-24T12:00:00Z".to_string(),
+            ended_at: Some("2026-04-24T12:05:00Z".to_string()),
+            deliverable,
+        }
+    }
+
+    fn make_row(
+        status: &str,
+        failure_reason: Option<String>,
+        deliverable: Option<String>,
+    ) -> TeamRunRow {
+        TeamRunRow {
+            id: "test-run-1".to_string(),
+            team_name: "alpha".to_string(),
+            goal: "test goal".to_string(),
+            status: status.to_string(),
+            failure_reason,
+            iteration: 1,
+            max_iterations: 3,
+            deliverable,
+            started_at: "2026-04-24T12:00:00Z".to_string(),
+            ended_at: Some("2026-04-24T12:05:00Z".to_string()),
+            trace_id: None,
+        }
+    }
+
+    #[test]
+    fn test_completed_with_short_deliverable() {
+        let run = make_run(RunStatus::Completed, Some("short text".to_string()));
+        let msg = build_run_completion_message(&run).unwrap();
+        assert_eq!(
+            msg.text,
+            "Team 'alpha' completed. Deliverable:\n\nshort text"
+        );
+        assert_eq!(msg.notification_kind, "deliverable");
+        assert_eq!(msg.deliverable_chars, 10);
+        assert!(!msg.truncated);
+    }
+
+    #[test]
+    fn test_completed_with_truncation() {
+        // Create a 5000-char deliverable with some multi-byte chars
+        let deliverable: String = "à".repeat(5000);
+        let run = make_run(RunStatus::Completed, Some(deliverable));
+        let msg = build_run_completion_message(&run).unwrap();
+
+        assert!(msg.truncated);
+        assert_eq!(msg.deliverable_chars, 5000);
+        assert!(msg.text.contains("[…truncated after 4000 chars"));
+        // Verify truncation is UTF-8 safe — the text should be valid
+        assert!(msg.text.is_char_boundary(msg.text.len()));
+    }
+
+    #[test]
+    fn test_completed_without_deliverable() {
+        let run = make_run(RunStatus::Completed, None);
+        let msg = build_run_completion_message(&run).unwrap();
+        assert_eq!(
+            msg.text,
+            "Team 'alpha' completed (no deliverable produced)."
+        );
+        assert_eq!(msg.notification_kind, "fallback");
+        assert_eq!(msg.deliverable_chars, 0);
+        assert!(!msg.truncated);
+    }
+
+    #[test]
+    fn test_failed() {
+        let run = make_run(
+            RunStatus::Failed("orchestrator timed out".to_string()),
+            None,
+        );
+        let msg = build_run_completion_message(&run).unwrap();
+        assert_eq!(msg.text, "Team 'alpha' failed: orchestrator timed out");
+        assert_eq!(msg.notification_kind, "failure");
+    }
+
+    #[test]
+    fn test_non_terminal_running() {
+        let run = make_run(RunStatus::Running, None);
+        assert!(build_run_completion_message(&run).is_none());
+    }
+
+    #[test]
+    fn test_non_terminal_suspended() {
+        let run = make_run(RunStatus::Suspended, None);
+        assert!(build_run_completion_message(&run).is_none());
+    }
+
+    // TeamRunRow-based tests (async path)
+
+    #[test]
+    fn test_row_completed_with_deliverable() {
+        let row = make_row("completed", None, Some("result text".to_string()));
+        let msg = build_run_completion_message_from_row(&row).unwrap();
+        assert_eq!(
+            msg.text,
+            "Team 'alpha' completed. Deliverable:\n\nresult text"
+        );
+        assert_eq!(msg.notification_kind, "deliverable");
+    }
+
+    #[test]
+    fn test_row_failed() {
+        let row = make_row("failed", Some("orchestrator timed out".to_string()), None);
+        let msg = build_run_completion_message_from_row(&row).unwrap();
+        assert_eq!(msg.text, "Team 'alpha' failed: orchestrator timed out");
+        assert_eq!(msg.notification_kind, "failure");
+    }
+
+    #[test]
+    fn test_row_failed_no_reason() {
+        let row = make_row("failed", None, None);
+        let msg = build_run_completion_message_from_row(&row).unwrap();
+        assert_eq!(msg.text, "Team 'alpha' failed: unknown error");
+    }
+
+    #[test]
+    fn test_row_cancelled() {
+        let row = make_row("cancelled", None, None);
+        let msg = build_run_completion_message_from_row(&row).unwrap();
+        assert_eq!(msg.text, "Team 'alpha' was cancelled.");
+        assert_eq!(msg.notification_kind, "cancelled");
+    }
+
+    #[test]
+    fn test_row_non_terminal() {
+        let row = make_row("running", None, None);
+        assert!(build_run_completion_message_from_row(&row).is_none());
+
+        let row = make_row("suspended", None, None);
+        assert!(build_run_completion_message_from_row(&row).is_none());
+    }
+
+    #[test]
+    fn test_truncation_exact_boundary() {
+        // Exactly MAX_DELIVERABLE_CHARS should not truncate
+        let deliverable: String = "a".repeat(MAX_DELIVERABLE_CHARS);
+        let run = make_run(RunStatus::Completed, Some(deliverable));
+        let msg = build_run_completion_message(&run).unwrap();
+        assert!(!msg.truncated);
+        assert_eq!(msg.deliverable_chars, MAX_DELIVERABLE_CHARS);
+    }
+
+    #[test]
+    fn test_truncation_one_over() {
+        let deliverable: String = "a".repeat(MAX_DELIVERABLE_CHARS + 1);
+        let run = make_run(RunStatus::Completed, Some(deliverable));
+        let msg = build_run_completion_message(&run).unwrap();
+        assert!(msg.truncated);
+        assert_eq!(msg.deliverable_chars, MAX_DELIVERABLE_CHARS + 1);
+    }
+}

--- a/crates/mika-agent/src/tools/run_team.rs
+++ b/crates/mika-agent/src/tools/run_team.rs
@@ -138,6 +138,61 @@ impl Tool for RunTeamTool {
         .await;
         team_db.shutdown();
 
+        // Consolidated team-run notification (sync path).
+        // Paired with dispatch_invoke_orchestrator (async path); see
+        // docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+        // for why this lives here and not in TeamEngine::finalize_and_shutdown
+        // (keeps the team engine free of a user_message_sender field).
+        if let Ok(ref run) = result
+            && let Some(msg) = crate::teams::notification::build_run_completion_message(run)
+        {
+            if let Some(ref sender) = ctx.message_sender {
+                match sender.send(&msg.text).await {
+                    Ok(crate::messaging::SendOutcome::Delivered) => {
+                        tracing::info!(
+                            team_run_id = %run.run_id,
+                            team_name = %run.team_name,
+                            status = %run.status,
+                            notification_kind = %msg.notification_kind,
+                            deliverable_chars = msg.deliverable_chars,
+                            truncated = msg.truncated,
+                            path = "sync",
+                            "team_run_notified"
+                        );
+                    }
+                    Ok(crate::messaging::SendOutcome::NoChannel) => {
+                        // NoChannel is permanent — silent per dispatcher policy.
+                    }
+                    Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                        tracing::warn!(
+                            team_run_id = %run.run_id,
+                            error = %reason,
+                            "team_run_notification_delivery_failed"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            team_run_id = %run.run_id,
+                            error = %e,
+                            "team_run_notification_send_error"
+                        );
+                    }
+                }
+            } else {
+                tracing::debug!(
+                    team_run_id = %run.run_id,
+                    "no message_sender available for team-run notification (sync path)"
+                );
+            }
+            // Log warning for completed-without-deliverable
+            if msg.notification_kind == "fallback" {
+                tracing::warn!(
+                    team_run_id = %run.run_id,
+                    "team run completed without a deliverable"
+                );
+            }
+        }
+
         match result {
             Ok(run) => {
                 if let Some(ref deliverable) = run.deliverable {

--- a/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+++ b/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
@@ -110,7 +110,7 @@ Observed failure: run `fd7ef7ef` (one concrete instance). mika-dev received 2 de
 
 ---
 
-- [ ] **Unit 1: Shared formatter + notification hooks at sync and async terminal states**
+- [x] **Unit 1: Shared formatter + notification hooks at sync and async terminal states**
 
 **Goal:** On every team-run terminal transition, emit exactly one user-facing message containing the deliverable (or failure reason). Both sync completion (via `run_team` tool) and async completion (via `dispatch_invoke_orchestrator`) route through a shared pure formatter.
 
@@ -184,7 +184,7 @@ info!(
 
 ---
 
-- [ ] **Unit 2: Suppress `send_message` in per-child team-callback silent turns**
+- [x] **Unit 2: Suppress `send_message` in per-child team-callback silent turns**
 
 **Goal:** Per-delegation `resume_agent` callbacks run their silent turn with a `NoopSender` instead of the user-facing `message_sender`. With Unit 1 in place, the net result is exactly one user message per team run.
 

--- a/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+++ b/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
@@ -1,0 +1,233 @@
+---
+title: "Fix: Team delegations produce multiple callback messages instead of consolidated delivery"
+type: fix
+status: active
+date: 2026-04-24
+---
+
+# Fix: Team delegations produce multiple callback messages instead of consolidated delivery
+
+## Overview
+
+A team run with N delegations produces N user-facing messages instead of one consolidated deliverable. The fix is a coupled two-part change to the task-engine's team callback plumbing: (1) add a single user-facing notification at team-run completion, sourced from the `deliverable` the team engine already produces; (2) suppress `send_message` in the per-child `resume_agent` silent turns so each delegation no longer independently notifies the user. Both parts must ship together — Part 1 alone produces N+1 messages (worse), Part 2 alone produces zero (silent).
+
+No new schema, no API change, no new public types. Both hooks live inside `task_engine::dispatcher` and reuse the existing `message_sender` wired into the dispatcher.
+
+## Problem Frame
+
+When a team engine delegates to multiple agents in one run, it creates N child `resume_agent` callback tasks (`teams/engine.rs:874-912`). Each child's callback, when fired via `dispatch_resume_agent` (`task_engine/dispatcher.rs:295`), runs a full silent agent turn with `message_sender: self.message_sender.clone()` (line 393). The agent's turn then independently calls `send_message`, producing one user-facing message per delegation.
+
+The parent `invoke_orchestrator` task (`dispatcher.rs:431`) fires once all children complete. It resumes the team engine via `resume_team_run`, which continues to the review/deliver phase and produces `team_runs.deliverable`. But it **does not** emit a user-facing message — the only user-visible path for team output today is the per-child silent turns.
+
+Observed: run `fd7ef7ef` (one concrete instance), mika-dev received 2 delegations → 2 callback tasks → 2 silent turns → 2 `send_message` calls → 2 user-visible messages in the TUI inbox.
+
+## Requirements Trace
+
+- **R1.** A completed team run must produce exactly one user-facing message containing the final deliverable.
+- **R2.** Per-delegation callbacks must not call `send_message` for user-facing channels. They may still run the silent turn for internal state if needed, or be short-circuited entirely — but the user-facing channel is closed to them.
+- **R3.** Failure modes remain observable — if the team run fails (timeout, orchestrator error), the user gets a single failure notification with the reason, not silence and not N partial-result messages.
+- **R4.** The fix must not regress single-delegation team runs (N=1 → still one message, not zero) or conversational-reply team turns (no delegation, no notification expected unless the orchestrator itself replied).
+
+## Scope Boundaries
+
+### In scope
+
+- `task_engine::dispatcher::dispatch_invoke_orchestrator` — add user-notification hook at completion
+- `task_engine::dispatcher::dispatch_resume_agent` — detect team-child callbacks and pass `NoopSender` (already imported at dispatcher.rs:965 for another path) instead of the user-facing sender
+- Synchronous team-run completion path (when all specialists finish inline without suspending) — add the same notification hook
+- Integration tests in `tests/eval/` covering 1-delegation, N-delegation, and failed-team-run scenarios
+
+### Deferred to Separate Tasks
+
+- **Coverage check (#286):** different bug class, separate plan
+- **Dashboard team-run surfacing:** the dashboard already displays the `deliverable` field; no new surfacing needed for this fix
+- **Message formatting customization:** the consolidated message uses the raw `deliverable` text (possibly with a short header). Richer formatting is a UX concern, not a bug fix
+- **Per-agent "I delegated this to you, here's the outcome" internal messages:** if product wants the orchestrator to personally notify each specialist's conversation thread about the team run, that's a separate feature — this plan only addresses the user-facing channel
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/teams/engine.rs:874-912` — child `resume_agent` callback tasks created per delegation with `team_run_id = Some(run_id)`, `parent_task_id = Some(parent_id)`, `trigger_type = "callback"`, `action_type = RESUME_AGENT`
+- `crates/mika-agent/src/teams/engine.rs:838-866` — parent `invoke_orchestrator` task with `action_type = INVOKE_ORCHESTRATOR`, fires when all children complete
+- `crates/mika-agent/src/teams/engine.rs:486-505` — `deliver_phase()` sets `self.run.deliverable` and emits `TeamEvent::Deliverable(...)` for live UI; does NOT send user message
+- `crates/mika-agent/src/task_engine/dispatcher.rs:295-425` — `dispatch_resume_agent`: per-callback silent turn, passes `message_sender: self.message_sender.clone()` at line 393
+- `crates/mika-agent/src/task_engine/dispatcher.rs:431-520` — `dispatch_invoke_orchestrator`: calls `resume_team_run`, no user notification
+- `crates/mika-agent/src/task_engine/dispatcher.rs:965` — `NoopSender` already exists in the file for another path; reuse it
+- `crates/mika-agent/src/async_db.rs:494` — `count_pending_callback_tasks_by_team_run` already exists for sibling-completion detection
+- `crates/mika-agent/CLAUDE.md` → MessageSender section: team engine agents intentionally have `message_sender: None`; this plan extends that discipline to per-child callback silent turns
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/callback-resume-agent-lifecycle.md` — describes the resume_agent callback pattern this plan modifies
+- `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md` — precedent for engine-level work in the callback path (metadata extraction runs BEFORE the silent turn); similar seam for suppressing the user-facing sender
+- `docs/solutions/architecture-patterns/generic-callback-framing-parent-task-id.md` — parent_task_id is already a first-class signal in the callback path
+
+### Unknowns to resolve during implementation
+
+- **Where exactly to hook the consolidated notification.** Candidates: (a) inside `dispatch_invoke_orchestrator` after `resume_team_run` returns, loading final `team_runs.deliverable`; (b) inside `resume_team_run` itself near the deliver-phase completion; (c) inside the `run_team` tool's caller for synchronous completion. Must handle both sync and async paths. Leaning toward (a) for async + a matching hook in the sync return path — resolved once the hooks are in place.
+- **Failure-path notification shape.** Existing `team_runs.status` values: `running`, `completed`, `failed`, `cancelled`, `suspended`. Plan: on `failed`/`cancelled`, send a short status line + failure_reason if present. On `completed`, send the deliverable.
+
+## Key Technical Decisions
+
+- **The two parts are coupled and must ship together.** Part 1 (add consolidated notification) alone = N+1 messages. Part 2 (suppress per-child) alone = zero messages. Both in the same PR, landing as sequenced commits so the diff is legible.
+- **Suppress via `NoopSender`, not by skipping the silent turn.** The silent turn may still serve internal state (memory updates, task health awareness per the CLAUDE.md "Silent Mode Agent Loop" section). Passing a `NoopSender` instead of `None` means `send_message` becomes a no-op without triggering the channel-routing code paths (which have their own warn-log side effects via `NoChannel`). **Rationale:** this is a minimal-footprint change at one dispatcher seam. Skipping the silent turn entirely is a larger behavioral change with unclear downstream effects (e.g., internal state the specialist might rely on next turn); defer that as a potential follow-up if the silent turn proves wasteful.
+- **Detect "team-child callback" via `team_run_id.is_some() && parent_task_id.is_some()`.** These are set together at child-creation time (engine.rs:877-878). A task with a team_run_id but no parent_task_id would be the parent itself (invoke_orchestrator); its path is different and not affected. **Rationale:** two-signal check avoids false-negatives if any other code path populates one but not the other; explicit is better than clever.
+- **Consolidated message is sent from `dispatch_invoke_orchestrator` after completion.** This hook sees the team run transitioning to `completed`/`failed`/`cancelled` after `resume_team_run` returns. It's the single convergence point for both async-suspended runs and post-review deliveries. **Rationale:** matches where `team_runs.deliverable` is already committed to the DB; avoids duplicating the hook in the synchronous path inside the team engine.
+- **Synchronous completion path also needs a hook.** If all specialists finish without suspending, the team engine completes inline inside `execute()` and never goes through `invoke_orchestrator`. The `run_team` tool is the caller in that case — it already returns the deliverable to the orchestrator conversation. Evaluate whether the per-child silent callbacks even fire in that path; if they do, the Part-1 hook needs a sibling inside the tool's completion handling. Resolved during implementation — a small investigation before Part 1 writes the code.
+- **No new schema, no API change.** `team_runs.deliverable` already exists. `message_sender` dispatch path already exists. `NoopSender` already exists. This is purely rewiring two seams.
+- **Observability via structured `info!`/`warn!` logs.** Log fields: `team_run_id`, `team_id`, `delegation_count`, `notification_kind` (`"deliverable"` | `"failure"` | `"suppressed_per_child"`). Locked schema below under Unit 1.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Can we skip the silent turn entirely for team-child callbacks?** Possible but larger blast radius. Deferred — NoopSender is the minimal change.
+- **Should the consolidated message go through the orchestrator's conversation or be a system message?** System message (same channel the current per-child silent turns use). The deliverable is already produced by the team engine; no LLM turn is needed to format it.
+- **What about the case where the orchestrator emits `{reply: "..."}` instead of delegating?** That path produces a conversational reply on the orchestrator's own channel (engine.rs:596, 651 set `deliverable = reply`). Current behavior is preserved — the consolidated-message hook fires at deliverable time regardless of whether delegations happened.
+
+### Deferred to Implementation
+
+- **Exact message format for the consolidated notification.** A simple `"Team '{name}' finished: {deliverable}"` or just the raw deliverable. Will pick when writing Unit 1; low-risk.
+- **Whether to also suppress the silent turn's entry in `llm_calls` table.** Probably keep — `llm_calls` is observability, not user-facing. Silent turn still happens, LLM call still recorded, just `send_message` is a no-op.
+
+## Implementation Units
+
+**Sequencing:** Both units land in the same PR as two commits. Unit 1 first (adds the consolidated hook, but user temporarily sees N+1 messages — do not deploy after commit 1). Commit 2 (Unit 2) suppresses per-child notifications; after it the user sees exactly 1 message per team run. Integration test for the full flow lives with Unit 2's commit.
+
+- [ ] **Unit 1: Consolidated team-run notification hook**
+
+**Goal:** When a team run reaches terminal status (`completed`/`failed`/`cancelled`), send exactly one user-facing message via `self.message_sender` on the dispatcher.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — extend `dispatch_invoke_orchestrator` to notify on terminal status after `resume_team_run`
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — **investigation step first**: confirm whether the synchronous completion path (team engine finishes inline in `execute()` without suspending) fires per-child callbacks. If yes, add the sibling hook; if no, document why only the async path needs one
+- Test: `crates/mika-agent/src/task_engine/dispatcher.rs#tests` — unit test for the notification formatter
+- Test: `crates/mika-agent/tests/eval/team_callback_consolidation.rs` (new) — integration test; see harness risk in Risks table
+
+**Approach:**
+- After `resume_team_run` returns in `dispatch_invoke_orchestrator`, load the final `team_runs` row via `self.db.load_team_run_by_id(team_run_id)`.
+- Build the message per this logic:
+  - `status == "completed"` AND `deliverable.is_some()` → `deliverable` text (truncated to a safe limit, TBD during implementation)
+  - `status == "failed"` OR `status == "cancelled"` → `"Team '{team_name}' {status}{optional_failure_reason}"`
+  - Anything else (unexpected status transition) → log `warn!` and emit a generic fallback
+- Call `self.message_sender.send(...)` with the standard `message` + `chat_id` resolution already used elsewhere in the dispatcher. Respect `Ok(SendOutcome::NoChannel)` (agent has no reply channel — do not warn or retry; matches existing dispatcher policy).
+- Emit a structured log line documenting what was sent. Locked schema:
+
+```rust
+info!(
+    team_run_id = %run.id,
+    team_id = %run.team_id,
+    team_name = %run.team_name,
+    status = %run.status,
+    delegation_count = children.len(),
+    notification_kind = %kind,  // "deliverable" | "failure" | "fallback"
+    deliverable_chars = run.deliverable.as_ref().map(|s| s.chars().count()).unwrap_or(0),
+    "team_run_notified"
+);
+```
+
+- Grep pattern: `grep team_run_notified server.log | jq`.
+
+**Patterns to follow:**
+- Existing `info!`/`warn!` structured logging conventions in the dispatcher
+- Existing `message_sender` dispatch call sites (look at how `verdict_handler` and `ci_success_handler` send notifications)
+- `MessageSender` trait's three outcomes (`Delivered`/`Failed`/`NoChannel`) handled per existing policy in this file
+
+**Test scenarios:**
+- **Happy path (completed + deliverable):** team_runs row has `status="completed"`, `deliverable=Some("...")`. Test: one `send_message` call issued, message contains the deliverable text, `team_run_notified` log emitted with `notification_kind="deliverable"`.
+- **Happy path (failed):** `status="failed"`, `failure_reason=Some("orchestrator timeout")`. Test: one call, message contains both the team name and the reason; log has `notification_kind="failure"`.
+- **Edge case (completed, no deliverable):** `status="completed"`, `deliverable=None` (shouldn't happen per team engine contract, but defensive). Test: `notification_kind="fallback"`, message is a generic status line, `warn!` emitted.
+- **Edge case (NoChannel):** `message_sender.send()` returns `Ok(NoChannel)`. Test: no retry, no warn, function returns `Ok(())`.
+- **Edge case (unexpected status):** `status="suspended"` at this point would be unexpected. Test: `warn!` emitted, no user-facing message (defer to the next fire of `invoke_orchestrator`).
+
+**Verification:**
+- `cargo test -p mika-agent task_engine::dispatcher` passes.
+- Manual sanity post-integration: after a team run completes in dev, `grep team_run_notified server.log | jq '.fields'` shows the event with expected fields.
+
+---
+
+- [ ] **Unit 2: Suppress `send_message` in per-child team-callback silent turns**
+
+**Goal:** Per-delegation `resume_agent` callbacks run their silent turn with a `NoopSender` instead of the user-facing `message_sender`, so `send_message` becomes a no-op. With Unit 1 in place, the net result is exactly one user message per team run.
+
+**Requirements:** R2, R4
+
+**Dependencies:** Unit 1 (sequencing; both in same PR)
+
+**Files:**
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — at `dispatch_resume_agent:393`, branch on `is_team_child_callback(task)` and pass `Arc::new(NoopSender)` in that branch instead of `self.message_sender.clone()`
+- Add: `crates/mika-agent/src/task_engine/dispatcher.rs` — small private helper `fn is_team_child_callback(task: &Task) -> bool { task.team_run_id.is_some() && task.parent_task_id.is_some() }`
+- Test: inline unit test for `is_team_child_callback` (predicate truth table)
+- Test: `crates/mika-agent/tests/eval/team_callback_consolidation.rs` — end-to-end assertion that an N-delegation team run produces exactly 1 user-facing message
+
+**Approach:**
+- `NoopSender` already exists in the file (dispatcher.rs:965); it returns `Ok(SendOutcome::Delivered)` without actually sending.
+- Log when suppression fires so we can audit:
+
+```rust
+info!(
+    task_id = %task.id,
+    team_run_id = ?task.team_run_id,
+    agent_id = %task.agent_id,
+    "team_child_callback_notification_suppressed"
+);
+```
+
+- No change to the silent turn itself — the turn still runs, still records `llm_calls`, still updates the specialist's memory as needed. Only the user-facing channel is gated.
+- Conversational-reply path is unaffected — no delegations means no children, means no per-child callbacks fire at all.
+
+**Patterns to follow:**
+- The existing `NoopSender` usage at dispatcher.rs:965 for its other path — mirror the instantiation pattern.
+- Existing structured logging conventions in the dispatcher.
+
+**Test scenarios:**
+- **Happy path (team child):** task with `team_run_id=Some(...)`, `parent_task_id=Some(...)` → `is_team_child_callback` returns `true`, `NoopSender` is passed to the silent turn, suppression log emitted.
+- **Happy path (non-team callback):** task with `team_run_id=None`, `parent_task_id=Some(...)` (e.g. a regular skill callback with a parent) → `is_team_child_callback` returns `false`, user-facing `message_sender` is passed as today.
+- **Edge case (team-root task):** task with `team_run_id=Some(...)`, `parent_task_id=None` (the `invoke_orchestrator` parent itself). Not routed through `dispatch_resume_agent` but defensive unit test ensures `is_team_child_callback` returns `false`.
+- **Integration (end-to-end):** 3-delegation team run via `MockLlmProvider`. Count `send_message` calls observed by the dispatcher's message_sender — exactly 1 (from Unit 1's consolidated hook). All 3 silent turns fire and record LLM calls, but none call user-facing `send_message`.
+- **Integration (single delegation):** 1-delegation team run → 1 message.
+- **Integration (failed run):** team run fails mid-execution → 1 message with failure reason.
+
+**Verification:**
+- `cargo test -p mika-agent task_engine::dispatcher::tests::team_child_callback_predicate` passes.
+- `cargo test -p mika-agent --test eval team_callback_consolidation` passes.
+- Manual sanity: run a team with N ≥ 2 delegations, observe exactly one message in the TUI inbox, and `grep team_run_notified server.log` finds one line per run.
+
+## System-Wide Impact
+
+- **Interaction graph:** Two seams inside `task_engine::dispatcher`. No changes to team engine internals or to public task/team APIs.
+- **Error propagation:** Unit 1's notification wraps `message_sender` failures per existing policy (warn on `Failed`, silent on `NoChannel`, `Err` logged and swallowed to not block the dispatcher loop).
+- **State lifecycle risks:** None — the silent turn still runs in Unit 2, so internal specialist state is unchanged. Only the external user-channel call becomes a no-op.
+- **API surface parity:** No external API change. `run_team` tool, dashboard API, A2A endpoints unchanged.
+- **Integration coverage:** Tests depend on a team-engine test harness that doesn't exist yet (see Risks). Unit-level tests on the predicate and notification formatter are unaffected.
+- **Unchanged invariants:** `team_runs` schema, `tasks` schema, `message_sender` trait, `SilentTrigger::Callback` semantics, team engine's inline specialist execution, per-specialist memory updates.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Unit 1 and Unit 2 land in different commits; if deployed between them, UX regresses (N+1 or 0 messages). | Commit sequencing lives inside one PR; ship atomically. PR description calls out "this fix is two coupled commits — do not cherry-pick one without the other." |
+| Synchronous completion path (all specialists finish inline without suspending) may not go through `dispatch_invoke_orchestrator`; the consolidated notification would miss those runs. | Unit 1 begins with a small investigation step. If sync path is unaffected (because per-child callbacks don't fire in that path either), no sibling hook needed; if per-child callbacks DO fire, add the hook in the `run_team` tool's return path. Outcome documented in the PR description regardless. |
+| **No existing team-engine test harness.** Same risk as #286's Unit 2 — `tests/eval/*` targets `run_agent()`, not team runs. Integration tests require a small new harness scripted against the full team flow. | Build the harness skeleton first. If it balloons, narrow Unit 2's integration test to mock `dispatch_resume_agent` and `dispatch_invoke_orchestrator` calls directly (with crafted `Task` rows and a fake `message_sender`), and defer full-flow testing to a follow-up. Unit-level tests on the predicate and formatter remain unaffected. Consider coordinating this harness with #286's — if both tickets land the same harness, either plan should reference the other in its PR. |
+| `NoopSender` semantics drift — if someone later changes it to log a warning or record telemetry, Unit 2's log dedupe breaks. | `NoopSender` is in the dispatcher module; add a test that asserts its current `Delivered` no-op behavior so future changes trip the test. One-line regression guard. |
+| Suppression log becomes noisy under high delegation volume. | `info!` not `warn!`. Can be filtered out downstream. The benefit — being able to audit "was the suppression active for this run?" — outweighs the volume cost. |
+| Team-run failure with `deliverable = None` produces a fallback message, but the team engine may not always set `failure_reason`. | Unit 1's fallback case covers this: emits a generic status line + `warn!`. Not user-hostile, but we note in the plan that populating `failure_reason` at team-engine failure points is a follow-up cleanliness fix (out of scope). |
+
+## Documentation / Operational Notes
+
+- Update `crates/mika-agent/CLAUDE.md` under the Task Engine section with a short note: "Team-run user notification is fired once at terminal status from `dispatch_invoke_orchestrator`; per-child `resume_agent` callbacks have their user-facing `send_message` suppressed via `NoopSender`."
+- No deployment, migration, or rollout concerns — purely an internal rewiring.
+
+## Sources & References
+
+- **Origin issue:** [senara-solutions/mika#287](https://github.com/senara-solutions/mika/issues/287)
+- Related code: `crates/mika-agent/src/teams/engine.rs`, `crates/mika-agent/src/task_engine/dispatcher.rs`
+- Related pattern: `docs/solutions/architecture-patterns/callback-resume-agent-lifecycle.md`
+- Related pattern: `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md`
+- Related code: `dispatcher.rs:965` — existing `NoopSender` reuse
+- Observed failure: team run `fd7ef7ef` — one concrete instance, not a provider-specific conclusion

--- a/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+++ b/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
@@ -132,6 +132,14 @@ Observed failure: run `fd7ef7ef` (one concrete instance). mika-dev received 2 de
   - `"cancelled"` → `"Team '{name}' was cancelled."`
   - Anything else (`running`, `suspended`) → `None` (hook should not fire in these states; defensive)
 - At both callsites, wrap the send in the existing `MessageSender` outcome handling: `Ok(Delivered)` → info log only; `Ok(NoChannel)` → silent (matches dispatcher policy elsewhere); `Ok(Failed)` → `warn!` and continue; `Err` → `warn!` and continue.
+- **Sync callsite must Option-check `ctx.message_sender`.** Verified: `ToolContext.message_sender: Option<Arc<dyn MessageSender>>` (not every ctx construction site populates it — some test paths and the `toggle_skill` tool construct with `None`). On `None`: `debug!` log and skip the notification. Don't `warn!` — the absence is legitimate for some call paths, not a bug.
+- **Async callsite reads `team_runs` via `self.db.load_team_run_by_id(...)`.** Verified: `resume_team_run` returns `Result<()>`, not `Result<TeamRun>` — the DB roundtrip is necessary. Single indexed PK read; negligible cost. Refactoring `resume_team_run` to return the final `TeamRun` would save the read but touches a larger API surface; out of scope for this fix (follow-up if anyone ever cares).
+- **Anchor both callsites with a short code comment** so a future maintainer doesn't "helpfully" consolidate them into `TeamEngine::finalize_and_shutdown`:
+  ```rust
+  // Paired with <other callsite>; see docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+  // for why this lives here and not in TeamEngine::finalize_and_shutdown (keeps the team
+  // engine free of a user_message_sender field).
+  ```
 - **Locked log schema** (observability contract — do not change field names without a plan update):
 
 ```rust
@@ -163,6 +171,7 @@ info!(
 - **Helper (completed without deliverable):** `status: "completed"`, `deliverable: None` → `Some("Team 'x' completed (no deliverable produced).")`.
 - **Helper (non-terminal):** `status: "running"` or `"suspended"` → `None`.
 - **Sync hook (tool):** mock `ctx.message_sender`; `teams::run_team()` returns a completed `TeamRun` with deliverable. Assert: exactly one `send` call, text matches helper output, `team_run_notified` log with `path = "sync"`.
+- **Sync hook (no message_sender):** `ctx.message_sender == None`. Assert: no send attempted, one `debug!` log emitted, tool return is unaffected.
 - **Sync hook (non-terminal suspension):** `teams::run_team()` returns `status = "suspended"`. Assert: helper returns `None`, no send call.
 - **Async hook (dispatcher):** `resume_team_run` returns success; `team_runs` table row has `status = "completed"`, `deliverable = Some(...)`. Assert: one send call, `team_run_notified` log with `path = "async"`.
 - **Async hook (failed resume):** resume_team_run completes with `status = "failed"`. Assert: one send call with failure reason.

--- a/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
+++ b/docs/plans/2026-04-24-003-fix-team-callback-consolidation-plan.md
@@ -9,114 +9,130 @@ date: 2026-04-24
 
 ## Overview
 
-A team run with N delegations produces N user-facing messages instead of one consolidated deliverable. The fix is a coupled two-part change to the task-engine's team callback plumbing: (1) add a single user-facing notification at team-run completion, sourced from the `deliverable` the team engine already produces; (2) suppress `send_message` in the per-child `resume_agent` silent turns so each delegation no longer independently notifies the user. Both parts must ship together — Part 1 alone produces N+1 messages (worse), Part 2 alone produces zero (silent).
+A team run with N delegations produces N user-facing messages instead of one consolidated deliverable. The fix is a coupled two-part change to the task-engine's team callback plumbing: (1) add a single user-facing notification at team-run terminal status, sourced from the `deliverable` the team engine already produces — fired from both the synchronous return path (`run_team` tool) and the asynchronous resume path (`dispatch_invoke_orchestrator`), using a shared formatter helper; (2) suppress `send_message` in the per-child `resume_agent` silent turns so each delegation no longer independently notifies the user. Both parts must ship together — Part 1 alone produces N+1 messages (worse), Part 2 alone produces zero (silent).
 
-No new schema, no API change, no new public types. Both hooks live inside `task_engine::dispatcher` and reuse the existing `message_sender` wired into the dispatcher.
+No new schema, no API change, no new public types, no new engine-struct fields. Reuses the existing `NoopSender` in the dispatcher, the existing `message_sender` dispatch chain, and the existing `team_runs.deliverable` field.
 
 ## Problem Frame
 
-When a team engine delegates to multiple agents in one run, it creates N child `resume_agent` callback tasks (`teams/engine.rs:874-912`). Each child's callback, when fired via `dispatch_resume_agent` (`task_engine/dispatcher.rs:295`), runs a full silent agent turn with `message_sender: self.message_sender.clone()` (line 393). The agent's turn then independently calls `send_message`, producing one user-facing message per delegation.
+When a team engine delegates to N agents in one run, it creates N child `resume_agent` callback tasks at `teams/engine.rs:874-912`. Each child's callback, when fired via `dispatch_resume_agent` at `task_engine/dispatcher.rs:295`, runs a full silent agent turn with `message_sender: self.message_sender.clone()` at line 393. The agent's turn independently calls `send_message`, producing one user-facing message per delegation.
 
-The parent `invoke_orchestrator` task (`dispatcher.rs:431`) fires once all children complete. It resumes the team engine via `resume_team_run`, which continues to the review/deliver phase and produces `team_runs.deliverable`. But it **does not** emit a user-facing message — the only user-visible path for team output today is the per-child silent turns.
+The run-level deliverable path is split:
+- **Sync completion** (all specialists finish inline, no suspension): `teams::run_team()` returns `TeamRun` with `status = "completed"` and `deliverable = Some(...)` to the `run_team` tool. The tool wraps it into `ToolOutput::success` for the orchestrator LLM (`tools/run_team.rs:144-151`). The user sees the deliverable only through the orchestrator's next turn, if the orchestrator decides to paraphrase it. No direct user-facing notification carries the deliverable text.
+- **Async completion** (team suspends, then resumes via `invoke_orchestrator`): `dispatch_invoke_orchestrator` calls `resume_team_run` which drives the team engine's deliver phase. The tool has long since returned; the orchestrator LLM never gets a tool-output update. No user-facing notification is emitted anywhere. Today, async-completed team runs surface to the user **only** through per-child silent callbacks.
 
-Observed: run `fd7ef7ef` (one concrete instance), mika-dev received 2 delegations → 2 callback tasks → 2 silent turns → 2 `send_message` calls → 2 user-visible messages in the TUI inbox.
+Meanwhile, `run_team` tool's `TeamEventCallback` (`tools/run_team.rs:97-126`) emits short progress announcements (`[Team] Phase: …`, `[Team] Agent 'alice' completed`, `[Team] Deliverable ready`, `[Team] Run failed: …`) to the orchestrator's channel during sync execution. On resume (async path), `new_for_resume` at `engine.rs:239` explicitly sets `callback: None` — so async runs produce no progress events either.
+
+Observed failure: run `fd7ef7ef` (one concrete instance). mika-dev received 2 delegations → 2 child callbacks → 2 silent turns → 2 `send_message` calls → 2 user-visible messages in the TUI inbox.
 
 ## Requirements Trace
 
-- **R1.** A completed team run must produce exactly one user-facing message containing the final deliverable.
-- **R2.** Per-delegation callbacks must not call `send_message` for user-facing channels. They may still run the silent turn for internal state if needed, or be short-circuited entirely — but the user-facing channel is closed to them.
-- **R3.** Failure modes remain observable — if the team run fails (timeout, orchestrator error), the user gets a single failure notification with the reason, not silence and not N partial-result messages.
-- **R4.** The fix must not regress single-delegation team runs (N=1 → still one message, not zero) or conversational-reply team turns (no delegation, no notification expected unless the orchestrator itself replied).
+- **R1.** A completed team run must produce exactly one user-facing message containing the final deliverable text (not just a "ready" announcement), on both synchronous and asynchronous completion paths.
+- **R2.** Per-delegation `resume_agent` callbacks must not call `send_message` on user-facing channels. The silent turn may still run (for internal state); only the user channel is gated.
+- **R3.** Failure modes remain observable — on `status in (failed, cancelled)`, the user gets a single failure notification including `failure_reason` when set, not silence and not N partial-result messages.
+- **R4.** The fix must not regress single-delegation team runs (N=1 → still one message, not zero) or conversational-reply team turns (orchestrator `{reply: "..."}` path unaffected).
 
 ## Scope Boundaries
 
 ### In scope
 
-- `task_engine::dispatcher::dispatch_invoke_orchestrator` — add user-notification hook at completion
-- `task_engine::dispatcher::dispatch_resume_agent` — detect team-child callbacks and pass `NoopSender` (already imported at dispatcher.rs:965 for another path) instead of the user-facing sender
-- Synchronous team-run completion path (when all specialists finish inline without suspending) — add the same notification hook
-- Integration tests in `tests/eval/` covering 1-delegation, N-delegation, and failed-team-run scenarios
+- `task_engine::dispatcher::dispatch_invoke_orchestrator` — add notification hook after `resume_team_run` (async path)
+- `tools::run_team::execute` — add notification hook after `teams::run_team()` returns (sync path)
+- A shared formatter helper in `teams::mod` or `teams::notification` for both callsites
+- `task_engine::dispatcher::dispatch_resume_agent` — branch on team-child detection; pass `NoopSender` instead of `self.message_sender`
+- Integration tests in `tests/eval/team_callback_consolidation.rs` covering N=1, N≥2, and failed team runs
 
 ### Deferred to Separate Tasks
 
-- **Coverage check (#286):** different bug class, separate plan
-- **Dashboard team-run surfacing:** the dashboard already displays the `deliverable` field; no new surfacing needed for this fix
-- **Message formatting customization:** the consolidated message uses the raw `deliverable` text (possibly with a short header). Richer formatting is a UX concern, not a bug fix
-- **Per-agent "I delegated this to you, here's the outcome" internal messages:** if product wants the orchestrator to personally notify each specialist's conversation thread about the team run, that's a separate feature — this plan only addresses the user-facing channel
+- **Coverage check (#286):** different bug class
+- **Removing `[Team] Deliverable ready` / `[Team] Run failed: …` from the existing `TeamEventCallback`:** these are now partially redundant with the new consolidated notification, but they fire *during* the run (not at completion) and are only present in the sync path. Removing them is a cleanup, not a fix. Out of scope; file as a follow-up if desired.
+- **Populating `TeamEventCallback` on resume:** `new_for_resume` drops the callback — the new consolidated notification makes this less bad, but if we ever want progress events during resumed runs, that's a separate fix.
+- **Orchestrator LLM paraphrasing of deliverable:** the orchestrator's next turn after a sync team run may send its own user message paraphrasing the deliverable. That's prompt-level behavior, not a plumbing bug. Out of scope.
+- **Skipping the silent turn entirely for team-child callbacks:** potential optimization (no wasted LLM call per child). Defer; `NoopSender` is the minimal-footprint fix.
 
 ## Context & Research
 
 ### Relevant Code and Patterns
 
 - `crates/mika-agent/src/teams/engine.rs:874-912` — child `resume_agent` callback tasks created per delegation with `team_run_id = Some(run_id)`, `parent_task_id = Some(parent_id)`, `trigger_type = "callback"`, `action_type = RESUME_AGENT`
-- `crates/mika-agent/src/teams/engine.rs:838-866` — parent `invoke_orchestrator` task with `action_type = INVOKE_ORCHESTRATOR`, fires when all children complete
-- `crates/mika-agent/src/teams/engine.rs:486-505` — `deliver_phase()` sets `self.run.deliverable` and emits `TeamEvent::Deliverable(...)` for live UI; does NOT send user message
-- `crates/mika-agent/src/task_engine/dispatcher.rs:295-425` — `dispatch_resume_agent`: per-callback silent turn, passes `message_sender: self.message_sender.clone()` at line 393
-- `crates/mika-agent/src/task_engine/dispatcher.rs:431-520` — `dispatch_invoke_orchestrator`: calls `resume_team_run`, no user notification
-- `crates/mika-agent/src/task_engine/dispatcher.rs:965` — `NoopSender` already exists in the file for another path; reuse it
-- `crates/mika-agent/src/async_db.rs:494` — `count_pending_callback_tasks_by_team_run` already exists for sibling-completion detection
-- `crates/mika-agent/CLAUDE.md` → MessageSender section: team engine agents intentionally have `message_sender: None`; this plan extends that discipline to per-child callback silent turns
+- `crates/mika-agent/src/teams/engine.rs:451` — **only site** where `RunStatus::Failed(e.to_string())` is set. `failure_reason` is therefore always populated when `status == "failed"`.
+- `crates/mika-agent/src/teams/engine.rs:507-544` — `finalize_and_shutdown()` converges sync and async paths on terminal state, but the team engine has no `user_message_sender` field — passing the notification through here would require rewiring the engine, which violates the "team engine's agents have `message_sender: None`" convention. The two-callsite approach at the engine's *callers* is cleaner.
+- `crates/mika-agent/src/tools/run_team.rs:140-158` — sync path returns `TeamRun` to the tool; tool wraps into `ToolOutput::success` for the orchestrator LLM. Already has `ctx.message_sender` in scope via `ctx`. Natural seam for the sync notification.
+- `crates/mika-agent/src/task_engine/dispatcher.rs:431-520` — `dispatch_invoke_orchestrator` handles async resume. Already has `self.message_sender` in scope. Natural seam for the async notification.
+- `crates/mika-agent/src/task_engine/dispatcher.rs:295-425` — `dispatch_resume_agent`: per-callback silent turn with user-facing `message_sender` at line 393
+- `crates/mika-agent/src/task_engine/dispatcher.rs:965` — existing `NoopSender` in the same module; reuse
+- `crates/mika-agent/src/async_db.rs:494` — `count_pending_callback_tasks_by_team_run` already exists (sibling-completion detection is solved upstream)
 
 ### Institutional Learnings
 
 - `docs/solutions/architecture-patterns/callback-resume-agent-lifecycle.md` — describes the resume_agent callback pattern this plan modifies
 - `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md` — precedent for engine-level work in the callback path (metadata extraction runs BEFORE the silent turn); similar seam for suppressing the user-facing sender
-- `docs/solutions/architecture-patterns/generic-callback-framing-parent-task-id.md` — parent_task_id is already a first-class signal in the callback path
-
-### Unknowns to resolve during implementation
-
-- **Where exactly to hook the consolidated notification.** Candidates: (a) inside `dispatch_invoke_orchestrator` after `resume_team_run` returns, loading final `team_runs.deliverable`; (b) inside `resume_team_run` itself near the deliver-phase completion; (c) inside the `run_team` tool's caller for synchronous completion. Must handle both sync and async paths. Leaning toward (a) for async + a matching hook in the sync return path — resolved once the hooks are in place.
-- **Failure-path notification shape.** Existing `team_runs.status` values: `running`, `completed`, `failed`, `cancelled`, `suspended`. Plan: on `failed`/`cancelled`, send a short status line + failure_reason if present. On `completed`, send the deliverable.
 
 ## Key Technical Decisions
 
-- **The two parts are coupled and must ship together.** Part 1 (add consolidated notification) alone = N+1 messages. Part 2 (suppress per-child) alone = zero messages. Both in the same PR, landing as sequenced commits so the diff is legible.
-- **Suppress via `NoopSender`, not by skipping the silent turn.** The silent turn may still serve internal state (memory updates, task health awareness per the CLAUDE.md "Silent Mode Agent Loop" section). Passing a `NoopSender` instead of `None` means `send_message` becomes a no-op without triggering the channel-routing code paths (which have their own warn-log side effects via `NoChannel`). **Rationale:** this is a minimal-footprint change at one dispatcher seam. Skipping the silent turn entirely is a larger behavioral change with unclear downstream effects (e.g., internal state the specialist might rely on next turn); defer that as a potential follow-up if the silent turn proves wasteful.
-- **Detect "team-child callback" via `team_run_id.is_some() && parent_task_id.is_some()`.** These are set together at child-creation time (engine.rs:877-878). A task with a team_run_id but no parent_task_id would be the parent itself (invoke_orchestrator); its path is different and not affected. **Rationale:** two-signal check avoids false-negatives if any other code path populates one but not the other; explicit is better than clever.
-- **Consolidated message is sent from `dispatch_invoke_orchestrator` after completion.** This hook sees the team run transitioning to `completed`/`failed`/`cancelled` after `resume_team_run` returns. It's the single convergence point for both async-suspended runs and post-review deliveries. **Rationale:** matches where `team_runs.deliverable` is already committed to the DB; avoids duplicating the hook in the synchronous path inside the team engine.
-- **Synchronous completion path also needs a hook.** If all specialists finish without suspending, the team engine completes inline inside `execute()` and never goes through `invoke_orchestrator`. The `run_team` tool is the caller in that case — it already returns the deliverable to the orchestrator conversation. Evaluate whether the per-child silent callbacks even fire in that path; if they do, the Part-1 hook needs a sibling inside the tool's completion handling. Resolved during implementation — a small investigation before Part 1 writes the code.
-- **No new schema, no API change.** `team_runs.deliverable` already exists. `message_sender` dispatch path already exists. `NoopSender` already exists. This is purely rewiring two seams.
-- **Observability via structured `info!`/`warn!` logs.** Log fields: `team_run_id`, `team_id`, `delegation_count`, `notification_kind` (`"deliverable"` | `"failure"` | `"suppressed_per_child"`). Locked schema below under Unit 1.
+- **Two callsites, one shared formatter helper.** Sync path: in `run_team` tool, after `teams::run_team()` returns, format the deliverable/failure message and call `ctx.message_sender.send(...)`. Async path: in `dispatch_invoke_orchestrator`, after `resume_team_run` returns, load final `team_runs` row via `self.db.load_team_run_by_id(...)` and call `self.message_sender.send(...)`. **Rationale:** each path already has `message_sender` in scope at the right terminal-state boundary. Routing through `finalize_and_shutdown` would require adding a `user_message_sender` field to the team engine struct — cleaner looking from one angle, but it weakens the "team engine's agents don't talk to users directly" boundary. Duplicated *dispatch call* with a shared *formatter* is the right trade.
+- **Shared helper: pure function, terminal-state only.** Lives at `teams::notification::build_run_completion_message(run: &TeamRun) -> Option<String>`. Returns `None` for non-terminal status (defensive; hook shouldn't fire in non-terminal paths anyway); returns `Some(text)` for `completed`/`failed`/`cancelled`. Trivial to unit-test without spinning up any engine harness.
+- **Message format is committed (no "we'll pick later"):**
+
+  | Status | Format |
+  |---|---|
+  | `completed` with deliverable | `"Team '{name}' completed. Deliverable:\n\n{deliverable_truncated}"` |
+  | `completed` with `deliverable = None` (defensive) | `"Team '{name}' completed (no deliverable produced)."` + `warn!` |
+  | `failed` | `"Team '{name}' failed: {failure_reason}"` — `failure_reason` is always present per `engine.rs:451` audit |
+  | `cancelled` | `"Team '{name}' was cancelled."` |
+
+  **Truncation:** deliverable longer than **4000 characters** (char count, not bytes — Unicode-safe boundary via `floor_char_boundary`) is cut and suffixed with `"\n\n[…truncated after 4000 chars — full deliverable persisted on team_runs.deliverable]"`. 4000 is below the Telegram 4096-char text limit with headroom for the prefix. The suffix explicitly names where the full text lives so the user isn't in the dark.
+
+- **Suppress via `NoopSender`, not by skipping the silent turn.** The silent turn may still serve internal state (memory updates, task health awareness). Passing `Arc::new(NoopSender)` means `send_message` returns `Ok(Delivered)` without transmission. **Rationale:** minimal-footprint change; skipping the silent turn entirely is a larger behavioral change with unclear downstream effects (specialist memory/fact updates might rely on the silent turn firing). Defer that as a potential follow-up.
+- **Detect "team-child callback" via `team_run_id.is_some() && parent_task_id.is_some()`.** Two-signal check; both columns are set together at child-creation time. Keep the helper `fn is_team_child_callback(task: &Task) -> bool` as a named predicate for intent clarity and test anchoring.
+- **Observability via two locked structured log events:** `team_run_notified` (fires from both notification sites) and `team_child_callback_notification_suppressed` (fires in the `dispatch_resume_agent` branch). Schema below in the respective units.
+- **`TeamEventCallback` untouched.** It fires short progress announcements during sync runs (`[Team] Phase: …`, etc.). Leaving it alone means sync runs produce: progress events during + deliverable at end. Async runs produce: deliverable at end only. The redundant `[Team] Deliverable ready` announcement is noted as out-of-scope cleanup.
 
 ## Open Questions
 
 ### Resolved During Planning
 
-- **Can we skip the silent turn entirely for team-child callbacks?** Possible but larger blast radius. Deferred — NoopSender is the minimal change.
-- **Should the consolidated message go through the orchestrator's conversation or be a system message?** System message (same channel the current per-child silent turns use). The deliverable is already produced by the team engine; no LLM turn is needed to format it.
-- **What about the case where the orchestrator emits `{reply: "..."}` instead of delegating?** That path produces a conversational reply on the orchestrator's own channel (engine.rs:596, 651 set `deliverable = reply`). Current behavior is preserved — the consolidated-message hook fires at deliverable time regardless of whether delegations happened.
+- **Sync path vs async path coverage:** Both paths need the hook. Resolved via two symmetric callsites + shared helper (above).
+- **Message format:** Committed to the table above. No "decide later."
+- **Failure path robustness:** `failure_reason` is always populated (audit: only `RunStatus::Failed(e.to_string())` at `engine.rs:451` ever sets failed state). The generic fallback case is unnecessary; dropped.
+- **Can we skip the silent turn entirely for team-child callbacks?** Possible but larger blast radius. Deferred — `NoopSender` is the minimal change.
+- **Should the consolidated message go through the orchestrator's conversation or be a system message?** System message. The deliverable is already produced by the team engine; no LLM turn needed.
+- **Conversational-reply team turns (`{reply: "..."}`):** unaffected. That path produces the reply on the orchestrator's own channel (`engine.rs:596, 651` set `deliverable = reply`). Current behavior preserved; the new hook fires at deliverable time regardless.
 
 ### Deferred to Implementation
 
-- **Exact message format for the consolidated notification.** A simple `"Team '{name}' finished: {deliverable}"` or just the raw deliverable. Will pick when writing Unit 1; low-risk.
-- **Whether to also suppress the silent turn's entry in `llm_calls` table.** Probably keep — `llm_calls` is observability, not user-facing. Silent turn still happens, LLM call still recorded, just `send_message` is a no-op.
+- **Exact module path for the shared helper.** `teams::notification::build_run_completion_message` is the leaning choice; finalize when creating the file.
+- **Whether the sync path should skip the new notification when the returned `TeamRun` has `status == "suspended"`:** yes — only fire for terminal states. Helper returns `None` for non-terminal; sync callsite sends only on `Some`.
 
 ## Implementation Units
 
-**Sequencing:** Both units land in the same PR as two commits. Unit 1 first (adds the consolidated hook, but user temporarily sees N+1 messages — do not deploy after commit 1). Commit 2 (Unit 2) suppresses per-child notifications; after it the user sees exactly 1 message per team run. Integration test for the full flow lives with Unit 2's commit.
+**Sequencing:** Both units land in the same PR as two commits. Unit 1 first (adds the consolidated hook; user temporarily sees N+1 messages on sync runs — do not deploy between commits). Commit 2 (Unit 2) suppresses per-child notifications; after it the user sees exactly 1 message per team run. Integration tests asserting the full flow land with Unit 2's commit.
 
-- [ ] **Unit 1: Consolidated team-run notification hook**
+---
 
-**Goal:** When a team run reaches terminal status (`completed`/`failed`/`cancelled`), send exactly one user-facing message via `self.message_sender` on the dispatcher.
+- [ ] **Unit 1: Shared formatter + notification hooks at sync and async terminal states**
+
+**Goal:** On every team-run terminal transition, emit exactly one user-facing message containing the deliverable (or failure reason). Both sync completion (via `run_team` tool) and async completion (via `dispatch_invoke_orchestrator`) route through a shared pure formatter.
 
 **Requirements:** R1, R3, R4
 
 **Dependencies:** None
 
 **Files:**
-- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — extend `dispatch_invoke_orchestrator` to notify on terminal status after `resume_team_run`
-- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — **investigation step first**: confirm whether the synchronous completion path (team engine finishes inline in `execute()` without suspending) fires per-child callbacks. If yes, add the sibling hook; if no, document why only the async path needs one
-- Test: `crates/mika-agent/src/task_engine/dispatcher.rs#tests` — unit test for the notification formatter
-- Test: `crates/mika-agent/tests/eval/team_callback_consolidation.rs` (new) — integration test; see harness risk in Risks table
+- Create: `crates/mika-agent/src/teams/notification.rs` — pure function `build_run_completion_message(run: &TeamRun) -> Option<String>` + inline `#[cfg(test)] mod tests`
+- Modify: `crates/mika-agent/src/teams/mod.rs` — register new submodule, re-export helper
+- Modify: `crates/mika-agent/src/tools/run_team.rs` — after `crate::teams::run_team(...)` returns, call the helper and send via `ctx.message_sender` if `Some(text)` returned
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — in `dispatch_invoke_orchestrator`, after `resume_team_run` returns, load final `team_runs` row, call the helper, send via `self.message_sender` if `Some(text)` returned
 
 **Approach:**
-- After `resume_team_run` returns in `dispatch_invoke_orchestrator`, load the final `team_runs` row via `self.db.load_team_run_by_id(team_run_id)`.
-- Build the message per this logic:
-  - `status == "completed"` AND `deliverable.is_some()` → `deliverable` text (truncated to a safe limit, TBD during implementation)
-  - `status == "failed"` OR `status == "cancelled"` → `"Team '{team_name}' {status}{optional_failure_reason}"`
-  - Anything else (unexpected status transition) → log `warn!` and emit a generic fallback
-- Call `self.message_sender.send(...)` with the standard `message` + `chat_id` resolution already used elsewhere in the dispatcher. Respect `Ok(SendOutcome::NoChannel)` (agent has no reply channel — do not warn or retry; matches existing dispatcher policy).
-- Emit a structured log line documenting what was sent. Locked schema:
+- Helper branches on `run.status`:
+  - `"completed"` with `run.deliverable == Some(d)` → format `"Team '{name}' completed. Deliverable:\n\n{d_truncated}"` with UTF-8-safe 4000-char truncation + suffix
+  - `"completed"` with `run.deliverable == None` → `"Team '{name}' completed (no deliverable produced)."` + caller should `warn!`
+  - `"failed"` → `"Team '{name}' failed: {failure_reason}"` (reason always present)
+  - `"cancelled"` → `"Team '{name}' was cancelled."`
+  - Anything else (`running`, `suspended`) → `None` (hook should not fire in these states; defensive)
+- At both callsites, wrap the send in the existing `MessageSender` outcome handling: `Ok(Delivered)` → info log only; `Ok(NoChannel)` → silent (matches dispatcher policy elsewhere); `Ok(Failed)` → `warn!` and continue; `Err` → `warn!` and continue.
+- **Locked log schema** (observability contract — do not change field names without a plan update):
 
 ```rust
 info!(
@@ -124,9 +140,10 @@ info!(
     team_id = %run.team_id,
     team_name = %run.team_name,
     status = %run.status,
-    delegation_count = children.len(),
-    notification_kind = %kind,  // "deliverable" | "failure" | "fallback"
+    notification_kind = %kind,       // "deliverable" | "failure" | "cancelled" | "fallback"
     deliverable_chars = run.deliverable.as_ref().map(|s| s.chars().count()).unwrap_or(0),
+    truncated = truncated,           // bool: true if deliverable was cut to 4000 chars
+    path = %path,                    // "sync" | "async"
     "team_run_notified"
 );
 ```
@@ -134,100 +151,108 @@ info!(
 - Grep pattern: `grep team_run_notified server.log | jq`.
 
 **Patterns to follow:**
-- Existing `info!`/`warn!` structured logging conventions in the dispatcher
-- Existing `message_sender` dispatch call sites (look at how `verdict_handler` and `ci_success_handler` send notifications)
-- `MessageSender` trait's three outcomes (`Delivered`/`Failed`/`NoChannel`) handled per existing policy in this file
+- Existing helper-function style in `teams::prompt::build_orchestrator_context` (pure, testable in-module)
+- Existing `MessageSender` outcome handling in `server::verdict_handler` and `server::ci_success_handler`
+- `UTF-8 safe char boundary` pattern at `teams/prompt.rs:206-213` (truncate at `is_char_boundary`)
 
 **Test scenarios:**
-- **Happy path (completed + deliverable):** team_runs row has `status="completed"`, `deliverable=Some("...")`. Test: one `send_message` call issued, message contains the deliverable text, `team_run_notified` log emitted with `notification_kind="deliverable"`.
-- **Happy path (failed):** `status="failed"`, `failure_reason=Some("orchestrator timeout")`. Test: one call, message contains both the team name and the reason; log has `notification_kind="failure"`.
-- **Edge case (completed, no deliverable):** `status="completed"`, `deliverable=None` (shouldn't happen per team engine contract, but defensive). Test: `notification_kind="fallback"`, message is a generic status line, `warn!` emitted.
-- **Edge case (NoChannel):** `message_sender.send()` returns `Ok(NoChannel)`. Test: no retry, no warn, function returns `Ok(())`.
-- **Edge case (unexpected status):** `status="suspended"` at this point would be unexpected. Test: `warn!` emitted, no user-facing message (defer to the next fire of `invoke_orchestrator`).
+- **Helper (happy, completed):** `TeamRun { status: "completed", team_name: "alpha", deliverable: Some("short text") }` → returns `Some("Team 'alpha' completed. Deliverable:\n\nshort text")`, `truncated = false`.
+- **Helper (truncation):** deliverable is a 5000-char string → output is ≤ 4000 chars before suffix, suffix appended, cut on a UTF-8 char boundary (test with a multi-byte UTF-8 string near the boundary).
+- **Helper (failed):** `status: "failed"`, `failure_reason: Some("orchestrator timed out")` → `Some("Team 'x' failed: orchestrator timed out")`.
+- **Helper (cancelled):** `status: "cancelled"` → `Some("Team 'x' was cancelled.")`.
+- **Helper (completed without deliverable):** `status: "completed"`, `deliverable: None` → `Some("Team 'x' completed (no deliverable produced).")`.
+- **Helper (non-terminal):** `status: "running"` or `"suspended"` → `None`.
+- **Sync hook (tool):** mock `ctx.message_sender`; `teams::run_team()` returns a completed `TeamRun` with deliverable. Assert: exactly one `send` call, text matches helper output, `team_run_notified` log with `path = "sync"`.
+- **Sync hook (non-terminal suspension):** `teams::run_team()` returns `status = "suspended"`. Assert: helper returns `None`, no send call.
+- **Async hook (dispatcher):** `resume_team_run` returns success; `team_runs` table row has `status = "completed"`, `deliverable = Some(...)`. Assert: one send call, `team_run_notified` log with `path = "async"`.
+- **Async hook (failed resume):** resume_team_run completes with `status = "failed"`. Assert: one send call with failure reason.
+- **Async hook (NoChannel):** message_sender returns `Ok(NoChannel)`. Assert: no retry, no warn, dispatcher continues.
 
 **Verification:**
-- `cargo test -p mika-agent task_engine::dispatcher` passes.
-- Manual sanity post-integration: after a team run completes in dev, `grep team_run_notified server.log | jq '.fields'` shows the event with expected fields.
+- `cargo test -p mika-agent teams::notification` passes (helper unit tests).
+- `cargo test -p mika-agent task_engine::dispatcher` passes (dispatcher hook tests).
+- `cargo test -p mika-agent tools::run_team` passes (tool hook tests).
 
 ---
 
 - [ ] **Unit 2: Suppress `send_message` in per-child team-callback silent turns**
 
-**Goal:** Per-delegation `resume_agent` callbacks run their silent turn with a `NoopSender` instead of the user-facing `message_sender`, so `send_message` becomes a no-op. With Unit 1 in place, the net result is exactly one user message per team run.
+**Goal:** Per-delegation `resume_agent` callbacks run their silent turn with a `NoopSender` instead of the user-facing `message_sender`. With Unit 1 in place, the net result is exactly one user message per team run.
 
 **Requirements:** R2, R4
 
 **Dependencies:** Unit 1 (sequencing; both in same PR)
 
 **Files:**
-- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — at `dispatch_resume_agent:393`, branch on `is_team_child_callback(task)` and pass `Arc::new(NoopSender)` in that branch instead of `self.message_sender.clone()`
-- Add: `crates/mika-agent/src/task_engine/dispatcher.rs` — small private helper `fn is_team_child_callback(task: &Task) -> bool { task.team_run_id.is_some() && task.parent_task_id.is_some() }`
+- Modify: `crates/mika-agent/src/task_engine/dispatcher.rs` — add private helper `fn is_team_child_callback(task: &Task) -> bool { task.team_run_id.is_some() && task.parent_task_id.is_some() }`; in `dispatch_resume_agent` near line 393, branch on the predicate and pass `Arc::new(NoopSender)` instead of `self.message_sender.clone()` when it returns `true`. Callsite comment explains *why* (see Minor Editorial).
 - Test: inline unit test for `is_team_child_callback` (predicate truth table)
-- Test: `crates/mika-agent/tests/eval/team_callback_consolidation.rs` — end-to-end assertion that an N-delegation team run produces exactly 1 user-facing message
+- Test: `crates/mika-agent/tests/eval/team_callback_consolidation.rs` (new) — end-to-end assertion that an N-delegation team run produces exactly 1 user-facing message
 
 **Approach:**
-- `NoopSender` already exists in the file (dispatcher.rs:965); it returns `Ok(SendOutcome::Delivered)` without actually sending.
-- Log when suppression fires so we can audit:
+- `NoopSender` already exists in the file (`dispatcher.rs:965`); reuse it.
+- Log when suppression fires so the auditor can correlate with `team_run_notified`:
 
 ```rust
 info!(
     task_id = %task.id,
     team_run_id = ?task.team_run_id,
+    parent_task_id = ?task.parent_task_id,
     agent_id = %task.agent_id,
     "team_child_callback_notification_suppressed"
 );
 ```
 
-- No change to the silent turn itself — the turn still runs, still records `llm_calls`, still updates the specialist's memory as needed. Only the user-facing channel is gated.
-- Conversational-reply path is unaffected — no delegations means no children, means no per-child callbacks fire at all.
+- No change to the silent turn itself — the turn still runs, still records `llm_calls`, still updates the specialist's memory if relevant. Only the user-facing channel is gated.
+- Conversational-reply path is unaffected (no delegations → no children → no per-child callbacks).
 
 **Patterns to follow:**
-- The existing `NoopSender` usage at dispatcher.rs:965 for its other path — mirror the instantiation pattern.
-- Existing structured logging conventions in the dispatcher.
+- Existing `NoopSender` usage at `dispatcher.rs:965`
+- Existing structured logging conventions in the dispatcher
 
 **Test scenarios:**
-- **Happy path (team child):** task with `team_run_id=Some(...)`, `parent_task_id=Some(...)` → `is_team_child_callback` returns `true`, `NoopSender` is passed to the silent turn, suppression log emitted.
-- **Happy path (non-team callback):** task with `team_run_id=None`, `parent_task_id=Some(...)` (e.g. a regular skill callback with a parent) → `is_team_child_callback` returns `false`, user-facing `message_sender` is passed as today.
-- **Edge case (team-root task):** task with `team_run_id=Some(...)`, `parent_task_id=None` (the `invoke_orchestrator` parent itself). Not routed through `dispatch_resume_agent` but defensive unit test ensures `is_team_child_callback` returns `false`.
-- **Integration (end-to-end):** 3-delegation team run via `MockLlmProvider`. Count `send_message` calls observed by the dispatcher's message_sender — exactly 1 (from Unit 1's consolidated hook). All 3 silent turns fire and record LLM calls, but none call user-facing `send_message`.
-- **Integration (single delegation):** 1-delegation team run → 1 message.
-- **Integration (failed run):** team run fails mid-execution → 1 message with failure reason.
+- **Predicate (team child):** `team_run_id = Some(...), parent_task_id = Some(...)` → `true`.
+- **Predicate (non-team callback):** `team_run_id = None, parent_task_id = Some(...)` → `false` (regular skill callback with a parent).
+- **Predicate (team root):** `team_run_id = Some(...), parent_task_id = None` — framed as an *invariant guard*: this shape isn't routed through `dispatch_resume_agent` today, but if someone later changes the team engine to route parents through this function, the predicate correctly returns `false`. Test catches the invariant violation if it slips.
+- **Dispatcher branching:** with `is_team_child_callback == true`, `dispatch_resume_agent` constructs `SilentAgentParams` with `message_sender: Arc::new(NoopSender)`. With `false`, it uses `self.message_sender.clone()`. Asserted via a fake sender that records calls.
+- **Integration (N=3 team run):** `MockLlmProvider` sequence drives a 3-delegation team run through to terminal status. Count `send_message` calls observed by the user-facing sender → exactly 1 (from Unit 1's hook). All 3 silent turns fire and record LLM calls; none hit the user channel.
+- **Integration (N=1):** single-delegation team run → exactly 1 user message.
+- **Integration (failed run):** team run fails during execute_tasks → exactly 1 user message containing the failure reason.
 
 **Verification:**
 - `cargo test -p mika-agent task_engine::dispatcher::tests::team_child_callback_predicate` passes.
 - `cargo test -p mika-agent --test eval team_callback_consolidation` passes.
-- Manual sanity: run a team with N ≥ 2 delegations, observe exactly one message in the TUI inbox, and `grep team_run_notified server.log` finds one line per run.
+- Manual sanity: run a team with N ≥ 2 delegations in dev, observe exactly one message in the TUI inbox, and `grep team_run_notified server.log` finds one line per run while `grep team_child_callback_notification_suppressed` shows N suppression lines.
 
 ## System-Wide Impact
 
-- **Interaction graph:** Two seams inside `task_engine::dispatcher`. No changes to team engine internals or to public task/team APIs.
-- **Error propagation:** Unit 1's notification wraps `message_sender` failures per existing policy (warn on `Failed`, silent on `NoChannel`, `Err` logged and swallowed to not block the dispatcher loop).
-- **State lifecycle risks:** None — the silent turn still runs in Unit 2, so internal specialist state is unchanged. Only the external user-channel call becomes a no-op.
+- **Interaction graph:** Two notification callsites (sync tool return, async dispatcher) plus one suppression branch in the callback dispatcher. Team engine internals and public APIs untouched.
+- **Error propagation:** Both notification callsites wrap `message_sender` outcomes per existing dispatcher policy (`NoChannel` silent, `Failed` warn, `Err` warn).
+- **State lifecycle risks:** None — silent turn still runs in Unit 2; internal specialist state unchanged. `team_runs.deliverable` is read, not written.
 - **API surface parity:** No external API change. `run_team` tool, dashboard API, A2A endpoints unchanged.
-- **Integration coverage:** Tests depend on a team-engine test harness that doesn't exist yet (see Risks). Unit-level tests on the predicate and notification formatter are unaffected.
-- **Unchanged invariants:** `team_runs` schema, `tasks` schema, `message_sender` trait, `SilentTrigger::Callback` semantics, team engine's inline specialist execution, per-specialist memory updates.
+- **Integration coverage:** Tests depend on a team-engine test harness that doesn't exist yet — see Risks.
+- **Unchanged invariants:** `team_runs` schema, `tasks` schema, `MessageSender` trait, `SilentTrigger::Callback` semantics, team engine's inline specialist execution, per-specialist memory updates, `TeamEventCallback` progress events in the sync path.
 
 ## Risks & Dependencies
 
 | Risk | Mitigation |
 |------|------------|
-| Unit 1 and Unit 2 land in different commits; if deployed between them, UX regresses (N+1 or 0 messages). | Commit sequencing lives inside one PR; ship atomically. PR description calls out "this fix is two coupled commits — do not cherry-pick one without the other." |
-| Synchronous completion path (all specialists finish inline without suspending) may not go through `dispatch_invoke_orchestrator`; the consolidated notification would miss those runs. | Unit 1 begins with a small investigation step. If sync path is unaffected (because per-child callbacks don't fire in that path either), no sibling hook needed; if per-child callbacks DO fire, add the hook in the `run_team` tool's return path. Outcome documented in the PR description regardless. |
-| **No existing team-engine test harness.** Same risk as #286's Unit 2 — `tests/eval/*` targets `run_agent()`, not team runs. Integration tests require a small new harness scripted against the full team flow. | Build the harness skeleton first. If it balloons, narrow Unit 2's integration test to mock `dispatch_resume_agent` and `dispatch_invoke_orchestrator` calls directly (with crafted `Task` rows and a fake `message_sender`), and defer full-flow testing to a follow-up. Unit-level tests on the predicate and formatter remain unaffected. Consider coordinating this harness with #286's — if both tickets land the same harness, either plan should reference the other in its PR. |
-| `NoopSender` semantics drift — if someone later changes it to log a warning or record telemetry, Unit 2's log dedupe breaks. | `NoopSender` is in the dispatcher module; add a test that asserts its current `Delivered` no-op behavior so future changes trip the test. One-line regression guard. |
-| Suppression log becomes noisy under high delegation volume. | `info!` not `warn!`. Can be filtered out downstream. The benefit — being able to audit "was the suppression active for this run?" — outweighs the volume cost. |
-| Team-run failure with `deliverable = None` produces a fallback message, but the team engine may not always set `failure_reason`. | Unit 1's fallback case covers this: emits a generic status line + `warn!`. Not user-hostile, but we note in the plan that populating `failure_reason` at team-engine failure points is a follow-up cleanliness fix (out of scope). |
+| Unit 1 and Unit 2 land in different commits; if deployed between them, UX regresses (N+1 messages on sync, 0 on async). | Both commits in one PR. PR body calls out "this fix is two coupled commits — do not cherry-pick one without the other." |
+| **No existing team-engine test harness.** `tests/eval/*` targets `run_agent()`, not team runs. Integration tests require a small new harness scripted against the full team flow. | Shared risk with #286's Unit 2. Build the harness skeleton first. If it balloons past ~150 lines, narrow Unit 2's integration test to mock `dispatch_resume_agent` and `dispatch_invoke_orchestrator` calls directly (with crafted `Task`/`TeamRun` rows and a fake `message_sender`) and defer full-flow testing to a follow-up. Unit tests on the predicate and formatter are unaffected. If both #286 and #287 merge near each other, whichever lands first owns the harness; the other references it. |
+| Orchestrator LLM's next turn after a sync team run may paraphrase the deliverable, producing a second user-visible message. | Out of scope — prompt-level behavior, not a plumbing bug. Document in the PR description; observe post-merge whether paraphrasing is actually happening and whether it's additive or confusing. Separate ticket if needed. |
+| Sync path's existing `TeamEventCallback` still fires `[Team] Deliverable ready` — now redundant with the new consolidated notification. | Acceptable for this fix; the "ready" announcement is short and fires during the run, not at completion. Removing it is out-of-scope cleanup. File a follow-up ticket if the redundancy feels noisy in practice. |
 
 ## Documentation / Operational Notes
 
-- Update `crates/mika-agent/CLAUDE.md` under the Task Engine section with a short note: "Team-run user notification is fired once at terminal status from `dispatch_invoke_orchestrator`; per-child `resume_agent` callbacks have their user-facing `send_message` suppressed via `NoopSender`."
-- No deployment, migration, or rollout concerns — purely an internal rewiring.
+- Update `crates/mika-agent/CLAUDE.md` under the Task Engine section: *"Team-run user notification is fired once at terminal status from two symmetric callsites (`run_team` tool for sync completion, `dispatch_invoke_orchestrator` for async resume), both routing through `teams::notification::build_run_completion_message`. Per-child `resume_agent` callbacks have their user-facing `send_message` suppressed via `NoopSender`; the silent turn still runs — it updates memory and records `llm_calls` — only the user channel is gated."*
+- No deployment, migration, or rollout concerns.
+- **Pre-existing hardening (optional, not required by this fix):** add a one-line test asserting `NoopSender` returns `Ok(SendOutcome::Delivered)`. If its semantics ever drift (e.g., someone adds a warn log), Unit 2's suppression log semantics would silently change. Include only if trivial; don't block the PR on it.
 
 ## Sources & References
 
 - **Origin issue:** [senara-solutions/mika#287](https://github.com/senara-solutions/mika/issues/287)
-- Related code: `crates/mika-agent/src/teams/engine.rs`, `crates/mika-agent/src/task_engine/dispatcher.rs`
+- Related code: `crates/mika-agent/src/teams/engine.rs`, `crates/mika-agent/src/task_engine/dispatcher.rs`, `crates/mika-agent/src/tools/run_team.rs`
 - Related pattern: `docs/solutions/architecture-patterns/callback-resume-agent-lifecycle.md`
 - Related pattern: `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md`
-- Related code: `dispatcher.rs:965` — existing `NoopSender` reuse
-- Observed failure: team run `fd7ef7ef` — one concrete instance, not a provider-specific conclusion
+- Reuse: `dispatcher.rs:965` — existing `NoopSender`
+- `failure_reason` audit: `engine.rs:451` is the sole `RunStatus::Failed` callsite, always passes `e.to_string()`; reason is always populated
+- Observed failure: team run `fd7ef7ef` — one concrete instance of the contract gap

--- a/docs/solutions/logic-errors/team-delegations-produce-multiple-callback-messages-2026-04-24.md
+++ b/docs/solutions/logic-errors/team-delegations-produce-multiple-callback-messages-2026-04-24.md
@@ -1,0 +1,100 @@
+---
+title: "Team delegations produce multiple callback messages instead of consolidated delivery"
+date: 2026-04-24
+category: logic-errors
+module: mika-agent — task_engine/dispatcher, teams/engine, tools/run_team
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "User receives N separate system messages for a single team run with N delegations"
+  - "Multiple callback tasks created per team run, each triggering independent send_message calls"
+  - "TUI inbox shows duplicate events for the same team run completion"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - team-engine
+  - callback
+  - notification
+  - message-sender
+  - noop-sender
+  - dispatch-resume-agent
+  - consolidated-delivery
+---
+
+# Team delegations produce multiple callback messages instead of consolidated delivery
+
+## Problem
+
+When a team agent receives multiple delegations during a single team run, each delegation completion triggers a separate callback task that calls `send_message` independently. The user receives N separate system messages instead of a single consolidated team result notification. Observed in team run `fd7ef7ef` where mika-dev received 2 delegations, creating 2 callback tasks that each produced a separate user-visible message.
+
+## Symptoms
+
+- User sees N system events in the TUI inbox for a single team run with N delegations
+- Each `resume_agent` callback task independently fires `send_message` via the user-facing `message_sender`
+- No consolidated deliverable notification — only per-agent fragments
+
+## What Didn't Work
+
+- **Routing through `TeamEngine::finalize_and_shutdown`**: Would require adding a `user_message_sender` field to the team engine struct, violating the architectural boundary that "team engine's agents don't talk to users directly." The team engine intentionally has `message_sender: None`.
+- **Skipping the silent turn entirely for team-child callbacks**: Larger behavioral change with unclear downstream effects — specialist memory/fact updates might rely on the silent turn firing.
+- **Single callback per run (removing per-child callbacks)**: The per-child callbacks serve internal state purposes (memory updates, `llm_calls` recording). Removing them entirely risks breaking specialist internal state.
+
+## Solution
+
+Two coupled changes that must ship together (Part 1 alone = N+1 messages; Part 2 alone = 0 messages):
+
+**Part 1: Shared formatter + notification hooks at terminal state**
+
+Created `teams::notification` module with a pure formatter function that builds the user-facing message from a team run's terminal state:
+
+```rust
+// teams/notification.rs
+pub(crate) fn build_run_completion_message(run: &TeamRun) -> Option<CompletionMessage> {
+    match &run.status {
+        RunStatus::Completed => { /* format deliverable with 4000-char UTF-8-safe truncation */ }
+        RunStatus::Failed(reason) => { /* format failure reason */ }
+        RunStatus::Running | RunStatus::Suspended => None, // non-terminal, no notification
+    }
+}
+```
+
+Two symmetric callsites invoke this helper:
+- **Sync path** (`tools/run_team.rs`): after `teams::run_team()` returns, sends via `ctx.message_sender`
+- **Async path** (`task_engine/dispatcher.rs`): after `resume_team_run` returns, loads final `team_runs` row via `self.db.load_team_run_by_id()`, sends via `self.message_sender`
+
+**Part 2: Suppress per-child `send_message` via `NoopSender`**
+
+```rust
+// dispatcher.rs — dispatch_resume_agent
+let message_sender = if is_team_child_callback(task) {
+    Some(Arc::new(NoopSender) as Arc<dyn MessageSender>)
+} else {
+    self.message_sender.clone()
+};
+```
+
+`is_team_child_callback` detects team-child callbacks via `task.team_run_id.is_some() && task.parent_task_id.is_some()` — both fields are set together at child-creation time in `engine.rs:874-912`.
+
+`NoopSender` (promoted to `pub` in `messaging.rs`) returns `Ok(SendOutcome::Delivered)` without transmission. The silent turn still runs — memory updates, `llm_calls` recording, and internal state all proceed normally. Only the user-facing channel is gated.
+
+## Why This Works
+
+The root cause is that each per-delegation `resume_agent` callback creates a full silent agent turn with the user-facing `message_sender`, and the agent's turn independently calls `send_message`. The team run already produces a consolidated `deliverable` field — but no code path was sending it to the user as a single notification.
+
+The fix adds the missing consolidated notification at the two terminal-state boundaries (sync and async), then suppresses the redundant per-child user channel. The `NoopSender` approach is minimal-footprint — it doesn't change the silent turn behavior at all, only the `send_message` outcome.
+
+The dual-callsite design preserves the architectural boundary that the team engine itself has no `user_message_sender` field. Each callsite lives at the *caller* of the team engine, where `message_sender` is already in scope.
+
+## Prevention
+
+- **Structural guard for one-consumer-per-channel**: When multiple code paths can send messages to the same user channel from the same logical operation, use a structural suppressor (`NoopSender`, `cli_mode` guard) rather than relying on ordering or timing. This mirrors the pattern from `callback-processing-race-steals-tui-notifications.md`.
+- **Observability contract**: Two locked structured log events (`team_run_notified` with `path=sync|async`, `team_child_callback_notification_suppressed`) allow operators to verify exactly-one delivery per team run via `grep team_run_notified server.log | jq`.
+- **Paired changes**: The plan explicitly documents that Parts 1 and 2 must ship together in one PR. The PR body warns against cherry-picking one without the other.
+
+## Related Issues
+
+- [senara-solutions/mika#287](https://github.com/senara-solutions/mika/issues/287) — origin issue
+- `docs/solutions/logic-errors/callback-processing-race-steals-tui-notifications.md` — same structural pattern (one-consumer guard via mode flag)
+- `docs/solutions/architecture-patterns/callback-resume-agent-lifecycle.md` — callback/resume lifecycle this fix modifies
+- `docs/solutions/architecture-patterns/engine-level-callback-metadata-extraction.md` — precedent for engine-level work in the callback path


### PR DESCRIPTION
## Summary

Closes #287

When a team run delegates to N agents, each delegation's callback independently calls `send_message`, producing N user-facing messages instead of one consolidated notification. This PR fixes both the missing consolidated delivery and the redundant per-child notifications.

**This fix is two coupled commits — do not cherry-pick one without the other.** Part 1 alone produces N+1 messages (worse); Part 2 alone produces zero (silent).

### Changes

- **Shared formatter** (`teams::notification`): Pure function `build_run_completion_message` builds the user-facing message at terminal state with UTF-8-safe 4000-char truncation (below Telegram's 4096 limit)
- **Sync notification hook** (`tools/run_team.rs`): After `teams::run_team()` returns, sends consolidated notification via `ctx.message_sender`
- **Async notification hook** (`task_engine/dispatcher.rs`): After `resume_team_run` returns, loads final `team_runs` row and sends via `self.message_sender`
- **Per-child suppression** (`task_engine/dispatcher.rs`): `is_team_child_callback()` predicate routes team-child callbacks through `NoopSender` — silent turn still runs for internal state, only the user channel is gated
- **`NoopSender`** (`messaging.rs`): Promoted to `pub` for reuse across modules

### What is NOT changed

- Team engine internals, public APIs, schema, `TeamEventCallback` progress events
- Silent turn execution — memory updates, `llm_calls` recording all continue normally
- The `[Team] Deliverable ready` progress announcement during sync runs (cleanup deferred)

### Observability

- `team_run_notified` structured log with `path=sync|async` — exactly one per team run
- `team_child_callback_notification_suppressed` — one per suppressed child callback
- Verify: `grep team_run_notified server.log | jq`

## Test plan

- [x] 13 unit tests for notification formatter (completed/failed/cancelled/running/suspended × TeamRun/TeamRunRow, truncation boundaries)
- [x] 4 predicate truth-table tests for `is_team_child_callback`
- [x] 1 test for `NoopSender` returns `Ok(Delivered)`
- [x] `cargo check` clean (no warnings)
- [x] `cargo clippy` clean
- [ ] Manual: run a team with N≥2 delegations, verify exactly one message in TUI inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>