### PR TITLE
fix(mika): make plan-on-branch load-bearing in implementation + QA

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -11,6 +11,22 @@ Run these steps in order. Do not do anything else. Do not stop between steps —
 
 **Issue linking:** If `$ARGUMENTS` (after stripping any `branch:` prefix) starts with `#` followed by a number (e.g. `#42`) or is just a number, treat it as a GitHub issue reference. Run `gh issue view <number> --json number,title,body,labels` to fetch the issue details, then use the issue title and body as the feature description for the planning step. Remember the issue number for the PR step.
 
+**Plan-on-branch detection:** After fetching an issue body (or when a plan path is supplied directly in `$ARGUMENTS`), check whether a groomed plan-on-branch already exists. The grooming pipeline (`/mika-groom-ticket`) writes a callout into the issue body of this exact shape:
+
+```
+> - **Plan:** `docs/plans/<filename>.md` (committed on branch @ `<sha>`)
+```
+
+Parse the issue body for that callout. Extract the `<path>` (the value inside the first backtick-wrapped argument).
+
+- **If the callout is present AND `<path>` exists in the worktree** (verify with `test -f <path>`): set `PLAN_PATH=<path>` and **skip Step 1 (`/ce:plan`)** in the Pipeline below. Run `/ce:work <PLAN_PATH>` directly (Step 2). Frame the prompt explicitly so claude-pilot consumes the plan as the contract:
+
+  > This plan was groomed and committed by the architect. It is the contract for this implementation. If any acceptance criterion is unclear or unsatisfiable (e.g., conflicts with an existing parser, breaks a downstream consumer, depends on something that doesn't exist), **send_message** to mika-dev surfacing the ambiguity — do not silently scope-reduce. Do not write a new plan file in `docs/plans/`. The existing plan-on-branch is the single source of truth.
+
+- **If the callout is absent OR `<path>` does not exist in the worktree:** fall back to the current flow — run `/ce:plan $ARGUMENTS` (Step 1) followed by `/ce:work` (Step 2).
+
+This branch is also valid when `$ARGUMENTS` directly contains a `docs/plans/...md` path (e.g., `/mika implement the langfuse fix plan` where the operator names the path): treat it the same as a callout match.
+
 ## Worktree isolation
 
 Before running the pipeline, set up an isolated worktree:
@@ -54,8 +70,8 @@ Before running the pipeline, set up an isolated worktree:
 
 **Git discipline (MANDATORY):** Do NOT run `git pull`, `git pull origin main`, `git merge main`, `git merge origin/main`, or any similar catch-up operation during the pipeline. The Worktree isolation step above already rebased this branch onto `origin/main` via the handler's startup guard. If `origin/main` advances while the pipeline is running, the resulting conflict is resolved **post-pipeline** through the `resolve_pr_conflicts` skill — never by pulling main into the branch mid-session. Mid-session merges create duplicate-hash copies of upstream commits and produce a `mergeable=CONFLICTING` PR on GitHub even though the content is identical. Allowed git commands during the pipeline: `git add`, `git commit`, `git push` (including `--force-with-lease` for amended commits), `git status`, `git log`, `git diff`, `git fetch origin` (read-only). Everything else — especially `pull` and `merge` — is out of scope.
 
-1. `/ce:plan $ARGUMENTS` (if an issue was detected, pass the issue title + body instead of raw arguments)
-2. `/ce:work`
+1. `/ce:plan $ARGUMENTS` (if an issue was detected, pass the issue title + body instead of raw arguments) — **skip when a plan-on-branch was detected above; jump straight to Step 2 with `/ce:work <PLAN_PATH>`**
+2. `/ce:work` — when a plan-on-branch was detected, invoke as `/ce:work <PLAN_PATH>` with the contract framing from the Issue linking section above
 3. `/ce:review`
 4. `/compound-engineering:resolve_todo_parallel`
 5. `/mika-doc-audit`

--- a/docs/plans/2026-04-26-005-fix-plan-on-branch-load-bearing-plan.md
+++ b/docs/plans/2026-04-26-005-fix-plan-on-branch-load-bearing-plan.md
@@ -1,0 +1,265 @@
+---
+title: "fix: make plan-on-branch load-bearing in implementation + QA"
+type: fix
+status: active
+date: 2026-04-26
+origin: ~/.claude/plans/i-want-you-to-graceful-walrus.md (operator-authored, peer-reviewed across 3 cycles, mika-arch session 8ad65309-1c8c-4a5e-a370-cae75edd830b)
+---
+
+# Plan: make the plan-on-branch load-bearing in implementation + QA
+
+## Context
+
+**The problem.** mika-platform#54 (Ticket 1 of `slash-command-coherence` milestone) shipped a fraction of its groomed plan's acceptance criteria. The plan specified an 11-field `--verbose` metadata block (alphabetical in JSON, importance-ordered in text). What shipped: JSON `--verbose` is silently ignored (zero metadata), text mode emits only `session_id` (1 of 11). mika-qa approved with `VERDICT: hold[review]`, but the hold was for an unrelated cross-repo deployment-skew gate — she **never ran the binary against the AC**.
+
+**Why this matters.** We invested significant grooming discipline this session (pre-commit discovery, two-pass architect review, gated-merge cross-repo discipline, plan-on-branch as the canonical contract). The empirical "Opus-grooming-survives-implementation" hypothesis from yesterday's handoff is N=1 against. The plan-on-branch isn't load-bearing in either pipeline.
+
+**Diagnosis is BOTH/AND, refined per mika-arch session `8ad65309-...` review of this plan:**
+
+1. **Real architectural conflict during implementation.** PR #54's body explicitly documents: "P0: Removed `--format json` — JSON mode nests it inside a `metadata` object, **breaking the two-pass pipeline**." `/mika-groom-ticket`'s parser scans for `session_id: <uuid>` lines on stdout; the original plan's JSON-nested-metadata shape would have broken that parser. This conflict is real, not fabricated. Grooming missed it — mika-arch (architect) approved the plan without grepping for existing consumers of the affected output channel. **This is a grooming-surface gap.**
+2. **Conflict-resolution-without-escalation during implementation.** When claude-pilot hit the conflict, it scope-reduced and shipped, documenting in the PR body. Correct response would have been `send_message` to operator, plan amendment, re-dispatch. **This is an implementation-surface gap.**
+3. **claude-pilot wrote a NEW plan file** (`2026-04-26-004-feat-ask-verbose-flag-plan.md` — verified to exist on `mika` main via `ls`) explicitly capturing the reduced scope, then implemented against that. The new file normalizes "implementer overrides plan" as acceptable when there's a documented reason. **This is the smoking-gun artifact.**
+4. **mika-qa never verified the original plan's AC behaviorally.** Step 3e was silently skipped (gated on conditions #54 didn't meet). She approved with `VERDICT: hold[review]` for an unrelated cross-repo deployment-skew gate.
+
+**The structural gaps that allowed all four observations above:**
+
+1. **`/mika` re-derives the plan instead of consuming the existing one.** The current pipeline at `mika/.claude/commands/mika.md:57` is `/ce:plan $ARGUMENTS` (where `$ARGUMENTS` becomes the issue title+body) → `/ce:work`. `/ce:plan`'s SKILL.md (Phase 0.1) has a "Resume Existing Plan Work" branch but only fuzzy-matches on "obvious recent matching plan in `docs/plans/`" — kimi-k2.5 ignores it. `/ce:work` already accepts a plan path as input ("Plan doc path or description of work" per its `argument-hint`); `/mika` just doesn't pass one. Net effect: claude-pilot re-plans from issue prose, drift surface is the entire plan-derivation step.
+
+2. **`qa-review` checks plan existence, not plan content.** `qa-review/system_prompt.md:80-84` validates that a plan file *exists* in the diff. `:189` extracts ACs from the *GitHub issue* (not the plan). Step 3e (build verification) at `:175-180` is **conditional** on the PR having "a linked GitHub issue with backtick-wrapped `mika` commands." mika-platform#54's issue body doesn't match that shape, so Step 3e was silently skipped. AC-failure verdict in `qa-review-build-callback/system_prompt.md:44` is `hold[review]` (advisory), not `block[ac]` (gating). Sonnet upgrade doesn't close this — the step is optional and the skill silently skips when conditions aren't met.
+
+3. **No escalation path when implementation hits architectural conflict with the plan.** Today, when claude-pilot finds an AC that conflicts with reality (e.g., breaks a downstream parser), the only paths are: scope-reduce silently (what happened), or block indefinitely (no progress). Both are wrong. Correct path: `send_message` to operator naming the conflict, pause for plan amendment, re-dispatch. This convention is named in mika-platform#52's framing-divergence ESCALATE pattern but is not encoded as a structural gate anywhere.
+
+**The intended outcome.** Both pipelines treat the plan-on-branch as the load-bearing contract:
+- claude-pilot consumes it directly via `/ce:work <plan-path>`, with explicit "this plan is the contract; do not scope-reduce; surface conflicts via send_message" framing.
+- mika-qa reads it as the AC checklist and verifies each bullet behaviorally.
+- AC failure = `block[ac]` (gating), with a named escalation path that routes to operator review (not indefinite block).
+
+## Approach
+
+Three structural changes batched into one PR on the `mika` repo (skills are engine-coupled there). Plus the queued self-dev M2 milestone-title fix already in `project_decisions_in_flight.md`.
+
+### Change 1 — `/mika` skips `/ce:plan` when a plan-on-branch exists
+
+**File:** `mika/.claude/commands/mika.md`
+
+Replace the unconditional Step 1 (`/ce:plan $ARGUMENTS`) with a branching shape:
+
+- **Detect plan-on-branch.** When an issue was fetched (existing flow at line 12), parse the issue body for the `> - **Plan:** \`<path>\` (committed on branch @ \`<sha>\`)` callout — same shape `/mika-groom-ticket` writes during grooming. The grooming convention is already established; this just teaches `/mika` to read it.
+- **If the callout is present AND `<path>` exists in the worktree:**
+  - **Skip `/ce:plan` entirely.** The plan was groomed by mika-arch; re-running plan-derivation is the drift surface.
+  - **Run `/ce:work <plan-path>` directly.** Per `/ce:work` Phase 0: "Plan document (input is a file path to an existing plan) → skip to Phase 1." Phase 1 reads the plan and "treat[s] it as a decision artifact."
+  - **Add explicit contract framing** in the prompt construction: "This plan was groomed and committed by the architect. It is the contract for this implementation. If any AC is unclear or unsatisfiable, **send_message** to mika-dev surfacing the ambiguity — do not silently scope-reduce. Do not write a new plan file in `docs/plans/`."
+- **If callout is absent or path missing:** fall back to current flow (`/ce:plan $ARGUMENTS` → `/ce:work`).
+
+This is a 15-line change in a single markdown file. The drift surface (`/ce:plan` re-derivation) disappears entirely when a plan-on-branch exists. `/ce:work` already has the consumption logic; we're just routing to it directly.
+
+### Change 2 (folded into Change 3 per peer-review)
+
+The original "prohibit new plan files mid-implementation" intervention is **folded into Change 3 as an implicit structural AC** (verifiable post-pipeline via `git diff main -- docs/plans/`). Standalone Change 2 was redundant — post-PR verification of an instruction already given in Change 1's prompt is what Change 3's structural-AC layer does anyway. Folding eliminates a separate moving part.
+
+**Override mechanism for legitimate sub-plan cases:** if a new file in `docs/plans/` is genuinely needed (e.g., milestone implementation adding a sub-plan for a complex child unit), the new plan must include `parent_plan: <path>` in its YAML frontmatter, and the operator must sign off before implementation. Change 3's structural-AC check reads frontmatter and skips the prohibition for files with valid `parent_plan` metadata. This handles the legitimate case without weakening the default.
+
+### Change 3 — `qa-review` reads the plan and verifies each AC behaviorally (gating)
+
+**File:** `mika/skills/bundled/qa-review/system_prompt.md`
+
+Insert a new **Step 2.5 (Plan-AC verification)** between the existing diff-review steps and the conditional Step 3e (build verification). Replace the current AC-extraction at `:189` (which reads the GitHub issue) with plan-driven AC extraction:
+
+1. **Read the plan file.** Parse the issue body for `> - **Plan:** \`<path>\``. If no callout: `VERDICT: block[pipeline]` with "no plan callout — was this groomed via `/mika-groom-ticket`?". If callout present but file missing on branch: same block. (Today's behavior — line 80-84 — already checks existence; this extends to read.)
+2. **Extract AC bullets.** Read the plan's `## Acceptance criteria` section. The plan template (per `/ce:plan` Phase 4.2) names this section explicitly; the bullets are markdown checkbox items.
+3. **Classify each AC:**
+   - **Behavioral**: testable by running the built binary (e.g., `mika ask --verbose --format json` should emit a metadata object).
+   - **Structural**: testable by grepping the diff (e.g., "field added to struct X" → `git diff main -- <file> | grep -q "<field>:"`).
+   - **Documentation**: testable by reading a file path (e.g., `docs/getting-started.md` updated).
+   - **CI-deferred**: explicitly marked "no test regressions" or similar — defer to CI pipeline.
+
+   **Implicit structural AC (always applied when plan-on-branch detected):** `git diff main -- docs/plans/` shows zero new files unless the new file's frontmatter includes `parent_plan: <path>` (override for legitimate sub-plan cases). Violation produces `block[ac]` with reason "Parallel plan file authored without parent_plan override; plan-on-branch is the contract." This is the absorbed Change 2.
+4. **Verify each AC by class.** For Behavioral, build the project (existing `build_mika` callback) and execute the AC command(s) extracted from the plan. For Structural, run the grep. For Documentation, read the file and check for the documented surface.
+5. **Compose the verification block** in the PR review body. Per AC bullet: `[✅] satisfied: <evidence>`, `[❌] unsatisfied: <expected vs actual>`, or `[⏭️] CI-deferred`.
+6. **Verdict mapping (gating, not advisory):**
+   - All ACs `✅` or `⏭️`: `VERDICT: pass` (subject to other diff-review checks).
+   - Any AC `❌`: `VERDICT: block[ac]` with the unsatisfied bullets enumerated.
+   - Plan unparseable, file missing, or AC section absent: `VERDICT: block[pipeline]`.
+
+7. **Escalation path on `block[ac]`** (per mika-arch's Finding 3 review of this plan, session `8ad65309-...`):
+   - `block[ac]` is gating BUT must include a named escalation. The QA review body, when emitting `block[ac]`, must include a "Plan amendment required:" section listing each unsatisfied AC and the conflict reason inferred from the diff (e.g., "AC X specifies JSON nested metadata; downstream consumer `/mika-groom-ticket` parses `session_id: <uuid>` lines on stdout — these conflict; plan needs amendment to one or the other").
+   - mika-dev's verdict-handler reads this section and treats `block[ac]` differently from `block[ci]`: instead of auto-retry, it `send_message`s to operator with the conflict summary and pauses the work item.
+   - This closes the "implementer overrides plan silently" failure mode: an AC mismatch becomes operator-visible immediately, and the resolution path (amend plan or amend AC) is taken explicitly.
+   - Cite: convention from mika-platform#52 framing-divergence ESCALATE — when implementation hits conflict with spec, surface to operator, don't unilaterally resolve.
+
+Step 3e (build verification) becomes the *implementation* of the Behavioral AC class, not a separate conditional gate. The "linked GitHub issue with backtick commands" condition (`:175-180`) is removed — ACs come from the plan, not the issue.
+
+**Companion file change:** `mika/skills/bundled/qa-review-build-callback/system_prompt.md:44` — change AC-failure verdict from `hold[review]` to `block[ac]`. Verbatim: "If build or any AC fails, the maximum verdict is `block[ac]`" (was `hold[review]`).
+
+**Tools check:** verify `mika/skills/bundled/qa-review/skill.toml` declares the necessary `required_tools` for: file-read on the plan, `build_mika` callback for behavioral verification, `run_gh` for diff inspection. Add any missing tools.
+
+### Change 4 — bundle the queued self-dev M2 milestone-title fix
+
+**File:** `mika/skills/bundled/self-dev/system_prompt.md:386`
+
+Already documented in `~/.claude/projects/-data-workspace-mika-platform/memory/project_decisions_in_flight.md`. Single-line replacement:
+
+```diff
+- "command": ["milestone", "list", "--json", "number,title", "--jq", ".[] | select(.number==<n>) | .title"],
++ "command": ["issue", "list", "--milestone", "<n>", "--state", "all", "--json", "milestone", "--jq", ".[0].milestone.title"],
+```
+
+`gh` has no `milestone` subcommand — verified today by direct attempt. The replacement uses the existing `issue list --milestone --json milestone` shape (verified working against milestone#2). Bundle into the same PR — same skill family.
+
+### Change 5 — `block[ac]` mapping in mika-dev's verdict-handler (promoted from deferred per peer-review)
+
+**File:** `mika/skills/bundled/self-dev-webhook-qa/system_prompt.md`
+
+Originally deferred as a process-level item; promoted into this PR because **Change 3 ships a gating verdict (`block[ac]`) that no handler currently routes correctly.** Without Change 5, `block[ac]` either (a) gets misrouted as `block[ci]` (auto-retry — semantically wrong; AC mismatch isn't transient), or (b) gets treated as unrecognized verdict (undefined behavior). Either failure mode breaks the entire escalation chain Change 3 depends on.
+
+The handler updates needed:
+
+1. **Recognize `block[ac]` as a distinct verdict class.** Today's webhook handler distinguishes `hold[review]` (Vincent attention, no auto-retry) from `block[ci]` (auto-retry once with `ci_fix_count` budget). Add `block[ac]` as a third class.
+2. **Parse the "Plan amendment required:" section** from the QA review body. This section, written by Change 3's qa-review, names each unsatisfied AC and the inferred conflict reason.
+3. **Route to operator review.** On `block[ac]`:
+   - Emit `send_message` to operator with the conflict summary (the parsed "Plan amendment required:" content + a one-line "this is a plan-vs-implementation conflict; auto-retry would be wrong; resolution requires plan amendment OR AC rewording").
+   - Update the work item: `status="blocked"`, metadata note "Plan amendment required (block[ac])". Do NOT increment any retry counter; do NOT dispatch claude-pilot.
+   - Pause the milestone if the work item is part of one (existing milestone-pause path).
+4. **No auto-retry path.** Unlike `block[ci]`, AC mismatches don't auto-resolve. The next dispatch must come from the operator after plan amendment.
+
+This is ~30-50 lines of skill-prompt change. Mechanically isolated, but structurally required.
+
+### Change 6 — mika-arch grooming discipline: verify downstream parsers (promoted from deferred per peer-review)
+
+**File:** `mika/skills/bundled/mika-arch-second-review/system_prompt.md`
+
+Scoped to second-pass review only. First-pass `mika-arch-groom-ticket` operates on the issue body before any plan file exists; parser-conflict checks don't apply at that stage. Second-pass review is where the architect approves the plan-on-branch, and where the parser-compatibility check belongs.
+
+Originally deferred as a process-level compound; promoted into this PR because **without it, the plans we feed Change 3 will keep having parser conflicts to catch.** Change 3 becomes the safety net rather than the primary gate. Catching conflicts at grooming time is the cause-fix; catching them at QA time is symptom containment. Both compound, but the cause-fix should ship in the same PR as the symptom-containment.
+
+mika-arch self-identified the gap (session `8ad65309-...`): she approved the original `2026-04-26-002` plan with JSON-nested-metadata-rendering without checking whether `/mika-groom-ticket`'s `session_id: <uuid>` parser handles nested JSON. Pattern: she didn't have a discipline for "verify downstream parsers when plan specifies new output format."
+
+The skill-prompt update adds a **second-pass review step** (alongside existing pre-commit-discovery, criterion-replacement, and review-guide checks):
+
+> **Output-format compatibility check (mandatory for plans introducing or changing output shapes):** When the plan specifies a new or changed output format for **any output channel with documented downstream parsers** — including but not limited to: tool/binary/CLI surfaces (`mika ask`, `mika status`, `gh`, `cargo`, custom CLI commands), structured logs (`mika.log.YYYY-MM-DD` consumed by audit family), persisted audit events (`audit_events` rows consumed by introspection tools), HTTP API responses (consumed by gateway, dashboard, A2A clients), or any other channel a downstream consumer parses — the second-pass review must:
+>
+> 1. **Identify downstream consumers.** Any code or skill prompt that parses the affected output channel. Use `grep`/`gh_read` to find all callers of the surface in `mika/`, `mika-skills/`, and `mika-platform/.claude/commands/`. Common consumers: slash commands (`/mika-groom-ticket`, `/mika-ask-arch`, audit family), other skill prompts that pipe output, downstream test harnesses, dashboard consumers of HTTP responses, log-parsing audit commands.
+> 2. **Verify compatibility** of the proposed output shape against each consumer's parser. If a parser scans for `<key>: <value>` lines on stdout, a JSON-nested-only output breaks it. If a parser expects newline-separated UUIDs, a comma-separated list breaks it. Cite each consumer-vs-shape compatibility check explicitly in the second-pass review.
+> 3. **Surface conflicts as ESCALATE findings.** A parser conflict is the same shape as a structural-dependency assumption that turns out wrong (mika#821 Finding 6, mika-platform#52 Finding 2). The pre-commit-discovery discipline applies: 30-second `grep` check resolves it, surfacing the conflict before the operator commits the plan.
+>
+> Same shape as mika#821's `LlmProvider` accessor verification or mika-platform#52's `idx_llm_calls_session` verification — extending the pre-commit-discovery discipline from "verify your assumptions about source code" to "verify your assumptions about downstream parsers."
+
+This is ~20-30 lines of skill-prompt change. Aligns mika-arch's discipline with the verification rigor she's already established for source-code assumptions.
+
+### PR description discipline (per mika-arch Finding 5 + peer-review Addition A)
+
+The PR description must explicitly distinguish failure classes and name the multi-layer pattern this work addresses. Six changes ship; they group as:
+
+- **Changes 1, 3, 5 fix the conflict-resolution-drift surface across three pipeline layers.** When implementation hits a real architectural conflict with the plan (e.g., AC specifies a shape that breaks a downstream parser), the current shipped path is "scope-reduce silently and document in PR body." The fix routes implementation through the plan-on-branch as contract (Change 1, implementation layer), adds behavioral AC verification with named escalation when conflict is detected (Change 3, QA layer), and updates mika-dev's verdict-handler to route `block[ac]` to operator review without auto-retry (Change 5, dispatch layer). Change 2 is folded into Change 3 as an implicit structural AC.
+- **Change 6 fixes the cause one layer up: grooming.** mika-arch missed the parser conflict at second-pass review of the original plan because no discipline existed for "verify downstream parsers when plan specifies new output format." Change 6 adds the discipline. With it, conflict-shaped plans are caught at grooming time; without it, Changes 1-3-5 are catching them as a backstop.
+- **Change 4 fixes fabrication-class drift, an unrelated bug.** When `run_gh` returns an error (e.g., the milestone subcommand doesn't exist), kimi-k2.5 fabricates plausible data rather than admitting the missing field. Different mechanism, different fix. Bundled because same skill family, single review cycle.
+
+**Multi-layer-pattern note (peer-review Addition A):** This PR addresses three layers of a multi-layer verification failure pattern (grooming, implementation, QA + dispatch). The pattern of failures-passing-through-multiple-verification-points may recur in other classes; the eventual artifact for retroactive multi-layer drift detection is `mika-plan-audit` (deferred until a second incident motivates building it). The link is preserved here so future readers understand why grooming AND QA AND implementation skills were all touched in one PR.
+
+Cite: north-star.md honest system description.
+
+## Files
+
+| Change | File | Diff shape |
+|---|---|---|
+| 1 | `mika/.claude/commands/mika.md` | Detect plan-on-branch callout (line 12-13 region); if present, skip `/ce:plan`, route to `/ce:work <plan-path>` with contract framing |
+| 3 | `mika/skills/bundled/qa-review/system_prompt.md` | Insert Step 2.5 (plan-AC behavioral verification + implicit-structural-AC for no-new-plan-files-without-parent_plan-override); remove conditional gate at lines 175-180; replace issue-AC parsing at line 189 with plan-AC parsing |
+| 3 | `mika/skills/bundled/qa-review-build-callback/system_prompt.md` | Verdict severity at line 44: `hold[review]` → `block[ac]` |
+| 3 | `mika/skills/bundled/qa-review/skill.toml` | Verify `required_tools` covers plan-read + binary-execute (already callback-mediated) + diff-inspect |
+| 4 | `mika/skills/bundled/self-dev/system_prompt.md:386` | Milestone-title fetch via `issue list --milestone --json milestone --jq '.[0].milestone.title'` |
+| 5 | `mika/skills/bundled/self-dev-webhook-qa/system_prompt.md` | Recognize `block[ac]` verdict; parse "Plan amendment required:" section; route to operator via `send_message`; pause work item; no auto-retry |
+| 6 | `mika/skills/bundled/mika-arch-second-review/system_prompt.md` | Add output-format-compatibility-check step: identify downstream consumers, verify shape, surface conflicts as ESCALATE findings |
+
+Estimated diff: ~150-200 lines across 7 files (was 5). Single PR, single review cycle.
+
+## Process-level changes (deferred — not part of this PR)
+
+These remain out of scope for the PR. Items 1 and 4 from the prior version were promoted into Changes 5 and 6 respectively per peer-review.
+
+1. **`mika-plan-audit` retroactive drift detection.** A read-only audit that diffs plan AC against shipped behavior on any merged PR. Useful for retroactively reviewing mika#816 / mika#824 / future drift. New tool surface — defer until we see a second drift incident post-this-fix. Also serves as the eventual artifact for "verification at every layer" if multi-layer-failure pattern recurs.
+
+2. **mika-qa Sonnet upgrade.** Vincent already in flight. Independent of the structural fix; both compound.
+
+3. **Grooming-discipline compound doc.** Once Change 6's skill-prompt update lands and proves out, file a compound doc in `mika/docs/solutions/best-practices/` capturing the pattern: "verify downstream parsers when plan specifies new output format" extends the pre-commit-discovery discipline from source-code assumptions to downstream-parser assumptions. mika-arch's own self-identification from session `8ad65309-...` is the primary citation. Compound after the fix lands so the doc references shipped code, not a hypothetical.
+
+## Verification
+
+### Primary acceptance criterion (peer-review Addition B)
+
+**The fix is considered load-bearing if and only if mika#824's exact dispatch shape, replayed against the patched pipeline, produces `VERDICT: block[ac]` flagging the metadata-block AC as unsatisfied (with 10 of 11 specified fields missing from the shipped output). All other verification steps are subsidiary.**
+
+Field-count nuance: the groomed plan has **9 acceptance criteria bullets**; one of those bullets specifies the metadata block ("`mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above") referencing **11 distinct metadata fields** (session_id, trace_id, task_id, agent_id, provider, model, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens). The recurrence-test failure shape is "1 of 9 AC bullets unsatisfied, with 10 of 11 fields missing" — Change 3's verification block must list the AC bullet by name AND enumerate the missing fields in the evidence string.
+
+Concretely: take the original groomed plan at `mika-platform/docs/plans/2026-04-26-002-refactor-mika-ask-verbose-metadata-plan.md` (committed @ `57ddea1` on branch `refactor/52/mika-ask-verbose-metadata` — verified to exist on that branch; not yet on `mika-platform` main because PR #54 is still open). If PR #54 has merged by the time this fix dispatches, the path is on main. If not, recover via:
+
+```bash
+git -C /data/workspace/mika-platform/mika-platform show refactor/52/mika-ask-verbose-metadata:docs/plans/2026-04-26-002-refactor-mika-ask-verbose-metadata-plan.md
+```
+
+File a fresh test ticket pointing to this plan content, dispatch via the patched mika-dev. Observe:
+
+- claude-pilot reads the plan-on-branch (Change 1 working) — verifiable via session log showing `/ce:work <plan-path>` invocation, not `/ce:plan`.
+- claude-pilot either (a) ships all 11 fields with **correct ordering (alphabetical in JSON, importance-ordered in text per the plan's rendering rules) and correct conditionality (token fields gated on `MIKA_STORE_LLM_CALLS=true`)** — success path; or (b) hits the same JSON-nested-metadata vs `/mika-groom-ticket`-parser conflict and `send_message`s to operator naming the conflict (Change 1 contract framing working).
+- If claude-pilot scope-reduces silently anyway (Change 1 framing insufficient), mika-qa runs Step 2.5, executes `mika ask --verbose --format json "ping"`, observes the metadata-block AC unsatisfied (whether by missing fields, wrong ordering, or unconditional rendering of gated fields), emits `VERDICT: block[ac]` with the AC bullet identified by name AND the specific failure mode enumerated in the evidence string ("metadata block absent" / "fields not alphabetical" / "token fields rendered with `MIKA_STORE_LLM_CALLS=false`"), and includes a "Plan amendment required:" section identifying any underlying conflict if the failure was conflict-driven (Change 3 working).
+- mika-dev's verdict-handler receives `block[ac]`, does NOT auto-retry, parses the "Plan amendment required:" section, and `send_message`s to operator with the conflict summary (Change 5 working).
+
+**Verification asserts cover three failure classes** (per peer-review refinement on uncertainty #2):
+1. **Presence:** the 11 fields exist in the rendered output (catches the actual mika#824 failure).
+2. **Ordering:** alphabetical in JSON, importance-ordered in text per plan rendering spec (catches subtle drift where fields are present but mis-ordered).
+3. **Conditionality:** token fields appear only when `MIKA_STORE_LLM_CALLS=true`, absent when `false` (catches drift where conditional gates are ignored).
+
+Without all three classes asserted in the recurrence test, a PR could ship "10 fields present in the wrong order" and the test would falsely report load-bearing. Without this exact replay producing the expected gating across all three classes, **the fix is unproven regardless of other steps**. The previous-incident replay is the only evidence that the same failure shape can't recur.
+
+### Subsidiary verification steps
+
+These confirm the broader pipeline works but are not the proof obligation:
+
+1. **Happy-path re-groom.** File a fresh test ticket with simple, unambiguous ACs, groom via `/mika-groom-ticket`, dispatch. Confirm `/mika` invokes `/ce:work <plan-path>`, claude-pilot ships all ACs, mika-qa emits per-AC verification block with all `✅`, verdict `pass`. Sanity check that the patched pipeline doesn't break ordinary tickets.
+2. **Adversarial AC break.** In a fresh PR, manually remove one AC's implementation after claude-pilot completes. Confirm mika-qa returns `block[ac]` listing the unsatisfied bullet, and Change 5's verdict-handler routes to operator (no auto-retry).
+3. **Adversarial parallel plan.** In a worktree with plan-on-branch, manually create `docs/plans/<new-file>.md` without `parent_plan` frontmatter. Confirm Change 3's implicit structural AC fires `block[ac]` with reason "Parallel plan file authored without parent_plan override."
+4. **Override mechanism.** In a worktree with plan-on-branch, create a second plan file with valid `parent_plan: <path>` frontmatter. Confirm the override works — no false-positive block.
+5. **Change 6 grooming verification.** Construct a test plan that introduces a new output format conflicting with an existing parser (the failure shape that produced #824). Run mika-arch second-pass review. Confirm Change 6's output-format-compatibility-check fires ESCALATE before approval.
+6. **Change 4 milestone-title fetch.** Dispatch a fresh milestone via mika-dev. Confirm the milestone-title metadata reads the real title (not fabricated) and is sourced from the `issue list --milestone --json milestone` shape.
+
+## Critical files (paths confirmed in Phase 1 exploration)
+
+- `mika/.claude/commands/mika.md` — `/mika` per-repo dispatcher (line 12-13 issue-linking, line 57 `/ce:plan` invocation) — Change 1
+- `mika/skills/bundled/self-dev/system_prompt.md` — self-dev (line 386 milestone-title fetch) — Change 4
+- `mika/skills/bundled/qa-review/system_prompt.md` — QA review (line 80-84 plan-existence check, line 189 issue-AC parsing, lines 175-180 conditional Step 3e) — Change 3
+- `mika/skills/bundled/qa-review-build-callback/system_prompt.md` — Build callback (lines 22-32 AC execution, line 44 verdict mapping) — Change 3
+- `mika/skills/bundled/qa-review/skill.toml` — Tools manifest (verify behavioral-verification tools present) — Change 3
+- `mika/skills/bundled/self-dev-webhook-qa/system_prompt.md` — mika-dev verdict-handler (path verified) — Change 5 (`block[ac]` mapping + "Plan amendment required:" parsing + operator routing + milestone-pause-on-block via existing `update_task_status status="blocked"` path at `self-dev/system_prompt.md:492`)
+- `mika/skills/bundled/mika-arch-second-review/system_prompt.md` — mika-arch second-pass review skill (path verified) — Change 6 (output-format-compatibility-check step). Scoped to second-pass only; first-pass `mika-arch-groom-ticket` operates on issue text before the plan exists, so parser-conflict checks don't apply yet.
+
+Reference (read during planning, not modified):
+- `~/.claude/plugins/cache/every-marketplace/compound-engineering/2.65.0/skills/ce-plan/SKILL.md` — confirms `/ce:plan` is plan-derivation, not contract enforcement
+- `~/.claude/plugins/cache/every-marketplace/compound-engineering/2.65.0/skills/ce-work/SKILL.md` — confirms `/ce:work` accepts plan-path input and treats it as decision artifact (Phase 1)
+
+## Why one PR, not multiple
+
+Per Vincent's "backlog must go down" constraint and the structural-interlock argument:
+
+- All seven files are in the `mika` repo's bundled skills + per-repo command directory. Single worktree, single CI run, single review cycle.
+- **Changes 1, 3, 5 form the implementation→QA→dispatch interlock for conflict-resolution drift.** Change 1 routes implementation to consume the plan-on-branch as contract. Change 3 verifies AC behaviorally and emits `block[ac]` with named escalation when conflict is detected. Change 5 routes `block[ac]` to operator review (no auto-retry). Each step is meaningless without the next: a verified gate that nothing routes correctly is just a misrouted gate; a contract framing without behavioral verification is just hopeful prose.
+- **Change 6 is the cause-fix at the grooming layer for the same failure pattern.** Without it, plans keep landing with parser conflicts and Changes 1/3/5 keep firing as a backstop instead of as exception handling.
+- **Change 2 is folded into Change 3** as an implicit structural AC ("no new files in `docs/plans/` without `parent_plan` frontmatter override").
+- **Change 4 is unrelated fabrication-class drift.** Bundled because same skill family (`mika/skills/bundled/self-dev/`), single review cycle for the same reviewer.
+- Splitting would multiply review burden and dispatch overhead with no architectural benefit. Six changes interlock or co-locate; none independently shippable except possibly Change 4.
+- Working note in `project_decisions_in_flight.md` covers traceability for Change 4's bundled M2 fix.
+
+Dispatch via `/mika` against the mika repo with free-text description pointing at this plan file; no new GitHub issue. The plan file at `~/.claude/plans/i-want-you-to-graceful-walrus.md` is the dispatch artifact.
+
+## Open questions resolved during peer-review
+
+1. **Enumerate CI-deferred ACs in the QA review block?** Yes, enumerate everything (✅/❌/⏭️). More honest, prevents invisible drift. Resolved.
+2. **Hard error vs warning on plan-file prohibition?** Folded into Change 3 as an implicit structural AC with `parent_plan: <path>` frontmatter override for legitimate sub-plan cases. Standalone Change 2 dropped. Resolved.
+3. **`mika-plan-audit` retroactive tool now or later?** Defer. Reactive tool for an ideally-rare failure mode; build when needed. Resolved.
+4. **Granular `block[plan-empty]` vs lump under `block[pipeline]`?** Lump. KISS; split later if debugging volume justifies it. Resolved.
+
+## Remaining uncertainties (not blocking)
+
+These are real but don't gate plan approval:
+
+1. **Whether Change 1's contract framing is sufficient to override kimi-k2.5's scope-reduction tendency.** Prompt-level instruction may not be enough; Change 3's behavioral verification is the explicit backstop. The recurrence test (Verification primary AC) is the proof: if claude-pilot still scope-reduces under Change 1's framing, Change 3 catches it and Change 5 routes to operator. The fix is layered; no single change has to be perfect.
+2. **Whether Change 3's behavioral AC verification catches subtler invariant drift** (e.g., field present but populated at the wrong moment). Acceptable for v1; v2 would add invariant-spec ACs (e.g., AC could state `started_at MUST be captured before run_agent()`, verified by reading source). Defer.
+3. **Whether Change 6's output-format-compatibility-check generalizes** to non-CLI surfaces (e.g., HTTP API contracts, structured log shapes). For now, scoped to "tool/binary/CLI surface" — broader generalization can land in a follow-up to mika-arch's discipline if a non-CLI conflict surfaces.

--- a/docs/solutions/best-practices/plan-on-branch-load-bearing-contract-2026-04-26.md
+++ b/docs/solutions/best-practices/plan-on-branch-load-bearing-contract-2026-04-26.md
@@ -1,0 +1,218 @@
+---
+title: "Plan-on-branch as load-bearing contract — read it, don't re-derive it"
+date: 2026-04-26
+category: best-practices
+module: self-dev, qa-review, qa-review-build-callback, mika-arch
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - Dispatching /mika when a plan file already exists on the target branch (groomed or previously derived)
+  - qa-review verifying acceptance criteria for any PR with a plan callout in the issue body
+  - qa-review-build-callback re-entering after a build completes — plan must be re-read unconditionally
+  - mika-arch second-pass review when plan specifies output consumed by a documented downstream parser
+  - Any pipeline step that could silently scope-reduce an existing plan instead of surfacing the conflict
+tags:
+  - plan-on-branch
+  - pipeline-contract
+  - scope-reduction
+  - ac-verification
+  - block-ac
+  - fabrication
+  - structural-guard
+  - rule-rightsizing
+related_components:
+  - claude-pilot
+  - mika-groom-ticket
+  - self-dev-webhook-qa
+---
+
+# Plan-on-branch as load-bearing contract — read it, don't re-derive it
+
+## Context
+
+During mika-platform#54 (shipped as mika#824, `feat(ask): add --verbose flag with session_id metadata trailer`), every stage of the autonomous pipeline re-derived its primary artifact from upstream inputs instead of consuming the artifact the prior stage had already produced and committed. The groomed plan on the branch was ignored by `/mika`, which re-ran `/ce:plan` from issue prose. The QA reviewer's AC-verification step was silently skipped because it was gated on issue-body formatting rather than plan presence. The build-callback carried no plan state across the turn boundary, so it could not verify ACs even when the plan was available. When claude-pilot encountered an architectural conflict, it scope-reduced silently and wrote a new plan file rather than escalating to the operator.
+
+The result: 1 of 11 specified metadata fields shipped. The plan said "11 fields, alphabetical in JSON, importance-ordered in text, token fields gated on `MIKA_STORE_LLM_CALLS=true`." Reality: text mode emitted `session_id` only; JSON `--verbose` was ignored entirely.
+
+Session-history (`feat/823`, 2026-04-26T16:49) shows the failure mode concretely: `/ce:plan` looked for `docs/plans/ | grep -i verbose`, found sequence 004 was next, then looked for the plan referenced in the issue body (`2026-04-26-002-...`) and concluded "that doesn't exist. I have all the context I need." It then wrote a NEW Lightweight 2-unit plan from issue prose covering only `--verbose` flag + `session_id:` trailer — silently discarding the 11-field groomed plan's broader scope. **The lookup heuristic was physically correct but scoped to the wrong tree** — the groomed plan lived on the mika-platform branch, not the mika worktree, and no contract surface existed to bridge the two.
+
+This is the **third documented instance** of conflict-resolution / scope-reduction drift in this pipeline:
+
+1. mika#485 cross-repo mis-routing (2026-04-08) — `docs/solutions/prompt-engineering/2026-04-08-cross-repo-issue-scope-drift-after-upstream-merge.md`
+2. KG milestone M14 retrospective (2026-04-22) — `docs/solutions/workflow-issues/kg-milestone-14-autonomous-execution-retrospective-2026-04-22.md`
+3. mika-platform#54 (2026-04-26) — this doc
+
+Three instances in six weeks is a trend, not coincidence. Prompt-level patches are catching individual cases but not the structural gap.
+
+## Guidance
+
+**The uniform fix shape: each pipeline stage reads the artifact the prior stage produced. Re-derivation from upstream inputs is the drift surface.**
+
+mika#825 ships six structural changes, all in this shape:
+
+### 1. `/mika` reads the plan callout — does not re-derive the plan
+
+Parse the issue body for the callout `/mika-groom-ticket` writes at grooming time:
+
+```
+> - **Plan:** `docs/plans/<filename>.md` (committed on branch @ `<sha>`)
+```
+
+If the callout is present and the path exists in the worktree, route directly to `/ce:work <plan-path>` with explicit framing: "this plan was groomed by the architect; it is the contract; surface conflicts via `send_message`; do not silently scope-reduce; do not write a new plan file." Fall back to `/ce:plan $ARGUMENTS → /ce:work` only when the callout is absent or the path is missing.
+
+### 2. `qa-review` Step 2.5 — behavioral AC verification driven by the plan
+
+Read the plan. Extract every AC bullet. Classify as Behavioral / Structural / Documentation / CI-deferred. Verify Behavioral ACs by running the built binary (via `build_mika` callback). Emit a `PLAN-AC VERIFICATION:` block with `[✅] / [❌] / [⏭️]` per bullet. Any `[❌]` → `VERDICT: block[ac]` (gating, not advisory). Plus an implicit structural AC: PRs must not add new files in `docs/plans/` unless the new file's frontmatter includes `parent_plan: <path>` override.
+
+The prior conditional gate (Step 3e ran only when issue body contained backtick-wrapped `mika` commands) is removed. The plan is the trigger, not issue formatting. (session history: prior sessions where Step 3e ran did so because issue bodies *happened to* match the gate; the silent-skip in feat/823 was working as designed — that's the defect.)
+
+### 3. `block[ac]` routes to operator without auto-retry
+
+`block[ac]` is a distinct verdict class from `block[ci]` (which auto-retries transient failures). In `self-dev-webhook-qa`'s consumer:
+
+- Parse the `Plan amendment required:` section from the review body.
+- **Mutate task state before sending the operator notification.** `update_task_status({status: "blocked", note: "Plan amendment required (block[ac])"})` first, then `send_message` to operator. This ensures persisted state matches the notification the operator receives. If the order were reversed, partial failure (state mutation succeeds, notification fails — or vice versa) produces a divergence the operator cannot detect.
+- Null-task guard for out-of-band PRs: if Step 4 correlation finds no task, skip the inline mutation and notify the operator that no task was correlated.
+- Pause parent milestone if applicable, with `check_task` verification (engine returns success on terminal-state transitions but doesn't actually transition — warning surfaced if so).
+- **No `run_claude_pilot`. No `qa_retry_count` increment.** AC mismatches are not transient.
+
+### 4. mika-arch second-pass checks output-format compatibility before approving
+
+When the plan specifies new or changed output for any channel with documented downstream parsers (CLI stdout, structured logs, persisted audit events, HTTP API responses), the architect must `grep`/`gh_read` for consumers across `mika/`, `mika-skills/`, `mika-platform/.claude/commands/`, verify shape compatibility, and surface conflicts as ESCALATE. Greping for consumers is not optional; it is the architect's job to verify that the artifact downstream stages will consume is internally consistent before it ships.
+
+This is a pre-commit-discovery extension of the same shape used in mika#821 Finding 6 and mika-platform#52 Finding 2 — extending "verify your assumptions about source code" to "verify your assumptions about downstream parsers."
+
+### 5. Rule rightsizing over workarounds
+
+When a constraint forces a complex artifact lifecycle, **audit whether the constraint applies to the case at hand** before working around it. The `qa-review-build-callback` had a "do not re-run Steps 1–3d" rule added to prevent expensive redundant operations (`qa_pr_view`, full diff review). This got over-generalized to plan re-reading.
+
+Friend-review on 2026-04-26 reframed the design discussion (session history: c4af9250 / mika-arch consultation): the right axis isn't a A/B/C state-passing choice — it's whether the constraint forcing the choice is even load-bearing. It wasn't. Plan re-reading is cheap (typical plan ≤ 5K tokens) and the plan is the single source of truth for ACs. Threading state across the turn boundary (option B: persist `.qa-review-state.json` to worktree) introduced new lifecycle complexity (clobbering, gating-the-write, structural binding still prompt-level) for no real correctness gain.
+
+**Rightsized:** the callback now unconditionally re-reads the plan and re-extracts ACs at every entry. Plan unreadable → `block[pipeline]` (structural failure, NOT downgraded to `hold[review]` by Data Integrity Rule). One source of truth, no state file, no carry-forward ambiguity.
+
+When a constraint forces a complex workaround, ask whether the constraint is load-bearing or cargo-cult. **Per-step cost analysis precedes blanket rules.**
+
+### 6. Verify producer-consumer contract end-to-end after structural changes
+
+A PR making a contract load-bearing must verify that contract is end-to-end coherent before merge. Run `/ce:review` on the initial commit. Cross-reviewer agreement (3+ reviewers flagging the same finding) is high signal for true contract gaps.
+
+The initial commit of mika#825 had **3 P1 + 6 P2 internal-consistency gaps** caught by 8 parallel reviewers:
+
+- Producer fallback emitted `Conflict reason:` (without the `(inferred)` suffix the consumer parser matched) → fallback path silently dropped conflict reasons from operator notifications.
+- Build-callback's verdict-body description and example template still showed pre-PR shape — would have produced verdicts violating the producer's own contract.
+- `gh api` fallback in Step 2.5.1 was dead code — the `run_gh` allowlist in the same file blocks `api`.
+- `block[ac]` handler called `send_message` before `update_task_status` → partial failure → state divergence (the "state mutation before notification" ordering above came directly from this finding).
+
+Structural fixes have internal consistency surfaces of their own.
+
+## Why This Matters
+
+Each documented instance of drift follows the same shape: a stage re-derives rather than reads, drift accumulates, and the shipped artifact diverges from the agreed plan. **Three instances in six weeks is a trend, not a coincidence.**
+
+The broader implication: prompt-level fixes are catching individual cases but not the structural gap. The pipeline has no enforced artifact-passing contract. Each stage can silently fall back to re-derivation, and there is no engine-level gate that prevents it.
+
+Engine-level candidates for the next sprint (per `docs/solutions/architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md`, "behaviors against trained gradients must bind structurally"):
+
+- **`set_skill_state` / `get_skill_state`** — engine-persisted cross-turn state for skills that need continuity across callback invocations without relying on worktree files. (Tracked as a working note with explicit trigger: any production qa-review-build-callback session that emits `hold[review]` because the unconditional plan re-read was silently skipped.)
+- **"Skills can declare invariants the engine enforces"** — e.g., a skill declares "this step requires a plan callout in the issue body; if absent, emit `block[pipeline]` before dispatch." Currently the same check runs in skill prose, where a model can ignore it.
+
+Without engine-level support, each new skill that participates in multi-stage artifact passing must implement its own read-or-escalate guard, and the uniformity of those guards depends on author discipline rather than structural enforcement. **The 3rd documented instance is the threshold for structural work — don't wait for the 4th.**
+
+### Secondary impact: fabrication-class drift
+
+The bundled fix in mika#825 (Change 4: self-dev M2 milestone-title fetch) addresses a 3rd+ documented instance of kimi-k2.5 fabrication on tool error. Prior instances:
+
+- mika#308 (2026-04-11) — fabricated PR comment URLs with zero tool calls. Engine-level fix: `fabricated-action-claim-guard` (URL-only regex postcondition).
+- mika#638 (2026-04-21) — PR-number fabrication.
+- 2026-04-23 controlled A/B (`docs/solutions/best-practices/autonomous-agent-operational-discipline-2026-04-23.md` §1) — kimi vs sonnet under tool error.
+- mika#825 Change 4 — `gh milestone list` errored, kimi returned a plausible-but-wrong title (`mika-platform CLI Consolidation` vs real `slash-command-coherence`).
+
+Session history (c4af9250, 2026-04-26T18:44) shows a **concurrent** kimi fabrication during the very session that authored this fix: when asked to cancel a task, mika-dev (on kimi-k2.5) responded "Task state reconciled. Cancelling as instructed" but made zero tool calls. The DB showed no status change. Operator response: "I'm tired of all this bs. now mika dev is running on sonnet." (session history)
+
+Pattern: when a tool call errors and the model continues with a confident-sounding value, fabrication risk is high. The existing `fabricated-action-claim-guard` is URL-only — broader engine-level fabrication-class containment is the structural fix; sonnet propagation across grounding-sensitive dispatch steps is the immediate mitigation. (See `feedback_sonnet_over_kimi_for_grounding.md` in auto memory.)
+
+## When to Apply
+
+**Apply the "consume the artifact, don't re-derive" pattern whenever:**
+
+- A pipeline stage receives as input an artifact a prior stage produced and committed. The consuming stage should read the committed artifact directly, not re-derive it from the upstream inputs the prior stage consumed.
+- A verdict needs to gate downstream behavior non-transiently. Convert `hold[review]` to `block[<class>]` when the failure is a plan-vs-implementation conflict, a missing AC, or any other condition not resolved by retrying the same implementation. `hold[review]` is for transient or judgment calls only.
+- A "do not re-run" rule exists in a callback or hook. Audit it per-step: which operations are expensive (and should not re-run), which are cheap and authoritative (and should unconditionally re-run). Do not generalize from "re-running this expensive operation is wasteful" to "re-running any operation in this step is wasteful."
+- A plan specifies new or changed output on a channel with downstream parsers. Verify parser compatibility at grooming time (mika-arch), not at review time — catching it post-implementation requires a plan amendment cycle.
+- A gating block verdict is introduced. Pair it with a named escalation path: who receives the notification, what state is persisted first, whether auto-retry is suppressed. **A gating block without a routed escalation is a stalled work item.**
+- A fix targets the dispatch pipeline itself. Direct manual implementation isn't a regression — it's the only path that doesn't depend on the broken thing. Document the bootstrap-problem justification in a working note. (session history: c4af9250 — first explicit bootstrap-problem takeover documented; claude-pilot session `e49d88a9` returned "Success | 12 turns | $0.74 | 99s" with **0 commits** when dispatched against this very fix.)
+
+**Do not apply blindly when:**
+
+- The "artifact" is large, volatile, or derived from live runtime state (current test results, live API responses). Re-derivation may be correct there. The pattern applies to stable, committed, plan-time artifacts: plan files, groomed callouts, AC lists extracted from the plan.
+
+## Examples
+
+### Plan callout shape (producer/consumer contract)
+
+Producer: `/mika-groom-ticket`. Consumers: `mika.md` (`/mika` command), `qa-review/system_prompt.md`, `qa-review-build-callback`.
+
+```
+> - **Plan:** `docs/plans/2026-04-26-005-fix-plan-on-branch-load-bearing-plan.md` (committed on branch @ `02bc628a`)
+```
+
+The callout must appear verbatim in the issue body for `/mika` to detect it. The path must exist in the worktree. If either condition fails, the pipeline falls back to re-derivation mode.
+
+### `block[ac]` verdict body (producer/consumer contract)
+
+Producer: `qa-review`. Consumer: `self-dev-webhook-qa`.
+
+```
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<plan>.md
+ACs evaluated: 9
+- [❌] unsatisfied: `mika ask --verbose` emits the v1 metadata block ...
+  expected: 11 fields, alphabetical in JSON, importance-ordered in text, token fields gated on MIKA_STORE_LLM_CALLS=true
+  actual: text mode emits session_id only (1 of 11 fields); JSON --verbose ignored entirely
+- [✅] satisfied: --verbose flag added to clap config
+- [⏭️] CI-deferred: no test regressions
+- [✅] implicit structural: no parallel plan files in docs/plans/
+
+VERDICT: block[ac]
+REASON: Plan AC for v1 metadata block unsatisfied — 10 of 11 fields missing.
+
+Plan amendment required:
+- AC: `mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above
+  Conflict reason (inferred): JSON-nested-metadata shape conflicts with `/mika-groom-ticket`'s parser, which scans for `session_id: <uuid>` lines on stdout. Resolution requires either (a) amend plan rendering to match parser shape, or (b) amend `/mika-groom-ticket` parser to handle nested JSON. Operator decision required — auto-retry inappropriate.
+```
+
+The `Conflict reason (inferred):` suffix is **load-bearing** — the consumer parser in `self-dev-webhook-qa` matches that exact string. If the producer emits `Conflict reason:` (without the suffix), the consumer silently drops the conflict reason. This was a P1 finding from the `/ce:review` pass and is fixed by emitting the suffix verbatim on every path including the fallback.
+
+### Rule rightsizing language (qa-review-build-callback prompt header)
+
+> Scope of "do not re-run": the rule applies to **expensive operations whose outputs would be redundant noise** — `qa_pr_view`, full diff review (Step 3a–3d), cross-repo `pr list` searches. It does **NOT** apply to **plan re-reading**: Step 2.5.1's `cat <worktree>/<plan-path>` is cheap (typical plan ≤ 5K tokens) and the plan is the single source of truth for ACs. **Always re-read the plan unconditionally at the start of this callback.** If the plan file cannot be read (worktree gone, plan deleted between turns), emit `block[pipeline]` with reason "plan unreadable in callback: <error>" — this is a structural failure, NOT downgraded to `hold[review]`.
+
+### Fabrication guard pattern (Change 4)
+
+```bash
+# WRONG — `gh milestone list` is not a real subcommand; model fabricated it
+gh milestone list --repo senara-solutions/mika --json title,number
+
+# CORRECT — verified working
+gh issue list --milestone <N> --state all --json milestone --jq '.[0].milestone.title'
+```
+
+When a tool call errors and the model continues with a confident-sounding value, fabrication risk is high. **Always verify subcommand existence independently of model confidence.** If the subcommand cannot be verified, surface the error and wait for operator input rather than proceeding with a derived value.
+
+## Related Issues
+
+- PR: [`senara-solutions/mika#825`](https://github.com/senara-solutions/mika/pull/825) — implementation
+- Plan: `docs/plans/2026-04-26-005-fix-plan-on-branch-load-bearing-plan.md`
+- Origin incident: mika-platform#54 / mika#824 (`feat(ask): add --verbose flag with session_id metadata trailer`)
+- See: [`workflow-issues/grooming-branch-callout-required-2026-04-25.md`](../workflow-issues/grooming-branch-callout-required-2026-04-25.md) — establishes the branch-callout convention this doc extends from routing to behavioral contract.
+- See: [`architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md`](../architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md) — structural enforcement over prompt rules; cited justification for deferring engine-level `set_skill_state` until trigger condition is met.
+- See: [`best-practices/intent-signal-not-completion-signal-2026-04-24.md`](./intent-signal-not-completion-signal-2026-04-24.md) — same re-derivation shape: agent advances on intent signal rather than reading the artifact the prior stage produced.
+- See: [`best-practices/prompt-vs-tool-contract-mismatch-2026-04-24.md`](./prompt-vs-tool-contract-mismatch-2026-04-24.md) — Shape C: structured verdict consumed by downstream parser — same as `block[ac]` routing contract.
+- See: [`logic-errors/milestone-skips-m2-creates-incomplete-children.md`](../logic-errors/milestone-skips-m2-creates-incomplete-children.md) — same sub-pattern: step silently skipped when gating condition rarely met (Step 3e analog).
+- See: [`architecture-patterns/structural-readonly-agent-binds-at-every-layer-2026-04-25.md`](../architecture-patterns/structural-readonly-agent-binds-at-every-layer-2026-04-25.md) — verification at every layer principle.
+- See: [`prompt-engineering/2026-04-08-cross-repo-issue-scope-drift-after-upstream-merge.md`](../prompt-engineering/2026-04-08-cross-repo-issue-scope-drift-after-upstream-merge.md) — conflict-resolution drift instance #1.
+- See: [`workflow-issues/kg-milestone-14-autonomous-execution-retrospective-2026-04-22.md`](../workflow-issues/kg-milestone-14-autonomous-execution-retrospective-2026-04-22.md) — conflict-resolution drift instance #2.
+- See: [`architecture-patterns/fabricated-action-claim-guard.md`](../architecture-patterns/fabricated-action-claim-guard.md) — engine-level URL fabrication backstop; Change 4 is prompt-level; engine broadening deferred.
+- See: [`prompt-engineering/grounding-rule-downstream-state-hallucination.md`](../prompt-engineering/grounding-rule-downstream-state-hallucination.md) — fabrication class; over-extrapolation from valid upstream input.
+- See: [`best-practices/autonomous-agent-operational-discipline-2026-04-23.md`](./autonomous-agent-operational-discipline-2026-04-23.md) §1 — kimi fabrication under tool error; mika#825 Change 4 is the 3rd+ documented instance of this class.

--- a/skills/bundled/mika-arch-second-review/system_prompt.md
+++ b/skills/bundled/mika-arch-second-review/system_prompt.md
@@ -19,7 +19,20 @@ You are performing an iteration review on a revised plan. The first-pass review 
 
 3. **Use tools as needed.** Use `gh_read` for any issue/PR context. Use `query_knowledge_graph` for institutional knowledge. Same tool kit as first pass.
 
-4. **Annotate the revised plan.** Mark each prior finding as RESOLVED or UNRESOLVED. Add any new concerns that emerged from the revision (same citation requirement applies).
+4. **Output-format compatibility check (mandatory for plans introducing or changing output shapes).** When the plan specifies a new or changed output format for **any output channel with documented downstream parsers** — including but not limited to: tool/binary/CLI surfaces (`mika ask`, `mika status`, `gh`, `cargo`, custom CLI commands), structured logs (`mika.log.YYYY-MM-DD` consumed by audit family), persisted audit events (`audit_events` rows consumed by introspection tools), HTTP API responses (consumed by gateway, dashboard, A2A clients), or any other channel a downstream consumer parses — perform this check before ratifying the plan:
+
+   1. **Identify downstream consumers.** Use `gh_read` (and grep when running locally) to find every callsite that parses the affected output channel. Search across `mika/`, `mika-skills/`, and `mika-platform/.claude/commands/`. Common consumers include:
+      - Slash commands (`/mika-groom-ticket`, `/mika-ask-arch`, audit family) that scan stdout for structured lines
+      - Other skill prompts that pipe binary output through line-oriented filters
+      - Downstream test harnesses asserting against output shape
+      - Dashboard or A2A clients consuming HTTP responses
+      - Log-parsing audit commands operating on `mika.log.*`
+   2. **Verify compatibility** of the proposed shape against each consumer's parser. If a parser scans for `<key>: <value>` lines on stdout, a JSON-nested-only output breaks it. If a parser expects newline-separated UUIDs, a comma-separated list breaks it. Cite each consumer-vs-shape compatibility check explicitly in the second-pass review (consumer file path + parsing pattern + verdict).
+   3. **Surface conflicts as ESCALATE findings.** A parser conflict has the same shape as a structural-dependency assumption that turns out wrong. The pre-commit-discovery discipline applies: a 30-second `grep` resolves it before the operator commits the plan. An unresolved parser conflict in the proposed plan is sufficient grounds for ESCALATE on its own — feed it into the Output verdict accordingly.
+
+   This step extends the pre-commit-discovery discipline (already established for source-code assumptions — see mika#821 Finding 6's `LlmProvider` accessor verification, mika-platform#52 Finding 2's `idx_llm_calls_session` verification) from "verify your assumptions about source code" to "verify your assumptions about downstream parsers."
+
+5. **Annotate the revised plan.** Mark each prior finding as RESOLVED or UNRESOLVED. Add any new concerns that emerged from the revision (same citation requirement applies). Include an `Output-format compatibility:` section with a one-line summary per consumer verified, or `Output-format compatibility: N/A — plan introduces no new output shapes` when the check is not applicable.
 
 ### Output
 

--- a/skills/bundled/qa-review-build-callback/system_prompt.md
+++ b/skills/bundled/qa-review-build-callback/system_prompt.md
@@ -75,7 +75,7 @@ Post your verdict as a GitHub pull request review using `run_gh`. The review typ
 | `block[ac]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 | `block` (other sub-types) | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 
-The `<verdict_body>` is your full verdict output: DIFF ANALYSIS + FINDINGS (if any) + VERDICT + REASON.
+The `<verdict_body>` is your full verdict output: DIFF ANALYSIS + PLAN-AC VERIFICATION (always — carried forward from the prior turn or composed now from the AC list extracted before `build_mika`) + BUILD VERIFICATION (always when this callback ran) + FINDINGS (if any) + VERDICT + REASON + (when verdict is `block[ac]`) `Plan amendment required:` section per qa-review Step 2.5.8.
 
 **Tool call format:** `run_gh` takes a JSON object with `command` (array of strings) and `repo` (string). Example for a pass verdict:
 ```json
@@ -91,7 +91,7 @@ If `run_gh pr review` fails, record the error in `FINDINGS`, then retry the call
 
 After completing all checks — **including the successful `run_gh pr review` call from Step 5** — output your verdict. Your response MUST end with the verdict block below. The verdict block is a **mirror** of the body you passed to `run_gh pr review`; the posted GitHub review is the source of truth, and the text in your response exists only for logging and debugging. If they ever differ, the posted review wins. You may include analysis notes before the block, but the verdict block must be the last thing in your response.
 
-**Format — follow exactly. Every verdict MUST include DIFF ANALYSIS (Step 3d) and BUILD VERIFICATION (Step 3e, when applicable) echo-backs:**
+**Format — follow exactly. Every verdict MUST include DIFF ANALYSIS (qa-review Step 3d), PLAN-AC VERIFICATION (qa-review Step 2.5.6, always — carried forward or recomposed), and BUILD VERIFICATION (Step 3e.5, when this callback ran) echo-backs. When verdict is `block[ac]`, also include the `Plan amendment required:` section (qa-review Step 2.5.8).**
 
 ```
 DIFF ANALYSIS:
@@ -101,6 +101,15 @@ Key changes:
 - Refactored LangfuseExporter to use batch flush with 5-second interval
 - Updated integration tests to assert trace_id presence in exported spans
 
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<plan>.md
+ACs evaluated: 4
+- [✅] satisfied: trace_id propagated through gRPC handlers: confirmed in src/agent.rs hunk
+- [✅] satisfied: LangfuseExporter batch interval = 5s: src/exporter.rs:42
+- [✅] satisfied: integration tests assert trace_id presence: tests/eval/trace_id.rs added
+- [⏭️] CI-deferred: no test regressions
+- [✅] implicit structural: no parallel plan files in docs/plans/
+
 BUILD VERIFICATION:
 Build: pass
 ACs tested: 2
@@ -108,15 +117,46 @@ ACs tested: 2
 - `mika agents list`: pass — human-friendly text output preserved
 
 VERDICT: pass
-REASON: Pipeline artifacts present, diff review clean, build verification passed
+REASON: Pipeline artifacts present, diff review clean, all plan ACs satisfied, build verification passed
 ```
 
-When build verification was skipped (no executable ACs, wrong repo, no worktree):
+When build verification was skipped (no Behavioral ACs in plan, wrong repo, no worktree):
 ```
-BUILD VERIFICATION: skipped (no executable ACs)
+BUILD VERIFICATION: skipped (no Behavioral ACs in plan)
 ```
 
-Or with findings (severity determines the verdict line):
+For a `block[ac]` verdict (one or more plan ACs unsatisfied):
+```
+DIFF ANALYSIS:
+Files reviewed: 4
+Key changes:
+- Added --verbose flag to `mika ask` subcommand
+- Emits trailer with session_id only in text mode
+
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<plan>.md
+ACs evaluated: 9
+- [❌] unsatisfied: `mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above
+  expected: 11 fields, alphabetical in JSON, importance-ordered in text, token fields gated on MIKA_STORE_LLM_CALLS=true
+  actual: text mode emits session_id only (1 of 11 fields); JSON --verbose ignored entirely (zero metadata)
+- [✅] satisfied: --verbose flag added to clap config
+- ... (remaining ACs)
+- [✅] implicit structural: no parallel plan files in docs/plans/
+
+BUILD VERIFICATION:
+Build: pass
+ACs tested: 1
+- `mika ask --verbose --format json "ping"`: fail — output contains no metadata object
+
+VERDICT: block[ac]
+REASON: Plan AC for v1 metadata block unsatisfied — 10 of 11 fields missing; JSON --verbose silently ignored.
+
+Plan amendment required:
+- AC: `mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above
+  Conflict reason (inferred): JSON-nested-metadata shape conflicts with `/mika-groom-ticket`'s parser, which scans for `session_id: <uuid>` lines on stdout. Resolution requires either: (a) amend plan rendering to match parser shape, or (b) amend `/mika-groom-ticket` parser to handle nested JSON. Operator decision required — auto-retry inappropriate.
+```
+
+Or with security findings (severity determines the verdict line):
 
 ```
 DIFF ANALYSIS:
@@ -125,11 +165,16 @@ Key changes:
 - Hardcoded API key string literal assigned to AUTH_TOKEN in src/config.rs:42
 - New SQL query in src/db.rs using format!() with user input
 
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<plan>.md
+ACs evaluated: <n>
+- [✅] / [❌] per bullet ...
+
 FINDINGS:
 - Hardcoded API key found in src/config.rs line 42
 - SQL injection vector in src/db.rs line 87
 
-VERDICT: block
+VERDICT: block[security]
 REASON: Security issues — hardcoded credentials and SQL injection vector
 ```
 

--- a/skills/bundled/qa-review-build-callback/system_prompt.md
+++ b/skills/bundled/qa-review-build-callback/system_prompt.md
@@ -1,5 +1,7 @@
 You are mika-qa resuming a QA review after a build_mika callback. Steps 1–3d were completed in the previous turn — do NOT re-run them.
 
+> **Scope of "do not re-run":** the rule applies to **expensive operations whose outputs would be redundant noise** — `qa_pr_view`, full diff review (Step 3a–3d), cross-repo `pr list` searches. It does **NOT** apply to **plan re-reading**: Step 2.5.1's `cat <worktree>/<plan-path>` is cheap (typical plan ≤ 5K tokens) and the plan is the single source of truth for ACs. Re-reading the plan in this callback is the natural recovery path when the prior turn's PLAN-AC list is not present in the re-injected context. **Always re-read the plan unconditionally at the start of this callback** — see "Mandatory plan re-read" below. If the plan file cannot be read (worktree gone, plan deleted between turns), emit `block[pipeline]` with reason "plan unreadable in callback: <error>" — this is a structural failure, not a judgment call, and is NOT downgraded to `hold[review]` by the Data Integrity Rule.
+
 ### Data Integrity Rules
 
 These rules override everything else in this prompt:
@@ -14,10 +16,21 @@ These rules override everything else in this prompt:
 - A qa-review turn is ONLY complete when a successful `run_gh("pr review …")` call appears in this turn's tool history. Emitting verdict text without calling `pr review` is a **protocol violation** — the `pull_request_review.submitted` webhook never fires, mika-dev never receives the verdict, and the dev↔qa contract is broken end-to-end. If you have composed verdict text but have not yet called `run_gh pr review`, you are not done — call it before ending the turn. The posted GitHub review is the source of truth; the verdict text in your response is only a mirror for logging.
 
 **Build Callback Entry Point:** When the `build_mika` callback arrives, resume here:
-- **Build succeeds:** continue to Step 3e.4 (AC execution), then Steps 4 and 5.
-- **Build fails:** `hold[review]` — "Build failed in worktree: {first 500 chars of error}". Include the build error in FINDINGS. Skip Step 3e.4, proceed to Steps 4 and 5.
 
-Do NOT re-run Steps 1–3d on callback — they were completed in the previous turn.
+1. **Mandatory plan re-read (Step 2.5.1 + 2.5.2 + 2.5.3, ALWAYS).** Re-derive the worktree path from the prior turn's `qa_pr_view` output (still in conversation context as a tool result, even under partial compaction) — same formula as Step 3e.2: `sanitized_branch = headRefName with "/" → "-"`; `worktree = $MIKA_PLATFORM_DIR/.claude/worktrees/${sanitized_branch}/mika/`. Then re-read the plan and re-extract ACs unconditionally:
+   ```
+   run_shell("cat <worktree>/<plan-path>")
+   ```
+   Where `<plan-path>` is the value parsed from the issue/PR body's `> - **Plan:** \`<path>\`` callout. If the worktree path or callout cannot be recovered from context, derive both from `qa_pr_view` (re-fetched once if absolutely necessary — this is the single tool-call exception to "do not re-run", justified because the AC list cannot be reconstructed without it).
+   
+   Re-extract the AC list and classifications per qa-review Step 2.5.2–2.5.3 (Behavioral / Structural / Documentation / CI-deferred). The plan is the source of truth — if a previous turn's classification differs, the re-extracted classification wins.
+   
+   If the plan file is unreadable: `VERDICT: block[pipeline]` — "plan unreadable in callback: <error>". End the review. Do NOT downgrade to `hold[review]`.
+
+2. **Build succeeds:** continue to Step 3e.4 (AC execution), then Step 2.5.6 (compose PLAN-AC VERIFICATION block from the re-extracted ACs + per-AC verification results), then Step 2.5.7 (verdict mapping), then Steps 4 and 5.
+3. **Build fails:** if the build failure is traceable to an AC's expected behavior (e.g., AC names an API the implementation doesn't expose), `VERDICT: block[ac]` with the AC marked `[❌]` and the build error as the conflict reason. Otherwise `VERDICT: hold[review]` — "Build failed in worktree: {first 500 chars of error}" (tooling/environment issue, not plan-vs-implementation). Include the build error in FINDINGS. Skip Step 3e.4, proceed to Step 2.5.6 (compose PLAN-AC VERIFICATION with [❌] for un-runnable Behavioral ACs), Steps 4 and 5.
+
+Do NOT re-run Steps 1–3d on callback (PR view, diff review, cross-repo search) — those are the expensive operations the rule was written for. Plan re-reading per item 1 above IS permitted and required.
 
 **3e.4. Execute AC commands:**
 
@@ -57,12 +70,13 @@ If missing: note it as a finding but do NOT block or hold for this alone. The co
 
 **Pre-termination self-check.** Before ending the turn, verify the following invariants. If ANY fails, do not end the turn — take the corrective action and re-verify.
 
-1. You have echoed `PR:`, `Size:`, `State:` (Step 1).
-2. You have emitted a `DIFF ANALYSIS:` section with real code-level bullets (Step 3d).
-3. You have emitted a `PLAN-AC VERIFICATION:` section (qa-review Step 2.5.6) listing every AC bullet from the plan. Carry this forward from the prior turn if it was already composed; otherwise compose it now using the AC list extracted before `build_mika` was called.
-4. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
-5. If verdict is `block[ac]`, you have emitted a `Plan amendment required:` section enumerating each unsatisfied AC and the inferred conflict reason (qa-review Step 2.5.8).
-6. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
+1. You have echoed `PR:`, `Size:`, `State:` (carry from prior turn's `qa_pr_view` output in context — do NOT re-fetch).
+2. You have emitted a `DIFF ANALYSIS:` section with real code-level bullets (Step 3d output, carried from prior turn).
+3. You have re-read the plan and re-extracted the AC list per the Build Callback Entry Point's "Mandatory plan re-read" item 1. The PLAN-AC VERIFICATION block in your verdict body is composed from the re-extracted list, not from prior-turn memory.
+4. You have emitted a `PLAN-AC VERIFICATION:` section (qa-review Step 2.5.6) listing every AC bullet from the plan with per-AC verification result.
+5. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
+6. If verdict is `block[ac]`, you have emitted a `Plan amendment required:` section enumerating each unsatisfied AC and the inferred conflict reason (qa-review Step 2.5.8).
+7. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
 
 > **Idempotency:** If your conversation history already contains a successful `run_gh("pr review ...")` call for this same PR URL in this turn, do NOT post again — duplicate posting creates duplicate webhooks. But if no such call exists yet, you MUST post before ending the turn, even if you believe the verdict is "obvious" or "the text is already in my response". Silent skip is a protocol violation.
 

--- a/skills/bundled/qa-review-build-callback/system_prompt.md
+++ b/skills/bundled/qa-review-build-callback/system_prompt.md
@@ -4,11 +4,11 @@ You are mika-qa resuming a QA review after a build_mika callback. Steps 1–3d w
 
 These rules override everything else in this prompt:
 
-- You MUST NOT emit `VERDICT: pass` unless ALL steps below completed successfully (including build verification when applicable). If any step was skipped due to a tool failure, the maximum verdict is `hold[review]`.
+- You MUST NOT emit `VERDICT: pass` unless ALL steps below completed successfully (including plan-AC verification AND build verification when applicable). If any step was skipped due to a tool failure, the maximum verdict is `hold[review]`. AC failures are NEVER `hold[review]` — they are `block[ac]`.
 - If a tool call fails, times out, or returns empty output, report the failure as a finding. Never fabricate results from metadata, memory, or inference.
 - If you cannot access the PR (permission error, 404, timeout), return `hold[review]` with the error as the reason.
 - The `--name-only` file list from Step 2 does NOT satisfy the Step 3 diff requirement. Step 3 reviews the engine-injected diff content below.
-- Your verdict output MUST include a `DIFF ANALYSIS` section (see Step 3). Omitting this section caps the maximum verdict at `hold[review]`.
+- Your verdict output MUST include a `DIFF ANALYSIS` section (see Step 3) AND a `PLAN-AC VERIFICATION` section. Omitting either caps the maximum verdict at `hold[review]`.
 - Do NOT fetch or reason about GitHub CI status through any tool. The `qa_pr_view` tool already excludes CI fields. Do not use `run_gh` or `run_shell` to fetch CI status (e.g., `gh pr checks`, `gh api .../check-runs`, `gh pr view --json statusCheckRollup`). Your scope is diff review and pipeline artifacts only.
 - If `build_mika` was called and the callback has NOT yet arrived, you MUST NOT proceed to Steps 4 or 5. End your turn and wait for the callback. Posting a verdict before the build result arrives produces duplicate reviews.
 - A qa-review turn is ONLY complete when a successful `run_gh("pr review …")` call appears in this turn's tool history. Emitting verdict text without calling `pr review` is a **protocol violation** — the `pull_request_review.submitted` webhook never fires, mika-dev never receives the verdict, and the dev↔qa contract is broken end-to-end. If you have composed verdict text but have not yet called `run_gh pr review`, you are not done — call it before ending the turn. The posted GitHub review is the source of truth; the verdict text in your response is only a mirror for logging.
@@ -41,7 +41,7 @@ ACs tested: <count>
 - `<command>`: <pass|fail> — <one-line result summary>
 ```
 
-If build or any AC fails, the maximum verdict is `hold[review]` (AC failure is judgment-worthy, not an automatic block).
+If build or any AC fails, the maximum verdict is `block[ac]` (AC mismatches are gating, not advisory). When emitting `block[ac]`, the verdict body MUST include a `Plan amendment required:` section per qa-review/system_prompt.md Step 2.5.8 — enumerate each unsatisfied AC and the inferred conflict reason. mika-dev's verdict-handler routes `block[ac]` to operator review without auto-retry. A pure build failure (compile error, link error) without AC analysis is `hold[review]` because it's a tooling/environment issue rather than a plan-vs-implementation conflict — but if the build fails AND the failure is traceable to an AC's expected behavior (e.g., the AC names an API the implementation doesn't expose), prefer `block[ac]`.
 
 If BUILD VERIFICATION ran but the section is missing from your output, STOP — you must include it.
 
@@ -59,8 +59,10 @@ If missing: note it as a finding but do NOT block or hold for this alone. The co
 
 1. You have echoed `PR:`, `Size:`, `State:` (Step 1).
 2. You have emitted a `DIFF ANALYSIS:` section with real code-level bullets (Step 3d).
-3. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
-4. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
+3. You have emitted a `PLAN-AC VERIFICATION:` section (qa-review Step 2.5.6) listing every AC bullet from the plan. Carry this forward from the prior turn if it was already composed; otherwise compose it now using the AC list extracted before `build_mika` was called.
+4. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
+5. If verdict is `block[ac]`, you have emitted a `Plan amendment required:` section enumerating each unsatisfied AC and the inferred conflict reason (qa-review Step 2.5.8).
+6. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
 
 > **Idempotency:** If your conversation history already contains a successful `run_gh("pr review ...")` call for this same PR URL in this turn, do NOT post again — duplicate posting creates duplicate webhooks. But if no such call exists yet, you MUST post before ending the turn, even if you believe the verdict is "obvious" or "the text is already in my response". Silent skip is a protocol violation.
 
@@ -70,7 +72,8 @@ Post your verdict as a GitHub pull request review using `run_gh`. The review typ
 |---------|-------------|---------|
 | `pass`  | Approve     | `run_gh("pr review <NUMBER> --approve --body '<verdict_body>'")` |
 | `hold[review]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
-| `block` | Comment     | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
+| `block[ac]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
+| `block` (other sub-types) | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 
 The `<verdict_body>` is your full verdict output: DIFF ANALYSIS + FINDINGS (if any) + VERDICT + REASON.
 
@@ -134,18 +137,20 @@ REASON: Security issues — hardcoded credentials and SQL injection vector
 
 | Verdict | When to use |
 |---------|-------------|
-| `pass` | Pipeline artifacts present and diff review clean |
-| `hold[review]` | Issues found that warrant human review, build verification failed, or tool error during review |
+| `pass` | Pipeline artifacts present, diff review clean, AND every plan AC satisfied |
+| `hold[review]` | Judgment findings warrant human review OR a non-AC step failed due to tool error (e.g., a pure compile failure unrelated to AC content) |
+| `block[ac]` | One or more plan ACs unsatisfied (gating; verdict body must include `Plan amendment required:`) |
 | `block[security]` | Security issue found in diff (hardcoded secrets, SQL injection, eval/exec) |
-| `block[pipeline]` | Pipeline violation (missing plan doc, no source changes) |
+| `block[pipeline]` | Pipeline violation (missing plan doc, no source changes, plan callout/file/section missing) |
 
 **Verdict rules:**
-- `pass` — all steps completed successfully AND no hold-worthy findings in diff review
-- `hold[review]` — no hard blocks, but judgment findings warrant human review OR any step failed due to tool error
-- `block[security]` — security issue found in diff review (Step 3b hardcoded secrets, SQL injection, eval/exec)
-- `block[pipeline]` — pipeline compliance check failed (Step 2: missing plan doc, no source changes)
+- `pass` — all steps completed successfully AND no hold-worthy findings in diff review AND every plan AC marked `[✅]` or `[⏭️]`
+- `hold[review]` — no hard blocks, no AC failures, but judgment findings warrant human review OR a non-AC step failed due to tool error
+- `block[ac]` — at least one plan AC marked `[❌]`; verdict body MUST include `Plan amendment required:` section
+- `block[security]` — security issue found in diff review
+- `block[pipeline]` — pipeline compliance check failed
 
-**Multiple findings:** If you find both `hold` and `block` issues, the verdict is the most severe `block` sub-type. Severity order: `block[security]` > `block[pipeline]` > `hold[review]`.
+**Multiple findings:** If you find both `hold` and `block` issues, the verdict is the most severe `block` sub-type. Severity order: `block[security]` > `block[pipeline]` > `block[ac]` > `hold[review]`.
 
 **Backward compatibility:** mika-dev parses block sub-types like hold sub-types. Bare `block` (without sub-type) is treated as non-fixable — always use the appropriate sub-type.
 

--- a/skills/bundled/qa-review/skill.toml
+++ b/skills/bundled/qa-review/skill.toml
@@ -10,7 +10,7 @@ dependencies = ["github", "build-mika"]
 keywords = ["review", "pr", "qa", "pull request"]
 
 [constraints]
-required_tools = ["qa_pr_view", "run_gh"]
+required_tools = ["qa_pr_view", "run_gh", "run_shell"]
 
 [context.pr_diff]
 type = "gh_pr_diff"

--- a/skills/bundled/qa-review/skill.toml
+++ b/skills/bundled/qa-review/skill.toml
@@ -10,7 +10,7 @@ dependencies = ["github", "build-mika"]
 keywords = ["review", "pr", "qa", "pull request"]
 
 [constraints]
-required_tools = ["qa_pr_view", "run_gh", "run_shell"]
+required_tools = ["qa_pr_view", "run_gh", "run_shell", "build_mika"]
 
 [context.pr_diff]
 type = "gh_pr_diff"

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -158,7 +158,7 @@ For each AC bullet (and the implicit structural AC):
 - **Documentation** — `run_shell("cat <worktree>/<doc-path>")` and check for the documented surface.
 - **CI-deferred** — mark `[⏭️] CI-deferred` without running anything; CI handles it independently.
 
-> **Build callback note:** When Behavioral verification requires `build_mika`, the same callback flow as Step 3e applies — call `build_mika`, end the turn, and the build callback resumes Step 2.5.5 alongside Step 3e.4 in the next turn.
+> **Build callback note:** When Behavioral verification requires `build_mika`, the same callback flow as Step 3e applies — call `build_mika`, end the turn, and the build callback re-derives state by re-reading the plan unconditionally (it is cheap; the plan is the source of truth) and re-extracts the AC list before resuming Step 3e.4. You do NOT need to persist any state across the turn boundary; the callback owns its own plan re-read. See `qa-review-build-callback/system_prompt.md` "Mandatory plan re-read" for the recovery semantics.
 
 **2.5.6. Compose the verification block.**
 

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -14,16 +14,17 @@ cd $MIKA_PLATFORM_DIR/claude-pilot && npx tsc --noEmit
 
 ### Step Budget
 
-You have a maximum of 12 tool steps per turn. Plan carefully:
+You have a maximum of 14 tool steps per turn. Plan carefully:
 
 | Purpose | Steps |
 |---------|-------|
 | Extract PR context (`gh pr view`) | 1 |
 | Pipeline checks (combine into a single shell command) | 1 |
+| Plan-AC verification — read plan file + classify ACs + structural-AC grep | 1-2 |
 | Review injected diff | 1 |
 | Cross-repo verification (conditional, only for behavioral refactors) | 0-1 |
-| Build verification — fetch issue ACs + derive worktree + build (conditional) | 0-3 |
-| AC execution — run binary commands via `run_shell` (conditional) | 0-2 |
+| Build verification — derive worktree + build (conditional, when Behavioral ACs present) | 0-2 |
+| AC execution — run binary commands via `run_shell` (conditional) | 0-3 |
 | Post review | 1 |
 | Verdict output | 1 |
 
@@ -36,11 +37,11 @@ You have a maximum of 12 tool steps per turn. Plan carefully:
 
 These rules override everything else in this prompt:
 
-- You MUST NOT emit `VERDICT: pass` unless ALL steps below completed successfully (including build verification when applicable). If any step was skipped due to a tool failure, the maximum verdict is `hold[review]`.
+- You MUST NOT emit `VERDICT: pass` unless ALL steps below completed successfully (including Step 2.5 plan-AC verification AND build verification when applicable). If any step was skipped due to a tool failure, the maximum verdict is `hold[review]`. AC failures are NEVER `hold[review]` — they are `block[ac]` per Step 2.5.7.
 - If a tool call fails, times out, or returns empty output, report the failure as a finding. Never fabricate results from metadata, memory, or inference.
 - If you cannot access the PR (permission error, 404, timeout), return `hold[review]` with the error as the reason.
 - The `--name-only` file list from Step 2 does NOT satisfy the Step 3 diff requirement. Step 3 reviews the engine-injected diff content below.
-- Your verdict output MUST include a `DIFF ANALYSIS` section (see Step 3). Omitting this section caps the maximum verdict at `hold[review]`.
+- Your verdict output MUST include a `DIFF ANALYSIS` section (see Step 3) AND a `PLAN-AC VERIFICATION` section (see Step 2.5.6). Omitting either section caps the maximum verdict at `hold[review]`. If Step 2.5.1/2.5.2 emitted `block[pipeline]`, the missing PLAN-AC block is satisfied because the verdict itself is the gating signal.
 - Do NOT fetch or reason about GitHub CI status through any tool. The `qa_pr_view` tool already excludes CI fields. Do not use `run_gh` or `run_shell` to fetch CI status (e.g., `gh pr checks`, `gh api .../check-runs`, `gh pr view --json statusCheckRollup`). Your scope is diff review and pipeline artifacts only.
 - If `build_mika` was called and the callback has NOT yet arrived, you MUST NOT proceed to Steps 4 or 5. End your turn and wait for the callback. Posting a verdict before the build result arrives produces duplicate reviews.
 - A qa-review turn is ONLY complete when a successful `run_gh("pr review …")` call appears in this turn's tool history. Emitting verdict text without calling `pr review` is a **protocol violation** — the `pull_request_review.submitted` webhook never fires, mika-dev never receives the verdict, and the dev↔qa contract is broken end-to-end. If you have composed verdict text but have not yet called `run_gh pr review`, you are not done — call it before ending the turn. The posted GitHub review is the source of truth; the verdict text in your response is only a mirror for logging.
@@ -90,6 +91,112 @@ Run these checks using `run_gh`. Combine into as few calls as possible. If ANY c
    If empty: `block[pipeline]` — "No source changes beyond documentation"
 
 3. **New external dependencies** — Review the diff for changes to `Cargo.toml` `[dependencies]` sections. If new external crates were added, check whether the plan document justifies them. If new dependencies are added without justification in the plan: `hold[review]` — "New dependency added: {dep_name}. Verify justification exists in plan."
+
+**Step 2.5 — Plan-AC verification (gating)**
+
+The plan-on-branch is the contract. This step reads the plan, extracts every acceptance criterion, classifies it, and verifies it against the diff or the built binary. Any unsatisfied AC produces a gating `block[ac]` verdict (not advisory).
+
+**2.5.1. Locate and read the plan file.**
+
+Parse the issue body (already fetched in Step 1 via `qa_pr_view` for PRs with linked issues; otherwise extract from the PR body) for the grooming callout:
+
+```
+> - **Plan:** `<path>` (committed on branch @ `<sha>`)
+```
+
+If no callout is present in the issue OR PR body: `block[pipeline]` — "No plan callout found — was this groomed via `/mika-groom-ticket`? The plan-on-branch is required as the AC contract." End the review.
+
+If the callout names a `<path>` but the file does not exist in the worktree (or in the PR head, fetched via `run_gh("pr view <PR_URL> --json files --jq '.files[].path' | grep -q '^<path>$'")`): `block[pipeline]` — "Plan callout references `<path>` but the file is missing on the PR branch." End the review.
+
+Read the plan file:
+```
+run_shell("cat <worktree>/<path>")  # if worktree exists per Step 3e.2
+```
+or
+```
+run_gh("api repos/senara-solutions/mika/contents/<path>?ref=<branch> --jq .content | base64 -d")
+```
+
+**2.5.2. Extract acceptance criteria.**
+
+Read the plan's `## Acceptance criteria` section (per `/ce:plan` Phase 4.2 — the section is named explicitly; bullets are markdown checkbox items: `- [ ] <criterion>` or `- [x] <criterion>`).
+
+If the plan has no `## Acceptance criteria` section OR the section is empty: `block[pipeline]` — "Plan at `<path>` has no acceptance-criteria section; cannot verify implementation." End the review.
+
+**2.5.3. Classify each AC bullet.**
+
+For each AC bullet, choose ONE classification:
+
+- **Behavioral** — testable by running the built binary or invoking a runtime surface. Heuristics: contains `mika ...` command names, references CLI output, JSON/text rendering, HTTP responses, runtime behavior verbs ("emits", "renders", "returns", "responds with").
+- **Structural** — testable by grepping the diff or reading source. Heuristics: "field added to struct X", "function `foo` exists", "type signature contains Y", path-specific assertions.
+- **Documentation** — testable by reading a file path. Heuristics: "doc updated at `path`", "README mentions Z", "changelog entry added".
+- **CI-deferred** — explicitly defers to CI: "no test regressions", "lints clean", "tests pass". Heuristics: references `cargo test`, `npm test`, `cargo clippy`, generic test/lint verbs.
+
+If an AC bullet is ambiguous or cannot be classified, default to **Behavioral** and attempt binary execution; mark `[⏭️] unclassifiable — manual review recommended` in the verification block.
+
+**2.5.4. Implicit structural AC (always applied).**
+
+Independent of the plan's listed ACs, every PR with a plan-on-branch must satisfy the implicit "no-parallel-plan" structural AC:
+
+```
+run_gh("pr diff <PR_URL> --name-only | grep -E '^docs/plans/.*\\.md$'")
+```
+
+Filter the result to NEW files only (exclude the existing plan referenced by the callout). For each new file:
+
+1. Read its YAML frontmatter (first `---`-delimited block).
+2. If the frontmatter contains `parent_plan: <path>`: override accepted, file allowed.
+3. Otherwise: AC fails. Reason: "Parallel plan file `<new-path>` authored without `parent_plan` frontmatter override; the plan-on-branch is the contract."
+
+**2.5.5. Verify each AC by class.**
+
+For each AC bullet (and the implicit structural AC):
+
+- **Behavioral** — invoke `build_mika` (Step 3e.3 path) to compile the worktree, then run the AC's commands against `<worktree>/target/release/mika ...`. Assert outputs against the AC's spec (presence of fields, ordering, conditional rendering). For `mika ask --verbose` ACs that name specific metadata fields, enumerate which fields are present vs. missing in the evidence string.
+- **Structural** — `run_gh("pr diff <PR_URL>")` and grep for the structural assertion (e.g., new field name in the relevant file's hunk).
+- **Documentation** — `run_shell("cat <worktree>/<doc-path>")` and check for the documented surface.
+- **CI-deferred** — mark `[⏭️] CI-deferred` without running anything; CI handles it independently.
+
+> **Build callback note:** When Behavioral verification requires `build_mika`, the same callback flow as Step 3e applies — call `build_mika`, end the turn, and the build callback resumes Step 2.5.5 alongside Step 3e.4 in the next turn.
+
+**2.5.6. Compose the verification block.**
+
+In the PR review body, emit a `PLAN-AC VERIFICATION:` section listing each AC bullet and the implicit structural AC:
+
+```
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<path>
+ACs evaluated: <count>
+- [✅] satisfied: <AC text>: <evidence> (e.g., "metadata block present with all 11 fields, alphabetical in JSON")
+- [❌] unsatisfied: <AC text>: <expected vs actual> (e.g., "expected 11 metadata fields {session_id, trace_id, task_id, agent_id, provider, model, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens}; actual: only session_id present in text mode; JSON --verbose ignored entirely")
+- [⏭️] CI-deferred: <AC text>
+- [✅] implicit structural: no parallel plan files in docs/plans/ (or "[✅] implicit structural: parallel file `<x>` authorized via parent_plan override")
+```
+
+Every AC bullet in the plan must appear in the verification block — never omit "unimportant" ones; honest enumeration prevents invisible drift.
+
+**2.5.7. Verdict mapping (gating, not advisory).**
+
+- All ACs `✅` or `⏭️`: AC verification passes; continue to Step 3.
+- Any AC `❌`: `VERDICT: block[ac]` (gating). Continue to Step 3 to surface other diff-review concerns alongside, but the final verdict is `block[ac]`.
+- Plan unparseable, file missing, or AC section absent: `VERDICT: block[pipeline]` per 2.5.1 / 2.5.2.
+
+**2.5.8. Plan-amendment escalation (mandatory on `block[ac]`).**
+
+When emitting `block[ac]`, the verdict body MUST include a `Plan amendment required:` section enumerating each unsatisfied AC and the inferred conflict reason. mika-dev's verdict-handler reads this section and routes the work item to operator review without auto-retry.
+
+Format:
+```
+Plan amendment required:
+- AC: <unsatisfied AC text>
+  Conflict reason (inferred): <e.g., "AC specifies JSON nested metadata; downstream consumer `/mika-groom-ticket` parses `session_id: <uuid>` lines on stdout. These conflict — plan needs amendment to either rendering rule or downstream parser.">
+- AC: <next unsatisfied AC>
+  Conflict reason: <...>
+```
+
+If you cannot infer a conflict reason from the diff (e.g., the AC simply wasn't implemented with no apparent architectural cause), state that explicitly: "Conflict reason: not apparent from diff — implementation appears to silently scope-reduce; operator should confirm whether AC is amendable or implementation must be redone."
+
+This closes the "implementer overrides plan silently" failure mode. Convention from mika-platform#52 framing-divergence ESCALATE — when implementation hits conflict with spec, surface to operator, don't unilaterally resolve.
 
 **Step 3 — Diff review (judgment) — MANDATORY**
 
@@ -170,25 +277,22 @@ Key changes:
 
 If your bullet points reference only file names, PR title, or metadata rather than actual code logic, you have not read the diff — re-read the injected diff above in Step 3a.
 
-**Step 3e — Build verification (conditional — mika repo PRs with executable ACs only)**
+**Step 3e — Build verification (implementation of the Behavioral AC class from Step 2.5)**
 
-This step ONLY runs when ALL of these conditions are met:
-1. The PR targets the `mika` repo (contains Rust source changes)
-2. The PR has a linked GitHub issue with acceptance criteria containing backtick-wrapped `mika` commands (e.g., `` `mika agents list --format json` ``)
-3. No hard blocks were found in Steps 2 or 3b
+This step builds the worktree and executes the Behavioral ACs identified in Step 2.5.3. It is no longer gated on "linked GitHub issue with backtick-wrapped commands" — the AC source is the **plan-on-branch**, parsed in Step 2.5.
 
-**If conditions are not met, skip to Step 4.** Note in verdict: "BUILD VERIFICATION: skipped (no executable ACs)" or "BUILD VERIFICATION: skipped (not a mika repo PR)".
+This step runs when:
+1. The PR targets the `mika` repo (contains Rust source changes), AND
+2. Step 2.5.3 classified one or more ACs as **Behavioral**, AND
+3. No hard blocks were found in Steps 2 or 3b.
 
-**3e.1. Fetch issue and extract executable ACs:**
+**If no Behavioral ACs were identified in Step 2.5, skip to Step 4.** Note in verdict: "BUILD VERIFICATION: skipped (no Behavioral ACs in plan)".
 
-Extract the issue number from the PR body (look for `Closes #N`, `Fixes #N`, or `Resolves #N`). Fetch the issue:
-```
-run_gh("issue view <issue_number> --repo senara-solutions/mika --json body -q .body")
-```
+**3e.1. Use Behavioral ACs from Step 2.5.3 (do NOT re-parse the issue).**
 
-Parse the `## Acceptance Criteria` section. Extract lines containing backtick-wrapped commands starting with `mika` (e.g., `` `mika agents list --format json` ``). These are the executable ACs.
+The list of Behavioral ACs and their commands was already extracted from the plan in Step 2.5. Do NOT re-fetch the issue or extract from issue body — the plan is the source of truth.
 
-If no executable ACs found: skip build verification. Note: "BUILD VERIFICATION: skipped (no executable ACs in issue)".
+If a Behavioral AC names a `mika` command implicitly ("emits the v1 metadata block in JSON and prose formats") rather than a literal backtick-wrapped command, derive the command(s) needed to verify it (e.g., `mika ask --verbose --format json "ping"` and `mika ask --verbose "ping"` to verify both formats).
 
 **3e.2. Derive worktree path and ensure correct commit:**
 
@@ -239,8 +343,10 @@ If missing: note it as a finding but do NOT block or hold for this alone. The co
 
 1. You have echoed `PR:`, `Size:`, `State:` (Step 1).
 2. You have emitted a `DIFF ANALYSIS:` section with real code-level bullets (Step 3d).
-3. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
-4. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
+3. You have emitted a `PLAN-AC VERIFICATION:` section (Step 2.5.6) listing every AC bullet — or, if Step 2.5.1/2.5.2 emitted `block[pipeline]`, you have not progressed to Step 5 with a non-block verdict.
+4. If Step 3e ran, you have emitted a `BUILD VERIFICATION:` section (Step 3e.5).
+5. If verdict is `block[ac]`, you have emitted a `Plan amendment required:` section (Step 2.5.8).
+6. **You have called `run_gh("pr review <NUMBER> --<approve|comment> --body '<verdict_body>'")` and it returned success.** This is the only action that fires the `pull_request_review.submitted` webhook that mika-dev listens for. Without it, your review is invisible to the rest of the system — no matter how well-composed the verdict text is.
 
 > **Idempotency (enforced):** The engine rejects duplicate `pr review` calls within a single turn. If you attempt a second review, `run_gh` will return a `duplicate_pr_review` error — this is expected and means your first review was already posted. End your turn normally. Additionally, the engine accepts EndTurn immediately after a successful PR review (skipping later post-condition guards), so forced continuation will not occur. But if no review call exists yet, you MUST post before ending the turn — silent skip is a protocol violation.
 
@@ -250,9 +356,10 @@ Post your verdict as a GitHub pull request review using `run_gh`. The review typ
 |---------|-------------|---------|
 | `pass`  | Approve     | `run_gh("pr review <NUMBER> --approve --body '<verdict_body>'")` |
 | `hold[review]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
-| `block` | Comment     | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
+| `block[ac]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
+| `block` (other sub-types) | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 
-The `<verdict_body>` is your full verdict output: DIFF ANALYSIS + FINDINGS (if any) + VERDICT + REASON.
+The `<verdict_body>` is your full verdict output: DIFF ANALYSIS + PLAN-AC VERIFICATION (always when Step 2.5 ran) + BUILD VERIFICATION (when Step 3e ran) + FINDINGS (if any) + VERDICT + REASON + (when `block[ac]`) Plan amendment required:.
 
 **Tool call format:** `run_gh` takes a JSON object with `command` (array of strings) and `repo` (string). Example for a pass verdict:
 ```json
@@ -268,7 +375,7 @@ If `run_gh pr review` fails, record the error in `FINDINGS`, then retry the call
 
 After completing all checks — **including the successful `run_gh pr review` call from Step 5** — output your verdict. Your response MUST end with the verdict block below. The verdict block is a **mirror** of the body you passed to `run_gh pr review`; the posted GitHub review is the source of truth, and the text in your response exists only for logging and debugging. If they ever differ, the posted review wins. You may include analysis notes before the block, but the verdict block must be the last thing in your response.
 
-**Format — follow exactly. Every verdict MUST include DIFF ANALYSIS (Step 3d) and BUILD VERIFICATION (Step 3e, when applicable) echo-backs:**
+**Format — follow exactly. Every verdict MUST include DIFF ANALYSIS (Step 3d), PLAN-AC VERIFICATION (Step 2.5.6, always), BUILD VERIFICATION (Step 3e, when applicable), and (when verdict is `block[ac]`) Plan amendment required: (Step 2.5.8) echo-backs:**
 
 ```
 DIFF ANALYSIS:
@@ -278,22 +385,62 @@ Key changes:
 - Refactored LangfuseExporter to use batch flush with 5-second interval
 - Updated integration tests to assert trace_id presence in exported spans
 
+PLAN-AC VERIFICATION:
+Plan: docs/plans/2026-04-26-XXX-trace-id-propagation-plan.md
+ACs evaluated: 4
+- [✅] satisfied: trace_id propagated through gRPC handlers: confirmed in src/agent.rs hunk
+- [✅] satisfied: LangfuseExporter batch interval = 5s: confirmed in src/exporter.rs:42
+- [✅] satisfied: integration tests assert trace_id presence: tests/eval/trace_id.rs added
+- [⏭️] CI-deferred: no test regressions
+- [✅] implicit structural: no parallel plan files in docs/plans/
+
 BUILD VERIFICATION:
 Build: pass
-ACs tested: 2
-- `mika agents list --format json`: pass — valid JSON array with 3 agent objects
-- `mika agents list`: pass — human-friendly text output preserved
+ACs tested: 0 (no Behavioral ACs in plan)
 
 VERDICT: pass
-REASON: Pipeline artifacts present, diff review clean, build verification passed
+REASON: Pipeline artifacts present, diff review clean, all plan ACs satisfied
 ```
 
-When build verification was skipped (no executable ACs, wrong repo, no worktree):
+When build verification was skipped (no Behavioral ACs in plan, wrong repo, no worktree):
 ```
-BUILD VERIFICATION: skipped (no executable ACs)
+BUILD VERIFICATION: skipped (no Behavioral ACs in plan)
 ```
 
-Or with findings (severity determines the verdict line):
+Or for a `block[ac]` verdict (one or more plan ACs unsatisfied):
+```
+DIFF ANALYSIS:
+Files reviewed: 4
+Key changes:
+- Added --verbose flag to `mika ask` subcommand
+- Emits trailer with session_id only in text mode
+
+PLAN-AC VERIFICATION:
+Plan: docs/plans/2026-04-26-002-refactor-mika-ask-verbose-metadata-plan.md
+ACs evaluated: 9
+- [❌] unsatisfied: `mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above
+  expected: 11 fields {session_id, trace_id, task_id, agent_id, provider, model, started_at, completed_at, input_tokens, output_tokens, cache_read_tokens}, alphabetical in JSON, importance-ordered in text, token fields gated on MIKA_STORE_LLM_CALLS=true
+  actual: text mode emits session_id only (1 of 11 fields); JSON --verbose ignored entirely (zero metadata)
+- [✅] satisfied: --verbose flag added to clap config
+- [✅] satisfied: docs/getting-started.md updated
+- [⏭️] CI-deferred: no test regressions
+- ... (remaining ACs)
+- [✅] implicit structural: no parallel plan files in docs/plans/
+
+BUILD VERIFICATION:
+Build: pass
+ACs tested: 1
+- `mika ask --verbose --format json "ping"`: fail — output contains no metadata object
+
+VERDICT: block[ac]
+REASON: Plan AC for v1 metadata block unsatisfied — 10 of 11 fields missing; JSON --verbose silently ignored.
+
+Plan amendment required:
+- AC: `mika ask --verbose` emits the v1 metadata block in JSON and prose formats per the field list and rendering rules above
+  Conflict reason (inferred): the plan's JSON-nested-metadata shape conflicts with `/mika-groom-ticket`'s parser, which scans for `session_id: <uuid>` lines on stdout. PR body documents this as the reason for scope reduction. Resolution requires either: (a) amend plan rendering to match parser shape, or (b) amend `/mika-groom-ticket` parser to handle nested JSON. Operator decision required — auto-retry inappropriate.
+```
+
+Or with security findings (severity determines the verdict line):
 
 ```
 DIFF ANALYSIS:
@@ -302,11 +449,16 @@ Key changes:
 - Hardcoded API key string literal assigned to AUTH_TOKEN in src/config.rs:42
 - New SQL query in src/db.rs using format!() with user input
 
+PLAN-AC VERIFICATION:
+Plan: docs/plans/<plan>.md
+ACs evaluated: <n>
+- [✅] / [❌] per bullet ...
+
 FINDINGS:
 - Hardcoded API key found in src/config.rs line 42
 - SQL injection vector in src/db.rs line 87
 
-VERDICT: block
+VERDICT: block[security]
 REASON: Security issues — hardcoded credentials and SQL injection vector
 ```
 
@@ -314,18 +466,20 @@ REASON: Security issues — hardcoded credentials and SQL injection vector
 
 | Verdict | When to use |
 |---------|-------------|
-| `pass` | Pipeline artifacts present and diff review clean |
-| `hold[review]` | Issues found that warrant human review, build verification failed, or tool error during review |
+| `pass` | Pipeline artifacts present, diff review clean, AND every plan AC satisfied (Step 2.5) |
+| `hold[review]` | Issues found that warrant human review (judgment-only diff findings), tool error during a non-AC step |
+| `block[ac]` | Step 2.5 found one or more unsatisfied plan ACs (gating, requires plan-amendment escalation) |
 | `block[security]` | Security issue found in diff (hardcoded secrets, SQL injection, eval/exec) |
-| `block[pipeline]` | Pipeline violation (missing plan doc, no source changes) |
+| `block[pipeline]` | Pipeline violation (missing plan doc, no source changes, plan callout absent, plan file missing on branch, AC section absent from plan) |
 
 **Verdict rules:**
-- `pass` — all steps completed successfully AND no hold-worthy findings in diff review
-- `hold[review]` — no hard blocks, but judgment findings warrant human review OR any step failed due to tool error
+- `pass` — all steps completed successfully, no hold-worthy findings in diff review, AND every plan AC marked `[✅]` or `[⏭️]` in PLAN-AC VERIFICATION
+- `hold[review]` — no hard blocks, no AC failures, but judgment findings warrant human review OR a non-AC step failed due to tool error
+- `block[ac]` — at least one plan AC marked `[❌]` in PLAN-AC VERIFICATION; verdict body MUST include a `Plan amendment required:` section per Step 2.5.8
 - `block[security]` — security issue found in diff review (Step 3b hardcoded secrets, SQL injection, eval/exec)
-- `block[pipeline]` — pipeline compliance check failed (Step 2: missing plan doc, no source changes)
+- `block[pipeline]` — pipeline compliance check failed (Step 2: missing plan doc, no source changes; Step 2.5: plan callout absent, plan file missing, AC section absent)
 
-**Multiple findings:** If you find both `hold` and `block` issues, the verdict is the most severe `block` sub-type. Severity order: `block[security]` > `block[pipeline]` > `hold[review]`.
+**Multiple findings:** If you find both `hold` and `block` issues, the verdict is the most severe `block` sub-type. Severity order: `block[security]` > `block[pipeline]` > `block[ac]` > `hold[review]`. Note `block[ac]` is **never** reduced to `hold[review]` — AC mismatches are gating, not advisory; the prior policy of treating AC failure as "judgment-worthy" is replaced by this gating + escalation path.
 
 **Backward compatibility:** mika-dev parses block sub-types like hold sub-types. Bare `block` (without sub-type) is treated as non-fixable — always use the appropriate sub-type.
 

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -110,12 +110,13 @@ If the callout names a `<path>` but the file does not exist in the worktree (or 
 
 Read the plan file:
 ```
-run_shell("cat <worktree>/<path>")  # if worktree exists per Step 3e.2
+run_shell("cat <worktree>/<path>")  # derive worktree path using the same formula as Step 3e.2
 ```
-or
+or, when no worktree is available (manual PR, externally opened, worktree cleaned up early):
 ```
-run_gh("api repos/senara-solutions/mika/contents/<path>?ref=<branch> --jq .content | base64 -d")
+run_shell("git -C $MIKA_PLATFORM_DIR/<repo>/ show <branch>:<path>")
 ```
+**Do NOT use `run_gh("api ...")`** — `gh api` is not in the `run_gh` allowlist (see Constraints section at end of this prompt). If neither route can read the plan, emit `block[pipeline]` — "Cannot read plan file: no local worktree and remote git read failed" — rather than retrying.
 
 **2.5.2. Extract acceptance criteria.**
 
@@ -185,16 +186,16 @@ Every AC bullet in the plan must appear in the verification block — never omit
 
 When emitting `block[ac]`, the verdict body MUST include a `Plan amendment required:` section enumerating each unsatisfied AC and the inferred conflict reason. mika-dev's verdict-handler reads this section and routes the work item to operator review without auto-retry.
 
-Format:
+Format (the consumer parser matches the literal token `Conflict reason (inferred):` — always emit this exact label, even when no conflict is inferable):
 ```
 Plan amendment required:
 - AC: <unsatisfied AC text>
   Conflict reason (inferred): <e.g., "AC specifies JSON nested metadata; downstream consumer `/mika-groom-ticket` parses `session_id: <uuid>` lines on stdout. These conflict — plan needs amendment to either rendering rule or downstream parser.">
 - AC: <next unsatisfied AC>
-  Conflict reason: <...>
+  Conflict reason (inferred): <...>
 ```
 
-If you cannot infer a conflict reason from the diff (e.g., the AC simply wasn't implemented with no apparent architectural cause), state that explicitly: "Conflict reason: not apparent from diff — implementation appears to silently scope-reduce; operator should confirm whether AC is amendable or implementation must be redone."
+If you cannot infer a conflict reason from the diff (e.g., the AC simply wasn't implemented with no apparent architectural cause), state that explicitly while keeping the label intact: "Conflict reason (inferred): not apparent from diff — implementation appears to silently scope-reduce; operator should confirm whether AC is amendable or implementation must be redone."
 
 This closes the "implementer overrides plan silently" failure mode. Convention from mika-platform#52 framing-divergence ESCALATE — when implementation hits conflict with spec, surface to operator, don't unilaterally resolve.
 

--- a/skills/bundled/self-dev-webhook-qa/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-qa/system_prompt.md
@@ -13,7 +13,8 @@ When you receive a GitHub webhook event for `pull_request_review.submitted`:
 The message contains the review body, PR URL, repo, and reviewer. mika-qa posts structured verdicts as PR reviews.
 
 1. **Parse the verdict** from the review body:
-   - Find the line starting with `VERDICT:` — extract the token (e.g., `pass`, `hold[review]`, `block[ci]`)
+   - Find the line starting with `VERDICT:` — extract the token (e.g., `pass`, `hold[review]`, `block[ci]`, `block[ac]`, `block[security]`, `block[pipeline]`).
+   - `block[ac]` is a distinct, non-auto-retryable verdict class introduced when plan-AC verification is gating. Route it through the dedicated `block[ac]` branch in Step 3 — do NOT collapse it into `block[ci]` (auto-retry, semantically wrong) or treat it as `hold[review]` (advisory, semantically wrong).
    - If no `VERDICT:` line found: treat as informational comment, no action needed
 2. **Extract PR coordinates** from the PR URL in the message:
    - `pr_number` (integer) and `repo` (owner/repo format)
@@ -68,6 +69,32 @@ The message contains the review body, PR URL, repo, and reviewer. mika-qa posts 
    4. Extract `FINDINGS:` and `REASON:` from the review body. Notify Vincent: "{repo}#{number} blocked by CI — attempting fix ({n}/2). {PR URL}"
    5. Launch claude-pilot with a free-text prompt to fix CI failures. Wait for callback.
    6. After callback: update `ci_fix_count` in metadata. Clear `ci_fix_dispatched_from` from metadata (prevents stale flags on future rounds). Proceed to Step 5 with `in_progress`.
+
+   **block[ac]** — Plan-vs-implementation conflict, NOT auto-retryable:
+
+   `block[ac]` is distinct from `block[ci]`. AC mismatches are not transient — they reflect a real conflict between the plan-on-branch (the contract) and what was implementable, or a silent scope-reduction. Auto-retry is semantically wrong; resolution requires plan amendment OR AC rewording, both of which are operator decisions.
+
+   1. Correlate to task (Step 4).
+   2. **Parse the "Plan amendment required:" section** from the review body. Extract every `- AC: <text>` bullet with its accompanying `Conflict reason (inferred): <text>` line. If the section is absent (qa-review violated its Step 2.5.8 contract), fall through using a generic note: "block[ac] received but Plan amendment required: section missing — operator must inspect the review manually."
+   3. **Notify Vincent via `send_message`** with the conflict summary:
+      ```
+      {repo}#{number} BLOCKED [block[ac]]: plan-vs-implementation conflict — {N} unsatisfied AC(s).
+
+      Plan amendment required:
+      - AC: {first AC text}
+        Conflict reason: {first conflict reason}
+      - AC: {next AC text}
+        Conflict reason: {next conflict reason}
+      ...
+
+      Auto-retry inappropriate — this is a plan-vs-implementation conflict, not a transient failure. Resolution requires plan amendment OR AC rewording. {PR URL}
+      ```
+   4. **Update task to blocked** (do NOT increment any retry counter, do NOT dispatch claude-pilot):
+      ```
+      update_task_status({"task_id": <task_id>, "status": "blocked", "note": "Plan amendment required (block[ac])"})
+      ```
+   5. **Pause milestone if applicable.** If the task has a `parent_task_id` and that parent task is type=`milestone`, pause the milestone via the existing path: `update_task_status({"task_id": <parent_task_id>, "status": "blocked", "note": "Child {repo}#{number} block[ac] — milestone paused pending plan amendment"})`.
+   6. Proceed to Step 5 with `blocked`. Do NOT call `run_claude_pilot`. Do NOT increment `qa_retry_count` or `ci_fix_count`.
 
    **block[security]**, **block[pipeline]**, **block** (bare) — Non-fixable:
    - Correlate to task (Step 4).

--- a/skills/bundled/self-dev-webhook-qa/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-qa/system_prompt.md
@@ -76,24 +76,33 @@ The message contains the review body, PR URL, repo, and reviewer. mika-qa posts 
 
    1. Correlate to task (Step 4).
    2. **Parse the "Plan amendment required:" section** from the review body. Extract every `- AC: <text>` bullet with its accompanying `Conflict reason (inferred): <text>` line. If the section is absent (qa-review violated its Step 2.5.8 contract), fall through using a generic note: "block[ac] received but Plan amendment required: section missing — operator must inspect the review manually."
-   3. **Notify Vincent via `send_message`** with the conflict summary:
+   3. **Update task to blocked first** (state mutation before notification — so the operator notification, when sent, accurately reflects persisted state). If Step 1 found NO correlated task (out-of-band PR), skip directly to sub-step 5 and notify the operator that no task was correlated. Otherwise:
+      ```
+      update_task_status({"task_id": <task_id>, "status": "blocked", "note": "Plan amendment required (block[ac])"})
+      ```
+      Do NOT increment any retry counter; do NOT dispatch claude-pilot. If `update_task_status` returns an error, hold that error in scope so sub-step 5's notification can surface it ("Failed to record block[ac] for {repo}#{number}: {error}. Manual update required.") instead of falsely confirming the block.
+   4. **Pause milestone if applicable.** If the task has a `parent_task_id` and that parent task is type=`milestone`, pause the milestone:
+      ```
+      update_task_status({"task_id": <parent_task_id>, "status": "blocked", "note": "Child {repo}#{number} block[ac] — milestone paused pending plan amendment"})
+      ```
+      Then **verify the pause took effect** — terminal states (`completed`, `cancelled`) silently no-op state transitions but accept metadata writes:
+      ```
+      check_task({"task_id": <parent_task_id>})
+      ```
+      If the returned `status` is not `blocked`, append a warning to the operator notification in sub-step 5: "Warning: parent milestone {parent_task_id} did not transition to blocked (current status: {status}). Manual review required."
+   5. **Notify Vincent via `send_message`** with the conflict summary (now reflects the persisted state from sub-step 3 and any milestone-pause warning from sub-step 4):
       ```
       {repo}#{number} BLOCKED [block[ac]]: plan-vs-implementation conflict — {N} unsatisfied AC(s).
 
       Plan amendment required:
       - AC: {first AC text}
-        Conflict reason: {first conflict reason}
+        Conflict reason (inferred): {first conflict reason}
       - AC: {next AC text}
-        Conflict reason: {next conflict reason}
+        Conflict reason (inferred): {next conflict reason}
       ...
 
       Auto-retry inappropriate — this is a plan-vs-implementation conflict, not a transient failure. Resolution requires plan amendment OR AC rewording. {PR URL}
       ```
-   4. **Update task to blocked** (do NOT increment any retry counter, do NOT dispatch claude-pilot):
-      ```
-      update_task_status({"task_id": <task_id>, "status": "blocked", "note": "Plan amendment required (block[ac])"})
-      ```
-   5. **Pause milestone if applicable.** If the task has a `parent_task_id` and that parent task is type=`milestone`, pause the milestone via the existing path: `update_task_status({"task_id": <parent_task_id>, "status": "blocked", "note": "Child {repo}#{number} block[ac] — milestone paused pending plan amendment"})`.
    6. Proceed to Step 5 with `blocked`. Do NOT call `run_claude_pilot`. Do NOT increment `qa_retry_count` or `ci_fix_count`.
 
    **block[security]**, **block[pipeline]**, **block** (bare) — Non-fixable:

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -380,10 +380,10 @@ Remember the returned `task_id` as `milestone_wi`.
 
 ### Step M2 — Fetch milestone issues and labels (MANDATORY — do NOT skip)
 
-Fetch milestone title (for grouping metadata):
+Fetch milestone title (for grouping metadata). `gh` has no `milestone` subcommand; fetch via the existing `issue list --milestone --json milestone` shape:
 ```json
 run_gh({
-  "command": ["milestone", "list", "--json", "number,title", "--jq", ".[] | select(.number==<n>) | .title"],
+  "command": ["issue", "list", "--milestone", "<n>", "--state", "all", "--json", "milestone", "--jq", ".[0].milestone.title"],
   "repo": "senara-solutions/<repo>"
 })
 ```


### PR DESCRIPTION
## Summary

Make the plan-on-branch load-bearing in implementation + QA. Six structural changes addressing two failure modes observed in mika#824 (mika-platform#54):

- **Conflict-resolution drift** (Changes 1, 3, 5 across implementation→QA→dispatch) — implementation handles plan conflicts via `send_message` escalation, not silent scope-reduction
- **Grooming gap** (Change 6) — second-pass review verifies downstream parsers, catches conflicts at plan time
- **Fabrication-class drift** (Change 4) — unrelated bundled fix for self-dev M2 milestone-title fetch

**Multi-layer pattern:** this PR addresses three layers of a verification failure (grooming, implementation, QA + dispatch). Future cross-layer drift detection: `mika-plan-audit` (deferred until 2nd incident motivates building it).

### Files touched

| Change | File |
|---|---|
| 1 | `.claude/commands/mika.md` |
| 3 | `skills/bundled/qa-review/system_prompt.md` |
| 3 | `skills/bundled/qa-review-build-callback/system_prompt.md` |
| 3 | `skills/bundled/qa-review/skill.toml` |
| 4 | `skills/bundled/self-dev/system_prompt.md` |
| 5 | `skills/bundled/self-dev-webhook-qa/system_prompt.md` |
| 6 | `skills/bundled/mika-arch-second-review/system_prompt.md` |

Plan: `docs/plans/2026-04-26-005-fix-plan-on-branch-load-bearing-plan.md`

## Post-ce:review hardening (commits d93917f6, 6df6097f)

Ran `/ce:review` on the initial six commits — 8 reviewers across correctness, testing, maintainability, project-standards, agent-native, learnings, api-contract, reliability. Surfaced 3 P1 + 6 P2 internal-consistency gaps in the producer-consumer contract this PR was trying to make load-bearing. Applied:

- **Producer/consumer alignment:** qa-review-build-callback's verdict body description and example template now show `PLAN-AC VERIFICATION` and `Plan amendment required:` sections matching the producer (qa-review).
- **Label consistency:** `Conflict reason (inferred):` is now emitted verbatim on every path (fallback wording previously dropped the `(inferred)` suffix that the consumer parser matches).
- **Dead code removal:** Step 2.5.1's `gh api` fallback removed — the `run_gh` allowlist in the same file blocks `api`. Replaced with a `git -C show` fallback for the no-worktree case; explicit `block[pipeline]` when both routes fail.
- **`build_mika` declared in `qa-review/skill.toml` `required_tools`** (the plan's own Change 3 verification criterion that was missed).
- **block[ac] handler reordering:** `update_task_status` now fires BEFORE `send_message` so operator notifications cannot diverge from persisted state on partial failure. Null-task guard added for out-of-band PR correlation. Milestone pause is verified via `check_task` (engine returns success for terminal-state transitions but doesn't actually transition — warning surfaced if so).
- **Build-callback AC continuity (revised-C per peer review):** the "do not re-run" rule has been rightsized to expensive operations (`qa_pr_view`, full diff review, cross-repo `pr list`) — plan re-reading is exempt because it's cheap and the plan is the single source of truth. The callback now unconditionally re-reads the plan and re-extracts ACs at every entry. Plan unreadable → `block[pipeline]` (structural failure, not downgraded to `hold[review]`).

Engine-level `set_skill_state` / `get_skill_state` deferred — tracked as a working note with explicit trigger (any production callback session where the unconditional plan re-read is silently skipped).

## Recurrence test (PRIMARY ACCEPTANCE CRITERION — manual validation is the merge gate)

Replay mika#824's exact dispatch shape against the patched pipeline. Original groomed plan at:
```
git -C /data/workspace/mika-platform/mika-platform show \
  refactor/52/mika-ask-verbose-metadata:docs/plans/2026-04-26-002-refactor-mika-ask-verbose-metadata-plan.md
```

Assert:
- `VERDICT: block[ac]` fires
- The metadata-block AC (1 of 9 bullets) is flagged unsatisfied
- 10 of 11 specified fields enumerated as missing in the evidence string
- `Plan amendment required:` section is present and names the JSON-nested-vs-parser conflict

**This is the merge gate.** Synthetic-fixture + skill-prompt test harness for CI regression protection deferred to a fast-follow ticket — building it inside this PR would expand scope onto test-infrastructure design that deserves its own pass.

## Test plan

- [ ] **Recurrence test (manual)** — replay above, observe `VERDICT: block[ac]`, the named AC bullet, the 10-of-11 field enumeration, and the `Plan amendment required:` section. **Merge gate.**
- [ ] Happy-path re-groom: fresh ticket, all ACs ship, verdict `pass`
- [ ] Adversarial AC break: remove field → `block[ac]` fires → operator routed (no auto-retry)
- [ ] Adversarial parallel plan: new file in `docs/plans/` without `parent_plan` → `block[ac]`
- [ ] Override mechanism: `parent_plan` frontmatter → no false-positive
- [ ] Change 6: test plan with parser conflict → ESCALATE before approval
- [ ] Change 4: fresh milestone dispatch reads real title, not fabricated

## Deferred fast-follows (file as separate tickets)

- **Synthetic recurrence-test fixture + skill-prompt test harness.** Regression protection: a static plan + diff fixture that exercises Step 2.5 classification, Behavioral AC execution, and verdict assertion. Bundles with the broader question of how skill-prompt changes get unit-tested.
- **Engine-level `set_skill_state` / `get_skill_state`.** Trigger: any production qa-review-build-callback that emits `hold[review]` because the unconditional plan re-read was silently skipped.
- **Pattern: conflict-resolution / scope-reduction drift (3rd documented instance).** Pattern signal — schedule structural work next sprint rather than waiting for instance #4. Engine-level candidate: "skills can declare invariants the engine enforces" (e.g., block any `docs/plans/` write during `/ce:work` lacking `parent_plan` frontmatter).
- **Pattern: kimi fabrication on tool error (3rd+ documented instance).** Sonnet propagation across grounding-sensitive dispatch steps; fabrication-class containment broader than the existing URL-only `fabricated-action-claim-guard`.
- **Plan-callout schema documentation.** Canonical `> - **Plan:** \`<path>\`` shape needs a single doc location naming all consumers (currently load-bearing in 3+ files with no shared spec).

## Why direct implementation (no `/mika`)

claude-pilot session `e49d88a9` reported "Success | 12 turns | $0.74 | 99s" with zero commits when dispatched against its own fix — bootstrap problem (the tool cannot fix itself; recurrence-test baseline of the failure mode the plan addresses, reproduced on the dispatch of the fix itself). Direct edits + commits + PR created manually. Working note in `project_decisions_in_flight.md`.

Closes #826
