### PR TITLE
feat(ui+dashboard): generalize StatusBadge to six-variant API, migrate hand-rolled status pills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - `crates/mika-agent/` — Agent container: SQLite DB, agent loop, tools, prompt assembly, skills, task engine, HTTP server (mika-server). See `crates/mika-agent/CLAUDE.md`.
 - `crates/mika-gateway/` — Telegram and GitHub webhook router: Postgres customer registry, message routing, A2A proxy. See `crates/mika-gateway/CLAUDE.md`.
 - `crates/mika-cli/` — TUI CLI binary (`mika`): ratatui chat interface, clap subcommands. See `crates/mika-cli/CLAUDE.md`.
-- `packages/ui/` — `@senara-solutions/ui` shared React component library (Vite library mode, published to GitHub Packages). Components: StatusBadge, Pagination, EmptyState, CopyButton, MarkdownContent, TaskStatusBadge.
+- `packages/ui/` — `@senara-solutions/ui` shared React component library (Vite library mode, published to GitHub Packages). Components: StatusBadge (six-variant: success/warning/error/info/neutral/blocked), Pagination, EmptyState, CopyButton, MarkdownContent, TaskStatusBadge (thin adapter delegating to StatusBadge). See `packages/ui/CLAUDE.md`.
 - `dashboard/` — React observability dashboard. See `dashboard/CLAUDE.md`.
 - `docs/` — Public documentation (architecture, configuration, deployment, runtime-structure, skills, slash-commands, getting-started) — **single source of truth** for all docs. See [docs/runtime-structure.md](docs/runtime-structure.md) for full `~/.mika` directory layout, DB schema, and log paths.
 - `docs/adr/` — Architecture Decision Records (numbered)

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -26,7 +26,7 @@ Event Timeline, Agents, Sessions, Traces, Tasks (+ detail), Team Runs, LLM Calls
 
 ## `packages/ui/`
 
-`@senara-solutions/ui` shared React component library (Vite library mode, published to GitHub Packages). Components: StatusBadge, Pagination, EmptyState, CopyButton, MarkdownContent, TaskStatusBadge. Utils: formatTime, badges, agentColors. Theme CSS with design tokens. Peer deps: React 19, Tailwind CSS v4, lucide-react.
+`@senara-solutions/ui` shared React component library (Vite library mode, published to GitHub Packages). Components: StatusBadge (six-variant: success/warning/error/info/neutral/blocked), TaskStatusBadge (thin adapter delegating to StatusBadge), Pagination, EmptyState, CopyButton, MarkdownContent. Utils: formatTime, badges, agentColors. Theme CSS with design tokens (colors, spacing scale). Peer deps: React 19, Tailwind CSS v4, lucide-react. See `packages/ui/CLAUDE.md` for the enforcement rules and canonical primitives table.
 
 ## Commands
 

