### PR TITLE
fix(skills): unblock bundled skills + add CI gate for oversized prompts

### DIFF
--- a/crates/mika-agent/tests/bundled_skills_load.rs
+++ b/crates/mika-agent/tests/bundled_skills_load.rs
@@ -1,0 +1,76 @@
+//! Regression gate for bundled-skill startup loading.
+//!
+//! WHY this test exists: on the 2026-04-26 deploy, three bundled skills were
+//! silently skipped at startup with `oversized prompt` errors (self-dev,
+//! qa-review, qa-review-build-callback). mika-dev came up without `self-dev`
+//! and mika-qa came up without `qa-review` — the autonomous loop ran in a
+//! degraded state that was discoverable only by reading log warnings on the
+//! host. Prior fixes ("monitor `wc -c` after every prompt edit",
+//! `max_prompt_size = 32768` on the offending skill) demonstrably did not
+//! hold across prompt growth.
+//!
+//! This test converts that silent-drop behaviour into a CI failure: if any
+//! bundled skill fails to load, `cargo test` fails and names the offending
+//! skill, its declared/default cap, and its actual prompt size.
+//!
+//! Scope boundary (intentional): this test covers `skills/bundled/`, the
+//! engine-coupled bundled skills compiled into mika-agent at build time. It
+//! does NOT cover marketplace skills loaded from the `mika-skills` repo at
+//! runtime — those enter mika via a separate scan path. Unit 3's audit (per
+//! `docs/plans/2026-04-27-001-feat-evaluate-mika-defaults-for-anthropic-plan.md`)
+//! decides whether a parallel marketplace-side check is needed.
+//!
+//! Drives through the same `scan_skills_dir()` entry point production uses,
+//! not internal helpers — refactors that change the entry point should
+//! refactor this test alongside them. That coupling is the point.
+
+use std::path::PathBuf;
+
+use mika_agent::skills::index::scan_skills_dir;
+
+fn bundled_skills_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR = .../mika/crates/mika-agent
+    // skills/bundled/    = .../mika/skills/bundled
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("skills")
+        .join("bundled")
+}
+
+#[test]
+fn bundled_skills_load_without_oversized_prompts() {
+    let skills_dir = bundled_skills_dir();
+    assert!(
+        skills_dir.is_dir(),
+        "bundled-skills directory not found at {} — repo layout changed?",
+        skills_dir.display()
+    );
+
+    let scan = scan_skills_dir(&skills_dir);
+
+    if !scan.skipped.is_empty() {
+        let mut report = String::from(
+            "\nBundled-skill scan dropped one or more skills at startup. \
+             Each skipped skill below is invisible at runtime — the agent \
+             will boot in a silently-degraded state until the cause is fixed.\n\n\
+             Per-skill remediation:\n  - 'oversized prompt': raise `max_prompt_size` \
+             in the skill's `skill.toml` (ceiling 64KB), or trim the prompt.\n  - other \
+             reasons: see the skill's manifest, prompt file, and `scan_skills_dir` \
+             error variants.\n\nDropped skills:\n",
+        );
+        for skipped in &scan.skipped {
+            report.push_str(&format!("  - {}: {}\n", skipped.name, skipped.reason));
+        }
+        panic!("{}", report);
+    }
+
+    // Defensive sanity check: production has 17 bundled engine-coupled skills as
+    // of this regression's introduction. If the count drops to zero, the test
+    // is pointing at the wrong tree and `skipped.is_empty()` is meaningless.
+    assert!(
+        !scan.entries.is_empty(),
+        "scan_skills_dir({}) returned zero entries — wrong path or empty tree?",
+        skills_dir.display()
+    );
+}

