### PR TITLE
feat(kg): add MIKA_KG_DOCS_ROOT env var and kg_docs_root config field (#738)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # and leaves remaining work for the next restart. `0` disables the phase entirely.
 # MIKA_KG_BATCH_BUDGET=500
 
+# Absolute path to the docs root for KG lexical ingestion (#738). Defaults to
+# <CWD>/docs/solutions when unset — works in containers where the Dockerfile copies
+# docs/ into the workdir. Needed on hosts where the service CWD != repo root
+# (e.g., OpenRC supervise-daemon). Also settable as kg_docs_root in config.toml.
+# MIKA_KG_DOCS_ROOT=/path/to/mika-repo/docs/solutions
+
 # ── Provider Selection ──
 # Set in config.toml (not here): llm_provider = "anthropic"
 # Available: anthropic, openai, openrouter, groq, ollama, mistral, google, deepseek

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Optional (Knowledge Graph LLM):
 - `MIKA_KG_EXTRACTION_MODEL` — Model for NER + fact-triple extraction (#690). Falls back to `MIKA_KG_INGESTION_MODEL` if unset. Task is mechanical JSON extraction — cheap/fast tier recommended.
 - `MIKA_KG_RESOLUTION_MODEL` — Model for entity resolution disambiguation (#691). Falls back to `MIKA_KG_INGESTION_MODEL` if unset. Mid-tier model recommended for better judgment on ambiguous matches.
 - `MIKA_KG_BATCH_BUDGET` — Per-batch LLM call cap on KG startup extraction and resolution (#757). Default `500`. Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch, one of each per agent). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely. Extraction idempotency (see `crates/mika-agent/src/db/kg_schema.rs` → **Idempotency key**) keeps the second and subsequent restarts free of extraction calls once marker rows are populated.
+- `MIKA_KG_DOCS_ROOT` — Absolute path to the docs root the `LexicalIngestor` reads (#738). Defaults to `<CWD>/docs/solutions` when unset — works in containers where the Dockerfile copies `docs/` into the workdir. Needed on hosts where the service starts with CWD ≠ repo root (e.g., OpenRC `supervise-daemon` launches with CWD=`/`). Also settable as `kg_docs_root` in config.toml. If set to an empty string, lexical ingestion skips with a distinct warn.
 
 ### Post-restart safety check (#757)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sqlite-vec",
  "subtle",

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -198,6 +198,10 @@ See `tests/eval/grounding_regressions/README.md` for the full vocabulary, capabi
 
 **Cross-cutting conventions:** See `docs/architecture/kg-implementation-conventions.md` (C1–C3) and `docs/architecture/kg-id-convention.md` for the `<type>:<name>` entity key format.
 
+## Knowledge Graph — Docs Root Configuration
+
+`src/kg/config.rs` — Resolution chain for the docs root path the lexical ingestor reads (#738). Resolution order (first hit wins): `MIKA_KG_DOCS_ROOT` env var > `kg_docs_root` config.toml field > `<CWD>/docs/solutions` (container-native default). `resolve_kg_docs_root(&Settings) -> (PathBuf, PathSource)` is the public API. For OpenRC hosts where the service starts with CWD ≠ repo root, set `MIKA_KG_DOCS_ROOT=/path/to/mika-repo/docs/solutions` in the service config, or use the existing `--chdir` init-script workaround.
+
 ## Knowledge Graph — Subject Extractor
 
 `src/kg/subject_extractor.rs` — Per-agent LLM-based extraction of named entities and fact triples from previously-ingested documents (#690). Uses constrained NER with approved entity/relationship types and structural validation (not just prompt-based).

--- a/crates/mika-agent/Cargo.toml
+++ b/crates/mika-agent/Cargo.toml
@@ -60,3 +60,4 @@ tempfile.workspace = true
 tower.workspace = true
 http-body-util.workspace = true
 mika-common = { workspace = true, features = ["test-utils"] }
+serial_test.workspace = true

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -352,6 +352,7 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
 | `kg_resolution_model` | `Option<String>` | None | `MIKA_KG_RESOLUTION_MODEL` | Model for entity resolution disambiguation (#691). Falls back to `kg_ingestion_model` if unset. Mid-tier model recommended for better judgment on ambiguous matches. |
 | `kg_batch_budget` | `Option<u32>` | None (effective default: 500) | `MIKA_KG_BATCH_BUDGET` | Per-batch LLM call cap on KG startup extraction and resolution (#757). Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely (no LLM calls). |
+| `kg_docs_root` | `Option<PathBuf>` | None | `MIKA_KG_DOCS_ROOT` | Absolute path to the docs root the lexical ingestor reads (#738). Resolution chain: env > config > `<CWD>/docs/solutions` (container-native default). Needed on hosts where the service CWD ≠ repo root (e.g., OpenRC `supervise-daemon`). |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -536,6 +537,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_KG_RESOLUTION_MODEL` | No | KG resolution model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_KG_BATCH_BUDGET` | No | Per-batch LLM call cap on KG extraction/resolution (#757; default: 500; `0` disables) |
+| `MIKA_KG_DOCS_ROOT` | No | Absolute path to docs root for KG lexical ingestion (default: `<CWD>/docs/solutions`; needed on hosts where CWD ≠ repo root) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/crates/mika-agent/src/kg/config.rs
+++ b/crates/mika-agent/src/kg/config.rs
@@ -1,0 +1,181 @@
+//! KG configuration helpers.
+//!
+//! This module provides the docs-root resolution chain consumed by the
+//! lexical ingestor at server startup and (in the future) by #778's
+//! per-agent resolver.
+
+use std::path::PathBuf;
+
+use mika_common::config::Settings;
+
+/// Source of the resolved docs root path.
+///
+/// Exposed so downstream consumers (e.g., #778's per-agent policy classifier)
+/// can distinguish "operator explicitly set this path; hard-error if missing"
+/// from "fell through to container-friendly default; warn-and-skip if missing".
+///
+/// **If you add a new variant**, update `resolve_per_agent_docs_root` in this
+/// module (when #778 lands) to classify it correctly. The exhaustive match
+/// will force a compile error, but this breadcrumb names the _why_.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSource {
+    /// Path came from `MIKA_KG_DOCS_ROOT` env var.
+    EnvVar,
+    /// Path came from `settings.kg_docs_root` (config.toml).
+    ConfigFile,
+    /// Path fell through to `std::env::current_dir().join("docs/solutions")`.
+    CwdDefault,
+}
+
+/// Resolve the KG docs root using the config cascade.
+///
+/// # Resolution order (first hit wins)
+///
+/// 1. `MIKA_KG_DOCS_ROOT` environment variable (absolute path).
+/// 2. `settings.kg_docs_root` field from config.toml (absolute path).
+/// 3. `<CWD>/docs/solutions` — container-native default.
+///
+/// # Why re-inspect the env var
+///
+/// Config-rs merges `MIKA_KG_DOCS_ROOT` into `settings.kg_docs_root`, so
+/// `Some(...)` could be _either_ env or config file. We re-inspect the env
+/// var directly to distinguish the two sources for `PathSource`.
+///
+/// # Public contract
+///
+/// This function is consumed by #778's per-agent resolver. Signature changes
+/// require coordinated update across both tickets. The `signature_binding`
+/// test below catches mechanical drift at compile time.
+///
+/// # No validation
+///
+/// Path existence is **not** checked here — the consumer site (`server/mod.rs`)
+/// owns the warn-and-skip policy. This keeps the resolver pure and allows
+/// #778 to apply a different policy (hard-error) downstream.
+pub fn resolve_kg_docs_root(settings: &Settings) -> (PathBuf, PathSource) {
+    // 1. Env var (highest priority).
+    if let Ok(env_path) = std::env::var("MIKA_KG_DOCS_ROOT") {
+        return (PathBuf::from(env_path), PathSource::EnvVar);
+    }
+
+    // 2. Config file field.
+    if let Some(config_path) = settings.kg_docs_root.clone() {
+        return (config_path, PathSource::ConfigFile);
+    }
+
+    // 3. CWD-based default (container-native).
+    let cwd_default = std::env::current_dir()
+        .unwrap_or_default()
+        .join("docs")
+        .join("solutions");
+    (cwd_default, PathSource::CwdDefault)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::path::PathBuf;
+
+    /// Clean env to avoid leaking across tests.
+    fn clean_kg_env() {
+        // Safety: tests set env vars; no production thread reads these.
+        unsafe {
+            std::env::remove_var("MIKA_KG_DOCS_ROOT");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn env_var_wins_over_config() {
+        clean_kg_env();
+        unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/env/docs") };
+
+        let mut settings = Settings::test_defaults();
+        settings.kg_docs_root = Some(PathBuf::from("/config/docs"));
+
+        let (path, source) = resolve_kg_docs_root(&settings);
+        assert_eq!(path, PathBuf::from("/env/docs"));
+        assert_eq!(source, PathSource::EnvVar);
+
+        clean_kg_env();
+    }
+
+    #[test]
+    #[serial]
+    fn config_file_used_when_no_env() {
+        clean_kg_env();
+
+        let mut settings = Settings::test_defaults();
+        settings.kg_docs_root = Some(PathBuf::from("/config/docs"));
+
+        let (path, source) = resolve_kg_docs_root(&settings);
+        assert_eq!(path, PathBuf::from("/config/docs"));
+        assert_eq!(source, PathSource::ConfigFile);
+    }
+
+    #[test]
+    #[serial]
+    fn cwd_fallback_when_nothing_set() {
+        clean_kg_env();
+
+        let settings = Settings::test_defaults();
+        let (path, source) = resolve_kg_docs_root(&settings);
+
+        assert_eq!(source, PathSource::CwdDefault);
+        // Path ends with docs/solutions regardless of CWD.
+        assert!(
+            path.ends_with("docs/solutions"),
+            "expected path ending with docs/solutions, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn empty_env_var_returns_env_source() {
+        clean_kg_env();
+        unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "") };
+
+        let settings = Settings::test_defaults();
+        let (path, source) = resolve_kg_docs_root(&settings);
+
+        assert_eq!(path, PathBuf::from(""));
+        assert_eq!(source, PathSource::EnvVar);
+
+        clean_kg_env();
+    }
+
+    #[test]
+    #[serial]
+    fn empty_config_returns_config_source() {
+        clean_kg_env();
+
+        let mut settings = Settings::test_defaults();
+        settings.kg_docs_root = Some(PathBuf::from(""));
+
+        let (path, source) = resolve_kg_docs_root(&settings);
+        assert_eq!(path, PathBuf::from(""));
+        assert_eq!(source, PathSource::ConfigFile);
+    }
+
+    /// Signature binding — prevents silent drift from the public contract
+    /// that #778 depends on.
+    #[test]
+    fn signature_binding() {
+        let _: fn(&Settings) -> (PathBuf, PathSource) = resolve_kg_docs_root;
+    }
+
+    /// Exhaustiveness check — adding a `PathSource` variant without updating
+    /// this match (and by extension, #778's `resolve_per_agent_docs_root`)
+    /// produces a compile error.
+    #[test]
+    fn path_source_exhaustive() {
+        let source = PathSource::CwdDefault;
+        match source {
+            PathSource::EnvVar => (),
+            PathSource::ConfigFile => (),
+            PathSource::CwdDefault => (),
+        }
+    }
+}

--- a/crates/mika-agent/src/kg/config.rs
+++ b/crates/mika-agent/src/kg/config.rs
@@ -123,12 +123,12 @@ mod tests {
         let (path, source) = resolve_kg_docs_root(&settings);
 
         assert_eq!(source, PathSource::CwdDefault);
-        // Path ends with docs/solutions regardless of CWD.
-        assert!(
-            path.ends_with("docs/solutions"),
-            "expected path ending with docs/solutions, got: {}",
-            path.display()
-        );
+        // Verify the full path is CWD-rooted, not just checking the suffix.
+        let expected = std::env::current_dir()
+            .unwrap()
+            .join("docs")
+            .join("solutions");
+        assert_eq!(path, expected);
     }
 
     #[test]

--- a/crates/mika-agent/src/kg/mod.rs
+++ b/crates/mika-agent/src/kg/mod.rs
@@ -23,6 +23,7 @@
 //!   in `kg_subject_resolutions` with confidence scores.
 
 pub mod chunker;
+pub mod config;
 pub mod domain_builder;
 pub mod entity_resolver;
 pub mod ingestion_orchestrator;

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -759,30 +759,34 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
     // into search_content for hybrid search. Runs after domain rebuild so each
     // KG layer's startup work composes cleanly for #690+.
     //
-    // docs_root is relative to the server working directory. In containers,
-    // the Dockerfile copies docs/ into the workdir.
+    // docs_root resolved via config cascade (#738):
+    //   MIKA_KG_DOCS_ROOT env > kg_docs_root config > <CWD>/docs/solutions
     {
-        let docs_root = std::env::current_dir()
-            .unwrap_or_default()
-            .join("docs")
-            .join("solutions");
+        let (docs_root, _source) = crate::kg::config::resolve_kg_docs_root(settings);
 
-        // Fan-out cost advisory (#757 R3). All agents use the same docs_root,
-        // so per-agent extraction/resolution scales N× with agent count.
-        // Only emit when there's actually a multiplier to warn about.
-        if docs_root.exists() && agents.len() >= 2 {
-            let shared_agents: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
-            info!(
-                event = "kg_shared_docs_root",
-                docs_root = %docs_root.display(),
-                agents = ?shared_agents,
-                agent_count = agents.len(),
-                "KG extraction and resolution run per agent; sharing docs_root means cost scales N×. \
-                 See MIKA_KG_BATCH_BUDGET (default 500) for the per-batch cap."
+        // Empty-path guard (#738): distinguish misconfigured empty value from
+        // genuinely missing directory so operators don't chase misleading logs.
+        if docs_root.as_os_str().is_empty() {
+            warn!(
+                "kg_docs_root is set to empty string — check MIKA_KG_DOCS_ROOT env var or \
+                 kg_docs_root in config.toml; skipping lexical ingestion"
             );
-        }
+        } else if docs_root.exists() {
+            // Fan-out cost advisory (#757 R3). All agents use the same docs_root,
+            // so per-agent extraction/resolution scales N× with agent count.
+            // Only emit when there's actually a multiplier to warn about.
+            if agents.len() >= 2 {
+                let shared_agents: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+                info!(
+                    event = "kg_shared_docs_root",
+                    docs_root = %docs_root.display(),
+                    agents = ?shared_agents,
+                    agent_count = agents.len(),
+                    "KG extraction and resolution run per agent; sharing docs_root means cost scales N×. \
+                     See MIKA_KG_BATCH_BUDGET (default 500) for the per-batch cap."
+                );
+            }
 
-        if docs_root.exists() {
             for (agent_name, agent_state) in &agents {
                 let ingestor = crate::kg::lexical_ingestor::LexicalIngestor::new(
                     agent_state.db.clone(),

--- a/crates/mika-agent/tests/kg_docs_root_resolution.rs
+++ b/crates/mika-agent/tests/kg_docs_root_resolution.rs
@@ -1,0 +1,115 @@
+//! Integration tests for KG docs root resolution (#738).
+//!
+//! Verifies that `resolve_kg_docs_root` returns the correct path and source
+//! under the scenarios described in the issue: env-set, config-set, CWD
+//! fallback, and empty-value edge cases.
+
+use mika_agent::kg::config::{PathSource, resolve_kg_docs_root};
+use mika_common::config::Settings;
+use serial_test::serial;
+use std::path::PathBuf;
+
+/// Clean env to avoid leaking across tests.
+fn clean_kg_env() {
+    // Safety: tests set env vars; no production thread reads these.
+    unsafe {
+        std::env::remove_var("MIKA_KG_DOCS_ROOT");
+    }
+}
+
+#[test]
+#[serial]
+fn env_var_overrides_cwd() {
+    clean_kg_env();
+
+    // Point env var at a known directory (doesn't need to exist for the
+    // resolver — existence checking is the consumer's responsibility).
+    let target = "/srv/mika-repo/docs/solutions";
+    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", target) };
+
+    let settings = Settings::test_defaults();
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(path, PathBuf::from(target));
+    assert_eq!(source, PathSource::EnvVar);
+
+    clean_kg_env();
+}
+
+#[test]
+#[serial]
+fn config_file_overrides_cwd() {
+    clean_kg_env();
+
+    let mut settings = Settings::test_defaults();
+    settings.kg_docs_root = Some(PathBuf::from("/opt/mika/docs/solutions"));
+
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(path, PathBuf::from("/opt/mika/docs/solutions"));
+    assert_eq!(source, PathSource::ConfigFile);
+}
+
+#[test]
+#[serial]
+fn cwd_default_when_nothing_configured() {
+    clean_kg_env();
+
+    let settings = Settings::test_defaults();
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(source, PathSource::CwdDefault);
+    assert!(
+        path.ends_with("docs/solutions"),
+        "expected path ending with docs/solutions, got: {}",
+        path.display()
+    );
+}
+
+#[test]
+#[serial]
+fn env_var_wins_over_config_file() {
+    clean_kg_env();
+    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/env/path") };
+
+    let mut settings = Settings::test_defaults();
+    settings.kg_docs_root = Some(PathBuf::from("/config/path"));
+
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(path, PathBuf::from("/env/path"));
+    assert_eq!(source, PathSource::EnvVar);
+
+    clean_kg_env();
+}
+
+#[test]
+#[serial]
+fn empty_env_var_returns_empty_path() {
+    clean_kg_env();
+    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "") };
+
+    let settings = Settings::test_defaults();
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(path, PathBuf::from(""));
+    assert_eq!(source, PathSource::EnvVar);
+
+    clean_kg_env();
+}
+
+#[test]
+#[serial]
+fn nonexistent_env_path_returns_verbatim() {
+    clean_kg_env();
+    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/nonexistent/path/docs/solutions") };
+
+    let settings = Settings::test_defaults();
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    // Resolver returns the path verbatim — no existence check.
+    assert_eq!(path, PathBuf::from("/nonexistent/path/docs/solutions"));
+    assert_eq!(source, PathSource::EnvVar);
+
+    clean_kg_env();
+}

--- a/crates/mika-agent/tests/kg_docs_root_resolution.rs
+++ b/crates/mika-agent/tests/kg_docs_root_resolution.rs
@@ -1,8 +1,9 @@
 //! Integration tests for KG docs root resolution (#738).
 //!
-//! Verifies that `resolve_kg_docs_root` returns the correct path and source
-//! under the scenarios described in the issue: env-set, config-set, CWD
-//! fallback, and empty-value edge cases.
+//! Unit-level scenarios (env wins, config wins, CWD default, empty values) are
+//! covered by `kg::config::tests` inline. These integration tests verify the
+//! public API surface and exercise scenarios that benefit from running outside
+//! the crate (verifying re-exports work, testing from a consumer perspective).
 
 use mika_agent::kg::config::{PathSource, resolve_kg_docs_root};
 use mika_common::config::Settings;
@@ -19,87 +20,6 @@ fn clean_kg_env() {
 
 #[test]
 #[serial]
-fn env_var_overrides_cwd() {
-    clean_kg_env();
-
-    // Point env var at a known directory (doesn't need to exist for the
-    // resolver — existence checking is the consumer's responsibility).
-    let target = "/srv/mika-repo/docs/solutions";
-    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", target) };
-
-    let settings = Settings::test_defaults();
-    let (path, source) = resolve_kg_docs_root(&settings);
-
-    assert_eq!(path, PathBuf::from(target));
-    assert_eq!(source, PathSource::EnvVar);
-
-    clean_kg_env();
-}
-
-#[test]
-#[serial]
-fn config_file_overrides_cwd() {
-    clean_kg_env();
-
-    let mut settings = Settings::test_defaults();
-    settings.kg_docs_root = Some(PathBuf::from("/opt/mika/docs/solutions"));
-
-    let (path, source) = resolve_kg_docs_root(&settings);
-
-    assert_eq!(path, PathBuf::from("/opt/mika/docs/solutions"));
-    assert_eq!(source, PathSource::ConfigFile);
-}
-
-#[test]
-#[serial]
-fn cwd_default_when_nothing_configured() {
-    clean_kg_env();
-
-    let settings = Settings::test_defaults();
-    let (path, source) = resolve_kg_docs_root(&settings);
-
-    assert_eq!(source, PathSource::CwdDefault);
-    assert!(
-        path.ends_with("docs/solutions"),
-        "expected path ending with docs/solutions, got: {}",
-        path.display()
-    );
-}
-
-#[test]
-#[serial]
-fn env_var_wins_over_config_file() {
-    clean_kg_env();
-    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/env/path") };
-
-    let mut settings = Settings::test_defaults();
-    settings.kg_docs_root = Some(PathBuf::from("/config/path"));
-
-    let (path, source) = resolve_kg_docs_root(&settings);
-
-    assert_eq!(path, PathBuf::from("/env/path"));
-    assert_eq!(source, PathSource::EnvVar);
-
-    clean_kg_env();
-}
-
-#[test]
-#[serial]
-fn empty_env_var_returns_empty_path() {
-    clean_kg_env();
-    unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "") };
-
-    let settings = Settings::test_defaults();
-    let (path, source) = resolve_kg_docs_root(&settings);
-
-    assert_eq!(path, PathBuf::from(""));
-    assert_eq!(source, PathSource::EnvVar);
-
-    clean_kg_env();
-}
-
-#[test]
-#[serial]
 fn nonexistent_env_path_returns_verbatim() {
     clean_kg_env();
     unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/nonexistent/path/docs/solutions") };
@@ -112,4 +32,28 @@ fn nonexistent_env_path_returns_verbatim() {
     assert_eq!(source, PathSource::EnvVar);
 
     clean_kg_env();
+}
+
+#[test]
+#[serial]
+fn cwd_default_produces_full_path() {
+    clean_kg_env();
+
+    let settings = Settings::test_defaults();
+    let (path, source) = resolve_kg_docs_root(&settings);
+
+    assert_eq!(source, PathSource::CwdDefault);
+    let expected = std::env::current_dir()
+        .unwrap()
+        .join("docs")
+        .join("solutions");
+    assert_eq!(path, expected);
+
+    clean_kg_env();
+}
+
+/// Verify that the public API types are accessible from outside the crate.
+#[test]
+fn public_api_accessible() {
+    let _: fn(&Settings) -> (PathBuf, PathSource) = resolve_kg_docs_root;
 }

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -403,6 +403,14 @@ pub static CONFIG_KEYS: &[ConfigKeyInfo] = &[
         secret: false,
         description: "Claude thinking level (low/medium/high/off)",
     },
+    // -- Knowledge Graph --
+    ConfigKeyInfo {
+        key: "kg_docs_root",
+        backend: ConfigBackend::File,
+        env_var: Some("MIKA_KG_DOCS_ROOT"),
+        secret: false,
+        description: "Absolute path to docs root for KG lexical ingestion. Defaults to <CWD>/docs/solutions when unset. Needed on hosts where the service CWD != repo root (e.g., OpenRC).",
+    },
     // ReadOnly (runtime-computed)
     ConfigKeyInfo {
         key: "home_dir",
@@ -525,6 +533,11 @@ pub fn get_effective_value(key: &str, settings: &Settings) -> Option<String> {
         "store_llm_calls" => Some(settings.store_llm_calls.to_string()),
         "store_tool_calls" => Some(settings.store_tool_calls.to_string()),
         "log_llm_bodies" => Some(settings.log_llm_bodies.to_string()),
+        // KG
+        "kg_docs_root" => settings
+            .kg_docs_root
+            .as_ref()
+            .map(|p| p.display().to_string()),
         // DB keys (timezone, thinking_level) not available from Settings
         _ => None,
     }
@@ -773,6 +786,14 @@ pub struct Settings {
     /// fan-out cost model.
     #[serde(default)]
     pub kg_batch_budget: Option<u32>,
+
+    /// KG docs root — absolute path to the docs directory the lexical ingestor
+    /// reads (#738). Resolution chain: `MIKA_KG_DOCS_ROOT` env > `kg_docs_root`
+    /// config field > `<CWD>/docs/solutions` (container-native default).
+    /// Needed on hosts where the service CWD ≠ repo root (e.g., OpenRC
+    /// `supervise-daemon` launches with CWD=`/`).
+    #[serde(default)]
+    pub kg_docs_root: Option<PathBuf>,
 
     /// Resolved home directory path (populated after load, not from config file)
     #[serde(skip)]
@@ -1260,6 +1281,7 @@ impl Settings {
             kg_extraction_model: None,
             kg_resolution_model: None,
             kg_batch_budget: None,
+            kg_docs_root: None,
         }
     }
 }
@@ -1384,6 +1406,7 @@ impl std::fmt::Debug for Settings {
                 "otlp_auth_header",
                 &self.otlp_auth_header.as_ref().map(|_| "[REDACTED]"),
             )
+            .field("kg_docs_root", &self.kg_docs_root)
             .field("home_dir", &self.home_dir)
             .finish()
     }
@@ -1401,6 +1424,7 @@ mod tests {
             std::env::remove_var("MIKA_LLM_PROVIDER");
             std::env::remove_var("MIKA_DB_PATH");
             std::env::remove_var("MIKA_DISABLE_BUNDLED_SKILLS");
+            std::env::remove_var("MIKA_KG_DOCS_ROOT");
         }
     }
 
@@ -1810,5 +1834,92 @@ mod tests {
         assert_eq!(settings.effective_kg_batch_budget(), 0);
 
         unsafe { std::env::remove_var("MIKA_KG_BATCH_BUDGET") };
+    }
+
+    #[test]
+    #[serial]
+    fn kg_docs_root_defaults_to_none() {
+        clean_env();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(settings.kg_docs_root, None);
+    }
+
+    #[test]
+    #[serial]
+    fn kg_docs_root_env_override() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/srv/mika/docs/solutions") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(
+            settings.kg_docs_root,
+            Some(PathBuf::from("/srv/mika/docs/solutions"))
+        );
+
+        unsafe { std::env::remove_var("MIKA_KG_DOCS_ROOT") };
+    }
+
+    #[test]
+    #[serial]
+    fn kg_docs_root_config_file() {
+        clean_env();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "kg_docs_root = \"/opt/mika/docs/solutions\"\n",
+        )
+        .unwrap();
+
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(
+            settings.kg_docs_root,
+            Some(PathBuf::from("/opt/mika/docs/solutions"))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn kg_docs_root_env_wins_over_config() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/env/path") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "kg_docs_root = \"/config/path\"\n").unwrap();
+
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        // Env var takes precedence over config file via config-rs cascade.
+        assert_eq!(settings.kg_docs_root, Some(PathBuf::from("/env/path")));
+
+        unsafe { std::env::remove_var("MIKA_KG_DOCS_ROOT") };
+    }
+
+    #[test]
+    #[serial]
+    fn kg_docs_root_get_effective_value() {
+        clean_env();
+        // Safety: test-only env var.
+        unsafe { std::env::set_var("MIKA_KG_DOCS_ROOT", "/effective/path") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let settings = Settings::load(tmp.path()).unwrap();
+
+        assert_eq!(
+            get_effective_value("kg_docs_root", &settings),
+            Some("/effective/path".to_string())
+        );
+
+        unsafe { std::env::remove_var("MIKA_KG_DOCS_ROOT") };
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,6 +352,7 @@ Complete table of all `Settings` struct fields for the agent (CLI and server mod
 | `kg_extraction_model` | `Option<String>` | None | `MIKA_KG_EXTRACTION_MODEL` | Model for NER + fact-triple extraction (#690). Falls back to `kg_ingestion_model` if unset. Cheap/fast tier recommended. |
 | `kg_resolution_model` | `Option<String>` | None | `MIKA_KG_RESOLUTION_MODEL` | Model for entity resolution disambiguation (#691). Falls back to `kg_ingestion_model` if unset. Mid-tier model recommended for better judgment on ambiguous matches. |
 | `kg_batch_budget` | `Option<u32>` | None (effective default: 500) | `MIKA_KG_BATCH_BUDGET` | Per-batch LLM call cap on KG startup extraction and resolution (#757). Worst-case per-startup cost is `2 × N_agents × budget` (extraction batch + resolution batch). Overflow emits a `kg_budget_exhausted` WARN and leaves remaining work for the next restart. `0` disables the phase entirely (no LLM calls). |
+| `kg_docs_root` | `Option<PathBuf>` | None | `MIKA_KG_DOCS_ROOT` | Absolute path to the docs root the lexical ingestor reads (#738). Resolution chain: env > config > `<CWD>/docs/solutions` (container-native default). Needed on hosts where the service CWD ≠ repo root (e.g., OpenRC `supervise-daemon`). |
 | `github_token` | `Option<String>` | None | `MIKA_GITHUB_TOKEN` | GitHub Personal Access Token for agent operations (context injection, work item enrichment, PR merge). Needs Pull requests R/W, Issues R/W, Contents R scopes. |
 | `investigate_github_token` | `Option<String>` | None | `MIKA_INVESTIGATE_GITHUB_TOKEN` | GitHub Personal Access Token for the investigation panel's issue creation tool only. Needs `repo` scope for private repos or `public_repo` for public. Both `investigate_github_token` and `github_repo` must be set to enable the tool. |
 | `github_repo` | `Option<String>` | None | `MIKA_GITHUB_REPO` | Target GitHub repository in `owner/repo` format (e.g. `senara-solutions/mika`). Validated at registration time — must contain exactly one `/`. |
@@ -536,6 +537,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_KG_EXTRACTION_MODEL` | No | KG extraction model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_KG_RESOLUTION_MODEL` | No | KG resolution model (falls back to `MIKA_KG_INGESTION_MODEL`) |
 | `MIKA_KG_BATCH_BUDGET` | No | Per-batch LLM call cap on KG extraction/resolution (#757; default: 500; `0` disables) |
+| `MIKA_KG_DOCS_ROOT` | No | Absolute path to docs root for KG lexical ingestion (default: `<CWD>/docs/solutions`; needed on hosts where CWD ≠ repo root) |
 | `MIKA_GITHUB_TOKEN` | No | GitHub token for agent operations |
 | `MIKA_INVESTIGATE_GITHUB_TOKEN` | No | GitHub token for investigation panel issue creation only |
 | `MIKA_GITHUB_REPO` | No | GitHub repo (`owner/repo`) for issue creation |

--- a/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
+++ b/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
@@ -1,0 +1,352 @@
+---
+title: "feat(kg): MIKA_KG_DOCS_ROOT env var + kg_docs_root config field"
+type: feat
+status: active
+date: 2026-04-24
+issue: senara-solutions/mika#738
+branch: feat/738/lexical-ingestor-cwd-dependent-docs-path-add
+milestone: senara-solutions/mika#17
+---
+
+# feat(kg): MIKA_KG_DOCS_ROOT env var + kg_docs_root config field
+
+## Overview
+
+`LexicalIngestor` today resolves its docs root via `std::env::current_dir().join("docs/solutions")`. This works inside the container (the Dockerfile COPYs `docs/` into the workdir) but breaks on OpenRC hosts where `supervise-daemon` launches `mika-server` with CWD=`/` — the ingestor logs `docs/solutions not found — skipping lexical ingestion` and the entire lexical / subject / resolution KG pipeline never runs. This plan adds a `MIKA_KG_DOCS_ROOT` env var and `kg_docs_root` config field so operators can point the ingestor at the repo's docs tree regardless of the process CWD, without changing container behavior.
+
+## Problem Frame
+
+Discovered 2026-04-22 while verifying KG milestone #14 deploy on a Gentoo OpenRC host: `/proc/1736/cwd` → `/`, the `docs/solutions not found` log line repeats across restarts, and only the in-memory domain graph survives — the lexical, subject, and resolution layers are empty. The CLI/TUI path doesn't construct `LexicalIngestor` at all, so this is a server-only failure mode and a hard block on populating KG on any non-container host. Milestone #16 (Evaluation) needs a populated KG to run meaningful self-knowledge evals.
+
+Global config is the right level (docs tree is repo-scoped, not agent-scoped), and per-agent docs_root is #778's concern — this ticket lands the env/config surface that #778's fallback chain reads.
+
+## Requirements Trace
+
+- **R1.** New config surface — `MIKA_KG_DOCS_ROOT` env var and `kg_docs_root` field in `Settings`.
+- **R2.** Resolution precedence: env > config file > existing CWD-based default.
+- **R3.** On-disk fallback absence preserves the current warn-and-skip behavior (non-fatal) — the server still comes up; KG layer stays empty.
+- **R4.** Documentation: `.env.example`, `crates/mika-agent/CLAUDE.md`, `docs/configuration.md`.
+- **R5.** Unit test: resolution chain across env-set / env-unset / config-set / both-set cases.
+- **R6.** Integration test: server startup from CWD != repo-root produces `lexical_ingest_complete` when `MIKA_KG_DOCS_ROOT` points at repo docs, and the existing `docs/solutions not found` warn when unset.
+- **R7.** Fallback resolver is a `pub fn` that #778's per-agent resolver can call — don't bury the logic inside `LexicalIngestor::new` or inline it in `server/mod.rs`.
+
+## Scope Boundaries
+
+- **Non-goal:** schema changes. Schema v27 is #786; data migration is #787.
+- **Non-goal:** per-agent `docs_root` config. That is #778; this plan lands the global fallback surface #778 reads.
+- **Non-goal:** hard-fail on missing path. #778 introduces hard-error startup for per-agent misconfiguration; #738 keeps the existing warn-and-skip global behavior so that agents without any override still come up gracefully on a CWD that happens to lack a `docs/solutions` subdirectory.
+- **Non-goal:** removing the OpenRC workaround hint from existing docs. Hosts running with `--chdir` must continue to work.
+- **Non-goal:** mika-cloud Helm changes. Helm already passes env vars through `values.yaml`; operators can set `MIKA_KG_DOCS_ROOT` there without a code change in mika-cloud.
+
+## Context & Research
+
+### Relevant code and patterns
+
+- **`Settings` and config cascade:** `crates/mika-common/src/config.rs` — struct at line 534, loader `Settings::load_for_agent` at 1108–1161 uses `config-rs` with a documented 6-step cascade: defaults → global config.toml → agent config.toml → agent `.env` → `~/.mika/.env` → `MIKA_*` env vars (highest). Env vars are wired via `Environment::with_prefix("MIKA").prefix_separator("_").separator("__")` at line 1156.
+- **Existing KG config field to mirror** (`config.rs:767-775`):
+  ```
+  /// KG per-batch LLM call budget — ...
+  #[serde(default)]
+  pub kg_batch_budget: Option<u32>,
+  ```
+  Pattern: `Option<T>` with `#[serde(default)]`, documented with a doc-comment that explains semantics and the disable-value convention.
+- **`CONFIG_KEYS` registry** (`config.rs:38`): every new config key must have a `ConfigKeyInfo` entry (`key`, `env_var: Some("MIKA_KG_DOCS_ROOT")`, `secret: false`, `description`). Consumed by `mika config get/set/list`, `mika doctor`, and the dashboard.
+- **`get_effective_value()` match arm:** also in `config.rs` — has a coverage test that fails CI if a File-backend key is missing its arm.
+- **Serial env-var test template** (`config.rs:1531-1543`): `test_disable_bundled_skills_from_env` uses `#[test] #[serial]` + `clean_env()` helper + `unsafe { std::env::set_var / remove_var }`. The `clean_env()` helper (lines 1393–1405) must be updated to remove `MIKA_KG_DOCS_ROOT` too.
+- **`LexicalIngestor` construction sites:** two — `crates/mika-agent/src/server/mod.rs:787` (startup ingest loop, the CWD-resolution site) and `crates/mika-agent/src/kg/ingestion_orchestrator.rs` (uses already-resolved `docs_root` from the caller). Only `server/mod.rs` is a construction site that computes the path; `ingestion_orchestrator.rs` just reads `self.docs_root`.
+- **Current CWD resolution** (`server/mod.rs:762-768`):
+  ```
+  let docs_root = std::env::current_dir()
+      .unwrap_or_default()
+      .join("docs")
+      .join("solutions");
+  ```
+- **Future #778 consumer:** agent identity currently at `crates/mika-agent/src/prompt.rs:46-93` (`Identity` struct, `load_identity()`). #778 will add a `[kg]` section or a sibling loader and call the resolver added here as the unset-fallback path.
+
+### Institutional learnings
+
+- **`docs/solutions/architecture-patterns/simplified-config-4-source-model.md`** — canonical cascade model. `MIKA_KG_DOCS_ROOT` maps natively to `kg_docs_root` (single underscores are literal); no `#[serde(rename)]` needed. Shell env always wins over `.env`.
+- **`docs/solutions/architecture-patterns/config-key-rename-across-layers.md`** — full checklist for touching a single config key across all layers. Even though this is an add (not rename), every bullet applies: registry entry, Settings field, `get_effective_value()` arm, `.env.example`, CLAUDE.md, `docs/configuration.md`, test-fixture coverage. Missing a layer creates silent-failure surfaces.
+- **`docs/solutions/architecture-patterns/config-key-registry-cli-management.md`** — `ConfigBackend::File` + `env_var: Some(...)` makes `mika config set/get kg_docs_root <path>` work, and env-var override resolves in `resolve_source()` before backend checks. This is why **don't hand-roll a 3-step resolution chain** — the registry handles env > config precedence automatically; the plan only needs to add CWD-based default as the `unwrap_or_else` branch.
+- **`docs/solutions/677-configurable-task-session-limit.md`** — mirrored specifically for the consumer-side fallback shape: `settings.field.clone().unwrap_or_else(|| default_expr)`. This plan applies that exact shape inside `resolve_kg_docs_root`. Not mirrored from #677: its direct `std::env::var` read (would bypass the config-rs cascade that this plan depends on) and its integer-typed field (the `PathBuf` type here is load-bearing for early validation at deserialization).
+- **`docs/solutions/workflow-issues/kg-milestone-14-autonomous-execution-retrospective-2026-04-22.md`** — the retrospective cited in the ticket body. Broader lesson: "prose/implicit state drifts, LLMs rationalize around it" — a process whose CWD depends on who launched it is exactly the kind of implicit state that breaks the KG pipeline silently. The config field makes the path explicit.
+- **`docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md`** — confirms resolution happens outside the composed-write transaction. Fallback chain + warn-on-missing add no transactional risk.
+
+## Key Technical Decisions
+
+- **Use the 4-source config cascade; don't hand-roll a 3-step resolver.** Config-rs's `Environment::with_prefix("MIKA")` source sits above the `File` source, so env-set > config-set is automatic once `kg_docs_root` is added to `Settings`. The only explicit fallback the plan needs is the CWD-based default inside `resolve_kg_docs_root()`, implemented as `settings.kg_docs_root.clone().unwrap_or_else(...)`. Rationale: mirrors `docs/solutions/architecture-patterns/simplified-config-4-source-model.md` and avoids reimplementing precedence logic that config-rs already provides and tests.
+
+- **Resolver lives in `crates/mika-agent/src/kg/config.rs` (new module).** Alternative was `impl Settings` in `mika-common` next to `active_llm_config()`, but `mika-common` has no other KG-specific concepts, and the research agent flagged that co-locating KG logic in `mika-agent/src/kg/` matches existing layering. Re-export via `pub mod config;` in `crates/mika-agent/src/kg/mod.rs`.
+
+- **Resolver is a `pub fn`, not a method on `Settings`.** #778 will need to call it from `prompt.rs` or a sibling module. A free function with an explicit `&Settings` parameter makes the call site obvious and avoids making `Settings` depend on `PathBuf` semantics it doesn't otherwise carry.
+
+- **No validation inside the resolver.** Path existence is checked at the consumer site (`server/mod.rs` continues to emit the existing `docs/solutions not found` warn). Validating inside the resolver would force #738 to bake a missing-path policy that #778 later has to override (hard-error vs warn-and-skip). Keep the resolver pure.
+
+- **Integration test uses `tempdir()` + `std::env::set_current_dir()` rather than a new CI step.** `.github/workflows/ci.yml` runs `cargo test --workspace` from repo root; a unit test that sets its own CWD is cheaper, more portable, and runs on every CI invocation without workflow surgery. Marked `#[serial]` like the other env-touching tests.
+
+- **`kg_docs_root: Option<PathBuf>`.** `PathBuf` over `String` — the consumer needs a path anyway, and early conversion catches bad inputs at deserialization. `Option` over `PathBuf` with a default — `None` is the honest representation of "use the CWD-based default"; `Default::default()` would be `""` which is meaningful-but-wrong.
+
+## Open Questions
+
+### Resolved during planning
+
+- **Q: Use config-rs auto-cascade or hand-rolled 3-level chain?** → Use auto-cascade. Config-rs `Environment` source sits above `File` source natively.
+- **Q: Resolver location — `mika-common` or `mika-agent/kg/config.rs`?** → `mika-agent/kg/config.rs`. Keeps KG concepts co-located; `mika-common` doesn't depend on KG.
+- **Q: Missing-path handling — hard-fail like #778, or warn-and-skip?** → Warn-and-skip. #738 is the global surface; #778's hard-fail is a per-agent contract concern.
+- **Q: CWD-diff test — new CI step or in-test `set_current_dir()`?** → In-test with `tempdir()` and `#[serial]`. Cheaper and portable.
+- **Q: mika-cloud Helm update required?** → No. Helm passes env vars through `values.yaml`; operators can set `MIKA_KG_DOCS_ROOT` without a code change downstream.
+
+### Deferred to implementation
+
+- Exact `ConfigKeyInfo` description wording — write it at implementation time by mirroring neighbor entries.
+- Exact placement of the `MIKA_KG_DOCS_ROOT` line in the `.env.example` KG block — insert adjacent to the other `MIKA_KG_*` vars at lines 41–52.
+
+## Implementation Units
+
+### Unit 1: Add `kg_docs_root` to `Settings` and `CONFIG_KEYS` registry
+
+- [ ] **Unit 1**
+
+**Goal:** Land the field, registry entry, and `get_effective_value()` match arm so the config-rs cascade wires env → config → `settings.kg_docs_root` automatically.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `crates/mika-common/src/config.rs`
+  - Add `pub kg_docs_root: Option<PathBuf>` with `#[serde(default)]` to the `Settings` struct (near `kg_batch_budget` at line 767).
+  - Add `ConfigKeyInfo` entry to the `CONFIG_KEYS` static registry (line 38 area): `key: "kg_docs_root"`, `env_var: Some("MIKA_KG_DOCS_ROOT")`, `secret: false`, `description: ...`, `backend: ConfigBackend::File`.
+  - Add the `get_effective_value()` match arm for `"kg_docs_root"` returning the field value.
+  - Add `MIKA_KG_DOCS_ROOT` to the `clean_env()` test helper (lines 1393–1405).
+
+**Approach:**
+- Mirror `kg_batch_budget` field style.
+- Mirror `test_disable_bundled_skills_from_env` (lines 1531–1543) for the env-var roundtrip test.
+- Use `PathBuf` (not `String`) — forces deserializer to validate path-shape early.
+
+**Patterns to follow:**
+- `crates/mika-common/src/config.rs:767-775` — `kg_batch_budget` field.
+- `crates/mika-common/src/config.rs:1531-1543` — serial env-var test template.
+- `docs/solutions/architecture-patterns/config-key-rename-across-layers.md` — full-layer checklist.
+
+**Test scenarios:**
+- Happy path: `Settings::from_str("")` → `kg_docs_root == None` (empty-TOML roundtrip).
+- Happy path: `MIKA_KG_DOCS_ROOT=/abs/path` env-set → `Settings::load()` → `kg_docs_root == Some(PathBuf::from("/abs/path"))`.
+- Happy path: `config.toml` with `kg_docs_root = "/abs/path"` only → `kg_docs_root == Some(PathBuf::from("/abs/path"))`.
+- Integration: env-set AND config-set with different paths → env value wins (verifies cascade).
+- Edge: `kg_docs_root = ""` in config.toml → deserializes to `Some(PathBuf::from(""))`; the resolver's consumer (Unit 3) is responsible for the existence check, not the deserializer.
+- Integration: `get_effective_value("kg_docs_root")` returns the expected source (File / Env) and value.
+
+**Verification:**
+- `cargo test -p mika-common config::tests` passes.
+- `get_effective_value()` coverage test passes (CI fails otherwise if the match arm is missing).
+
+### Unit 2: Create `kg::config::resolve_kg_docs_root`
+
+- [ ] **Unit 2**
+
+**Goal:** A pure `pub fn` that returns the resolved docs root without doing I/O beyond what's already in `std::env::current_dir()`. Callable from `server/mod.rs` (Unit 3) and later from #778's per-agent resolver.
+
+**Requirements:** R2, R7.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Create: `crates/mika-agent/src/kg/config.rs`
+- Modify: `crates/mika-agent/src/kg/mod.rs` (add `pub mod config;`)
+- Test: `crates/mika-agent/src/kg/config.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Signature: `pub fn resolve_kg_docs_root(settings: &Settings) -> PathBuf`
+- Body:
+  ```
+  settings
+      .kg_docs_root
+      .clone()
+      .unwrap_or_else(|| {
+          std::env::current_dir()
+              .unwrap_or_default()
+              .join("docs")
+              .join("solutions")
+      })
+  ```
+- No existence check, no canonicalization — callers remain responsible for I/O and for distinguishing empty-path vs nonexistent-path (see Unit 3).
+- Doc comment must explain two things:
+  1. Env > config precedence is handled by `Settings` loading (config-rs cascade); this function only covers the `None` → CWD-based default branch.
+  2. **Public contract consumed by #778's per-agent resolver** — signature changes require coordinated update across both tickets. Compile-time binding in `tests` module catches the mechanical drift; this comment addresses the human side.
+
+**Technical design** (directional, not implementation spec):
+```
+Settings (from config-rs cascade)
+    │
+    ├─ kg_docs_root: Some(path)  ──►  return path
+    │
+    └─ kg_docs_root: None        ──►  CWD-join("docs/solutions")
+```
+
+**Patterns to follow:**
+- `crates/mika-agent/src/kg/mod.rs` re-export style for existing sibling modules.
+
+**Test scenarios:**
+- Happy path: `settings.kg_docs_root = Some(PathBuf::from("/x"))` → returns `/x` regardless of CWD.
+- Happy path: `settings.kg_docs_root = None`, CWD = `/tmp/fake-repo` → returns `/tmp/fake-repo/docs/solutions`.
+- Edge: `settings.kg_docs_root = Some(PathBuf::from(""))` → returns empty path verbatim. The caller (Unit 3) is responsible for detecting this and emitting a distinct warn — the resolver is pure.
+- Contract: compile-time signature binding — `let _: fn(&Settings) -> PathBuf = resolve_kg_docs_root;` inside a `#[test]` module. Compiles-or-fails; no runtime assertion. Prevents silent drift from the public contract #778 depends on.
+
+**Not tested** (preserved by construction, not by induction): the `unwrap_or_default()` branch on `std::env::current_dir()` failure. Today's code uses the same expression; peer review flagged that inducing CWD failure via `tempdir()` + `remove_dir` is platform-dependent (Linux returns the stale path, macOS behavior varies) and flaky on CI. Diff-reading the `unwrap_or_default()` expression against the pre-plan implementation is the verification; test induction would be brittle theatre.
+
+**Verification:**
+- `cargo test -p mika-agent kg::config::tests` passes.
+- Function is reachable from `crates/mika-agent/src/prompt.rs` (verify by grep after merge; #778 will close the loop).
+
+### Unit 3: Wire resolver into `LexicalIngestor` construction
+
+- [ ] **Unit 3**
+
+**Goal:** Replace the inline CWD resolution at `server/mod.rs:762-768` with a call to `kg::config::resolve_kg_docs_root`. Preserve the existing warn-and-skip when the resolved path does not exist.
+
+**Requirements:** R2, R3, R6.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/mod.rs` (replace the current CWD join with a resolver call; add the empty-path warn branch).
+- Test: Create `crates/mika-agent/tests/kg_docs_root_resolution.rs` (new file). One test file, one owner, unambiguous. A future ticket may consolidate startup-flow integration tests — that is a consolidation ticket's concern, not this one.
+
+**Approach:**
+- Import: `use crate::kg::config::resolve_kg_docs_root;`
+- Call:
+  ```
+  let docs_root = resolve_kg_docs_root(&settings);
+  ```
+- Before the existing existence check, distinguish the empty-path case so operators don't chase a misleading `docs/solutions not found` log when the real problem is an empty config value:
+  ```
+  if docs_root.as_os_str().is_empty() {
+      tracing::warn!("kg_docs_root is set to empty string — check MIKA_KG_DOCS_ROOT / config.toml");
+      // skip lexical ingest
+  } else if !docs_root.exists() {
+      // existing warn-and-skip preserved verbatim
+  }
+  ```
+- Keep all other surrounding startup flow exactly as today — only the `let docs_root = ...` expression and the new empty-path branch change.
+
+**Execution note:** Test-first is recommended here. Write the CWD-from-`/tmp` integration test before the server wiring change so the failing-pre / passing-post transition is explicit.
+
+**Patterns to follow:**
+- `crates/mika-agent/src/server/mod.rs:762-786` — preserve surrounding startup flow and warn-and-skip exactly; only the `let docs_root = ...` expression changes.
+- `serial_test::serial` + `tempdir()` for the CWD-change test (see Unit 1's env-var test pattern).
+
+**Test scenarios:**
+- Happy path (current behavior preserved): No env, no config, CWD = repo root → resolver returns `<repo>/docs/solutions`, lexical ingest runs, `lexical_ingest_complete` emitted.
+- Happy path (the bug fix): `MIKA_KG_DOCS_ROOT=<repo>/docs/solutions`, CWD = `/tmp/<tempdir>` → resolver returns the repo docs path, lexical ingest runs, `lexical_ingest_complete` emitted.
+- Error path (existing behavior preserved): No env, no config, CWD = `/tmp/<tempdir>` → resolver returns `/tmp/<tempdir>/docs/solutions`, the existence check fails, the existing `docs/solutions not found — skipping lexical ingestion` warn fires, server startup completes.
+- Error path (new distinct log): `MIKA_KG_DOCS_ROOT=""` (empty string) — or the config field is set to an empty string — → resolver returns an empty `PathBuf`, the new `kg_docs_root is set to empty string — check MIKA_KG_DOCS_ROOT / config.toml` warn fires (not the generic not-found warn), server startup completes. This is the operator-ergonomics scenario Vincent flagged during peer review.
+- Error path: `MIKA_KG_DOCS_ROOT=/nonexistent/path`, any CWD → generic warn-and-skip, no panic, no empty-string warn.
+- Integration: `ingestion_orchestrator.rs` reingest path (`reingest_and_reextract` at line 191) continues to use `self.docs_root` — verify by grep that no additional changes are needed in that file.
+
+**Verification:**
+- `cargo test -p mika-agent --test kg_docs_root_resolution` passes the 4 scenarios above.
+- Manual verification (mika-dev-executable, post-merge, not in AC): `cargo build --release && cd /tmp && MIKA_KG_DOCS_ROOT=$REPO/docs/solutions ./target/release/mika-server --agent test` logs `lexical_ingest_complete`.
+
+### Unit 4: Documentation — `.env.example`, CLAUDE.md, configuration.md
+
+- [ ] **Unit 4**
+
+**Goal:** Every operator-facing surface that lists config keys mentions `MIKA_KG_DOCS_ROOT` / `kg_docs_root` with the same semantics.
+
+**Requirements:** R4.
+
+**Dependencies:** Unit 1 (key shape must be final before docs ship).
+
+**Files:**
+- Modify: `.env.example` — insert `MIKA_KG_DOCS_ROOT=` in the KG block (currently lines 41–52, adjacent to `MIKA_KG_INGESTION_MODEL`, `MIKA_KG_EXTRACTION_MODEL`, etc.). Include an inline comment referencing the OpenRC workaround note.
+- Modify: `crates/mika-agent/CLAUDE.md` — add a short note under `## Knowledge Graph — Subject Extractor` (line 201 area) covering the resolution chain (env > config > CWD) and a one-line "for OpenRC hosts, either set `MIKA_KG_DOCS_ROOT` or use the `--chdir` init-script workaround" pointer. Do NOT remove any existing workaround documentation elsewhere.
+- Modify: `docs/configuration.md` — add `kg_docs_root` row to the config-key table near lines 351–354 (neighbors: `kg_ingestion_model`, `kg_extraction_model`, `kg_resolution_model`, `kg_batch_budget`) and add `MIKA_KG_DOCS_ROOT` row to the env-var table near lines 535–538.
+- Modify: `CLAUDE.md` (mika repo root) — add `MIKA_KG_DOCS_ROOT` to the `Optional (Knowledge Graph LLM):` block at line 115, immediately after the existing four `MIKA_KG_*` entries at lines 116–119. Description: "Optional override for the docs root `LexicalIngestor` reads. Defaults to `<CWD>/docs/solutions` when unset. Needed on hosts where the service starts with CWD ≠ repo root (e.g., OpenRC `supervise-daemon`). If the path is unset OR empty, the lexical ingest phase skips with a distinct warn — operator-facing so misconfiguration is obvious in logs." (Grooming-time check confirmed the block exists at the cited line.)
+
+**Approach:**
+- Mirror the description style of the existing `kg_batch_budget` / `MIKA_KG_BATCH_BUDGET` entries.
+- Call out the default: "Defaults to `<CWD>/docs/solutions` when unset (container-native)."
+- Call out the OpenRC host case briefly so operators don't need to dig through solution docs.
+
+**Patterns to follow:**
+- `.env.example` existing KG block structure (one comment + one env-var line per key).
+- `docs/configuration.md` table formatting at lines 351–354 and 535–538.
+
+**Test expectation:** none — pure documentation. CI's markdown-lint and link-check (if present) will flag formatting regressions.
+
+**Verification:**
+- Grep `MIKA_KG_DOCS_ROOT` across the repo; every expected doc surface has an entry.
+- No grep hit for the env var name that looks like a leftover scaffold (e.g., `TODO`, `FIXME`, placeholder `/path/to/...` without context).
+
+## System-Wide Impact
+
+- **Interaction graph:** New resolver is on the startup path only (`server::agent_task` calls `LexicalIngestor::new`). No effect on the hot path; no effect on CLI/TUI (which doesn't construct `LexicalIngestor`).
+- **Error propagation:** Unchanged. Missing path → existing `tracing::warn!` + skip; non-fatal startup.
+- **State lifecycle risks:** None. Resolver is pure and side-effect-free.
+- **API surface parity:** The new `pub fn resolve_kg_docs_root` is the surface #778 will call. Signature must be stable across this and the next ticket — don't rename or change the parameter type when #778 lands.
+- **Integration coverage:** Unit 3's CWD-diff integration test exercises the server startup → resolver → LexicalIngestor path end-to-end. Unit-test-only coverage would miss the `docs_root.exists()` check behavior.
+- **Unchanged invariants:**
+  - `LexicalIngestor::ingest_single_doc_inner()` composed-write semantics unchanged (resolution happens upstream).
+  - `ingestion_orchestrator.rs` `reingest_and_reextract` continues to use `self.docs_root` — no cascade back into that file.
+  - CLI/TUI behavior unchanged (still no `LexicalIngestor` call site there).
+  - Dockerfile layout unchanged (existing container behavior is the `None` → CWD-based default, which still works because the Dockerfile puts the workdir where the docs live).
+  - Existing OpenRC `--chdir` workaround continues to work — it just becomes one of two valid operator paths instead of the only one.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Forgetting a layer in the `CONFIG_KEYS` / `get_effective_value` / `.env.example` / CLAUDE.md / configuration.md chain produces silent-failure surfaces. | `config-key-rename-across-layers.md` checklist is baked into Units 1 and 4. `get_effective_value()` coverage test fails CI if the match arm is missing. |
+| Env var + config-rs single-underscore mapping breaks if the field is ever renamed. | `MIKA_KG_DOCS_ROOT` → `kg_docs_root` is native (no `serde(rename)`) — flagged in Key Technical Decisions. |
+| #778's downstream resolver silently diverges from the signature this plan ships. | Unit 2 makes `resolve_kg_docs_root(&Settings) -> PathBuf` the public contract. #778's grooming will carry this signature forward; if the parameter type needs changing, it's a #778-time decision, not a silent drift. |
+| Test that sets CWD pollutes other tests running in parallel. | Marked `#[serial]` via `serial_test`. Uses `tempdir()` so the directory disappears at test teardown. |
+| OpenRC host operators who already use the `--chdir` workaround miss the new env var and never migrate. | Workaround is explicitly preserved. The env var is additive, not replacing. CLAUDE.md note mentions both paths. |
+| CWD-based default lands an empty path if `current_dir()` fails (rare — deleted CWD). | Matches today's behavior via `unwrap_or_default()` → `PathBuf::new().join("docs/solutions")` → existence check fails → warn-and-skip. No regression. |
+
+## Documentation / Operational Notes
+
+- Operators on OpenRC hosts get a one-line fix: set `MIKA_KG_DOCS_ROOT=/path/to/mika-repo/docs/solutions` in `/etc/conf.d/mika-server` (or the per-agent `.env`), restart the service, observe `lexical_ingest_complete` in logs.
+- Existing OpenRC init scripts using `directory=/path/to/mika-repo` or `supervise_daemon_args="--chdir /path/to/mika-repo"` continue to work unchanged.
+- Container deploys: no action required. The `None` → CWD-based default still resolves to `<workdir>/docs/solutions` as today.
+- mika-cloud (Helm): operators who want to set this in K8s can add `MIKA_KG_DOCS_ROOT` to the chart's env block — this is a values.yaml change, not a chart-code change, so it stays out of the mika-cloud repo unless that repo's `values.yaml` defaults need the line for self-documentation (optional follow-up, not part of this plan).
+
+## Ownership and capability check (autonomous-loop gate)
+
+Per Milestone #17 dispatch constraint: every step in this plan must be executable by mika-dev without Vincent's intervention.
+
+| Step | Executor | Capability verified |
+|------|----------|---------------------|
+| Unit 1 (Settings + registry) | mika-dev | `cargo build -p mika-common && cargo test -p mika-common config::tests` |
+| Unit 2 (resolver module) | mika-dev | `cargo build -p mika-agent && cargo test -p mika-agent kg::config::tests` |
+| Unit 3 (wire into server) | mika-dev | `cargo test -p mika-agent --test kg_docs_root_resolution` |
+| Unit 4 (docs) | mika-dev | Grep-based verification; no runtime gate |
+| PR creation | mika-dev | Standard `/mika` pipeline |
+| CI pass | mika-dev | Standard CI; no new workflow steps |
+| Merge | mika-dev | Auto-merge once CI green; no Vincent approval step on AC path |
+| Post-merge verification (optional) | Vincent, post-milestone | Deploy to OpenRC host, verify `lexical_ingest_complete` log — NOT on AC path, NOT blocking milestone close |
+
+No SQL to run, no manual deploy, no human-in-the-loop on the AC path. Safe for full-autonomous dispatch.
+
+## Sources & References
+
+- **Origin issue:** [senara-solutions/mika#738](https://github.com/senara-solutions/mika/issues/738)
+- **Milestone:** [senara-solutions/mika#17 — Knowledge Graph: corpus dedup & per-agent config](https://github.com/senara-solutions/mika/milestone/17)
+- **Discovery context:** `docs/solutions/workflow-issues/kg-milestone-14-autonomous-execution-retrospective-2026-04-22.md`
+- **Downstream consumer:** #778 (per-agent docs_root config) — depends on this resolver's public signature
+- **Related patterns:**
+  - `docs/solutions/architecture-patterns/simplified-config-4-source-model.md`
+  - `docs/solutions/architecture-patterns/config-key-rename-across-layers.md`
+  - `docs/solutions/architecture-patterns/config-key-registry-cli-management.md`
+  - `docs/solutions/677-configurable-task-session-limit.md`
+  - `docs/solutions/best-practices/kg-lexical-ingestion-composed-write-2026-04-22.md`
+- **Anchor files:**
+  - `crates/mika-common/src/config.rs:38` (`CONFIG_KEYS`), `:534` (`Settings` struct), `:767-775` (pattern field), `:1108-1161` (loader), `:1393-1405` (`clean_env`), `:1531-1543` (env-var test template)
+  - `crates/mika-agent/src/server/mod.rs:762-787` (construction site)
+  - `crates/mika-agent/src/kg/ingestion_orchestrator.rs:75-86,102,191` (downstream consumer)
+  - `crates/mika-agent/src/prompt.rs:46-93` (future #778 caller)
+  - `.env.example:41-52` (KG env-var block)
+  - `docs/configuration.md:351-354,535-538` (config-key and env-var tables)
+  - `crates/mika-agent/CLAUDE.md:201` (`## Knowledge Graph — Subject Extractor`)
+  - `.github/workflows/ci.yml:16,38,41,44` (test job)

--- a/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
+++ b/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
@@ -158,41 +158,59 @@ Global config is the right level (docs tree is repo-scoped, not agent-scoped), a
 - Test: `crates/mika-agent/src/kg/config.rs` (inline `#[cfg(test)] mod tests`)
 
 **Approach:**
-- Signature: `pub fn resolve_kg_docs_root(settings: &Settings) -> PathBuf`
+- Signature: `pub fn resolve_kg_docs_root(settings: &Settings) -> (PathBuf, PathSource)`
+- `PathSource` enum, defined adjacent to the function:
+  ```
+  pub enum PathSource {
+      EnvVar,       // path came from MIKA_KG_DOCS_ROOT env var
+      ConfigFile,   // path came from settings.kg_docs_root (config.toml)
+      CwdDefault,   // path fell through to std::env::current_dir().join("docs/solutions")
+  }
+  ```
 - Body:
   ```
-  settings
-      .kg_docs_root
-      .clone()
-      .unwrap_or_else(|| {
-          std::env::current_dir()
-              .unwrap_or_default()
-              .join("docs")
-              .join("solutions")
-      })
+  // Env var check first (config-rs resolves MIKA_KG_DOCS_ROOT into settings.kg_docs_root,
+  // but we need to know whether the value came from env vs config file, so re-inspect env).
+  if let Ok(env_path) = std::env::var("MIKA_KG_DOCS_ROOT") {
+      return (PathBuf::from(env_path), PathSource::EnvVar);
+  }
+  if let Some(config_path) = settings.kg_docs_root.clone() {
+      return (config_path, PathSource::ConfigFile);
+  }
+  let cwd_default = std::env::current_dir()
+      .unwrap_or_default()
+      .join("docs")
+      .join("solutions");
+  (cwd_default, PathSource::CwdDefault)
   ```
 - No existence check, no canonicalization — callers remain responsible for I/O and for distinguishing empty-path vs nonexistent-path (see Unit 3).
-- Doc comment must explain two things:
-  1. Env > config precedence is handled by `Settings` loading (config-rs cascade); this function only covers the `None` → CWD-based default branch.
+- Doc comment must explain three things:
+  1. Env > config precedence: the resolver re-inspects `MIKA_KG_DOCS_ROOT` directly (not just `settings.kg_docs_root`) to distinguish the env-var case from the config-file case. Config-rs already merges env into `settings.kg_docs_root`, so `Some` could be either source — the re-inspection gives the true source.
   2. **Public contract consumed by #778's per-agent resolver** — signature changes require coordinated update across both tickets. Compile-time binding in `tests` module catches the mechanical drift; this comment addresses the human side.
+  3. **Source-of-origin exposed for #778's per-agent policy classifier.** #778 uses `PathSource::{EnvVar, ConfigFile}` to distinguish "operator explicitly set this path; hard-error if it doesn't exist" from `PathSource::CwdDefault` → "fell through to container-friendly default; warn-and-skip if it doesn't exist". **If you add a new source here (e.g., workspace-level config), update `resolve_per_agent_docs_root` in kg/config.rs to classify it correctly.** The exhaustive match on `PathSource` in `resolve_per_agent_docs_root` will force a compile error if variants are added, but this breadcrumb names the why.
 
 **Technical design** (directional, not implementation spec):
 ```
-Settings (from config-rs cascade)
+Settings (from config-rs cascade) + process env
     │
-    ├─ kg_docs_root: Some(path)  ──►  return path
+    ├─ MIKA_KG_DOCS_ROOT env var set  ──►  (PathBuf::from(env_val), EnvVar)
     │
-    └─ kg_docs_root: None        ──►  CWD-join("docs/solutions")
+    ├─ settings.kg_docs_root = Some(path)  ──►  (path, ConfigFile)
+    │
+    └─ (neither)                           ──►  (CWD-join("docs/solutions"), CwdDefault)
 ```
 
 **Patterns to follow:**
 - `crates/mika-agent/src/kg/mod.rs` re-export style for existing sibling modules.
 
 **Test scenarios:**
-- Happy path: `settings.kg_docs_root = Some(PathBuf::from("/x"))` → returns `/x` regardless of CWD.
-- Happy path: `settings.kg_docs_root = None`, CWD = `/tmp/fake-repo` → returns `/tmp/fake-repo/docs/solutions`.
-- Edge: `settings.kg_docs_root = Some(PathBuf::from(""))` → returns empty path verbatim. The caller (Unit 3) is responsible for detecting this and emitting a distinct warn — the resolver is pure.
-- Contract: compile-time signature binding — `let _: fn(&Settings) -> PathBuf = resolve_kg_docs_root;` inside a `#[test]` module. Compiles-or-fails; no runtime assertion. Prevents silent drift from the public contract #778 depends on.
+- Happy path (env var wins): env `MIKA_KG_DOCS_ROOT=/e`, `settings.kg_docs_root = Some(PathBuf::from("/c"))` → returns `(PathBuf::from("/e"), PathSource::EnvVar)`. Env takes precedence over config file even when both are set.
+- Happy path (config file): env unset, `settings.kg_docs_root = Some(PathBuf::from("/x"))` → returns `(PathBuf::from("/x"), PathSource::ConfigFile)`.
+- Happy path (CWD fallback): env unset, `settings.kg_docs_root = None`, CWD = `/tmp/fake-repo` → returns `(/tmp/fake-repo/docs/solutions, PathSource::CwdDefault)`.
+- Edge: env set to empty string → `(PathBuf::from(""), PathSource::EnvVar)`. Empty-path classification still applies (Unit 3's distinct warn handles the empty-path case). Source is EnvVar because the operator did explicitly set it to an empty value — policy still "hard-error downstream" if the consumer cares about existence.
+- Edge: `settings.kg_docs_root = Some(PathBuf::from(""))` (config file set to empty) → `(PathBuf::from(""), PathSource::ConfigFile)`. Same semantics as above — empty but explicit.
+- Contract (signature binding): `let _: fn(&Settings) -> (PathBuf, PathSource) = resolve_kg_docs_root;` inside a `#[test]` module. Compiles-or-fails; no runtime assertion. Prevents silent drift from the public contract #778 depends on.
+- Contract (PathSource exhaustiveness): a `#[test]` that matches on all three `PathSource` variants — `match source { PathSource::EnvVar => (), PathSource::ConfigFile => (), PathSource::CwdDefault => () }`. Adding a future variant without updating this test (and by extension, `resolve_per_agent_docs_root` in #778) produces a compile error. Belt-and-suspenders for the breadcrumb in the doc comment.
 
 **Not tested** (preserved by construction, not by induction): the `unwrap_or_default()` branch on `std::env::current_dir()` failure. Today's code uses the same expression; peer review flagged that inducing CWD failure via `tempdir()` + `remove_dir` is platform-dependent (Linux returns the stale path, macOS behavior varies) and flaky on CI. Diff-reading the `unwrap_or_default()` expression against the pre-plan implementation is the verification; test induction would be brittle theatre.
 
@@ -215,10 +233,12 @@ Settings (from config-rs cascade)
 - Test: Create `crates/mika-agent/tests/kg_docs_root_resolution.rs` (new file). One test file, one owner, unambiguous. A future ticket may consolidate startup-flow integration tests — that is a consolidation ticket's concern, not this one.
 
 **Approach:**
-- Import: `use crate::kg::config::resolve_kg_docs_root;`
+- Import: `use crate::kg::config::{resolve_kg_docs_root, PathSource};`
 - Call:
   ```
-  let docs_root = resolve_kg_docs_root(&settings);
+  let (docs_root, _source) = resolve_kg_docs_root(&settings);
+  // #738 itself doesn't care about `_source` — the warn-and-skip downstream behavior is
+  // the same for all three sources. #778 is the consumer that branches on PathSource.
   ```
 - Before the existing existence check, distinguish the empty-path case so operators don't chase a misleading `docs/solutions not found` log when the real problem is an empty config value:
   ```

--- a/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
+++ b/docs/plans/2026-04-24-005-feat-kg-docs-root-config-plan.md
@@ -246,7 +246,7 @@ Settings (from config-rs cascade)
 - Integration: `ingestion_orchestrator.rs` reingest path (`reingest_and_reextract` at line 191) continues to use `self.docs_root` — verify by grep that no additional changes are needed in that file.
 
 **Verification:**
-- `cargo test -p mika-agent --test kg_docs_root_resolution` passes the 4 scenarios above.
+- `cargo test -p mika-agent --test kg_docs_root_resolution` passes all scenarios above.
 - Manual verification (mika-dev-executable, post-merge, not in AC): `cargo build --release && cd /tmp && MIKA_KG_DOCS_ROOT=$REPO/docs/solutions ./target/release/mika-server --agent test` logs `lexical_ingest_complete`.
 
 ### Unit 4: Documentation — `.env.example`, CLAUDE.md, configuration.md
@@ -303,6 +303,7 @@ Settings (from config-rs cascade)
 | #778's downstream resolver silently diverges from the signature this plan ships. | Unit 2 makes `resolve_kg_docs_root(&Settings) -> PathBuf` the public contract. #778's grooming will carry this signature forward; if the parameter type needs changing, it's a #778-time decision, not a silent drift. |
 | Test that sets CWD pollutes other tests running in parallel. | Marked `#[serial]` via `serial_test`. Uses `tempdir()` so the directory disappears at test teardown. |
 | OpenRC host operators who already use the `--chdir` workaround miss the new env var and never migrate. | Workaround is explicitly preserved. The env var is additive, not replacing. CLAUDE.md note mentions both paths. |
+| Operator sets `MIKA_KG_DOCS_ROOT=""` or leaves `kg_docs_root` as empty string in config → resolver returns empty `PathBuf` → operator chases a misleading `docs/solutions not found` log for 20 minutes before realizing the config value itself is empty. | Unit 3's consumer branches on `docs_root.as_os_str().is_empty()` and emits a distinct warn (`kg_docs_root is set to empty string — check MIKA_KG_DOCS_ROOT / config.toml`) before the generic existence check. Test scenario in Unit 3 covers it. |
 | CWD-based default lands an empty path if `current_dir()` fails (rare — deleted CWD). | Matches today's behavior via `unwrap_or_default()` → `PathBuf::new().join("docs/solutions")` → existence check fails → warn-and-skip. No regression. |
 
 ## Documentation / Operational Notes

--- a/docs/solutions/architecture-patterns/kg-docs-root-config-driven-resolution-2026-04-24.md
+++ b/docs/solutions/architecture-patterns/kg-docs-root-config-driven-resolution-2026-04-24.md
@@ -1,0 +1,133 @@
+---
+title: "KG Docs Root — Config-Driven Path Resolution with Source Disambiguation"
+date: 2026-04-24
+status: documented
+category: architecture-patterns
+tags: [configuration, knowledge-graph, lexical-ingestion, path-resolution, config-cascade]
+modules:
+  - mika-common (config.rs — Settings field, CONFIG_KEYS entry, get_effective_value arm)
+  - mika-agent (kg/config.rs — resolve_kg_docs_root + PathSource, server/mod.rs — empty-path guard)
+problem_type: silent_failure
+severity: high
+symptoms:
+  - Lexical ingestor logs "docs/solutions not found — skipping lexical ingestion" on every restart
+  - KG lexical, subject, and resolution layers remain permanently empty
+  - Only affects non-container hosts where CWD != repo root (e.g., OpenRC supervise-daemon with CWD=/)
+---
+
+# KG Docs Root — Config-Driven Path Resolution with Source Disambiguation
+
+## Problem
+
+`LexicalIngestor` resolved its docs root via `std::env::current_dir().join("docs/solutions")`. Inside Docker containers this works because the Dockerfile COPYs `docs/` into the workdir. On non-container hosts where an init system (OpenRC `supervise-daemon`, systemd) launches `mika-server` with CWD=`/`, the path resolves to `/docs/solutions` which does not exist. The ingestor silently skips, and the entire lexical/subject/resolution KG pipeline never populates.
+
+This was a hard block for KG milestone #14 on the Gentoo OpenRC host — only the in-memory domain graph survived across restarts.
+
+## Root Cause
+
+Implicit CWD dependency in the path resolution. The code assumed the process working directory would always be the repo root, which is only true for container deploys and manual `cargo run` invocations.
+
+## Solution
+
+### Resolution chain in `kg::config::resolve_kg_docs_root`
+
+New module `crates/mika-agent/src/kg/config.rs` with a pure resolver function:
+
+```rust
+pub fn resolve_kg_docs_root(settings: &Settings) -> (PathBuf, PathSource)
+```
+
+Resolution order (first hit wins):
+
+1. `MIKA_KG_DOCS_ROOT` environment variable — direct `std::env::var` read.
+2. `settings.kg_docs_root` field — populated by config-rs from `config.toml`.
+3. `<CWD>/docs/solutions` — backward-compatible container default.
+
+### Why re-inspect the env var
+
+Config-rs merges `MIKA_KG_DOCS_ROOT` into `settings.kg_docs_root`, so a `Some(...)` value could originate from either the env var or the config file. The resolver checks `std::env::var("MIKA_KG_DOCS_ROOT")` directly to distinguish the two sources via `PathSource`.
+
+### `PathSource` enum for downstream classification
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSource {
+    EnvVar,
+    ConfigFile,
+    CwdDefault,
+}
+```
+
+Returned alongside the path so consumers can apply source-appropriate policies. The current consumer (`server/mod.rs`) uses warn-and-skip for all sources. Future ticket #778 (per-agent `docs_root`) will use `PathSource` to distinguish "operator explicitly configured this path — hard-error if missing" from "fell through to container default — warn-and-skip if missing".
+
+### Why config-rs cascade instead of hand-rolled 3-step
+
+The existing 4-source config model (documented in `simplified-config-4-source-model.md`) already handles env > config file precedence via `config-rs`'s `Environment::with_prefix("MIKA")` source. Adding `kg_docs_root: Option<PathBuf>` to `Settings` with `#[serde(default)]` gets env > config.toml precedence for free. The only hand-written fallback is the CWD default in step 3, which config-rs cannot express (it is not a config source, it is a runtime computation). This avoids reimplementing precedence logic that config-rs already provides and tests.
+
+### Empty-path guard
+
+`server/mod.rs` checks `docs_root.as_os_str().is_empty()` before the existence check and emits a distinct warning naming both possible config sources:
+
+```
+kg_docs_root is set to empty string — check MIKA_KG_DOCS_ROOT env var or kg_docs_root in config.toml; skipping lexical ingestion
+```
+
+Without this guard, an empty string would pass the emptiness check, fail the `docs_root.exists()` check, and produce the generic "not found" message — leaving operators chasing a filesystem problem when the real issue is a misconfigured value.
+
+### No path validation in the resolver
+
+The resolver returns the path without checking existence. Validation policy belongs to the consumer site. This keeps the resolver pure (testable without filesystem state) and allows #778 to apply a stricter policy (hard-error) downstream without forking the resolution logic.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-common/src/config.rs` | `kg_docs_root: Option<PathBuf>` field on `Settings`, `CONFIG_KEYS` entry, `get_effective_value` match arm, `test_defaults()` default, `Debug` impl field, `clean_env()` cleanup |
+| `crates/mika-agent/src/kg/config.rs` | New module — `resolve_kg_docs_root()`, `PathSource` enum, 7 unit tests |
+| `crates/mika-agent/src/kg/mod.rs` | `pub mod config;` re-export |
+| `crates/mika-agent/src/server/mod.rs` | Replace inline CWD resolution with `resolve_kg_docs_root()` call + empty-path guard |
+| `crates/mika-agent/tests/kg_docs_root_resolution.rs` | 3 integration tests verifying public API from outside the crate |
+| `.env.example`, `docs/configuration.md`, `crates/mika-agent/CLAUDE.md`, root `CLAUDE.md` | Documentation of new env var and config field |
+
+## Testing
+
+**Unit tests** (`kg::config::tests`, 7 tests): env wins over config, config used when no env, CWD fallback when nothing set, empty env returns `EnvVar` source, empty config returns `ConfigFile` source, signature binding (compile-time drift detection for #778), `PathSource` exhaustiveness check (compile error on new variant).
+
+**Config-layer tests** (`config.rs`, 5 tests): `kg_docs_root` defaults to `None`, env override populates `Some`, config file populates `Some`, env wins over config file through config-rs cascade, `get_effective_value` returns the display string.
+
+**Integration tests** (`tests/kg_docs_root_resolution.rs`, 3 tests): nonexistent env path returned verbatim (no existence check), CWD default produces full path, public API types accessible from outside the crate.
+
+All tests use `#[serial]` + env cleanup to avoid cross-test interference from `std::env::set_var`.
+
+## Key Decisions
+
+1. **Resolver lives in `mika-agent::kg::config`, not `mika-common`** — `mika-common` has no KG-specific concepts. Co-locating with the KG module matches existing layering and keeps the `pub fn` discoverable for #778.
+
+2. **`PathSource` exists now, not deferred to #778** — adding the enum later would require changing the return type of a `pub fn` that #778 already depends on. Shipping it now means #778 can pattern-match on the source without a breaking signature change.
+
+3. **Signature binding test** — `let _: fn(&Settings) -> (PathBuf, PathSource) = resolve_kg_docs_root;` catches accidental signature drift at compile time. #778 depends on this exact contract.
+
+4. **Warn-and-skip, not hard-error** — consistent with the existing behavior where a missing `docs/solutions` directory is non-fatal. The server still boots; the KG layer stays empty. #778 will introduce hard-error semantics for per-agent misconfiguration using `PathSource` to distinguish the two policies.
+
+## Operator Guidance
+
+For non-container hosts where `mika-server` starts with CWD != repo root:
+
+```bash
+# Option A: env var (recommended for init scripts)
+MIKA_KG_DOCS_ROOT=/path/to/mika-repo/docs/solutions
+
+# Option B: config.toml
+# In ~/.mika/config.toml:
+kg_docs_root = "/path/to/mika-repo/docs/solutions"
+
+# Option C: init-script --chdir (existing workaround, still works)
+supervise-daemon mika-server --chdir /path/to/mika-repo ...
+```
+
+## Related
+
+- **#738** — this ticket (CWD-dependent docs path fix)
+- **#778** — per-agent `docs_root` using `PathSource` for policy classification
+- **`simplified-config-4-source-model.md`** — the config cascade this solution builds on
+- **`config-key-registry-cli-management.md`** — `CONFIG_KEYS` registry pattern followed for the new key


### PR DESCRIPTION
## Summary

- Add `MIKA_KG_DOCS_ROOT` env var and `kg_docs_root` config field so the KG lexical ingestor can find the docs directory on hosts where CWD ≠ repo root (e.g., OpenRC `supervise-daemon` with CWD=`/`)
- Resolution chain: env > config.toml > `<CWD>/docs/solutions` (container-native default) — leverages config-rs cascade, only the CWD fallback is hand-written
- `resolve_kg_docs_root(&Settings) -> (PathBuf, PathSource)` pub fn in `kg::config` module — `PathSource` enum exposes the origin for #778's per-agent policy classifier
- Empty-path guard with distinct warning for operator ergonomics
- 15 tests across unit, config-layer, and integration levels

Closes #738

## Changes

| File | Change |
|------|--------|
| `crates/mika-common/src/config.rs` | `kg_docs_root: Option<PathBuf>` field, `CONFIG_KEYS` entry, `get_effective_value` arm, `clean_env`, `Debug` impl, 5 tests |
| `crates/mika-agent/src/kg/config.rs` | New module — resolver + `PathSource` + 7 unit tests |
| `crates/mika-agent/src/server/mod.rs` | Replace inline CWD join with resolver call + empty-path guard |
| `crates/mika-agent/tests/kg_docs_root_resolution.rs` | 3 integration tests |
| `.env.example`, `CLAUDE.md`, `crates/mika-agent/CLAUDE.md`, `docs/configuration.md` | Documentation |

## Test plan

- [x] `cargo test -p mika-common config::tests` — all 27 tests pass (5 new)
- [x] `cargo test -p mika-agent -- kg::config` — all 7 unit tests pass
- [x] `cargo test -p mika-agent --test kg_docs_root_resolution` — all 3 integration tests pass
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt -- --check` clean
- [ ] Post-merge: deploy to OpenRC host, set `MIKA_KG_DOCS_ROOT`, verify `lexical_ingest_complete` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)