--- a/dashboard/src/pages/AgentDetail.tsx
+++ b/dashboard/src/pages/AgentDetail.tsx
@@ -90,7 +90,7 @@ export default function AgentDetail() {
           <div>
             <div className="flex items-center gap-3">
               <h2 className="text-heading text-xl font-semibold">{agent.name}</h2>
-              <StatusBadge active={agent.active} />
+              <StatusBadge variant={agent.active ? 'success' : 'warning'} label={agent.active ? 'Active' : 'Inactive'} />
             </div>
             <p className="text-xs text-muted/50 font-mono mt-0.5">
               ID: {agent.id} &middot; Created {formatRelativeTime(agent.created_at)}

--- a/dashboard/src/pages/AgentDetail.tsx
+++ b/dashboard/src/pages/AgentDetail.tsx
@@ -90,7 +90,7 @@ export default function AgentDetail() {
           <div>
             <div className="flex items-center gap-3">
               <h2 className="text-heading text-xl font-semibold">{agent.name}</h2>
-              <StatusBadge variant={agent.active ? 'success' : 'warning'} label={agent.active ? 'Active' : 'Inactive'} />
+              <StatusBadge variant={agent.active ? 'success' : 'neutral'} label={agent.active ? 'Active' : 'Inactive'} />
             </div>
             <p className="text-xs text-muted/50 font-mono mt-0.5">
               ID: {agent.id} &middot; Created {formatRelativeTime(agent.created_at)}

--- a/dashboard/src/pages/Agents.tsx
+++ b/dashboard/src/pages/Agents.tsx
@@ -66,7 +66,7 @@ export default function Agents() {
                     </p>
                   </div>
                 </div>
-                <StatusBadge variant={agent.active ? 'success' : 'warning'} label={agent.active ? 'Active' : 'Inactive'} />
+                <StatusBadge variant={agent.active ? 'success' : 'neutral'} label={agent.active ? 'Active' : 'Inactive'} />
               </div>
               <div className="flex items-center justify-between text-xs text-muted pt-3 border-t border-white/[0.04]">
                 <div className="flex items-center gap-4">

--- a/dashboard/src/pages/Agents.tsx
+++ b/dashboard/src/pages/Agents.tsx
@@ -66,7 +66,7 @@ export default function Agents() {
                     </p>
                   </div>
                 </div>
-                <StatusBadge active={agent.active} />
+                <StatusBadge variant={agent.active ? 'success' : 'warning'} label={agent.active ? 'Active' : 'Inactive'} />
               </div>
               <div className="flex items-center justify-between text-xs text-muted pt-3 border-t border-white/[0.04]">
                 <div className="flex items-center gap-4">

--- a/dashboard/src/pages/LlmCallDetail.tsx
+++ b/dashboard/src/pages/LlmCallDetail.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from 'react-router'
 import { useLlmCall } from '../api/llmCalls.ts'
-import { CopyButton, formatRelativeTime } from '@senara-solutions/ui'
+import { CopyButton, StatusBadge, formatRelativeTime } from '@senara-solutions/ui'
+import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import { MetadataRow } from '../components/MetadataRow.tsx'
 
 function formatTokens(n: number | null): string {
@@ -14,29 +15,11 @@ function formatLatency(ms: number): string {
   return `${ms}ms`
 }
 
-function statusBadge(status: string) {
+function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
-    case 'success':
-      return (
-        <span className="inline-flex items-center gap-1.5 text-emerald-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-          success
-        </span>
-      )
-    case 'error':
-      return (
-        <span className="inline-flex items-center gap-1.5 text-red-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-          error
-        </span>
-      )
-    default:
-      return (
-        <span className="inline-flex items-center gap-1.5 text-muted/60">
-          <span className="w-1.5 h-1.5 rounded-full bg-muted/40" />
-          {status}
-        </span>
-      )
+    case 'success': return { variant: 'success', label: 'Success' }
+    case 'error': return { variant: 'error', label: 'Error' }
+    default: return { variant: 'neutral', label: status }
   }
 }
 
@@ -72,7 +55,7 @@ export default function LlmCallDetail() {
             {call.provider} / {call.model}
           </h2>
           <div className="flex items-center gap-3 mt-2">
-            {statusBadge(call.status)}
+            <StatusBadge {...llmStatusVariant(call.status)} />
             <CopyButton text={call.id} title="Copy ID" />
           </div>
         </div>

--- a/dashboard/src/pages/LlmCalls.tsx
+++ b/dashboard/src/pages/LlmCalls.tsx
@@ -1,33 +1,16 @@
 import { Link } from 'react-router'
 import { useLlmCalls, type LlmCallsFilters } from '../api/llmCalls.ts'
 import { useAgents } from '../api/agents.ts'
-import { Pagination, EmptyState, formatTimestamp } from '@senara-solutions/ui'
+import { Pagination, EmptyState, StatusBadge, formatTimestamp } from '@senara-solutions/ui'
+import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import { useSearchParamsFilter } from '../hooks/useSearchParamsFilter.ts'
 import { Search } from 'lucide-react'
 
-function statusBadge(status: string) {
+function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
-    case 'success':
-      return (
-        <span className="inline-flex items-center gap-1 text-emerald-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-          <span className="text-[10px]">success</span>
-        </span>
-      )
-    case 'error':
-      return (
-        <span className="inline-flex items-center gap-1 text-red-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-          <span className="text-[10px]">error</span>
-        </span>
-      )
-    default:
-      return (
-        <span className="inline-flex items-center gap-1 text-muted/60">
-          <span className="w-1.5 h-1.5 rounded-full bg-muted/40" />
-          <span className="text-[10px]">{status}</span>
-        </span>
-      )
+    case 'success': return { variant: 'success', label: 'Success' }
+    case 'error': return { variant: 'error', label: 'Error' }
+    default: return { variant: 'neutral', label: status }
   }
 }
 
@@ -165,7 +148,7 @@ export default function LlmCalls() {
                       {formatLatency(row.latency_ms)}
                     </td>
                     <td className="px-4 py-3">
-                      {statusBadge(row.status)}
+                      <StatusBadge {...llmStatusVariant(row.status)} />
                     </td>
                     <td className="px-4 py-3">
                       {row.trace_id ? (

--- a/dashboard/src/pages/SessionDetail.tsx
+++ b/dashboard/src/pages/SessionDetail.tsx
@@ -4,7 +4,8 @@ import { useSessionDetail, useSessionMessages, type Message } from '../api/sessi
 import { useTeamRun, useTeamWorkspace, type TeamWorkspaceEntry } from '../api/teams.ts'
 import { useSessionLlmCalls } from '../api/llmCalls.ts'
 import { useSessionToolCalls, useSessionSkills, useTraceToolCalls } from '../api/toolCalls.ts'
-import { CopyButton, Pagination, EmptyState, formatTimestamp, getAgentColor } from '@senara-solutions/ui'
+import { CopyButton, Pagination, EmptyState, StatusBadge, formatTimestamp, getAgentColor } from '@senara-solutions/ui'
+import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import InvestigationPanel, {
   type InvestigationScope,
 } from '../components/InvestigationPanel.tsx'
@@ -175,17 +176,7 @@ function ToolCallsTable({
                     </td>
                     {/* Status */}
                     <td className="px-2 py-2">
-                      {tc.success ? (
-                        <span className="inline-flex items-center gap-1 text-emerald-400">
-                          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                          <span className="text-[10px]">ok</span>
-                        </span>
-                      ) : (
-                        <span className="inline-flex items-center gap-1 text-red-400">
-                          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                          <span className="text-[10px]">fail</span>
-                        </span>
-                      )}
+                      <StatusBadge variant={tc.success ? 'success' : 'error'} label={tc.success ? 'Ok' : 'Fail'} />
                     </td>
                     {/* Tool name */}
                     <td className="px-2 py-2 font-mono text-heading font-medium max-w-[160px] truncate">
@@ -298,29 +289,11 @@ function formatLatency(ms: number): string {
   return `${ms}ms`
 }
 
-function llmStatusBadge(status: string) {
+function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
-    case 'success':
-      return (
-        <span className="inline-flex items-center gap-1 text-emerald-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-          <span className="text-[10px]">success</span>
-        </span>
-      )
-    case 'error':
-      return (
-        <span className="inline-flex items-center gap-1 text-red-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-          <span className="text-[10px]">error</span>
-        </span>
-      )
-    default:
-      return (
-        <span className="inline-flex items-center gap-1 text-muted/60">
-          <span className="w-1.5 h-1.5 rounded-full bg-muted/40" />
-          <span className="text-[10px]">{status}</span>
-        </span>
-      )
+    case 'success': return { variant: 'success', label: 'Success' }
+    case 'error': return { variant: 'error', label: 'Error' }
+    default: return { variant: 'neutral', label: status }
   }
 }
 
@@ -351,19 +324,15 @@ function AgentAvatar({ name }: { name: string }) {
   )
 }
 
-function statusBadge(status: string) {
-  const styles: Record<string, string> = {
-    running: 'bg-blue-500/15 text-blue-400',
-    completed: 'bg-emerald-500/15 text-emerald-400',
-    failed: 'bg-red-500/15 text-red-400',
-    suspended: 'bg-amber-500/15 text-amber-400',
-    cancelled: 'bg-white/[0.06] text-muted/60',
+function sessionStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
+  switch (status) {
+    case 'running': return { variant: 'info', label: 'Running' }
+    case 'completed': return { variant: 'success', label: 'Completed' }
+    case 'failed': return { variant: 'error', label: 'Failed' }
+    case 'suspended': return { variant: 'warning', label: 'Suspended' }
+    case 'cancelled': return { variant: 'neutral', label: 'Cancelled' }
+    default: return { variant: 'neutral', label: status }
   }
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase ${styles[status] ?? styles.cancelled}`}>
-      {status}
-    </span>
-  )
 }
 
 function roleConfig(role: string) {
@@ -730,21 +699,17 @@ export default function SessionDetail() {
               <h2 className="text-heading text-lg font-semibold font-mono">{sessionId}</h2>
               <CopyButton text={sessionId ?? ''} className="ml-1" />
               {session && !session.ended_at && (
-                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase bg-emerald-500/15 text-emerald-400">
-                  Active
-                </span>
+                <StatusBadge variant="success" label="Active" />
               )}
               {session && session.ended_at && (
-                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase bg-white/[0.06] text-muted/60">
-                  Ended
-                </span>
+                <StatusBadge variant="neutral" label="Ended" />
               )}
               {isTeamSession && (
                 <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase bg-purple-500/15 text-purple-400">
                   <Users size={10} /> Team
                 </span>
               )}
-              {teamRun && statusBadge(teamRun.status)}
+              {teamRun && <StatusBadge {...sessionStatusVariant(teamRun.status)} />}
             </div>
             {session && (
               <div className="flex items-center gap-3 mt-1">
@@ -936,7 +901,7 @@ export default function SessionDetail() {
                       <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right">{formatTokens(row.output_tokens)}</td>
                       <td className="px-4 py-3 text-xs text-muted/40 font-mono text-right">{formatTokens(row.cache_read_tokens)}</td>
                       <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right whitespace-nowrap">{formatLatency(row.latency_ms)}</td>
-                      <td className="px-4 py-3">{llmStatusBadge(row.status)}</td>
+                      <td className="px-4 py-3"><StatusBadge {...llmStatusVariant(row.status)} /></td>
                       <td className="px-4 py-3">
                         {row.trace_id ? (
                           <Link
@@ -1023,17 +988,7 @@ export default function SessionDetail() {
                             {row.skill_name ?? <span className="text-muted/30">-</span>}
                           </td>
                           <td className="px-4 py-3">
-                            {row.success ? (
-                              <span className="inline-flex items-center gap-1 text-emerald-400">
-                                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                                <span className="text-[10px]">ok</span>
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center gap-1 text-red-400">
-                                <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                                <span className="text-[10px]">fail</span>
-                              </span>
-                            )}
+                            <StatusBadge variant={row.success ? 'success' : 'error'} label={row.success ? 'Ok' : 'Fail'} />
                           </td>
                           <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right whitespace-nowrap">
                             {formatLatency(row.latency_ms)}

--- a/dashboard/src/pages/Timeline.tsx
+++ b/dashboard/src/pages/Timeline.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router'
 import { useTimeline, type TimelineFilters } from '../api/timeline.ts'
 import { useAgents } from '../api/agents.ts'
-import { Pagination, EmptyState, formatTimestamp, eventTypeBadge } from '@senara-solutions/ui'
+import { Pagination, EmptyState, StatusBadge, formatTimestamp, eventTypeBadge } from '@senara-solutions/ui'
 import { useSearchParamsFilter } from '../hooks/useSearchParamsFilter.ts'
 import { Search } from 'lucide-react'
 
@@ -36,10 +36,7 @@ export default function Timeline() {
           <div className="flex items-center gap-3">
             <h2 className="text-heading text-xl font-semibold">Unified Event Timeline</h2>
             {autoRefresh && (
-              <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase bg-emerald-500/15 text-emerald-400">
-                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                Live
-              </span>
+              <StatusBadge variant="success" label="Live" dotPulse />
             )}
           </div>
           <p className="text-sm text-muted/60 mt-1">

--- a/dashboard/src/pages/ToolCallDetail.tsx
+++ b/dashboard/src/pages/ToolCallDetail.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router'
 import { useToolCall } from '../api/toolCalls.ts'
-import { CopyButton, formatRelativeTime } from '@senara-solutions/ui'
+import { CopyButton, StatusBadge, formatRelativeTime } from '@senara-solutions/ui'
 import { MetadataRow } from '../components/MetadataRow.tsx'
 
 function formatLatency(ms: number): string {
@@ -51,17 +51,7 @@ export default function ToolCallDetail() {
         <div>
           <h2 className="text-heading text-xl font-semibold font-mono">{call.tool_name}</h2>
           <div className="flex items-center gap-3 mt-2">
-            {call.success ? (
-              <span className="inline-flex items-center gap-1.5 text-emerald-400 text-sm">
-                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                success
-              </span>
-            ) : (
-              <span className="inline-flex items-center gap-1.5 text-red-400 text-sm">
-                <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                failed
-              </span>
-            )}
+            <StatusBadge variant={call.success ? 'success' : 'error'} label={call.success ? 'Success' : 'Failed'} />
             <span className={`inline-flex items-center text-[10px] font-semibold px-2 py-0.5 rounded-full ${sourceBadge(call.tool_source)}`}>
               {call.tool_source}
             </span>

--- a/dashboard/src/pages/ToolCalls.tsx
+++ b/dashboard/src/pages/ToolCalls.tsx
@@ -2,7 +2,7 @@ import { useState, Fragment } from 'react'
 import { Link } from 'react-router'
 import { useToolCalls, type ToolCallsFilters } from '../api/toolCalls.ts'
 import { useAgents } from '../api/agents.ts'
-import { CopyButton, Pagination, EmptyState, formatTimestamp } from '@senara-solutions/ui'
+import { CopyButton, Pagination, EmptyState, StatusBadge, formatTimestamp } from '@senara-solutions/ui'
 import { useSearchParamsFilter } from '../hooks/useSearchParamsFilter.ts'
 import { Search, ChevronRight, ChevronDown } from 'lucide-react'
 
@@ -167,17 +167,7 @@ export default function ToolCalls() {
                           {row.skill_name ?? <span className="text-muted/30">-</span>}
                         </td>
                         <td className="px-4 py-3">
-                          {row.success ? (
-                            <span className="inline-flex items-center gap-1 text-emerald-400">
-                              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                              <span className="text-[10px]">ok</span>
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center gap-1 text-red-400">
-                              <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                              <span className="text-[10px]">fail</span>
-                            </span>
-                          )}
+                          <StatusBadge variant={row.success ? 'success' : 'error'} label={row.success ? 'Ok' : 'Fail'} />
                         </td>
                         <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right whitespace-nowrap">
                           {formatLatency(row.latency_ms)}

--- a/dashboard/src/pages/TraceDetail.tsx
+++ b/dashboard/src/pages/TraceDetail.tsx
@@ -4,6 +4,7 @@ import { useTraceDetail, useTraceMessages, type TraceMessage } from '../api/time
 import { useTraceLlmCalls } from '../api/llmCalls.ts'
 import { useTraceToolCalls } from '../api/toolCalls.ts'
 import { CopyButton as UiCopyButton, EmptyState, StatusBadge, formatTimestamp, eventTypeBadge, eventTypeColor } from '@senara-solutions/ui'
+import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import InvestigationPanel, {
   type InvestigationScope,
 } from '../components/InvestigationPanel.tsx'
@@ -96,29 +97,11 @@ function formatLatency(ms: number): string {
   return `${ms}ms`
 }
 
-function llmStatusBadge(status: string) {
+function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
-    case 'success':
-      return (
-        <span className="inline-flex items-center gap-1 text-emerald-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-          <span className="text-[10px]">success</span>
-        </span>
-      )
-    case 'error':
-      return (
-        <span className="inline-flex items-center gap-1 text-red-400">
-          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-          <span className="text-[10px]">error</span>
-        </span>
-      )
-    default:
-      return (
-        <span className="inline-flex items-center gap-1 text-muted/60">
-          <span className="w-1.5 h-1.5 rounded-full bg-muted/40" />
-          <span className="text-[10px]">{status}</span>
-        </span>
-      )
+    case 'success': return { variant: 'success', label: 'Success' }
+    case 'error': return { variant: 'error', label: 'Error' }
+    default: return { variant: 'neutral', label: status }
   }
 }
 
@@ -646,7 +629,7 @@ export default function TraceDetail() {
                     <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right">{formatTokens(row.input_tokens)}</td>
                     <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right">{formatTokens(row.output_tokens)}</td>
                     <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right whitespace-nowrap">{formatLatency(row.latency_ms)}</td>
-                    <td className="px-4 py-3">{llmStatusBadge(row.status)}</td>
+                    <td className="px-4 py-3"><StatusBadge {...llmStatusVariant(row.status)} /></td>
                   </tr>
                 ))}
               </tbody>
@@ -715,17 +698,7 @@ export default function TraceDetail() {
                           {row.skill_name ?? <span className="text-muted/30">-</span>}
                         </td>
                         <td className="px-4 py-3">
-                          {row.success ? (
-                            <span className="inline-flex items-center gap-1 text-emerald-400">
-                              <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                              <span className="text-[10px]">ok</span>
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center gap-1 text-red-400">
-                              <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                              <span className="text-[10px]">fail</span>
-                            </span>
-                          )}
+                          <StatusBadge variant={row.success ? 'success' : 'error'} label={row.success ? 'Ok' : 'Fail'} />
                         </td>
                         <td className="px-4 py-3 text-xs text-muted/70 font-mono text-right whitespace-nowrap">
                           {formatLatency(row.latency_ms)}

--- a/dashboard/src/pages/TraceDetail.tsx
+++ b/dashboard/src/pages/TraceDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router'
 import { useTraceDetail, useTraceMessages, type TraceMessage } from '../api/timeline.ts'
 import { useTraceLlmCalls } from '../api/llmCalls.ts'
 import { useTraceToolCalls } from '../api/toolCalls.ts'
-import { CopyButton as UiCopyButton, EmptyState, formatTimestamp, eventTypeBadge, eventTypeColor } from '@senara-solutions/ui'
+import { CopyButton as UiCopyButton, EmptyState, StatusBadge, formatTimestamp, eventTypeBadge, eventTypeColor } from '@senara-solutions/ui'
 import InvestigationPanel, {
   type InvestigationScope,
 } from '../components/InvestigationPanel.tsx'
@@ -237,17 +237,7 @@ function ToolCallsTable({
                       {isOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                     </td>
                     <td className="px-2 py-2">
-                      {tc.success ? (
-                        <span className="inline-flex items-center gap-1 text-emerald-400">
-                          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                          <span className="text-[10px]">ok</span>
-                        </span>
-                      ) : (
-                        <span className="inline-flex items-center gap-1 text-red-400">
-                          <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
-                          <span className="text-[10px]">fail</span>
-                        </span>
-                      )}
+                      <StatusBadge variant={tc.success ? 'success' : 'error'} label={tc.success ? 'Ok' : 'Fail'} />
                     </td>
                     <td className="px-2 py-2 font-mono text-heading font-medium max-w-[160px] truncate">
                       {tc.name}

--- a/docs/design/luminescent-core.md
+++ b/docs/design/luminescent-core.md
@@ -117,6 +117,23 @@ Forbid 1px divider lines. Separate list items using the **Spacing Scale**:
 
 - Use `surface_bright` as the background with a 2px inner "glow" dot using the `primary` token to signify an active agent.
 
+### 5.1 Multi-state status grammar
+
+The active-agent chip above is the canonical surface form. For surfaces requiring multi-state status indication (success/failed operations, pending/blocked task states, info/neutral classifications), the design system declares six variants. `<StatusBadge />` from `@senara-solutions/ui` is the canonical rendering primitive for this grammar.
+
+| Variant | Token | Semantic meaning |
+|---|---|---|
+| `success` | `--color-success` | Operation completed successfully; agent active; positive terminal state |
+| `warning` | `--color-warning` | Degraded, paused, pending — caution but not failure; can resume |
+| `error` | `--color-error` | Operation failed; intervention required |
+| `info` | `--color-accent` | Active operation in progress; informational/in-motion state |
+| `neutral` | `--color-muted` | Cancelled, archived, or stateless; no active signal |
+| `blocked` | `--color-blocked` | External-dependency wait; visually distinct from `warning` to preserve at-a-glance signal when paired with pending/suspended states in tabular contexts |
+
+Labels render UPPERCASE with `tracking-wide` (`0.05em` letter-spacing) per §3 typography. The active-agent chip above is a specialized form of `success` with the `dotPulse` modifier.
+
+**Hand-rolled status pills are forbidden.** Any new surface code rendering its own status pill (success/error inline indicators, custom colored dots with text) is a review fail. Use `<StatusBadge variant="..." label="..." />` from `@senara-solutions/ui`. For task-domain status (`pending`, `in_progress`, `completed`, etc.), use `<TaskStatusBadge status={...} />` which delegates to `<StatusBadge />` with the canonical task→variant mapping.
+
 ### Input Fields
 
 - Background: `surface_container_lowest`.

--- a/docs/plans/2026-04-27-001-feat-657-dashboard-visual-rhythm-plan.md
+++ b/docs/plans/2026-04-27-001-feat-657-dashboard-visual-rhythm-plan.md
@@ -232,6 +232,10 @@ Labels render UPPERCASE with `tracking-wide` (`0.05em` letter-spacing) per §3 t
 
 This addition is the design-system contract for the grammar Change 2 introduces. It declares variants, semantic meaning, canonical rendering surface, and the hand-rolled-forbidden rule. Future variants extend the table here, not in the codebase first.
 
+**Layering discipline (per architect second-pass sharpening):** the rulebook references tokens *by name* (`--color-blocked`, `--color-success`, etc.); concrete hex values live in `theme.css` (Change 1). Avoiding hex literals in `luminescent-core.md` keeps the layering clean — rulebook declares grammar, theme defines values, component consumes both. Single definition point per token.
+
+**Follow-up trigger named:** `recurring_active → info` is a semantic generalization. If operational context requires visual distinction between `in_progress` and `recurring_active` (e.g., "agent doing something right now" vs "task scheduled to run on cadence"), add `--color-recurring` token + extend §5.1's table in a follow-up. Not a blocker for #657.
+
 Net diff: ~25 lines added to `luminescent-core.md`.
 
 ### Change 5 — Document canonical-primitive enforcement in `packages/ui/CLAUDE.md`

--- a/docs/plans/2026-04-27-001-feat-657-dashboard-visual-rhythm-plan.md
+++ b/docs/plans/2026-04-27-001-feat-657-dashboard-visual-rhythm-plan.md
@@ -1,0 +1,376 @@
+---
+title: "feat(ui+dashboard): align StatusBadge/TaskStatusBadge to luminescent-core, add spacing tokens, migrate hand-rolled status pills"
+type: feat
+status: active
+date: 2026-04-27
+origin: senara-solutions/mika#657
+---
+
+# Plan — dashboard visual rhythm: tokens + status pill alignment + migration (mika#657)
+
+**Issue:** [mika#657](https://github.com/senara-solutions/issues/657) — `Dashboard > Visual rhythm: recent-activity widgets and tables lack proportion, shared spacing tokens, consistent status pills`
+**Branch:** `feat/657/dashboard-visual-rhythm-tokens-pills`
+**Type:** feat (Phase 2 primitive in milestone #13)
+**Labels:** enhancement, dashboard
+
+## Problem (per issue body, leading callout)
+
+> mostly subsumed by `mika/docs/design/luminescent-core.md` (rulebook now covers tokens, status pills, spacing, typography). Remaining scope: audit existing components against the rulebook and migrate any non-conforming instances.
+
+The body's broader proposal (build out `<StatusPill />`, `<RecentActivityCard />`, table column ratio conventions, aspect ratios) is largely covered by sibling tickets. This plan focuses on the body's *actual* remaining scope.
+
+## Audit results (verified during planning)
+
+### What luminescent-core.md prescribes
+
+| Concern | Rulebook prescription | Cite |
+|---|---|---|
+| Spacing scale | 8px base, doubled (`spacing-1`=4px, `spacing-2`=8px, `spacing-4`=16px, …, `spacing-16`=64px) | §6 |
+| Color tokens | `--color-primary`, `--color-error`, `surface_*`, `on_surface_variant`, etc. — full table | §2 |
+| Typography (status labels) | Use `label-md`/`label-sm` UPPERCASE with `0.05em` letter-spacing for "system metadata" | §3 |
+| Active-agent chip | `surface_bright` bg + 2px `primary`-token glow dot | §5 |
+| Roundedness | `xl` (1.5rem) or `lg` (1rem) for cards; pills can use `rounded-full` | §4 |
+| Multi-state status grammar (success/warn/error/info/neutral) | **Silent** | — |
+| Aspect ratios for cards | **Silent** | — |
+| Row density tokens, "recent N" caps | **Silent** | — |
+| ID truncation + copy | **Silent** | — |
+
+The rulebook is **silent** on multi-state pill grammar, recent-N caps, and ID truncation. Those silences map to sibling tickets:
+- Multi-state grammar → in scope here as a minimal extension, but only what's needed to migrate existing hand-rolled instances.
+- Recent-N caps + aspect ratios → mika#658 (state catalog) or future Phase 4 cross-cutting work.
+- ID truncation + copy → `<TraceIdWidget />` consumed by mika#651, mika#652, mika#653 (already named in those tickets' bodies).
+
+### What `@senara-solutions/ui` ships today
+
+| Component | File | API | Drift from rulebook |
+|---|---|---|---|
+| `<StatusBadge>` | `packages/ui/src/components/StatusBadge.tsx` | `{ active: boolean }` — binary only | Hardcoded emerald/amber, not design tokens; only 2 states |
+| `<TaskStatusBadge>` | `packages/ui/src/components/TaskStatusBadge.tsx` | `{ status: string }` — 10 task states | Hardcoded yellow/blue/green/red/emerald/orange/gray/purple; labels not uppercase + tracking-wide |
+| `<Pagination>` | `…/Pagination.tsx` | 4-prop API | OK (audited mika#663) |
+| `<EmptyState>` | `…/EmptyState.tsx` | `{ message }` | Will be extended in mika#658 |
+| `<CopyButton>` | `…/CopyButton.tsx` | `{ text, className?, title? }` | Visual-confirm refinement in mika#665 |
+| `<MarkdownContent>` | `…/MarkdownContent.tsx` | `{ content }` | OK |
+
+`packages/ui/src/theme.css` (13 lines, lines 1–13) defines color + font tokens but **no spacing tokens** — rulebook §6 prescribes `spacing-1` through `spacing-16` and they are absent.
+
+### Hand-rolled status pills found in dashboard
+
+Verified via `grep -rn "rounded-full" mika/dashboard/src/pages/*.tsx` plus targeted reads. Each row is a place where `<StatusBadge />` (after generalization) should be used:
+
+| File | Line(s) | Current shape | Migrates to |
+|---|---|---|---|
+| `LlmCalls.tsx` | 130–147 | success/failed dot+text inline | `<StatusBadge variant="success" label="Success" />` / `variant="error" label="Failed"` |
+| `LlmCallDetail.tsx` | 71–87 | same shape as LlmCalls | same |
+| `ToolCallDetail.tsx` | 54–67 | success/failed dots inline | same |
+| `TraceDetail.tsx` | 225–232 | success/failed dots inline | same |
+| `Timeline.tsx` | 39 | live indicator with pulse | `<StatusBadge variant="success" label="Live" dotPulse />` |
+| `SessionDetail.tsx` | various inline pills (209–372 region) | success/failed indicators | same |
+| `ToolCalls.tsx` | 113–120 | success/failed dots inline | same |
+
+**Out of scope (named explicitly):**
+- `Sessions.tsx:137` — channel pill (`system` / `github`). This is a *content pill*, not a status pill. Different semantics. Files a follow-up ticket if needed; not migrated here.
+- `ToolCalls.tsx:37–44` — `sourceBadge()` helper for tool source (builtin/skill/mcp). Also a typed-source classifier, not a status. Could be a `<SourceBadge />` primitive in a future ticket. Not migrated here.
+- All UUID/trace-ID truncation drift — `<TraceIdWidget />` is sibling-ticket scope (#651/#652/#653).
+
+## Approach
+
+Five changes, two layers (`packages/ui/` + `dashboard/`):
+
+### Change 1 — Add spacing tokens to `packages/ui/src/theme.css`
+
+**File:** `mika/packages/ui/src/theme.css` (existing, 13 lines)
+
+Per rulebook §6, add the 8px-base spacing scale to the `@theme` block. Tailwind v4 reads `--spacing-N` tokens from `@theme` and exposes them as utility classes (`p-1`, `gap-4`, etc., remapped to the token values).
+
+```css
+@theme {
+  /* existing colors and fonts unchanged */
+
+  /* Status pill variant for external-dependency wait (per Change 6 luminescent-core extension) */
+  --color-blocked: #f97316;        /* orange-500 — sharper than warning, distinct at-a-glance */
+
+  /* Spacing scale per luminescent-core §6 (8px base, doubled rhythm) */
+  --spacing-1: 0.25rem;   /*  4px */
+  --spacing-2: 0.5rem;    /*  8px */
+  --spacing-3: 0.75rem;   /* 12px */
+  --spacing-4: 1rem;      /* 16px */
+  --spacing-5: 1.25rem;   /* 20px */
+  --spacing-6: 1.5rem;    /* 24px */
+  --spacing-8: 2rem;      /* 32px */
+  --spacing-12: 3rem;     /* 48px */
+  --spacing-16: 4rem;     /* 64px */
+}
+```
+
+Note: Tailwind v4's default spacing scale is already 4px-based. This change makes the scale **explicit** in the design system layer, establishing tokens future components can reference by name (e.g., a row-density component can declare `padding: var(--spacing-4)` instead of `p-4`). For *existing* components, no migration is required — Tailwind utilities continue to work because the resolved values are identical to defaults.
+
+**Why this matters even though values match Tailwind defaults:** the rulebook prescribes the scale; making it explicit in `@theme` (a) names the intent (these are design tokens, not Tailwind defaults that happen to be 4px), (b) lets `<StatusBadge />` and future components reference `var(--spacing-N)` directly when CSS-in-JS or computed styling is needed, and (c) makes drift visible — anyone changing the scale changes the rulebook, not a coincidence. Net diff: ~12 lines added.
+
+### Change 2 — Generalize `<StatusBadge />` from binary to multi-variant (six variants)
+
+**File:** `mika/packages/ui/src/components/StatusBadge.tsx` (existing, 22 lines)
+
+Current API: `{ active: boolean }`. Replace with:
+
+```typescript
+interface StatusBadgeProps {
+  variant: 'success' | 'warning' | 'error' | 'info' | 'neutral' | 'blocked'
+  label: string
+  dotPulse?: boolean
+}
+```
+
+**Variant count resolved at plan time (per architect Finding 2, first-pass):** six variants, not five. The sixth variant `blocked` is included because external-dependency-wait carries meaningfully distinct semantics from "not yet started" (`pending` → `warning`) and "paused, resumable" (`suspended` → `warning`). At-a-glance visual distinction matters — collapsing three task states (`pending`, `blocked`, `suspended`) into one `warning` variant loses signal. `blocked` gets its own variant; `pending` and `suspended` map to `warning` (text discriminates).
+
+Variants map to design-token-derived classNames (using existing `--color-success`, `--color-warning`, `--color-error`, `--color-accent`, `--color-muted`, plus a new `--color-blocked` derived from rulebook `--color-warning` with sharper saturation):
+
+| variant | bg | text | dot | semantic meaning |
+|---|---|---|---|---|
+| `success` | `bg-success/10` | `text-success` | `bg-success` | Operation completed successfully; agent active |
+| `warning` | `bg-warning/10` | `text-warning` | `bg-warning` | Degraded, paused, or pending — caution but not failure |
+| `error` | `bg-error/10` | `text-error` | `bg-error` | Operation failed; needs intervention |
+| `info` | `bg-accent/10` | `text-accent` | `bg-accent` | Active operation in progress; informational state |
+| `neutral` | `bg-white/[0.06]` | `text-muted` | `bg-muted` | Cancelled, archived, or no-state |
+| `blocked` | `bg-blocked/15` | `text-blocked` | `bg-blocked` | External-dependency wait; distinct from warning to preserve at-a-glance signal |
+
+Labels render UPPERCASE with `tracking-wide` (Tailwind utility for `0.05em` letter-spacing), per rulebook §3:
+
+```tsx
+<span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide ${variantBg} ${variantText}`}>
+  <span className={`w-1.5 h-1.5 rounded-full ${variantDot} ${dotPulse ? 'animate-pulse' : ''}`} />
+  {label}
+</span>
+```
+
+**Migrating existing binary callsites:**
+- `Agents.tsx` (line 46 import + render) → `<StatusBadge variant={agent.active ? 'success' : 'warning'} label={agent.active ? 'Active' : 'Inactive'} />`
+- `AgentDetail.tsx` (line 93 import + render) → same shape
+
+**Net diff (Change 2):** ~30 lines in `StatusBadge.tsx` (rewrite component), ~2 lines per existing callsite (2 callsites = 4 lines).
+
+### Change 3 — Refactor `<TaskStatusBadge />` to thin adapter delegating to `<StatusBadge />`
+
+**File:** `mika/packages/ui/src/components/TaskStatusBadge.tsx` (existing, 27 lines)
+
+Per architect Finding 3 (first-pass): `<TaskStatusBadge />` is **NOT merged into `<StatusBadge />`**; it becomes a thin adapter. Typed `status: string` (the task vocabulary) → `variant + label` mapping lives in `<TaskStatusBadge />`; the actual rendering primitive is `<StatusBadge />`. This factoring (a) keeps a typed domain API for task consumers (no re-derivation of `task → variant` at every callsite), (b) ensures consistent rendering by routing through a single primitive, and (c) prevents future refactor pressure to merge — the delegation pattern is the architecture.
+
+```typescript
+import StatusBadge from './StatusBadge'
+
+const TASK_VARIANT_MAP: Record<string, { variant: 'success' | 'warning' | 'error' | 'info' | 'neutral' | 'blocked'; label?: string }> = {
+  pending: { variant: 'warning', label: 'PENDING' },
+  in_progress: { variant: 'info', label: 'IN PROGRESS' },
+  running: { variant: 'info', label: 'RUNNING' },
+  completed: { variant: 'success', label: 'COMPLETED' },
+  delivered: { variant: 'success', label: 'DELIVERED' },
+  failed: { variant: 'error', label: 'FAILED' },
+  blocked: { variant: 'blocked', label: 'BLOCKED' },
+  cancelled: { variant: 'neutral', label: 'CANCELLED' },
+  suspended: { variant: 'warning', label: 'SUSPENDED' },
+  recurring_active: { variant: 'info', label: 'RECURRING' },
+}
+
+const DEFAULT = { variant: 'neutral' as const, label: undefined }
+
+export default function TaskStatusBadge({ status }: { status: string }) {
+  const mapped = TASK_VARIANT_MAP[status] ?? DEFAULT
+  return <StatusBadge variant={mapped.variant} label={mapped.label ?? status.replace(/_/g, ' ').toUpperCase()} />
+}
+```
+
+**Six-variant mapping (resolved at plan time per architect Finding 2):**
+- `pending`, `suspended` → `warning` (caution, not failure)
+- `in_progress`, `running`, `recurring_active` → `info` (active operation)
+- `completed`, `delivered` → `success`
+- `failed` → `error`
+- `blocked` → `blocked` (sixth variant — external wait, visually distinct from warning)
+- `cancelled` → `neutral`
+
+`recurring_active` maps to `info` rather than its current `purple` because `purple` is not in the rulebook palette and the semantics ("scheduled-recurring, currently active") fits `info`. If Vincent's hand-rolled-purple was load-bearing, raise as a follow-up — purple is not a luminescent-core token.
+
+API stays `{ status: string }` — no consumer changes. Net diff: full rewrite from inline `STATUS_STYLES` map (with hardcoded Tailwind classes) to the adapter shape (~25-line file replacing 27 lines).
+
+### Change 4 — Migrate hand-rolled status pills to `<StatusBadge />`
+
+**Files (7):** `dashboard/src/pages/{LlmCalls,LlmCallDetail,ToolCalls,ToolCallDetail,TraceDetail,Timeline,SessionDetail}.tsx`
+
+For each hand-rolled success/failed/live pill listed in the audit table, replace the inline `<span>` with `<StatusBadge variant="…" label="…" />`. The audit table above names every callsite by file:line. Net diff: ~7 lines deleted + ~3 lines added per callsite × ~10 callsites = ~70 lines net reduction (component substitution shrinks each callsite).
+
+After migration, `grep -rn "inline-flex items-center.*rounded-full" mika/dashboard/src/pages/` should return only:
+- `Sessions.tsx:137` (channel pill — out of scope)
+- `ToolCalls.tsx:113–120` if not migrated (success/failed) — verify migrated
+- Any pills inside `packages/ui/` components (StatusBadge.tsx, TaskStatusBadge.tsx, etc. — bubbles up)
+
+This grep becomes the post-migration drift detector (and is added to the verification block).
+
+### Change 6 — Extend `luminescent-core.md` with multi-state status pill grammar
+
+**File:** `mika/docs/design/luminescent-core.md` (existing rulebook)
+
+**Per architect Finding 1 (first-pass, dispatch-blocker):** the rulebook is silent on multi-state grammar (success/warning/error/info/neutral/blocked) but Change 2 introduces a six-variant `<StatusBadge />` API. Without naming this as a rulebook extension, the codebase silently diverges from the design system doc — next designer or developer reads luminescent-core.md, doesn't see multi-state grammar, and either re-derives differently or treats `<StatusBadge />`'s variants as implementation detail rather than design system contract.
+
+Add a new subsection to luminescent-core.md (likely under §5 "AI Agent Status Chips" or as a new §5.1):
+
+```markdown
+### 5.1 Multi-state status grammar
+
+The active-agent chip (§5) is the canonical surface form. For surfaces requiring multi-state status indication (success/failed operations, pending/blocked task states, info/neutral classifications), the design system declares six variants. `<StatusBadge />` from `@senara-solutions/ui` is the canonical rendering primitive for this grammar.
+
+| Variant | Token | Semantic meaning |
+|---|---|---|
+| `success` | `--color-success` | Operation completed successfully; agent active; positive terminal state |
+| `warning` | `--color-warning` | Degraded, paused, pending — caution but not failure; can resume |
+| `error` | `--color-error` | Operation failed; intervention required |
+| `info` | `--color-accent` | Active operation in progress; informational/in-motion state |
+| `neutral` | `--color-muted` | Cancelled, archived, or stateless; no active signal |
+| `blocked` | `--color-blocked` | External-dependency wait; visually distinct from `warning` to preserve at-a-glance signal when paired with pending/suspended states in tabular contexts |
+
+Labels render UPPERCASE with `tracking-wide` (`0.05em` letter-spacing) per §3 typography. The active-agent chip (§5) is a specialized form of `success` with the `dotPulse` modifier.
+
+**Hand-rolled status pills are forbidden.** Any new surface code rendering its own status pill (success/error inline indicators, custom colored dots with text) is a review fail. Use `<StatusBadge variant="..." label="..." />` from `@senara-solutions/ui`. For task-domain status (`pending`, `in_progress`, `completed`, etc.), use `<TaskStatusBadge status={...} />` which delegates to `<StatusBadge />` with the canonical task→variant mapping.
+```
+
+This addition is the design-system contract for the grammar Change 2 introduces. It declares variants, semantic meaning, canonical rendering surface, and the hand-rolled-forbidden rule. Future variants extend the table here, not in the codebase first.
+
+Net diff: ~25 lines added to `luminescent-core.md`.
+
+### Change 5 — Document canonical-primitive enforcement in `packages/ui/CLAUDE.md`
+
+**File:** `mika/packages/ui/CLAUDE.md` (does not exist yet — `mika#663` plan creates it)
+
+If `mika#663` ships first, extend its enforcement table with a `<StatusBadge />` row (Audited clean — mika#657). If `mika#657` ships first, this plan creates `packages/ui/CLAUDE.md` from scratch using the same shape as `mika#663`'s plan (component table + escape-hatch + migration-status column) and seeds it with `<StatusBadge />` and `<TaskStatusBadge />` as `Audited clean (mika#657)`.
+
+Sequencing note: ship-order is operator's call. Either ticket can seed the file; the other extends it. The plan files for both tickets reference `packages/ui/CLAUDE.md` as a load-bearing artifact, so whichever ships second updates the existing table.
+
+**Net diff:** if seeding the file, ~50 lines (per `mika#663`'s plan). If extending, ~5 lines (one row + entry in narrative).
+
+## Files
+
+| Change | File | Diff shape |
+|---|---|---|
+| 1 | `mika/packages/ui/src/theme.css` | +13 lines: `--color-blocked` + `--spacing-1` through `--spacing-16` in `@theme` block |
+| 2 | `mika/packages/ui/src/components/StatusBadge.tsx` | Full rewrite: ~22 lines → ~32 lines, API change `{active}` → `{variant, label, dotPulse?}`, six variants |
+| 2 | `mika/dashboard/src/pages/Agents.tsx` | Update binary callsite → variant API |
+| 2 | `mika/dashboard/src/pages/AgentDetail.tsx` | Update binary callsite → variant API |
+| 3 | `mika/packages/ui/src/components/TaskStatusBadge.tsx` | Refactor to thin adapter delegating to `<StatusBadge />`; typed task→variant map |
+| 4 | `mika/dashboard/src/pages/LlmCalls.tsx` | Replace inline success/failed pills with `<StatusBadge>` |
+| 4 | `mika/dashboard/src/pages/LlmCallDetail.tsx` | Same |
+| 4 | `mika/dashboard/src/pages/ToolCalls.tsx` | Same (success/failed only — sourceBadge stays out of scope) |
+| 4 | `mika/dashboard/src/pages/ToolCallDetail.tsx` | Same |
+| 4 | `mika/dashboard/src/pages/TraceDetail.tsx` | Same |
+| 4 | `mika/dashboard/src/pages/Timeline.tsx` | Replace Live indicator with `<StatusBadge variant="success" label="Live" dotPulse />` |
+| 4 | `mika/dashboard/src/pages/SessionDetail.tsx` | Replace inline success/failed pills (multiple in 209–372 region) |
+| 5 | `mika/packages/ui/CLAUDE.md` | Add `<StatusBadge />` row to enforcement table (or seed file if not yet created) |
+| 6 | `mika/docs/design/luminescent-core.md` | +25 lines: new §5.1 multi-state status pill grammar (six variants, semantic meanings, canonical rendering surface, hand-rolled-forbidden rule) |
+
+Estimated diff: ~150-200 lines across 12-13 files. Net reduction in dashboard/ since substitutions are shorter than originals; net addition in packages/ui/.
+
+## Tests
+
+`@senara-solutions/ui` currently has no test scaffolding (verified — no `packages/ui/**/*.test.{ts,tsx}` files exist). Verification is by:
+
+1. **Build verification** — `npm run build` in `packages/ui/` and `dashboard/` both succeed without TypeScript errors after API changes.
+2. **Visual verification** — `npm run dev:dashboard` (per root CLAUDE.md), navigate to each migrated page (Agents, LlmCalls, ToolCalls, Timeline, etc.) and verify status pills render with token colors, uppercase labels, tracking-wide letter-spacing, and the Live indicator on Timeline pulses.
+3. **Drift grep** — `grep -rn "inline-flex items-center.*rounded-full" mika/dashboard/src/pages/` should return only `Sessions.tsx:137` (channel — out of scope) plus pills inside library components. Any other match means a hand-rolled instance was missed.
+4. **Color-token grep** — `grep -rn "bg-emerald-400\|bg-red-400\|bg-amber-400" mika/packages/ui/src/components/` should return zero matches after Change 2 + Change 3 land. All colors must reference design tokens.
+
+If/when `@senara-solutions/ui` test scaffolding is added (separate ticket), `<StatusBadge />` and `<TaskStatusBadge />` should get unit tests for variant→className mapping. Out of scope here.
+
+## Acceptance criteria
+
+- [ ] `mika/docs/design/luminescent-core.md` includes a new §5.1 declaring the six-variant multi-state grammar (success/warning/error/info/neutral/blocked) with semantic meanings, canonical rendering surface (`<StatusBadge />`), and the hand-rolled-forbidden rule.
+- [ ] `mika/packages/ui/src/theme.css` declares `--color-blocked` and `--spacing-1` through `--spacing-16`.
+- [ ] `mika/packages/ui/src/components/StatusBadge.tsx` API is `{ variant, label, dotPulse? }` with six variants; binary `active: boolean` API removed.
+- [ ] `mika/packages/ui/src/components/TaskStatusBadge.tsx` is refactored to a thin adapter that delegates to `<StatusBadge />` via a typed task→variant mapping. No standalone rendering remains.
+- [ ] `<StatusBadge />` (and therefore `<TaskStatusBadge />` via delegation) renders labels UPPERCASE with `tracking-wide`.
+- [ ] All hand-rolled success/failed/live pills in `dashboard/src/pages/{LlmCalls,LlmCallDetail,ToolCalls,ToolCallDetail,TraceDetail,Timeline,SessionDetail}.tsx` use `<StatusBadge />` (per audit table file:line).
+- [ ] `grep -rn "bg-emerald-400\|bg-red-400\|bg-amber-400" mika/packages/ui/src/components/` returns zero matches.
+- [ ] Secondary sweep: `grep -rn "bg-.*green\|bg-.*red\|bg-.*emerald\|bg-.*amber\|text-emerald-\|text-red-\|text-yellow-" mika/dashboard/src/pages/*.tsx` matches only inside out-of-scope items (channel pill, source badge, lucide icon containers); each match is named in the PR description as out-of-scope.
+- [ ] `grep -rn "inline-flex items-center.*rounded-full" mika/dashboard/src/pages/` returns only out-of-scope rows.
+- [ ] `mika/packages/ui/CLAUDE.md` enforcement table lists `<StatusBadge />` with `Audited clean (mika#657)` migration status. (If file doesn't yet exist, this plan seeds it; if `mika#663` shipped first, extends it.)
+- [ ] `npm run build` succeeds in `packages/ui/` and `dashboard/`.
+- [ ] Visual check on migrated pages (success/failed/live indicators + task statuses) confirms token colors render correctly and `blocked` is visually distinct from `warning`.
+
+## Out of scope
+
+- **Channel pill in `Sessions.tsx`** — content pill, not status. File a `<ChannelPill />` ticket if drift surfaces.
+- **`sourceBadge()` helper in `ToolCalls.tsx`** — typed-source classifier (builtin/skill/mcp), not status. File a `<SourceBadge />` ticket if migration is justified.
+- **`<TraceIdWidget />`** — explicitly named in mika#651/#652/#653 issue bodies; ID truncation + copy belongs there.
+- **`<RecentActivityCard />`** — issue body's broader proposal; rulebook is silent on row caps and aspect ratios; defer to Phase 4 cross-cutting work or fold into mika#658's state-catalog scope.
+- **Aspect-ratio convention for cards** — rulebook silent; Stitch design pass would own this.
+- **Table column ratio rules** — rulebook silent; Stitch design pass would own this.
+- **`<EmptyState />` extensions to `<LoadingState />`/`<ErrorState />`** — mika#658's scope.
+- **`<CopyButton />` visual-confirm refinement** — mika#665's scope (already groomed).
+- **Adding new variants beyond `success/warning/error/info/neutral`** to `<StatusBadge />` — only the five variants the rulebook supports cleanly, or a sixth `blocked` if `<TaskStatusBadge />` collapse loses signal (decided in implementation).
+- **Removing or redesigning `<TaskStatusBadge />`** — keep as task-domain specialization; only realign colors and label styling. Renaming it to `<StatusPill>` or merging into `<StatusBadge />` would break consumers and isn't justified by the body's "audit-and-migrate" framing.
+- **Schema for `tracking-wide`** — Tailwind v4 utility maps to `0.05em` per default; matches rulebook §3 prescription. No theme.css change needed.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Generalizing `<StatusBadge />` from `{active}` to `{variant, label}` breaks all 2 binary callsites | Both callsites (`Agents.tsx`, `AgentDetail.tsx`) are migrated in Change 2 atomically. TypeScript catches any missed callsite at build time. |
+| `<TaskStatusBadge />` color realignment loses meaningful distinction (e.g., blocked vs pending both → warning) | Implementation evaluates side-by-side; if collapse loses signal, add `blocked` as a sixth variant to `<StatusBadge />` in this PR. Explicit fallback path. |
+| Hand-rolled pill substitution renders differently because the original used different sizing | Verify by reading the original className for each migration target — most use `text-xs` or `text-[10px]`; `<StatusBadge />`'s `text-[10px] font-semibold` matches the dominant pattern. Outliers documented in PR. |
+| Sequencing collision with mika#663 on `packages/ui/CLAUDE.md` | Both plans reference the same file. Ship-order is operator's call; whichever ships second extends rather than seeds. Both plans explicitly handle either case in Change 5. |
+| `--spacing-N` tokens conflict with Tailwind v4's default scale | Verified — Tailwind v4 reads `--spacing-N` from `@theme` as overrides; if values match defaults, behavior is identical. The intent is explicitness; existing `p-4`, `gap-2`, etc. continue to work. |
+| Visual check requires running the dashboard locally — easy to skip | AC explicitly names visual check; PR description must include screenshots of migrated pages. Reviewer fails the AC if screenshots are absent or pills look wrong. |
+
+## Sequencing
+
+1. **Change 6 first** (luminescent-core.md grammar extension). Rulebook declares the six-variant grammar before code consumes it. Architectural ordering: design system contract precedes implementation.
+2. **Change 1 second** (theme.css `--color-blocked` + spacing tokens). Adds the design tokens Change 6 references.
+3. **Change 2 third** (StatusBadge generalization + 2 callsite migrations). Implements the grammar declared in Change 6 using tokens from Change 1.
+4. **Change 3 fourth** (TaskStatusBadge thin-adapter refactor). Delegates to Change 2's `<StatusBadge />`.
+5. **Change 4 fifth** (migrate hand-rolled status pills across 7 dashboard pages). Depends on Change 2 (new `<StatusBadge />` API).
+6. **Change 5 last** (`packages/ui/CLAUDE.md` enforcement table — seed or extend depending on mika#663's ship state).
+7. **Visual + drift verification** (run greps, run dashboard, screenshot migrated pages).
+8. **Open PR** cross-referencing #657 with screenshots.
+
+Note on PR ordering: Changes 1, 2, 6 are tightly coupled (rulebook + tokens + component) and must ship in the same PR. Changes 3, 4, 5 build on that foundation but are not order-sensitive within the PR — a reviewer can read them in any order. Changes 1+2+6 are reviewed first.
+
+## Verification
+
+```bash
+# Confirm rulebook extension declares the multi-state grammar
+grep -c "5.1 Multi-state status grammar" mika/docs/design/luminescent-core.md  # → 1
+grep -c "Hand-rolled status pills are forbidden" mika/docs/design/luminescent-core.md  # → 1
+
+# Confirm spacing tokens + --color-blocked declared
+grep -c "^\s*--spacing-" mika/packages/ui/src/theme.css  # → 9 (one per spacing-1, -2, -3, -4, -5, -6, -8, -12, -16)
+grep -c "^\s*--color-blocked" mika/packages/ui/src/theme.css  # → 1
+
+# Confirm StatusBadge six-variant API
+grep -A 5 "interface StatusBadgeProps" mika/packages/ui/src/components/StatusBadge.tsx
+# → expects variant: 'success' | 'warning' | 'error' | 'info' | 'neutral' | 'blocked'
+
+# Confirm TaskStatusBadge delegates to StatusBadge (not standalone rendering)
+grep -c "import StatusBadge" mika/packages/ui/src/components/TaskStatusBadge.tsx  # → 1
+grep -c "<StatusBadge" mika/packages/ui/src/components/TaskStatusBadge.tsx  # → 1
+
+# Confirm no hardcoded Tailwind colors in library components (primary drift detector)
+grep -rn "bg-emerald-400\|bg-red-400\|bg-amber-400\|bg-yellow-400\|bg-blue-400\|bg-purple-400\|bg-orange-400\|bg-gray-400" mika/packages/ui/src/components/  # → 0 matches
+
+# Confirm no hardcoded Tailwind status colors in dashboard pages (per architect aux finding — secondary sweep for color-hardcoded patterns the structural grep might miss)
+grep -rn "bg-.*green\|bg-.*red\|bg-.*emerald\|bg-.*amber\|text-emerald-\|text-red-\|text-yellow-" mika/dashboard/src/pages/*.tsx  # → matches only inside out-of-scope items (channel pill, source badge, lucide icon containers)
+
+# Confirm hand-rolled status pills migrated
+grep -rn "inline-flex items-center.*rounded-full" mika/dashboard/src/pages/ | grep -v "Sessions.tsx:137"  # → ideally empty (ToolCalls source badge if still hand-rolled is expected and named in PR description)
+
+# Confirm packages/ui/CLAUDE.md lists StatusBadge as audited clean
+grep "StatusBadge.*Audited clean.*mika#657" mika/packages/ui/CLAUDE.md  # → match
+
+# Build verification
+npm run build --prefix mika/packages/ui  # → succeeds
+npm run build --prefix mika/dashboard    # → succeeds
+```
+
+## Discovery items (verified during planning)
+
+1. **luminescent-core.md is silent on multi-state status grammar** — only specifies the active-agent chip (§5). The five-variant `<StatusBadge />` shape (success/warning/error/info/neutral) is a minimal extension justified by the migration targets, not by the rulebook directly. Worth flagging to architect.
+2. **`packages/ui/src/theme.css` lacks spacing tokens entirely** — only color and font tokens. Rulebook §6 explicitly prescribes the 8px-doubled scale.
+3. **`<StatusBadge />` is currently binary** — `{ active: boolean }`. Generalizing to multi-variant is the migration's foundational change; without it, hand-rolled pills can't migrate to `<StatusBadge />`.
+4. **`<TaskStatusBadge />` has 10 states with arbitrary Tailwind colors** — domain vocabulary is correct; color mapping needs realignment to design tokens.
+5. **Hand-rolled status pills found in 7 dashboard files** — all success/failed/live patterns; verified by grep. Channel pills and tool source badges are explicitly different concerns and out of scope.
+6. **`packages/ui/CLAUDE.md` is shared-artifact territory with mika#663** — both plans reference it. Ship-order matters but is operator's call; both plans handle either case.
+7. **No test scaffolding in `packages/ui/`** — verification is by build + visual check + drift grep. Future ticket can add Vitest/RTL scaffolding.

--- a/docs/solutions/best-practices/design-system-status-pill-migration-2026-04-27.md
+++ b/docs/solutions/best-practices/design-system-status-pill-migration-2026-04-27.md
@@ -1,0 +1,156 @@
+---
+title: "Migrate hand-rolled status pills to shared StatusBadge component"
+date: 2026-04-27
+category: best-practices
+module: packages/ui
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding or modifying status indicators in dashboard pages
+  - Creating new status pill patterns for success/error/warning states
+  - Extending the StatusBadge variant set for new status domains
+tags:
+  - status-badge
+  - design-system
+  - dashboard
+  - hand-rolled-pills
+  - luminescent-core
+  - packages-ui
+  - tailwind-tokens
+---
+
+# Migrate hand-rolled status pills to shared StatusBadge component
+
+## Context
+
+Dashboard pages independently rendered status indicators (success/error dots, status pills) using inline JSX with hardcoded Tailwind color utilities (`bg-emerald-400`, `text-red-400`). Each page's implementation drifted: different gap values (`gap-1` vs `gap-1.5`), different text sizes (`text-[10px]` vs `text-sm` vs inherited), presence or absence of pill backgrounds, and inconsistent label casing. The luminescent-core rulebook (the design system contract) was silent on multi-state grammar, leaving each developer to improvise.
+
+The pattern appeared across 9 dashboard pages with 4+ different visual treatments for the same data type (LLM call status, tool call success/fail, session state).
+
+## Guidance
+
+### 1. Generalize the shared component with a typed variant API
+
+Replace binary or ad-hoc component APIs with a constrained variant union:
+
+```tsx
+// Before: binary prop, hardcoded colors
+interface StatusBadgeProps { active: boolean }
+
+// After: typed variant union, design-token-derived styles
+type StatusBadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral' | 'blocked'
+interface StatusBadgeProps {
+  variant: StatusBadgeVariant
+  label: string
+  dotPulse?: boolean
+}
+```
+
+Map variants to design tokens (not Tailwind color utilities):
+
+```tsx
+const VARIANT_STYLES: Record<StatusBadgeVariant, { bg: string; text: string; dot: string }> = {
+  success: { bg: 'bg-success/10', text: 'text-success', dot: 'bg-success' },
+  warning: { bg: 'bg-warning/10', text: 'text-warning', dot: 'bg-warning' },
+  // ...
+}
+```
+
+### 2. Use typed adapter components for domain-specific vocabulary
+
+Don't force every consumer to map domain status to variant. Create thin adapters:
+
+```tsx
+// TaskStatusBadge: typed task status -> StatusBadge variant
+const TASK_VARIANT_MAP: Record<string, { variant: StatusBadgeVariant; label?: string }> = {
+  pending: { variant: 'warning', label: 'PENDING' },
+  completed: { variant: 'success', label: 'COMPLETED' },
+  // ...
+}
+export default function TaskStatusBadge({ status }: { status: string }) {
+  const mapped = TASK_VARIANT_MAP[status] ?? DEFAULT
+  return <StatusBadge variant={mapped.variant} label={mapped.label ?? status.toUpperCase()} />
+}
+```
+
+### 3. Write all Tailwind class names literally in source
+
+Never derive class names via string interpolation. Tailwind's JIT compiler scans source for literal class names — dynamically constructed classes are purged in production builds. Use explicit mapping records, not `"bg-" + color`.
+
+### 4. Extend the design system rulebook before the code
+
+When the design system is silent on a pattern you need (e.g., multi-state grammar), extend the rulebook first (luminescent-core.md), then implement against it. This prevents future drift where the code introduces variants the rulebook doesn't declare.
+
+### 5. Audit thoroughly — grep for the pattern, not the component name
+
+Hand-rolled pills won't appear in import searches. Use structural greps:
+
+```bash
+# Find hand-rolled pills by their shape, not their name
+grep -rn "inline-flex items-center.*rounded-full" dashboard/src/pages/
+# Find hardcoded status colors bypassing design tokens
+grep -rn "bg-emerald-400\|bg-red-400\|bg-amber-400" packages/ui/src/components/
+```
+
+In this migration, a TraceDetail.tsx file with two hand-rolled patterns was initially missed because the audit focused on the plan's named files. The structural grep caught it during review.
+
+## Why This Matters
+
+- **Visual consistency:** Same status data renders identically across all pages without per-page tuning
+- **Maintenance cost:** Color changes, spacing adjustments, or accessibility improvements happen in one component, not N pages
+- **Tailwind purge safety:** Literal class strings in a Record are scanner-visible; ad-hoc inline classes risk production purge
+- **Semantic alignment:** Design token names (`--color-success`, `--color-blocked`) carry meaning; Tailwind utilities (`bg-emerald-400`) don't communicate intent
+
+## When to Apply
+
+- When creating any new dashboard page that shows status indicators
+- When a design system extension adds new status semantics (e.g., a seventh variant)
+- When migrating other hand-rolled patterns (source badges, channel pills) to shared components
+- When the `packages/ui` enforcement rules in `packages/ui/CLAUDE.md` flag a review fail
+
+## Examples
+
+**Before (LlmCalls.tsx):**
+```tsx
+function statusBadge(status: string) {
+  switch (status) {
+    case 'success':
+      return (
+        <span className="inline-flex items-center gap-1 text-emerald-400">
+          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+          <span className="text-[10px]">success</span>
+        </span>
+      )
+    // ...10 more lines per case
+  }
+}
+// Usage: {statusBadge(row.status)}
+```
+
+**After (LlmCalls.tsx):**
+```tsx
+import { StatusBadge } from '@senara-solutions/ui'
+import type { StatusBadgeVariant } from '@senara-solutions/ui'
+
+function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
+  switch (status) {
+    case 'success': return { variant: 'success', label: 'Success' }
+    case 'error': return { variant: 'error', label: 'Error' }
+    default: return { variant: 'neutral', label: status }
+  }
+}
+// Usage: <StatusBadge {...llmStatusVariant(row.status)} />
+```
+
+**Net effect:** ~25 lines of inline JSX per page replaced by ~5 lines of typed mapping + 1-line component call. Across 9 pages: ~190 lines deleted, ~50 lines added.
+
+## Related
+
+- `docs/solutions/architecture-patterns/extract-shared-ui-package.md` — packages/ui architecture and checklist
+- `docs/solutions/ui-bugs/dashboard-tool-calls-tabular-ux.md` — Tailwind JIT purge failure mode
+- `docs/solutions/architecture-patterns/enhance-shared-ui-emptystate-theme-tokens.md` — semantic token conventions
+- `docs/design/luminescent-core.md` §5.1 — multi-state status grammar declaration
+- `packages/ui/CLAUDE.md` — enforcement rules and canonical primitives table
+- mika#657 — parent issue (visual rhythm: tokens + status pills)
+- mika#663 — sibling issue (Pagination audit, shares packages/ui/CLAUDE.md)

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,32 @@
+# @senara-solutions/ui — Shared Component Library
+
+Vite library mode, published to GitHub Packages. Peer deps: React 19, Tailwind CSS v4, lucide-react.
+
+## Design System
+
+All components implement the [luminescent-core](../../docs/design/luminescent-core.md) rulebook. Design tokens live in `src/theme.css`. Before adding or modifying a component, read:
+
+- [`docs/design/north-star.md`](../../docs/design/north-star.md) — the WHY
+- [`docs/design/luminescent-core.md`](../../docs/design/luminescent-core.md) — the rulebook (colors, typography, surfaces, components, do/don'ts)
+
+## Canonical Primitives
+
+| Component | Purpose | API | Migration status |
+|---|---|---|---|
+| `<StatusBadge>` | Multi-state status indicator (6 variants: success/warning/error/info/neutral/blocked) | `{ variant, label, dotPulse? }` | Audited clean (mika#657) |
+| `<TaskStatusBadge>` | Task-domain status — thin adapter delegating to `<StatusBadge />` via typed task→variant mapping | `{ status: string }` | Audited clean (mika#657) |
+| `<Pagination>` | Table/list pagination | `{ page, totalPages, total, onPageChange }` | Audited clean (mika#663) |
+| `<EmptyState>` | Empty data placeholder | `{ message }` | — |
+| `<CopyButton>` | Click-to-copy with visual confirm | `{ text, className?, title? }` | — |
+| `<MarkdownContent>` | Render markdown content | `{ content }` | — |
+
+## Enforcement Rules
+
+- **Hand-rolled status pills are forbidden.** Any dashboard or consumer code rendering its own colored dot + text status indicator is a review fail. Use `<StatusBadge variant="..." label="..." />`. For task statuses, use `<TaskStatusBadge status={...} />`.
+- **Design tokens over hardcoded colors.** Status colors must reference design tokens (`--color-success`, `--color-warning`, `--color-error`, `--color-accent`, `--color-muted`, `--color-blocked`), not Tailwind color utilities (`bg-emerald-400`, `text-red-400`, etc.).
+- **Escape hatch:** If a surface genuinely needs a pill shape not covered by `<StatusBadge />` (e.g., channel pills, source badges), document the justification in the PR description and name the gap. Do not silently hand-roll.
+
+## Commands
+
+- `npm run build --prefix packages/ui` — Build the library
+- `npm run dev:dashboard` — Dev server (builds ui first, requires mika-server on :8080)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senara-solutions/ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/src/components/StatusBadge.tsx
+++ b/packages/ui/src/components/StatusBadge.tsx
@@ -1,22 +1,33 @@
+type StatusBadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral' | 'blocked'
+
 interface StatusBadgeProps {
-  active: boolean
+  variant: StatusBadgeVariant
+  label: string
+  dotPulse?: boolean
 }
 
-export default function StatusBadge({ active }: StatusBadgeProps) {
+const VARIANT_STYLES: Record<StatusBadgeVariant, { bg: string; text: string; dot: string }> = {
+  success: { bg: 'bg-success/10', text: 'text-success', dot: 'bg-success' },
+  warning: { bg: 'bg-warning/10', text: 'text-warning', dot: 'bg-warning' },
+  error: { bg: 'bg-error/10', text: 'text-error', dot: 'bg-error' },
+  info: { bg: 'bg-accent/10', text: 'text-accent', dot: 'bg-accent' },
+  neutral: { bg: 'bg-white/[0.06]', text: 'text-muted', dot: 'bg-muted' },
+  blocked: { bg: 'bg-blocked/15', text: 'text-blocked', dot: 'bg-blocked' },
+}
+
+export default function StatusBadge({ variant, label, dotPulse = false }: StatusBadgeProps) {
+  const style = VARIANT_STYLES[variant]
+
   return (
     <span
-      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${
-        active
-          ? 'bg-emerald-400/10 text-emerald-400'
-          : 'bg-amber-400/10 text-amber-400'
-      }`}
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide ${style.bg} ${style.text}`}
     >
       <span
-        className={`w-1.5 h-1.5 rounded-full ${
-          active ? 'bg-emerald-400' : 'bg-amber-400'
-        }`}
+        className={`w-1.5 h-1.5 rounded-full ${style.dot} ${dotPulse ? 'animate-pulse' : ''}`}
       />
-      {active ? 'Active' : 'Inactive'}
+      {label}
     </span>
   )
 }
+
+export type { StatusBadgeVariant, StatusBadgeProps }

--- a/packages/ui/src/components/TaskStatusBadge.tsx
+++ b/packages/ui/src/components/TaskStatusBadge.tsx
@@ -1,27 +1,22 @@
-const STATUS_STYLES: Record<string, { bg: string; text: string; dot: string }> = {
-  pending: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', dot: 'bg-yellow-400' },
-  in_progress: { bg: 'bg-blue-500/10', text: 'text-blue-400', dot: 'bg-blue-400' },
-  completed: { bg: 'bg-green-500/10', text: 'text-green-400', dot: 'bg-green-400' },
-  failed: { bg: 'bg-red-500/10', text: 'text-red-400', dot: 'bg-red-400' },
-  delivered: { bg: 'bg-emerald-500/10', text: 'text-emerald-400', dot: 'bg-emerald-400' },
-  blocked: { bg: 'bg-orange-500/10', text: 'text-orange-400', dot: 'bg-orange-400' },
-  cancelled: { bg: 'bg-gray-500/10', text: 'text-gray-400', dot: 'bg-gray-400' },
-  running: { bg: 'bg-blue-500/10', text: 'text-blue-400', dot: 'bg-blue-400' },
-  suspended: { bg: 'bg-amber-500/10', text: 'text-amber-400', dot: 'bg-amber-400' },
-  recurring_active: { bg: 'bg-purple-500/10', text: 'text-purple-400', dot: 'bg-purple-400' },
+import StatusBadge from './StatusBadge'
+import type { StatusBadgeVariant } from './StatusBadge'
+
+const TASK_VARIANT_MAP: Record<string, { variant: StatusBadgeVariant; label?: string }> = {
+  pending: { variant: 'warning', label: 'PENDING' },
+  in_progress: { variant: 'info', label: 'IN PROGRESS' },
+  running: { variant: 'info', label: 'RUNNING' },
+  completed: { variant: 'success', label: 'COMPLETED' },
+  delivered: { variant: 'success', label: 'DELIVERED' },
+  failed: { variant: 'error', label: 'FAILED' },
+  blocked: { variant: 'blocked', label: 'BLOCKED' },
+  cancelled: { variant: 'neutral', label: 'CANCELLED' },
+  suspended: { variant: 'warning', label: 'SUSPENDED' },
+  recurring_active: { variant: 'info', label: 'RECURRING' },
 }
 
-const DEFAULT_STYLE = { bg: 'bg-gray-500/10', text: 'text-gray-400', dot: 'bg-gray-400' }
+const DEFAULT = { variant: 'neutral' as const, label: undefined }
 
 export default function TaskStatusBadge({ status }: { status: string }) {
-  const style = STATUS_STYLES[status] ?? DEFAULT_STYLE
-
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${style.bg} ${style.text}`}
-    >
-      <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
-      {status.replace(/_/g, ' ')}
-    </span>
-  )
+  const mapped = TASK_VARIANT_MAP[status] ?? DEFAULT
+  return <StatusBadge variant={mapped.variant} label={mapped.label ?? status.replace(/_/g, ' ').toUpperCase()} />
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 // Components
 export { default as StatusBadge } from './components/StatusBadge.tsx'
+export type { StatusBadgeVariant, StatusBadgeProps } from './components/StatusBadge.tsx'
 export { default as Pagination } from './components/Pagination.tsx'
 export { default as EmptyState } from './components/EmptyState.tsx'
 export type { EmptyStateProps } from './components/EmptyState.tsx'

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -10,6 +10,18 @@
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
+  --color-blocked: #f97316;
+
+  /* Spacing scale per luminescent-core §6 (8px base, doubled rhythm) */
+  --spacing-1: 0.25rem;   /*  4px */
+  --spacing-2: 0.5rem;    /*  8px */
+  --spacing-3: 0.75rem;   /* 12px */
+  --spacing-4: 1rem;      /* 16px */
+  --spacing-5: 1.25rem;   /* 20px */
+  --spacing-6: 1.5rem;    /* 24px */
+  --spacing-8: 2rem;      /* 32px */
+  --spacing-12: 3rem;     /* 48px */
+  --spacing-16: 4rem;     /* 64px */
 }
 
 html {


### PR DESCRIPTION
Closes #657

## Summary

- **Generalize `<StatusBadge />`** from binary `{active: boolean}` to six-variant `{variant, label, dotPulse?}` API aligned with luminescent-core design system
- **Refactor `<TaskStatusBadge />`** to thin adapter delegating to `<StatusBadge />` via typed task→variant mapping (10 task states → 6 variants)
- **Migrate all hand-rolled status pills** across 9 dashboard pages (LlmCalls, LlmCallDetail, ToolCalls, ToolCallDetail, TraceDetail, Timeline, SessionDetail, Agents, AgentDetail)
- **Add design tokens**: `--color-blocked` + spacing scale `--spacing-1` through `--spacing-16` to `theme.css`
- **Extend luminescent-core.md** with §5.1 multi-state status grammar (six variants, semantic meanings, hand-rolled-forbidden rule)
- **Create `packages/ui/CLAUDE.md`** with enforcement table and escape-hatch documentation
- **Bump `@senara-solutions/ui`** to 0.3.0 (breaking: StatusBadge API change)

## Design system changes

Six-variant status grammar (`success`/`warning`/`error`/`info`/`neutral`/`blocked`):

| Variant | Token | Semantic meaning |
|---|---|---|
| `success` | `--color-success` | Completed, active, positive terminal state |
| `warning` | `--color-warning` | Degraded, paused, pending — caution |
| `error` | `--color-error` | Failed, needs intervention |
| `info` | `--color-accent` | Active operation in progress |
| `neutral` | `--color-muted` | Cancelled, archived, inactive, stateless |
| `blocked` | `--color-blocked` | External-dependency wait |

## Out of scope (named in plan)

- Channel pills (`Sessions.tsx`) — content pill, not status
- Source badges (`sourceBadge`/`toolSourceBadge` in ToolCalls, ToolCallDetail, SessionDetail, TraceDetail) — typed-source classifier, not status. Escape hatch per `packages/ui/CLAUDE.md`
- Team badge (`SessionDetail.tsx`) — classification badge with icon, not status
- `<TraceIdWidget />` — mika#651/#652/#653
- `<RecentActivityCard />` — Phase 4 cross-cutting
- Test scaffolding for `packages/ui` — deferred to future ticket

## Test plan

- [x] `npm run build --prefix packages/ui` succeeds
- [x] `npm run build --prefix dashboard` succeeds (TypeScript + Vite)
- [x] All pre-commit hooks pass (typecheck, lint, secrets scan)
- [x] `grep -rn "bg-emerald-400\|bg-red-400\|bg-amber-400" packages/ui/src/components/` returns 0 matches
- [x] `grep -rn "inline-flex items-center.*rounded-full" dashboard/src/pages/` returns only out-of-scope items (channel pill, Team badge, event type badges, source badges)
- [ ] Visual check on migrated pages confirms token colors render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)