--- a/docs/plans/2026-04-27-001-feat-evaluate-mika-defaults-for-anthropic-plan.md
+++ b/docs/plans/2026-04-27-001-feat-evaluate-mika-defaults-for-anthropic-plan.md
@@ -1,0 +1,302 @@
+---
+title: "Evaluate Mika defaults for Anthropic provider and Sonnet model"
+type: feat
+status: active
+date: 2026-04-27
+issue: senara-solutions/mika#827
+---
+
+# Evaluate Mika defaults for Anthropic provider and Sonnet model
+
+## Overview
+
+mika-dev and mika-qa now run on Claude Sonnet (~200K-token context) via the Anthropic provider, but several Mika defaults were chosen for an earlier era of smaller-context, lower-cost models. The 2026-04-26 deploy made the gap visible: three bundled skills were silently dropped at startup with `oversized prompt` errors, leaving mika-dev without `self-dev` and mika-qa without `qa-review` — silently breaking the autonomous loop.
+
+This plan ships the work in three phases:
+
+1. **Unblock** the three failing bundled skills with concrete byte-target changes (no engine changes required).
+2. **Audit** the remaining context-coupled dials (engine ceilings, completion-token caps, retrieval windows, truncation thresholds) and write a durable audit doc that survives future model swaps.
+3. **Apply** the audit's recommendations as a separate set of focused changes.
+
+A startup regression backstop (Unit 2) is added so the same silent-drop failure mode cannot recur — the next prompt edit that nudges a skill past its declared ceiling fails CI loudly instead of failing prod silently.
+
+## Problem Frame
+
+Three concrete failures observed in `server.log` on the 2026-04-26 deploy:
+
+```
+qa-review:                 35008B (limit 32768B)
+qa-review-build-callback:  18595B (limit 16384B)
+self-dev:                  49195B (limit 49152B)
+```
+
+The skill loader at `crates/mika-agent/src/skills/index.rs:499-516` calls `load_snippet_with_limit()` and pushes oversized prompts onto `ScanResult.skipped`. The skill is **not** loaded. There is a startup WARN line per skipped skill, but mika-server keeps booting — the autonomous loop comes up missing core skills and silently misbehaves until the next deploy.
+
+The immediate fix is small (three TOML edits). The durable question is broader: what other config defaults assume a smaller, cheaper model than Sonnet, and how do we stop discovering them piecemeal at deploy time?
+
+## Requirements Trace
+
+- **R1.** Re-deploy on the head of this branch produces zero `oversized prompt` warnings for bundled skills (`self-dev`, `qa-review`, `qa-review-build-callback` all load).
+- **R2.** mika-dev's `self-dev` skill and mika-qa's `qa-review` skill are present in `SkillRegistry.entries` after startup (verified by a regression test, not just by re-deploying).
+- **R3.** A durable audit doc lives at `docs/architecture/anthropic-sonnet-defaults-audit-2026-04-27.md` enumerating each context-coupled dial with `(current value, where it lives, rationale at the time, Sonnet changes the answer Y/N, recommendation)`. This doc is the artifact future model swaps consult before flipping the provider.
+- **R4.** Recommendations from the audit that the audit itself classifies as "ship now" land in this same branch (audit-driven changes shipped together with the audit, not deferred).
+- **R5.** The pattern of *silently dropped bundled skills* is replaced with *fail-loud at startup* (or fail-loud in CI) so the next prompt-size regression is caught before deploy.
+
+## Scope Boundaries
+
+- **In scope:** bundled skills under `skills/bundled/`, the `MAX_PROMPT_SIZE_CEILING` constant, the default `llm_max_tokens` in mika-common and the TUI defaults file, and any other dial the audit surfaces as Sonnet-relevant.
+- **Out of scope:** community skills in `mika-skills/` (separate repo, separate concern). If the audit reveals a marketplace skill that depends on a default we change, document it in the audit, do not auto-edit.
+- **Out of scope:** per-skill provider/model variant prompts (a heavier pattern; warranted only when the prompt itself must differ across providers, not when "fits in budget" is the only difference).
+- **Out of scope:** any migration that changes runtime cost meaningfully on non-Sonnet providers — bumps must be cheap on Sonnet and not worse on Kimi/Qwen/DeepSeek.
+
+### Deferred to Separate Tasks
+
+- **Per-model variant skill prompts for non-Sonnet providers** — if the audit decides a dial should differ across providers and we don't already have a variant pattern for that surface, file a follow-up. Don't expand provider-aware config in this branch beyond what already exists.
+- **Marketplace skill audit** — community skills shipped from `mika-skills/` are surveyed separately; if any downstream change is needed there, file a `mika-skills` ticket from the audit.
+- **P1 escalation carve-out (severity-based, NOT scope-deferred):** if Unit 3's audit surfaces a marketplace skill in `mika-skills/` whose `actual_size > declared_cap` *right now* (i.e., same failure class as the three triggering #827, just on the marketplace path that Unit 2's CI gate doesn't cover), this is P1 — same severity as the fire #827 is fighting. Behavior: file a `mika-skills` issue with `p1-important` immediately, surface the finding to the operator before #827 merges, and link from the audit doc. Distinct from the `bump (follow-up ticket)` queue, which is for non-failing dials. Severity is determined by *active impact*, not by which repo the skill lives in.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Skill loader gate** — `crates/mika-agent/src/skills/index.rs:482-516`. `max_size = manifest.skill.max_prompt_size.map(|v| v.min(MAX_PROMPT_SIZE_CEILING)).unwrap_or(MAX_PROMPT_SNIPPET_SIZE)`. Oversize → push to `skipped`, log error, continue. `MAX_PROMPT_SIZE_CEILING = 64 * 1024` (line 22), `MAX_PROMPT_SNIPPET_SIZE = 16 * 1024` (line 18).
+- **Manifest declaration** — `crates/mika-agent/src/skills/manifest.rs:142,199,222`. `max_prompt_size: Option<u64>` on `SkillFields`, `ProviderSkillFields`, and `ProviderSkillOverride`. The validation gate uses `skill.max_prompt_size`.
+- **Default `llm_max_tokens`** — `crates/mika-common/src/claude.rs:803` (`max_tokens: 16384`) and the TUI default config emitted by `crates/mika-cli/src/tui/commands/handlers.rs:1850` (`llm_max_tokens = 16384`).
+- **`max_tokens` validation warning** — `crates/mika-agent/src/validate.rs:73`. There's already a soft cap warning above 32768; the audit decides whether the warn band still makes sense for Sonnet.
+- **Skill scan tests** — `crates/mika-agent/src/skills/index.rs:2106-2255` already has `scan.skipped` assertions for oversized cases. The existing test infra is the right place to add a regression that asserts the *bundled* skills load with `skipped.is_empty()`.
+- **Bundled-skill discovery** — `crates/mika-agent/build.rs` walks `skills/bundled/` at build time; `BUNDLED_SKILL_MANIFESTS` is generated. Tests can iterate it without filesystem access.
+- **Per-agent identity overrides** — `[skills].allowlist` and `[tools].disabled` in `identity.toml` already exist (#811). Provider/model-aware identity-driven config has prior art if the audit needs it.
+
+### Institutional Learnings
+
+- **`mika-skills/docs/solutions/integration-issues/2026-03-29-self-dev-prompt-silently-dropped-size-limit.md`** — same failure mode, different skill, in March. The lesson recorded then was "set `max_prompt_size = 32768` on self-dev". That fix has now been *outgrown* (49195B). The unblock alone is not the lesson — the lesson is that the silent-drop behavior keeps biting us.
+- **`mika-skills/docs/solutions/architecture-patterns/2026-03-31-tactical-dispatch-and-pipeline-resilience.md`** — explicitly flags "Monitor self-dev prompt size after every change." A *human discipline* recommendation that has demonstrably not held. R5 replaces it with a *structural* check.
+- **`feedback_compound_infra_fixes.md`** — infra fixes evaporate faster than product fixes; compound every non-trivial one. The audit doc itself is half of the compound; Unit 5 closes the loop.
+- **`feedback_prompt_enforcement_fragile.md`** — don't lean on prompt-level budgets/limits when a structural constraint will do. The startup test (Unit 2) is exactly that structural constraint.
+
+### External References
+
+- **Anthropic Sonnet 4.6 model card** — 200K input context, 64K output max for Sonnet 4.x, prompt-caching cost benefits at larger inputs. Confirms that 64KB system-prompt budgets are inexpensive in the Sonnet regime.
+- **Anthropic prompt caching guide** — relevant to the audit's "Sonnet changes the answer Y/N" column for token-budget dials, since cached prompts shift the cost calculus.
+
+## Key Technical Decisions
+
+- **Bump per-skill `max_prompt_size` first; touch `MAX_PROMPT_SIZE_CEILING` only if the audit demands it.** All three failing skills fit under the existing 64KB ceiling. Raising the ceiling is a separate decision the audit owns — don't conflate "unblock startup" with "ceiling policy change".
+- **Concrete byte targets:** round up to clean power-of-two-ish values, leave headroom for the *next* prompt edit, **don't sit flush against the ceiling**.
+
+  | Skill | Current declared | Actual size | New declared | Headroom |
+  |---|---|---|---|---|
+  | `self-dev` | 49152 | 49195 | **57344** (56KB) | ~8KB |
+  | `qa-review` | 32768 | 35008 | **49152** | ~14KB |
+  | `qa-review-build-callback` | (default 16384) | 18595 | **32768** (declared) | ~14KB |
+
+- **`self-dev` does NOT land at the ceiling.** Earlier draft of this plan parked `self-dev` at 65536 (= ceiling) to force the audit's hand on ceiling policy. Architect first-pass review (mika-arch session `3b808dd8`) flagged this as Unit 1 encoding Unit 3 assumptions — orthogonality violation. Revised target is 57344 (~8KB headroom), which holds Unit 1 self-contained: if Unit 3's audit recommends raising the ceiling or declaring per-model caps, Unit 4 can revisit `self-dev`'s value in the same PR; if the audit leaves the ceiling alone, 57344 is fine indefinitely. Cite: review-guide.md § Orthogonality.
+- **Commit ordering matters.** Unit 1 must land before Unit 2 so the regression test is green from its first commit (otherwise Unit 2 reads as a failing test for a bug the author is still mid-fix on). Unit 3's audit doc must commit standalone before Unit 4 begins, so the audit's `Recommendations to ship in #827` section is the *committed* spec the reviewer can diff Unit 4's changes against.
+- **Add a structural CI gate, not a process discipline.** Past institutional notes ("monitor `wc -c` after every change") have not held. The regression test makes prompt-size violations a CI failure.
+- **Audit deliverable is a durable doc, not a checklist.** The doc lives at `docs/architecture/anthropic-sonnet-defaults-audit-2026-04-27.md` so the next provider/model swap (Opus, GPT-5, whatever) has a living artifact to amend, not a closed PR to archaeologize.
+- **Provider/model awareness is a tool of last resort.** Where one global default works on every supported provider, just bump it. Per-provider variance only when the dial truly should differ — keeps config simple.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `MAX_PROMPT_SIZE_CEILING` be raised in this branch?** No — defer to the audit (Unit 3). Unblocking only requires per-skill bumps; raising the ceiling is a policy change with broader implications (marketplace skills, cost on non-Sonnet providers).
+- **Why not just trim the skill prompts?** Already considered and rejected on the issue. Sonnet handles long structured prompts well; trimming on every edit is a recurring tax that creates pressure to drop legitimately useful workflow guidance.
+
+### Deferred to Implementation
+
+- **Exact list of dials Unit 3's audit will surface.** The four candidates listed in the ticket are the seed; the audit may surface more (KG retrieval window, tool-result truncation thresholds, conversation-history compaction threshold, callback-budget defaults). Implementer should follow the threads as they appear, capping the audit at "things that touch context, output budget, or per-turn token cost".
+- **Whether any audit recommendation requires touching mika-cloud Helm defaults.** If a dial is reflected in K8s ConfigMap defaults, surface it during the audit and decide whether to file a companion PR.
+
+## Implementation Units
+
+- [ ] **Unit 1: Bump per-skill `max_prompt_size` for the three failing bundled skills**
+
+**Goal:** Restore mika-dev and mika-qa to a fully-loaded skill set on the next deploy.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `skills/bundled/self-dev/skill.toml`
+- Modify: `skills/bundled/qa-review/skill.toml`
+- Modify: `skills/bundled/qa-review-build-callback/skill.toml`
+
+**Approach:**
+- Set `max_prompt_size = 57344` on `self-dev` (~8KB headroom; deliberately *not* flush against the 64KB ceiling — see Key Technical Decisions).
+- Set `max_prompt_size = 49152` on `qa-review`.
+- Add `max_prompt_size = 32768` on `qa-review-build-callback` (currently undeclared → defaulting to 16KB).
+- No engine changes. No prompt edits.
+- **Commit ordering:** this unit's commit MUST precede Unit 2's commit on the branch, so Unit 2's regression test is green from its first commit.
+
+**Patterns to follow:**
+- Existing declaration shape in `skills/bundled/self-dev/skill.toml` (already has `max_prompt_size`); the new line on `qa-review-build-callback` mirrors that placement under `[skill]`.
+
+**Test scenarios:**
+- *Test expectation: none — pure config, behavior verified by Unit 2's regression test and by Unit 3's startup-log check.*
+
+**Verification:**
+- A clean release build of mika-server starts with `loaded=N disabled=0 skipped=0` and no `oversized prompt` log lines for these three skills.
+
+- [ ] **Unit 2: Add a startup regression test that fails CI when bundled skills exceed their declared limits**
+
+**Goal:** Convert silent-drop into a loud CI failure so the same regression class cannot recur.
+
+**Requirements:** R5.
+
+**Dependencies:** Unit 1 (so the test passes on this branch's head).
+
+**Files:**
+- Create: `crates/mika-agent/tests/bundled_skills_load.rs` (or equivalent integration test location — implementer picks based on existing eval-harness conventions)
+- Possibly modify: `crates/mika-agent/src/skills/index.rs` (only if the test needs a new pub helper to enumerate bundled-skill scan results)
+
+**Approach:**
+- Drive `scan_skills()` (or the equivalent build-time bundled-skill loader) over `BUNDLED_SKILL_MANIFESTS` and assert `scan.skipped.is_empty()`.
+- On failure, the assertion message must list each skipped skill with its size and limit so the diff in CI shows the operator exactly what to bump.
+- Test must run in `cargo test` without API keys, network, or `--ignored` gating — it's a pure manifest+filesystem scan.
+- **Scope boundary (named explicitly):** this test covers `BUNDLED_SKILL_MANIFESTS` (compiled from `mika/skills/bundled/` at build time). Marketplace skills loaded from the `mika-skills` repo at runtime are NOT covered by this gate — they enter `mika` via a separate scan path and only get checked at deploy time. Unit 3's audit must surface whether a parallel check is needed for the marketplace load path; if so, file as a follow-up ticket (do not in-scope here).
+
+**Patterns to follow:**
+- Existing tests at `crates/mika-agent/src/skills/index.rs:2106` and `:2235` already exercise `ScanResult.skipped` against synthetic skills. Reuse the same assertion shape, point it at bundled skills.
+- `EvalHarness` and `MockLlmProvider` patterns are *not* needed here — this is a manifest test, not an agent-loop test.
+
+**Test scenarios:**
+- *Happy path:* `scan_skills(skills/bundled/)` returns `skipped == []`. Test passes silently.
+- *Regression simulation:* (optional, as a second test) inject a synthetic oversized prompt into a tmpdir-staged copy of one bundled skill and assert the test would have caught it. This documents the regression-detection contract.
+
+**Verification:**
+- `cargo test -p mika-agent --test bundled_skills_load` passes locally.
+- A deliberate temporary edit (e.g., padding `qa-review/system_prompt.md` past 49152) makes the test fail with a message naming `qa-review` and the actual byte size.
+
+- [ ] **Unit 3: Audit Sonnet-relevant defaults and write the durable audit doc**
+
+**Goal:** Produce the audit table and recommendations the ticket asks for.
+
+**Requirements:** R3.
+
+**Dependencies:** None (can be done in parallel with Unit 1).
+
+**Files:**
+- Create: `docs/architecture/anthropic-sonnet-defaults-audit-2026-04-27.md`
+
+**Approach:**
+- Walk the codebase for context-coupled and token-coupled dials. The seed list from the ticket:
+  1. Per-skill `max_prompt_size` (already addressed in Unit 1; reference, don't re-explore)
+  2. `MAX_PROMPT_SIZE_CEILING` at `crates/mika-agent/src/skills/index.rs:22`
+  3. `MAX_PROMPT_SNIPPET_SIZE` at `crates/mika-agent/src/skills/index.rs:18` (the *default* when `max_prompt_size` is undeclared — half the bundled skills inherit this and qa-review-build-callback's failure is direct evidence the default is the wrong size)
+  4. Default `llm_max_tokens` in `crates/mika-common/src/claude.rs:803` and the TUI default at `crates/mika-cli/src/tui/commands/handlers.rs:1850`
+  5. `max_tokens > 32768` validation warn at `crates/mika-agent/src/validate.rs:73`
+  6. Conversation compaction threshold (50 messages, keep 20)
+  7. Tool input/payload caps: `MAX_INPUT_LEN = 10_000` chars, `MAX_PAYLOAD_BYTES = 200 * 1024` (`crates/mika-agent/src/tools/`)
+  8. Tool history metadata cap: `TOOL_METADATA_MAX = 4000` chars
+  9. KG ingestion / resolution batch budget: `MIKA_KG_BATCH_BUDGET` default 500 — already provider-aware via `MIKA_KG_INGESTION_MODEL` etc., note in audit but don't recommend changes
+  10. KG query result caps: 20 entities / 30 edges / 10 chunks — relevant if Sonnet wants more context per query
+  11. Image bytes budget per turn (from per-turn dedup guard cited in `crates/mika-agent/CLAUDE.md`)
+  12. **Pre-failure watch row:** `self-dev-webhook-qa` actual size 14949B against the 16KB undeclared default — 87% of cap, no failure yet but next prompt edit likely overflows. Must appear as a named row in the skill-caps section with status `monitor — included in Unit 2's regression test, declare an explicit cap if size grows past 14KB`. Demonstrates that the audit's value isn't only retrospective — it should also surface skills sliding toward the same failure class.
+- For each dial, produce one row of the audit table. Implementer runs `git grep` and reads the citing module to fill the "rationale at the time" column honestly — don't fabricate, write "rationale unclear, need archaeology" if the answer isn't in code or commit messages.
+- For each row, the recommendation column is exactly one of: `bump (this branch)`, `bump (follow-up ticket)`, `make provider/model-aware (follow-up ticket)`, `leave`, `needs more investigation`.
+- Surface any dial that crosses into mika-cloud or mika-skills as an explicit cross-repo callout — do not auto-edit those repos.
+
+**Patterns to follow:**
+- `docs/architecture/review-guide.md` is the closest existing artifact in tone — durable architecture doc, code citations, reasoned recommendations. Match its citation discipline (file path + line number for every claim).
+- `mika-cloud/docs/` model-comparison docs and `mika/docs/solutions/kg/kg-provider-evaluation-2026-04-24.md` are reference for "decision-matrix in markdown" formatting.
+
+**Test scenarios:**
+- *Test expectation: none — documentation deliverable. Verification is editorial (Unit 4 reads this doc to drive its changes).*
+
+**Verification:**
+- The audit doc exists at the path above and contains a table with at least the 11 dials listed in Approach.
+- Every row cites a file path and (where relevant) a line number.
+- The doc closes with a "Recommendations to ship in #827" section enumerating the rows tagged `bump (this branch)` — that section is the input contract for Unit 4.
+
+- [ ] **Unit 4: Apply audit recommendations tagged "bump (this branch)"**
+
+**Goal:** Land the audit-driven changes the audit itself classifies as ship-now.
+
+**Requirements:** R4.
+
+**Dependencies:** Unit 3 — and specifically, **the audit doc must be committed before Unit 4 begins implementation**. Concretely: Unit 3's audit doc lands as a standalone commit; the `Recommendations to ship in #827` section of *that committed doc* is the authoritative spec for Unit 4's diff. PR reviewers can diff applied changes against the committed spec. This makes Unit 4 mechanically auditable rather than re-derived from conversation.
+
+**Files:**
+- Modify: whichever files the audit identifies. Must include source-citation paths from Unit 3.
+- *Likely candidates* (pre-audit guess; the audit decides the final list): `crates/mika-agent/src/skills/index.rs` (raise `MAX_PROMPT_SNIPPET_SIZE` default if audit says so), `crates/mika-common/src/claude.rs` (raise `llm_max_tokens` default if audit says so), `crates/mika-cli/src/tui/commands/handlers.rs` (matching TUI default).
+
+**Approach:**
+- Read Unit 3's "Recommendations to ship in #827" section. Implement each row mechanically.
+- For any row tagged `bump (follow-up ticket)` or `make provider/model-aware (follow-up ticket)`, file a child issue under #827 with the row's content as the issue body. Do not implement them in this branch.
+- For any row tagged `needs more investigation`, log it in the audit doc's "Open questions" section and surface it on the PR description as a known unknown.
+
+**Patterns to follow:**
+- Mechanical: each change is one constant or one default-config field. No new abstractions.
+- Match the existing test patterns in the relevant module — bumping a constant typically doesn't need new tests, but Unit 2's bundled-skill regression test should still pass after the change.
+
+**Test scenarios:**
+- *Per audit recommendation, scoped to that recommendation.* Example: if the audit recommends raising `MAX_PROMPT_SNIPPET_SIZE` from 16KB to 32KB, an existing test that asserts the default (e.g., `crates/mika-agent/src/skills/index.rs:2106` if applicable) needs its expected value updated.
+- *Negative test (where applicable):* If a constant change would break an existing assertion, the broken assertion is a signal — fix the assertion intentionally with a one-line commit-message note explaining the new ceiling, don't suppress the test.
+
+**Verification:**
+- `cargo test` passes.
+- Unit 2's bundled-skills regression test still passes (no skill exceeds its declared or default ceiling after the change).
+- The audit doc's "Recommendations to ship in #827" section has every row marked done with the commit SHA.
+
+- [ ] **Unit 5: Compound the lesson — record the model-defaults audit pattern in `docs/solutions/`**
+
+**Goal:** Make this audit pattern a reusable artifact for the next provider/model swap.
+
+**Requirements:** R3 (durability beyond this branch).
+
+**Dependencies:** Units 3 and 4.
+
+**Files:**
+- Create: `docs/solutions/best-practices/model-defaults-audit-pattern-2026-04-27.md`
+
+**Approach:**
+- One-page solution doc. Frontmatter: `module: skills | mika-agent | configuration`, `tags: [provider, model, defaults, audit, anthropic, sonnet]`, `problem_type: configuration`.
+- Sections: *Problem* (silent skill drop on model swap), *Pattern* (audit table shape, where the durable doc lives, when to invoke it), *Triggers* (next time we change a default model on a deployed agent, or add a new provider), *Anti-patterns* (don't trim prompts to fit; don't lean on human discipline; don't bump everything to the ceiling without an audit), *Reference* (link to `docs/architecture/anthropic-sonnet-defaults-audit-2026-04-27.md` and to this issue/PR).
+
+**Patterns to follow:**
+- `docs/solutions/best-practices/kg-provider-eval-harness-reproducible-comparison-2026-04-24.md` — same shape, recent precedent.
+- `docs/solutions/integration-issues/` frontmatter style.
+
+**Test scenarios:**
+- *Test expectation: none — documentation deliverable.*
+
+**Verification:**
+- Doc exists at the path, frontmatter validates, links to Unit 3's audit doc and to this PR resolve.
+
+## System-Wide Impact
+
+- **Interaction graph:** Bundled-skill loader (mika-agent) → `SkillRegistry` → all agent-loop entry points (conversation, silent, callback). Unit 1 affects which skills load; Unit 4 may shift defaults that feed into LLM call construction in `mika-common::claude`.
+- **Error propagation:** The current "skip silently, log WARN, continue boot" behavior is preserved. Unit 2 adds a *test-time* failure path so the silent-skip cannot be the first signal in production.
+- **State lifecycle risks:** None — these are config and constant changes. No DB migrations. No lossy data transformations.
+- **API surface parity:** No public API changes. The skill manifest schema (`max_prompt_size`) is unchanged.
+- **Integration coverage:** Unit 2's regression test runs in CI's normal `cargo test` job — no new gating, no new infra.
+- **Unchanged invariants:** `MAX_PROMPT_SIZE_CEILING` (unless the audit says otherwise; defaults and per-skill caps are the lever, the ceiling is a separate decision); the skill manifest schema; the silent-drop behavior at runtime (intentionally — Unit 2 catches it earlier in CI, doesn't change runtime behavior).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Audit (Unit 3) surfaces more dials than expected and balloons scope | Cap audit at the seed list + dials within one `git grep` hop; defer everything else to follow-up tickets per Scope Boundaries. |
+| Bumping `llm_max_tokens` defaults raises cost on Kimi/DeepSeek/Qwen routes | Audit must explicitly check provider-by-provider before recommending `bump (this branch)` for output-token dials; leave provider-specific overrides alone. |
+| `self-dev` headroom is tighter than ideal at 8KB (57344 cap, 49195 actual) | Mitigated by Unit 2's CI gate — overflow becomes a CI failure, not a silent prod drop. Unit 3's audit is the right place to recommend a structural answer (raise ceiling, declare per-model caps, or accept 8KB as canonical). Don't pre-decide in Unit 1. |
+| Unit 2's regression test depends on bundled-skill discovery internals (`BUNDLED_SKILL_MANIFESTS`) and breaks on engine refactors | The test should drive through `scan_skills()` (the same entry point production uses) rather than poking internals. If a refactor changes the entry point, the test should refactor with it — that coupling is desirable. |
+| Audit doc rots as Mika adds new dials | Unit 5's compound doc names the audit as a living document; the next model swap is the trigger to amend it. Rot is acceptable between swaps. |
+
+## Documentation / Operational Notes
+
+- **PR description should call out R5 explicitly** — the structural fix is the headline. The byte bumps are the visible diff, the regression test is the durable change.
+- **No deploy ordering required.** All changes ship in one PR; the bundled-skill changes take effect on the next `make deploy` of mika-agent.
+- **Post-deploy verification** is one log check: `grep "oversized prompt" server.log` returns zero hits on the second-restart steady state.
+
+## Sources & References
+
+- **Origin issue:** [senara-solutions/mika#827](https://github.com/senara-solutions/mika/issues/827)
+- **Skill loader gate:** `crates/mika-agent/src/skills/index.rs:482-516`
+- **Default constants:** `crates/mika-agent/src/skills/index.rs:18,22`
+- **`llm_max_tokens` defaults:** `crates/mika-common/src/claude.rs:803`, `crates/mika-cli/src/tui/commands/handlers.rs:1850`
+- **`max_tokens` validation warn:** `crates/mika-agent/src/validate.rs:73`
+- **Prior failure (different skill, same class):** `mika-skills/docs/solutions/integration-issues/2026-03-29-self-dev-prompt-silently-dropped-size-limit.md`
+- **Prior tactical guidance (since outgrown):** `mika-skills/docs/solutions/architecture-patterns/2026-03-31-tactical-dispatch-and-pipeline-resilience.md`
+- **Architecture review reference:** `docs/architecture/review-guide.md`

--- a/docs/solutions/best-practices/structural-check-replaces-human-discipline-2026-04-27.md
+++ b/docs/solutions/best-practices/structural-check-replaces-human-discipline-2026-04-27.md
@@ -1,0 +1,125 @@
+---
+title: When human-discipline mitigation fails N=3 for the same failure class, replace it with a CI-time structural check
+date: 2026-04-27
+category: best-practices
+module: skills
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - "A failure class has been mitigated with a 'review checklist' or 'always run wc -c' style human-discipline rule"
+  - "The same failure class recurs after the discipline rule is documented"
+  - "The failure mode is silent at runtime (warning, not error) and visible only in logs"
+related_components:
+  - testing_framework
+  - tooling
+tags:
+  - structural-check
+  - ci-gate
+  - max_prompt_size
+  - silent-drop
+  - always_on
+  - compound-discipline
+---
+
+# When human-discipline mitigation fails N=3 for the same failure class, replace it with a CI-time structural check
+
+## Context
+
+The bundled-skill `oversized prompt` silent-drop has now hit Mika three times. Each prior fix was a human-discipline rule that failed across the next round of growth:
+
+| Date | Doc | Mitigation type |
+|------|-----|-----------------|
+| 2026-03-29 | `docs/solutions/integration-issues/skill-prompt-snippet-size-limit-configurable.md` | **Config**: introduced `max_prompt_size` per-skill override. Default 16KB, ceiling 64KB. (Necessary infrastructure — not a discipline rule by itself.) |
+| 2026-03-29 | `docs/solutions/integration-issues/always-on-skill-oversized-prompt-loud-failure.md` | **Engine**: oversized `always_on` skills are now skipped at startup with an `error!` (loud-er, but still runtime-only). |
+| 2026-04-17 | `docs/solutions/prompt-engineering/2026-04-17-always-on-skill-prompt-size-headroom.md` | **Discipline**: "set `max_prompt_size` with 40% headroom" + "review with `wc -c` vs `grep max_prompt_size` before merge". The doc itself flagged this: *"This is a footgun until we replace size policing at the config level."* |
+| 2026-04-26 | (this incident, mika#827) | **Structural**: CI-time test asserts `scan_skills_dir(skills/bundled).skipped.is_empty()`. |
+
+On the 2026-04-26 deploy, `self-dev` had grown from 33,868B (when the 04-17 doc was written) to 49,195B — past its declared 49,152B cap by 43 bytes. `qa-review` had grown to 35,008B against its declared 32,768B. `qa-review-build-callback` had no declared cap and was at 18,595B against the 16KB default. mika-dev came up without `self-dev` and mika-qa came up without `qa-review`. The autonomous loop ran in a degraded state until a human read the startup log.
+
+The 04-17 `wc -c` review check was documented, lived in `docs/solutions/`, and was discoverable. It still didn't hold across nine days of prompt edits. (auto memory [claude] — `feedback_compound_infra_fixes.md` recommends compounding every infra fix and looking back for prior related fixes; this compound is that look-back made explicit.)
+
+## Guidance
+
+When a failure class has been mitigated with a human-discipline rule (review checklist, "always run X before merge", "monitor Y after every change") and the same failure class recurs, the next mitigation should be a **structural check that fires automatically** — not another, more careful, version of the same discipline.
+
+Concretely for this class:
+
+```rust
+// crates/mika-agent/tests/bundled_skills_load.rs
+use mika_agent::skills::index::scan_skills_dir;
+
+#[test]
+fn bundled_skills_load_without_oversized_prompts() {
+    let scan = scan_skills_dir(&bundled_skills_dir());
+    if !scan.skipped.is_empty() {
+        // panic message names every skipped skill, its declared/default cap,
+        // and the actual prompt size — so CI logs surface exactly which
+        // skill.toml needs a max_prompt_size bump.
+        panic!("...");
+    }
+}
+```
+
+Drives through the **same entry point production uses at startup** (`scan_skills_dir`), not internal helpers. Refactors that change the production scan path will refactor this test alongside them. That coupling is the point — the test must keep tracking the production behavior, not a snapshot of it.
+
+The 40%-headroom advice from the 04-17 doc is **not** superseded — it's still good guidance for choosing the cap *value* when you bump it. What is superseded is the human-review enforcement of size compliance: that's what the structural check now does.
+
+## Why This Matters
+
+Human-discipline mitigations have a known half-life:
+
+1. **They depend on review attention surviving each new contributor.** New people don't read `docs/solutions/` before their first PR.
+2. **They depend on the failure being legible at review time.** A PR that adds 600 bytes of prompt text passes review easily; the cumulative-cap-crossing problem is invisible per-commit.
+3. **They depend on the doc itself being current.** The 04-17 doc was current. It still didn't hold.
+
+A structural CI check has none of those failure modes:
+- Runs on every PR, every contributor, no exceptions.
+- Failure message names the skill, the cap, and the actual size — no human inference required.
+- Can't go stale; it tracks the production scan path by construction.
+
+The cost of the structural check is one integration test (76 lines, single `scan_skills_dir` call, no API keys, no network). The cost of the discipline rule failing is the autonomous loop running degraded for an unknown window post-deploy.
+
+Cite: `feedback_prompt_enforcement_fragile.md` (auto memory [claude]) — *"Don't use prompt-level budgets/limits; LLMs rationalize crossing them. Use structural constraints."* Same principle applied one layer up — humans-reviewing-size-limits is the same shape of fragile-rule.
+
+## When to Apply
+
+- The same failure class has hit the codebase **two or more times after a mitigation was documented**.
+- The current mitigation is a "remember to do X before merge" rule rather than an automated check.
+- The failure surface is reachable from a production code path that can be exercised in a unit or integration test (i.e., the check doesn't require running the full system).
+- The structural test would be cheap to write — single function call, no fixtures, no orchestration.
+
+If the test would require building a fixture rig more elaborate than the bug, the discipline rule may still be the right call — but flag explicitly that the next recurrence should trigger a re-evaluation of "is the rig still too expensive?"
+
+## Examples
+
+**Before (discipline-based, from the 04-17 doc):**
+```bash
+# Reviewer's pre-merge check:
+limit=$(grep '^max_prompt_size' skills/bundled/<name>/skill.toml | awk '{print $3}')
+size=$(wc -c < skills/bundled/<name>/system_prompt.md)
+[ "$size" -gt "$limit" ] && echo "OVER LIMIT"
+```
+Failure mode: reviewer doesn't run it, or runs it on the wrong skill, or a non-skill PR that nudges shared prose past the cap is reviewed without anyone running it at all.
+
+**After (structural, this incident):**
+```rust
+// crates/mika-agent/tests/bundled_skills_load.rs (76 lines total)
+let scan = scan_skills_dir(&bundled_skills_dir());
+assert!(scan.skipped.is_empty(), /* descriptive message naming offenders */);
+```
+Failure mode: none discovered yet. CI runs on every PR; the assertion message tells the contributor what to fix.
+
+**Bonus orthogonal lesson from this incident** (architect's pre-commit review on the plan): Unit 1's per-skill cap bumps should not encode Unit 3's ceiling-policy decisions. An earlier draft parked `self-dev` flush at the 64KB ceiling deliberately to "force the audit's hand" on ceiling policy. mika-arch flagged this as Unit 1 encoding Unit 3 assumptions — orthogonality violation per `docs/architecture/review-guide.md` § Orthogonality. Final cap landed at 57344 (~8KB headroom). The lesson generalizes: **don't use a Unit-1 fire-fix to pre-decide a Unit-N policy question, even if the policy question is in the same plan.** The fix is orthogonal to the policy.
+
+**Bootstrap near-miss caught in this session:** the natural next step after grooming #827 was `mika ask --agent mika-dev "implement mika issue#827"`. But mika-dev is the agent broken by #827 (no `self-dev` skill loaded). Same shape as mika#825's PR body documents — *"the tool cannot fix itself; direct edits + commits + PR created manually."* When the agent that would normally implement a fix is broken **by** that fix, the dispatch path is closed; inline implementation in the worktree is the only path.
+
+## Related
+
+- `docs/solutions/integration-issues/skill-prompt-snippet-size-limit-configurable.md` — introduced `max_prompt_size` (2026-03-29)
+- `docs/solutions/integration-issues/always-on-skill-oversized-prompt-loud-failure.md` — engine-side loud failure for `always_on` (2026-03-29)
+- `docs/solutions/prompt-engineering/2026-04-17-always-on-skill-prompt-size-headroom.md` — the now-superseded discipline check
+- `crates/mika-agent/tests/bundled_skills_load.rs` — the structural replacement
+- `crates/mika-agent/src/skills/index.rs:361` — `scan_skills_dir` entry point
+- mika#825 — bootstrap lesson reference (*"the tool cannot fix itself"*)
+- mika#827 — this incident

--- a/skills/bundled/qa-review-build-callback/skill.toml
+++ b/skills/bundled/qa-review-build-callback/skill.toml
@@ -3,6 +3,7 @@ name = "qa-review-build-callback"
 description = "Build callback resumption for qa-review — continues QA verdict after build_mika completes"
 version = "0.1.0"
 always_on = false
+max_prompt_size = 32768
 dependencies = ["qa-review"]
 
 [triggers]

--- a/skills/bundled/qa-review/skill.toml
+++ b/skills/bundled/qa-review/skill.toml
@@ -3,7 +3,7 @@ name = "qa-review"
 description = "Quality gate for PR review — produces structured pass/hold/block verdicts for mika-dev"
 version = "0.8.0"
 always_on = true
-max_prompt_size = 32768
+max_prompt_size = 49152
 dependencies = ["github", "build-mika"]
 
 [triggers]

--- a/skills/bundled/self-dev/skill.toml
+++ b/skills/bundled/self-dev/skill.toml
@@ -4,7 +4,7 @@ description = "Orchestrator: delegates implementation work to Claude Code via cl
 version = "0.2.0"
 always_on = true
 timeout_secs = 30
-max_prompt_size = 49152
+max_prompt_size = 57344
 dependencies = [
     "build-mika",
     "deploy-mika",


### PR DESCRIPTION
Closes #827

## Summary

- **Unblock**: bumps `max_prompt_size` on three bundled skills that were silently skipped at startup on the 2026-04-26 deploy. mika-dev came up without `self-dev`; mika-qa came up without `qa-review`. Autonomous loop ran in a degraded state.
- **Structural anti-recurrence**: adds `crates/mika-agent/tests/bundled_skills_load.rs` — a CI regression gate that drives `scan_skills_dir()` over `skills/bundled/` and asserts `ScanResult.skipped.is_empty()`. Same entry point production uses at startup. Failure message names the offending skill, declared/default cap, and actual size.
- **Compound**: `docs/solutions/best-practices/structural-check-replaces-human-discipline-2026-04-27.md` documents this as the third documented hit of the same failure class. Each prior fix was a human-discipline rule (`wc -c` review, "set headroom") that demonstrably failed across the next round of growth. Structural CI gate replaces that pattern.

## Why this approach (the headline)

The 2026-04-17 solution doc on this exact failure class wrote: *"This is a footgun until we replace size policing at the config level."* The 2026-04-26 incident is that footgun firing again — `self-dev` grew from 33,868B to 49,195B between the two events, crossing its own declared cap of 49,152B by 43 bytes. A `wc -c` review check, even when documented and discoverable, did not hold across nine days of contributors editing prompts. The structural CI gate replaces the human-discipline mitigation (per plan R5).

The 40%-headroom advice from the 04-17 doc is preserved, not deleted — still useful for choosing cap *values*. What's superseded is human-review enforcement of size compliance.

## Byte targets (per plan §Unit 1)

| Skill | Was | Is | Headroom |
|---|---|---|---|
| `self-dev` | 49152 | **57344** (~56KB) | ~8KB |
| `qa-review` | 32768 | **49152** | ~14KB |
| `qa-review-build-callback` | undeclared (default 16384) | **32768** | ~14KB |

`self-dev` deliberately not parked at the 64KB ceiling — that ceiling-policy decision belongs to a follow-up audit, not to this unblock. Per `docs/architecture/review-guide.md` § Orthogonality (architect's pre-commit review on the plan flagged the original 65536 target as Unit 1 encoding Unit 3 assumptions; revised to 57344).

## What ships here vs deferred

**Ships in this PR (Units 1+2+5 of the groomed plan):**
- Unit 1: three `skill.toml` cap bumps
- Unit 2: CI regression gate
- Unit 5: compound doc on structural-replaces-discipline

**Deferred to follow-up issue(s) — to be filed:**
- Unit 3: durable Anthropic+Sonnet defaults audit doc enumerating ~12 dials (`MAX_PROMPT_SIZE_CEILING`, `MAX_PROMPT_SNIPPET_SIZE` default, `llm_max_tokens` defaults, etc.) with per-dial recommendations
- Unit 4: applying any "ship now" recommendations the audit produces
- The audit is durability work for the next provider/model swap, not fire-fighting. Splitting it out keeps this PR focused on the fire.

## Bootstrap note

Dispatching `mika ask --agent mika-dev "implement #827"` is not viable for this issue: mika-dev is the agent broken by #827 (no `self-dev` skill loaded). Same shape as mika#825's PR body documents (*"the tool cannot fix itself"*). PR was prepared inline in the worktree.

## Test plan

- [x] `cargo test -p mika-agent --test bundled_skills_load` passes locally on this branch
- [x] `bash scripts/verify-pipeline.sh` passes (plan + compound both detected)
- [x] lefthook pre-commit gates green (no-secrets, no-large-files, toml-syntax, rust-fmt, rust-clippy)
- [ ] Post-merge: `make deploy` on the host; verify zero `oversized prompt` lines in `server.log` at startup; verify mika-dev and mika-qa load `self-dev`/`qa-review` respectively
- [ ] Adversarial: temporarily pad one bundled skill's `system_prompt.md` past its declared cap; assert CI fails the new test with a readable message naming the skill

## Plan + grooming history

- Plan: `docs/plans/2026-04-27-001-feat-evaluate-mika-defaults-for-anthropic-plan.md`
- Groomed via `/mika-groom-ticket`: mika-arch first-pass `Disposition: ITERATE` (1 dispatch-blocker on `self-dev` cap target + 5 non-blocking polish items, all applied) → second-pass `Verdict: GROOMED` on session `3b808dd8-7416-4366-8ab7-717f0a203d49`

🤖 Generated with [Claude Code](https://claude.com/claude-code)