### PR TITLE
feat(ui): dashboard copy feedback — visual confirmation on copy-to-clipboard actions

### DIFF
--- a/dashboard/src/components/CopyButton.test.tsx
+++ b/dashboard/src/components/CopyButton.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { CopyButton } from '@senara-solutions/ui'
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders Copy icon visible by default', () => {
+    render(<CopyButton text="abc" />)
+    const copyIcon = screen.getByTestId('copy-icon')
+    const checkIcon = screen.getByTestId('check-icon')
+    expect(copyIcon.classList.toString()).toContain('opacity-100')
+    expect(checkIcon.classList.toString()).toContain('opacity-0')
+  })
+
+  it('crossfades to Check icon after click', async () => {
+    render(<CopyButton text="abc" />)
+    const button = screen.getByTestId('copy-button')
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    const copyIcon = screen.getByTestId('copy-icon')
+    const checkIcon = screen.getByTestId('check-icon')
+    expect(checkIcon.classList.toString()).toContain('opacity-100')
+    expect(copyIcon.classList.toString()).toContain('opacity-0')
+  })
+
+  it('reverts to Copy icon after timeout', async () => {
+    render(<CopyButton text="abc" />)
+    const button = screen.getByTestId('copy-button')
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(2100)
+    })
+
+    const copyIcon = screen.getByTestId('copy-icon')
+    const checkIcon = screen.getByTestId('check-icon')
+    expect(copyIcon.classList.toString()).toContain('opacity-100')
+    expect(checkIcon.classList.toString()).toContain('opacity-0')
+  })
+
+  it('calls clipboard.writeText with the text prop', async () => {
+    render(<CopyButton text="hello world" />)
+    const button = screen.getByTestId('copy-button')
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world')
+  })
+
+  it('stops event propagation', async () => {
+    const parentHandler = vi.fn()
+    render(
+      <div onClick={parentHandler}>
+        <CopyButton text="abc" />
+      </div>,
+    )
+    const button = screen.getByTestId('copy-button')
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(parentHandler).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/pages/TraceDetail.tsx
+++ b/dashboard/src/pages/TraceDetail.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router'
 import { useTraceDetail, useTraceMessages, type TraceMessage } from '../api/timeline.ts'
 import { useTraceLlmCalls } from '../api/llmCalls.ts'
 import { useTraceToolCalls } from '../api/toolCalls.ts'
-import { CopyButton as UiCopyButton, EmptyState, LoadingState, ErrorState, formatApiError, StatusBadge, formatTimestamp, eventTypeBadge, eventTypeColor } from '@senara-solutions/ui'
+import { CopyButton, EmptyState, LoadingState, ErrorState, formatApiError, StatusBadge, formatTimestamp, eventTypeBadge, eventTypeColor } from '@senara-solutions/ui'
 import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import InvestigationPanel, {
   type InvestigationScope,
@@ -14,8 +14,6 @@ import {
   Bot,
   Settings,
   Wrench,
-  Copy,
-  Check,
   ChevronRight,
   ChevronDown,
   Search,
@@ -116,39 +114,6 @@ function toolSourceBadge(source: string) {
     default:
       return 'bg-white/[0.06] text-muted/60'
   }
-}
-
-function CopyButton({
-  text,
-  className,
-  title = 'Copy to clipboard',
-}: {
-  text: string
-  className?: string
-  title?: string
-}) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async (e: React.MouseEvent) => {
-    e.stopPropagation()
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Silently fail
-    }
-  }
-
-  return (
-    <button
-      onClick={handleCopy}
-      className={`opacity-40 hover:opacity-100 transition-opacity shrink-0 ${className ?? ''}`}
-      title={title}
-    >
-      {copied ? <Check size={12} className="text-emerald-400" /> : <Copy size={12} />}
-    </button>
-  )
 }
 
 function ToolCallsTable({
@@ -710,7 +675,7 @@ export default function TraceDetail() {
                                 <div>
                                   <div className="flex items-center gap-2">
                                     <span className="text-[10px] text-muted/40 uppercase tracking-wider">Input</span>
-                                    <UiCopyButton text={row.input} title="Copy input" />
+                                    <CopyButton text={row.input} title="Copy input" />
                                   </div>
                                   <div className="font-mono text-xs text-muted/70 pl-2 border-l border-white/[0.06] mt-1 whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
                                     {row.input}
@@ -721,7 +686,7 @@ export default function TraceDetail() {
                                 <div>
                                   <div className="flex items-center gap-2">
                                     <span className="text-[10px] text-muted/40 uppercase tracking-wider">Output</span>
-                                    <UiCopyButton text={row.output} title="Copy output" />
+                                    <CopyButton text={row.output} title="Copy output" />
                                   </div>
                                   <div className="font-mono text-xs text-muted/70 pl-2 border-l border-white/[0.06] mt-1 whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
                                     {row.output}

--- a/docs/plans/2026-04-26-007-feat-665-dashboard-copy-feedback-plan.md
+++ b/docs/plans/2026-04-26-007-feat-665-dashboard-copy-feedback-plan.md
@@ -1,0 +1,156 @@
+---
+title: "feat(ui): dashboard copy feedback — visual confirmation on copy-to-clipboard actions"
+type: feat
+status: active
+date: 2026-04-26
+origin: senara-solutions/mika#665
+---
+
+# Plan — dashboard copy feedback (mika#665)
+
+**Issue:** [mika#665](https://github.com/senara-solutions/issues/665) — `Dashboard > Copy feedback: visual confirmation on copy-to-clipboard actions`
+**Branch:** `feat/665/dashboard-copy-feedback-confirmation`
+**Type:** feat (Phase 2 primitive in milestone #13)
+**Labels:** enhancement, dashboard
+
+## Problem
+
+Copy icons appear next to IDs and content across multiple dashboard pages. Clicking them copies content to the clipboard but provides minimal visible confirmation — user clicks, doesn't notice the change, tries again (and may trigger double paste elsewhere).
+
+## Discovery (verified during planning)
+
+Audit answer for the issue body's "Does it provide feedback today and it's just hidden, or does it genuinely have none?":
+
+**`<CopyButton />` already provides feedback** (verified at `packages/ui/src/components/CopyButton.tsx:13,19-20,32`):
+- `useState(copied: boolean)` tracks the copy state.
+- After `await navigator.clipboard.writeText(text)`, sets `copied=true` for 2000ms.
+- Icon swap: `<Copy size={12} />` → `<Check size={12} className="text-emerald-400" />`.
+
+**Gaps in the existing feedback:**
+1. Icon swap is abrupt — no CSS transition on the icon itself. Only the button has `transition-opacity` for hover (line 29). Per rulebook §5 ("Soft Minimalism", transition states), the `Copy → Check` swap should have a smooth transition.
+2. **Hand-rolled clipboard call exists** at `dashboard/src/pages/TraceDetail.tsx` (verified via grep — duplicates the exact pattern of CopyButton, ~5 lines of `useState(copied)` + `navigator.clipboard.writeText` + 2s timeout). Should be migrated to `<CopyButton />`.
+3. **`<TraceIdWidget />` does NOT exist yet** — per `docs/design/dashboard-stitch-map.md` Phase 2, this primitive will be built from mika#652 and mika#653 work. Out of scope for #665. The acceptance criterion "`<TraceIdWidget />` uses `<CopyButton />` internally" is forward-looking — when TraceIdWidget is built later, it must consume `<CopyButton />`. We don't build TraceIdWidget here; we just ensure the prerequisite (CopyButton) is solid.
+
+## Approach
+
+### Change 1 — Smooth the icon-swap transition in `<CopyButton />`
+
+**File:** `mika/packages/ui/src/components/CopyButton.tsx`
+
+Wrap the icon swap in a transition (CSS opacity + scale fade, ~150ms). Keep the existing `Copy/Check` swap and the 2000ms timeout. Per rulebook §5: "no harsh notifications" — the icon transition is the soft visual confirmation pattern.
+
+Suggested implementation (final form is implementer's call within the rulebook envelope):
+
+```tsx
+<button onClick={handleCopy} className={...} title={title}>
+  <span className="relative inline-flex items-center justify-center">
+    <Copy
+      size={12}
+      className={`transition-opacity duration-150 ${copied ? 'opacity-0' : 'opacity-100'}`}
+    />
+    <Check
+      size={12}
+      className={`absolute transition-opacity duration-150 text-emerald-400 ${copied ? 'opacity-100' : 'opacity-0'}`}
+    />
+  </span>
+</button>
+```
+
+**Use pure CSS opacity transition. Do NOT add framer-motion.** Per architect Finding 1 (session `f9191e17-...`): `framer-motion` is not in either `packages/ui/package.json` or `dashboard/package.json` (verified `grep -c "framer-motion"` returns 0 in both). Even if it were available, KISS applies — framer-motion is appropriate for layout animations, not 2-element icon crossfades (review-guide.md § 6 + KISS).
+
+**Use `data-testid` attributes** on the button and both icon containers per architect Finding 3:
+- `data-testid="copy-button"` on the button element.
+- `data-testid="copy-icon"` on the `Copy` icon container.
+- `data-testid="check-icon"` on the `Check` icon container.
+
+This removes test fragility — SVG-presence or button-role queries break if `lucide-react` swaps icons. Shared component library convention is to ship `data-testid` for stable consumer test handles. Cite: test-stability over implementation-shape (review-guide.md § 6).
+
+**No toast.** Issue body says "optional toast" — YAGNI for v1. The icon swap is the established pattern across `@senara-solutions/ui`. A toast adds notification surface (positioning, dismissal, ARIA-live region) for marginal value when the click happens at the affordance itself. If operator demand surfaces post-merge, file a follow-up.
+
+**Rapid-click edge case:** the absolute-overlay shape is preferred over `key={copied}` remount (architect Finding 2 second-pass — implementer-discretion within envelope). Absolute-overlay is more predictable under rapid clicks because there's no animation-interrupt edge case; the `setTimeout` simply re-fires and the opacity stays at 1.0 throughout. `key={copied}` remount triggers React reconciliation on each toggle and risks animation-interrupt visual artifacts under rapid clicks. Implementer can deviate within rulebook envelope, but absolute-overlay is the recommended default.
+
+### Change 2 — Migrate `dashboard/src/pages/TraceDetail.tsx` hand-rolled clipboard
+
+**File:** `mika/dashboard/src/pages/TraceDetail.tsx`
+
+Replace the hand-rolled `navigator.clipboard.writeText` + `useState(copied)` + setTimeout with `<CopyButton text={...} />` from `@senara-solutions/ui`. Pre-edit discovery: read the surrounding context to confirm the hand-rolled instance is purely a copy-button (not, e.g., a copy-action embedded in some other UI). Verified via grep that the hand-rolled pattern is identical to CopyButton's own implementation — straightforward migration.
+
+### Change 3 — Audit grep for any other hand-rolled callsites
+
+**Command:** `grep -rln "navigator.clipboard" mika/dashboard/src/ mika/packages/ui/src/`
+
+Two callsites today: `CopyButton.tsx` itself (the canonical), and `TraceDetail.tsx` (the hand-rolled one to migrate). If any new callsites appear during implementation (e.g., from in-flight work on other branches), migrate them too. AC closes the gap explicitly.
+
+## Files
+
+| Change | File | Diff shape |
+|---|---|---|
+| 1 | `packages/ui/src/components/CopyButton.tsx` | +5 lines: icon-swap transition (CSS opacity/scale on Copy and Check icons) |
+| 2 | `dashboard/src/pages/TraceDetail.tsx` | -10/+3: replace hand-rolled `useState(copied)` + clipboard write with `<CopyButton text={...} />` import + JSX |
+
+Net diff: ~15 lines changed, 2 files. Smallest grooming session of the night.
+
+## Tests
+
+Inline in `packages/ui/src/components/CopyButton.test.tsx` (new test file or existing — verify presence during implementation). Tests query by `data-testid` attributes per architect Finding 3 — stable across icon-library changes.
+
+1. **`renders Copy icon visible by default`** — render `<CopyButton text="abc" />`, assert element with `data-testid="copy-icon"` has `opacity-100`, `data-testid="check-icon"` has `opacity-0`.
+2. **`crossfades to Check icon after click`** — mock `navigator.clipboard.writeText`, click `data-testid="copy-button"`, assert `data-testid="check-icon"` transitions to `opacity-100`, `data-testid="copy-icon"` to `opacity-0`.
+3. **`reverts to Copy icon after timeout`** — same setup, advance fake timers by 2100ms, assert opacities revert (`copy-icon` to `opacity-100`, `check-icon` to `opacity-0`).
+4. **`calls clipboard.writeText with the text prop`** — mock clipboard, click `data-testid="copy-button"`, assert called with the exact `text` prop value.
+5. **`stops event propagation`** — render inside a parent with `onClick` handler, click `data-testid="copy-button"`, assert parent handler NOT called.
+
+These tests verify the canonical primitive's contract; downstream consumers don't need their own copy tests after migration.
+
+## Acceptance criteria
+
+- [ ] `<CopyButton />` icon swap uses a smooth CSS transition (opacity-based, ~150ms) per rulebook §5 — no hard cut.
+- [ ] `dashboard/src/pages/TraceDetail.tsx` uses `<CopyButton />` instead of hand-rolled `navigator.clipboard.writeText`.
+- [ ] `grep -rn "navigator.clipboard" mika/dashboard/src/ mika/packages/ui/src/` returns only the `CopyButton.tsx` callsite (the canonical implementation). Any other hits indicate a missed migration.
+- [ ] All 5 tests above pass.
+- [ ] `npm run build --prefix dashboard` clean.
+- [ ] No existing test regressions (`cargo test` and dashboard test suite).
+
+## Out of scope
+
+- Toast notifications. Issue body marks them "optional" — defer until operator demand surfaces post-merge.
+- `<TraceIdWidget />` migration. The widget doesn't exist yet — built later by mika#652 / mika#653 work per dashboard-stitch-map. The forward-looking acceptance criterion "`<TraceIdWidget />` uses `<CopyButton />` internally" is preserved as a constraint for the implementer of those tickets, not for this one.
+- Migrating CopyButton's caller convention (e.g., adding new props like `onCopySuccess` callback) — YAGNI; current API is sufficient for the dashboard's needs.
+
+## Forward constraint for #652/#653 (per architect Finding 2)
+
+Post-grooming, add a comment to mika#665's issue body or a follow-up note that surfaces the forward constraint to mika#652 and mika#653 implementers: **"`<TraceIdWidget />` (built by mika#652/#653) MUST use `<CopyButton />` internally."** The constraint lives in the issue body where milestone tooling (and future implementers) will surface it. Cite: issue-as-versioned-contract pattern (mika-platform#52 body-edit convention).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Icon-swap transition introduces visual flicker on slow devices | 150ms is a standard fast-feedback duration; tested across modern browsers in development. If flicker reported post-merge, reduce to 100ms or revert to instant swap. |
+| `<CopyButton />` API change breaks existing dashboard callers | API unchanged: same `text` and `className` props. Visual output changes (smooth transition vs hard cut), no consumer-side change required. |
+| Hidden third hand-rolled callsite I missed in grep | AC #3 (post-implementation grep) catches any missed callsite. |
+| `framer-motion` dependency conflict if implementer picks that route | The plan's suggested shape uses pure CSS transitions — no new dependency. If the implementer prefers `framer-motion`, verify it's already in `package.json` (not in our current dependency tree per implementation memory) before committing to that route. |
+
+## Sequencing
+
+1. **Change 1 first** (CopyButton transition refinement). Small, contained.
+2. **Change 2 second** (TraceDetail.tsx migration). Builds on Change 1's smoothed CopyButton.
+3. **Tests inline.**
+4. **Run** dashboard test suite + `npm run build`.
+5. **Open PR** cross-referencing #665. PR description describes Change 1 as primitive refinement and Change 2 as dashboard cleanup — small, easy ship per issue body.
+
+## Verification
+
+End-to-end manual test:
+
+1. Run dashboard dev server: `VITE_MIKA_DASHBOARD_TOKEN=<token> npm run dev:dashboard`.
+2. Navigate to any page with a copy button (Agent detail section title, Team Runs run ID, Trace detail).
+3. Click the copy button. Observe: smooth icon transition from Copy → Check → Copy (~2s on, then fade back).
+4. Verify TraceDetail-specific copy buttons behave identically to other pages.
+5. Inspect DOM: confirm the `<CopyButton />` component is in use everywhere (no inline `useState(copied)` patterns).
+
+## Discovery items (resolved during planning)
+
+1. **`<CopyButton />` already has feedback** — `packages/ui/src/components/CopyButton.tsx:13,19-20,32`. The audit asked by the issue body resolves to "feedback exists; refine the transition shape, don't add a new mechanism."
+2. **One hand-rolled callsite to migrate** — `dashboard/src/pages/TraceDetail.tsx`. Verified via grep across `dashboard/src/` and `packages/ui/src/`.
+3. **`<TraceIdWidget />` does not exist** — per dashboard-stitch-map.md Phase 2 inventory, the widget is "build new" pending mika#652/#653. Forward-looking constraint preserved for those tickets, not this one.
+4. **No `framer-motion` in current dependency tree** — implementer should use pure CSS transitions to avoid adding a dependency for a 150ms fade.

--- a/docs/plans/2026-04-26-007-feat-665-dashboard-copy-feedback-plan.md
+++ b/docs/plans/2026-04-26-007-feat-665-dashboard-copy-feedback-plan.md
@@ -117,9 +117,17 @@ These tests verify the canonical primitive's contract; downstream consumers don'
 - `<TraceIdWidget />` migration. The widget doesn't exist yet — built later by mika#652 / mika#653 work per dashboard-stitch-map. The forward-looking acceptance criterion "`<TraceIdWidget />` uses `<CopyButton />` internally" is preserved as a constraint for the implementer of those tickets, not for this one.
 - Migrating CopyButton's caller convention (e.g., adding new props like `onCopySuccess` callback) — YAGNI; current API is sufficient for the dashboard's needs.
 
-## Forward constraint for #652/#653 (per architect Finding 2)
+## Forward constraint for #652/#653 (per architect Finding 2 + second-pass clarification)
 
-Post-grooming, add a comment to mika#665's issue body or a follow-up note that surfaces the forward constraint to mika#652 and mika#653 implementers: **"`<TraceIdWidget />` (built by mika#652/#653) MUST use `<CopyButton />` internally."** The constraint lives in the issue body where milestone tooling (and future implementers) will surface it. Cite: issue-as-versioned-contract pattern (mika-platform#52 body-edit convention).
+Post-grooming, add the forward constraint via **body-edit (not comment)** to **all three issue bodies** (#665, #652, #653) — defense-in-depth on cross-ticket constraint mirroring per architect second-pass review. Body-edits are versioned-contract surface (what `/mika-groom-ticket`'s parser scans + milestone-tooling renders on the primary view); comments are audit-trail-only.
+
+| Issue | Body callout to add |
+|---|---|
+| #665 | `> - **Forward constraint:** This primitive's API is consumed by \`<TraceIdWidget />\` from mika#652/#653 — when those tickets build the widget, it MUST use \`<CopyButton />\` internally per AC3.` |
+| #652 | `> - **Constraint from mika#665 AC3:** When building \`<TraceIdWidget />\`, use \`<CopyButton />\` from \`@senara-solutions/ui\` internally — do not author a parallel copy-on-click implementation.` |
+| #653 | (same as #652 — both build the widget per dashboard-stitch-map.md) |
+
+Cite: issue-as-versioned-contract pattern (mika-platform#52/#53 conventions) + cross-ticket constraint mirroring (analogous to cross-repo-awareness discipline).
 
 ## Risks
 

--- a/docs/solutions/best-practices/ui-component-consolidation-copy-feedback-2026-04-27.md
+++ b/docs/solutions/best-practices/ui-component-consolidation-copy-feedback-2026-04-27.md
@@ -1,0 +1,77 @@
+---
+title: "Consolidate hand-rolled UI patterns to canonical shared primitives"
+date: 2026-04-27
+category: best-practices
+module: packages/ui
+problem_type: best_practice
+component: tooling
+severity: low
+applies_when:
+  - Adding copy-to-clipboard or other interactive micro-affordances to dashboard pages
+  - Noticing duplicated UI patterns across dashboard page files
+  - Refining visual transitions in shared component library
+tags:
+  - copy-button
+  - ui-primitives
+  - component-consolidation
+  - css-transitions
+  - dashboard
+---
+
+# Consolidate hand-rolled UI patterns to canonical shared primitives
+
+## Context
+
+`<CopyButton />` in `@senara-solutions/ui` already provided clipboard feedback via icon swap (Copy -> Check), but the swap was abrupt (no CSS transition). Meanwhile, `dashboard/src/pages/TraceDetail.tsx` had a hand-rolled duplicate of the entire CopyButton implementation (~30 lines) rather than importing the canonical primitive.
+
+This pattern — hand-rolled duplicates of shared components — creates maintenance drift: when the primitive improves, duplicates don't benefit. When bugs are fixed in the primitive, duplicates retain the bug.
+
+## Guidance
+
+1. **Grep for `navigator.clipboard` (or the relevant browser API) across `dashboard/src/` and `packages/ui/src/` before shipping.** Only the canonical primitive (`CopyButton.tsx`) should contain the raw API call. Any other hits indicate a missed migration.
+
+2. **Use CSS opacity transitions for icon-swap feedback, not framer-motion.** A 150ms `transition-opacity` crossfade between two absolutely-positioned icons (one visible, one hidden) produces a smooth visual confirmation without adding a dependency. The absolute-overlay pattern avoids React reconciliation artifacts from `key={state}` remounts under rapid clicks.
+
+3. **Add `data-testid` attributes to shared primitives.** Querying by `data-testid` rather than SVG presence or button role makes tests stable across icon library upgrades (e.g., lucide-react swapping SVG internals).
+
+## Why This Matters
+
+Hand-rolled duplicates of shared components accumulate silently. A quick `grep -rn "navigator.clipboard" dashboard/src/` catches copy-button drift; similar greps work for other patterns (status pills, filter dropdowns, loading states). The `packages/ui/CLAUDE.md` enforcement rules exist precisely to prevent this — this learning reinforces the existing discipline with a concrete migration example.
+
+## When to Apply
+
+- Before any PR that adds interactive UI affordances to dashboard pages
+- During milestone audits (e.g., mika#13 dashboard improvements) to catch accumulated drift
+- When improving a shared primitive's visual behavior — check that all consumers use the import, not a local copy
+
+## Examples
+
+**Before (hand-rolled in TraceDetail.tsx):**
+```tsx
+// 30 lines duplicating CopyButton's exact logic
+function CopyButton({ text, className, title }) {
+  const [copied, setCopied] = useState(false)
+  // ... navigator.clipboard.writeText, setTimeout, icon swap ...
+}
+```
+
+**After (import the canonical primitive):**
+```tsx
+import { CopyButton } from '@senara-solutions/ui'
+// Used directly: <CopyButton text={row.input} title="Copy input" />
+```
+
+**Smooth transition pattern (in the shared primitive):**
+```tsx
+<span className="relative inline-flex items-center justify-center w-3 h-3">
+  <Copy className={`transition-opacity duration-150 ${copied ? 'opacity-0' : 'opacity-100'}`} />
+  <Check className={`absolute transition-opacity duration-150 text-emerald-400 ${copied ? 'opacity-100' : 'opacity-0'}`} />
+</span>
+```
+
+## Related
+
+- [mika#665](https://github.com/senara-solutions/mika/issues/665) — Dashboard copy feedback
+- [mika#13](https://github.com/senara-solutions/mika/issues/13) — Dashboard improvements milestone
+- `packages/ui/CLAUDE.md` — Enforcement rules for hand-rolled patterns
+- `docs/design/luminescent-core.md` — Rulebook section 5, transition states

--- a/packages/ui/src/components/CopyButton.tsx
+++ b/packages/ui/src/components/CopyButton.tsx
@@ -28,8 +28,20 @@ export default function CopyButton({
       onClick={handleCopy}
       className={`opacity-40 hover:opacity-100 transition-opacity shrink-0 ${className ?? ''}`}
       title={title}
+      data-testid="copy-button"
     >
-      {copied ? <Check size={12} className="text-emerald-400" /> : <Copy size={12} />}
+      <span className="relative inline-flex items-center justify-center w-3 h-3">
+        <Copy
+          size={12}
+          data-testid="copy-icon"
+          className={`transition-opacity duration-150 ${copied ? 'opacity-0' : 'opacity-100'}`}
+        />
+        <Check
+          size={12}
+          data-testid="check-icon"
+          className={`absolute transition-opacity duration-150 text-emerald-400 ${copied ? 'opacity-100' : 'opacity-0'}`}
+        />
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary

- **CopyButton smooth transition:** Added CSS opacity-based crossfade (~150ms) between Copy and Check icons in `@senara-solutions/ui`'s `<CopyButton />`, replacing the abrupt icon swap. Per luminescent-core rulebook §5 (transition states, no harsh notifications).
- **TraceDetail migration:** Removed the hand-rolled 30-line CopyButton duplicate from `dashboard/src/pages/TraceDetail.tsx`, now imports the canonical `<CopyButton />` from `@senara-solutions/ui`.
- **Test coverage:** 5 new tests covering icon visibility, crossfade animation, timeout revert, clipboard API call, and event propagation — all using `data-testid` attributes for stability.

Closes #665

## Acceptance criteria verified

- [x] `<CopyButton />` icon swap uses smooth CSS transition (opacity-based, ~150ms)
- [x] `TraceDetail.tsx` uses `<CopyButton />` — no hand-rolled clipboard code
- [x] `grep -rn "navigator.clipboard" dashboard/src/ packages/ui/src/` returns only `CopyButton.tsx`
- [x] All 5 tests pass
- [x] `npm run build --prefix dashboard` clean
- [x] Full dashboard test suite passes (32 tests)

## Test plan

- [x] Dashboard test suite passes (`npx vitest run` — 32 tests, 5 files)
- [x] Dashboard production build clean
- [x] Pre-commit hooks pass (typecheck, lint, secrets scan)
- [ ] Visual verification: click copy button on any dashboard page, observe smooth icon transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)