### PR TITLE
refactor(dev-pilot): delegate branch + worktree derivation to platform scripts

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -34,33 +34,34 @@ Before running the pipeline, set up an isolated worktree:
 1. **Parse branch:** Determine the branch name using this priority order (first match wins):
    a. **Explicit `branch:` prefix:** If `$ARGUMENTS` starts with `branch:<name>`, extract `<name>` and strip the prefix.
    b. **Issue body callout:** If an issue was fetched above, search the issue body for a line matching `> - **Branch:**` followed by a backtick-wrapped branch name (e.g., `` `feat/687/domain-graph-builder` ``). Extract that branch name. This is how pre-planned tickets communicate their branch — **always use it when present**.
-   c. **Derive from args (deterministic):** Only if (a) and (b) both miss, derive the branch name using this **exact bash recipe** — do not re-derive with the LLM or substitute your own kebab-casing, since redispatches must produce the same slug:
+   c. **Derive via canonical script:** Only if (a) and (b) both miss, invoke the canonical script `mika-platform/scripts/derive-branch-name`. The script enforces priority order (body callout → conventional-commit prefix → label override → default `feat`) and the canonical 40-char truncation. See senara-solutions/mika-platform#58 for context on the drift class this eliminates.
       ```bash
-      # Inputs: $ISSUE_NUMBER (optional, set when an issue was fetched), raw title/text
-      raw="${ISSUE_TITLE:-$ARGUMENTS}"
-      if printf '%s' "$raw" | grep -qE '^(feat|fix|chore|docs|eval|test|refactor|perf)(\([^)]+\))?: '; then
-        type=$(printf '%s' "$raw" | sed -nE 's/^([a-z]+)(\([^)]+\))?: .*$/\1/p')
-        body=$(printf '%s' "$raw" | sed -E 's/^[a-z]+(\([^)]+\))?: *//')
-      else
-        type=feat
-        body="$raw"
-      fi
-      slug=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]' \
-        | LC_ALL=C sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
-        | cut -c1-45 | sed -E 's/-[^-]*$//; s/-+$//')
-      if [ -n "${ISSUE_NUMBER:-}" ]; then
-        BRANCH="${type}/${ISSUE_NUMBER}/${slug}"
-      else
-        BRANCH="${type}/${slug}"
-      fi
+      # Walk up from $PWD to locate mika-platform/scripts/ — works from
+      # both <meta>/mika/ (main checkout) and <meta>/.claude/worktrees/<slug>/mika/.
+      SCRIPTS_DIR=""
+      d="$(pwd)"
+      while [ "$d" != "/" ]; do
+        if [ -x "$d/scripts/derive-branch-name" ]; then SCRIPTS_DIR="$d/scripts"; break; fi
+        d=$(dirname "$d")
+      done
+      [ -z "$SCRIPTS_DIR" ] && { echo "Error: could not locate mika-platform scripts/" >&2; exit 1; }
+
+      BRANCH=$("$SCRIPTS_DIR/derive-branch-name" \
+        --title "${ISSUE_TITLE:-$ARGUMENTS}" \
+        --issue "${ISSUE_NUMBER:-}" \
+        --labels "${LABELS:-}" \
+        --body-callout "${ISSUE_BODY:-}")
       ```
 2. **Skip if no branch or no args:** If there are no arguments (backlog eval mode), skip worktree creation and run the pipeline in the current directory.
 3. **Detect existing worktree (MANDATORY):** Run `git rev-parse --git-dir` and `git rev-parse --git-common-dir`. If they differ, you are ALREADY inside a worktree. **STOP worktree setup immediately** — set `CREATED_WORKTREE=false`, run `command -v lefthook >/dev/null 2>&1 && lefthook install` (non-blocking — skip silently if lefthook is not installed), and proceed directly to the Pipeline section below. Do NOT attempt to create, remove, or modify any worktree. Do NOT clean up or recreate. Just use the current directory as-is.
 4. **Sync main:** Run `git fetch origin main:main` to fast-forward local `main` to match remote. This ensures the worktree branches from the latest code. If it fails (e.g., `main` is checked out with uncommitted changes), fall back to `git fetch origin` and use `origin/main` as the base ref in the next step.
-5. **Create worktree:** Set `WORKTREE=../.claude/worktrees/<sanitized-branch>/mika/` (sanitize branch name: replace `/` with `-`). Record `ORIGINAL_DIR=$(pwd)`.
-   - If the worktree path already exists, remove it first: `git worktree remove --force <WORKTREE>` (ignore errors).
-   - Try: `git worktree add -b <branch> <WORKTREE> main`
-   - If that fails (branch already exists): `git worktree add <WORKTREE> <branch>`
+5. **Create worktree:** Compute the worktree path via `derive-worktree-path` (enforces the invariant `slug == sanitize(branch_ref)`). Record `ORIGINAL_DIR=$(pwd)`.
+   ```bash
+   WORKTREE=$("$SCRIPTS_DIR/derive-worktree-path" --branch "$BRANCH" --repo mika)
+   ```
+   - If the worktree path already exists, remove it first: `git worktree remove --force "$WORKTREE"` (ignore errors).
+   - Try: `git worktree add -b "$BRANCH" "$WORKTREE" main`
+   - If that fails (branch already exists): `git worktree add "$WORKTREE" "$BRANCH"`
    - cd into the worktree. Set `CREATED_WORKTREE=true`.
 6. **Install lefthook hooks:** Run `command -v lefthook >/dev/null 2>&1 && lefthook install` to ensure pre-commit hooks (fmt, clippy, secrets scan) are active in the worktree. Non-blocking — skip silently if lefthook is not installed.
 

--- a/docs/plans/2026-04-28-001-refactor-dev-pilot-derive-scripts-companion-plan.md
+++ b/docs/plans/2026-04-28-001-refactor-dev-pilot-derive-scripts-companion-plan.md
@@ -1,0 +1,71 @@
+---
+title: "refactor: Switch dev-pilot + /mika to mika-platform derive-* scripts (companion)"
+type: refactor
+status: active
+date: 2026-04-28
+origin: https://github.com/senara-solutions/mika-platform/issues/58
+---
+
+# refactor: Switch dev-pilot + /mika to mika-platform derive-* scripts (companion)
+
+## Overview
+
+Companion to senara-solutions/mika-platform#58. The canonical plan lives in
+the meta-repo at
+`mika-platform/docs/plans/2026-04-28-001-refactor-centralize-branch-worktree-derivation-plan.md`.
+
+This document captures the mika-side slice so this repo's pipeline-artifact
+gate has a plan doc to verify against.
+
+## Problem Frame
+
+Branch-slug derivation drifted across multiple sites in this workspace; the
+mika#844 dispatch failure on 2026-04-28 (`exit 128, branch already checked
+out at $OTHER_PATH`) was the visible symptom — the dispatcher's `cut -c1-40`
+and the slash command's `cut -c1-45` were producing different slugs for the
+same input. The mika-platform PR introduces two centralized scripts and this
+PR switches the runtime authority (the dev-pilot handler) over to them.
+
+## Scope (this repo)
+
+- `skills/bundled/dev-pilot/handlers/run.sh` — replace inline derivation block
+  (originally lines 218-248) with subprocess calls to
+  `$PLATFORM_DIR/scripts/derive-branch-name` and
+  `$PLATFORM_DIR/scripts/derive-worktree-path`. Format `LABELS` as CSV via
+  `jq -r '[.labels[].name] | join(",")'` to match the script's `--labels`
+  API. Fix dangling `${SANITIZED}` reference in dry-run cleanup at line 310
+  (P0 from CE review on the meta-repo PR) by switching to
+  `derive-worktree-path --no-repo` for the parent dir.
+- `.claude/commands/mika.md` — replace inline 45-char branch-slug recipe
+  with a walk-up SCRIPTS_DIR resolution and subprocess calls to the canonical
+  scripts. Walk-up (vs. the meta-repo's `dirname (git rev-parse
+  --git-common-dir)` idiom) is required because `git-common-dir` from inside
+  this sub-repo's checkout returns the sub-repo's `.git`, not the meta-repo's.
+
+## Out of scope
+
+- The new scripts themselves (live in mika-platform).
+- Sub-repo `/mika` slash command edits in mika-cloud and mika-skills (their
+  own companion PRs).
+- The `--type-override` flag-removal cleanup, naming consistency between
+  `mika-platform-*` scripts and the new `derive-*` scripts, and the
+  `run_case` test-helper deduplication — all flagged by CE review as P3
+  follow-ups, deferred.
+
+## Verification
+
+- `sh -n` syntax check on edited handler PASSES (verified locally).
+- `bash` smoke test from dev-pilot context: cross-script invariant
+  `WORKTREE_DIR == $PLATFORM_DIR/.claude/worktrees/sanitize($BRANCH)/$REPO`
+  holds for a representative ticket title.
+- End-to-end dispatch verification deferred to post-merge: requires
+  mika-platform PR #59 to merge first so the scripts land in the operator's
+  `~/workspace/mika-platform/scripts/` directory.
+
+## Sources & References
+
+- **Origin issue:** [senara-solutions/mika-platform#58](https://github.com/senara-solutions/mika-platform/issues/58)
+- **Canonical plan:** `mika-platform/docs/plans/2026-04-28-001-refactor-centralize-branch-worktree-derivation-plan.md`
+- **Companion meta-repo PR:** senara-solutions/mika-platform#59
+- **Drift symptom:** [senara-solutions/mika#844](https://github.com/senara-solutions/mika/issues/844)
+- **Compounded learning:** `mika-platform/docs/solutions/cross-repo-patterns/centralized-derivation-load-bearing-invariant-2026-04-28.md`

--- a/docs/solutions/workflow-issues/centralized-branch-derivation-companion-2026-04-28.md
+++ b/docs/solutions/workflow-issues/centralized-branch-derivation-companion-2026-04-28.md
@@ -1,0 +1,134 @@
+---
+title: "Centralize cross-file invariants in shared code (companion slice)"
+date: 2026-04-28
+problem_type: workflow_issue
+category: workflow-issues
+module: dev-pilot, slash-commands
+component: dev-pilot-handler, mika-slash-command
+tags:
+  - centralization
+  - drift-class
+  - dev-pilot
+  - slash-commands
+  - cross-repo
+  - exit-code-contract
+applies_when: >
+  Editing the dev-pilot handler or this repo's `/mika` slash command in a way
+  that touches branch-name or worktree-path derivation. Defer to the canonical
+  mika-platform scripts.
+---
+
+# Centralize cross-file invariants in shared code (companion slice)
+
+## Context
+
+mika-platform issue #58 surfaced after the mika#844 dispatch failure on
+2026-04-28 (`exit 128, fatal: branch already checked out at $OTHER_PATH`).
+Branch-slug derivation was inlined in three independent sites across the
+workspace — including this repo's dev-pilot handler (`cut -c1-40`) and
+`.claude/commands/mika.md` (`cut -c1-45`). The implicit cross-file invariant
+`worktree_path_slug == sanitize(branch_ref)` was nowhere named, only honored
+by parallel manual updates — and drift broke a real dispatch.
+
+The full pattern, rationale, and alternatives (six learnings — single source
+of truth, CLI agent-readiness, post-refactor dangling references, plan/code
+drift handling, `git -C` relative-path bug, SCRIPTS_DIR resolution asymmetry)
+are documented in the canonical compound at:
+
+- `mika-platform/docs/solutions/cross-repo-patterns/centralized-derivation-load-bearing-invariant-2026-04-28.md`
+
+This file captures the mika-specific slice so this repo's pipeline gate has
+a local compound doc to verify against, and so a contributor reading mika's
+solutions store sees the centralization edict and the related correctness
+findings.
+
+## Guidance
+
+### Dev-pilot handler
+
+The dev-pilot handler at `skills/bundled/dev-pilot/handlers/run.sh` is the
+runtime authority for autonomous dispatch — it creates real branches that
+get pushed to GitHub. It **must** invoke the canonical scripts at
+`$PLATFORM_DIR/scripts/`:
+
+```sh
+LABELS=$(printf '%s' "$ISSUE_JSON" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
+
+BRANCH=$("$PLATFORM_DIR/scripts/derive-branch-name" \
+    --title "$ISSUE_TITLE" \
+    --issue "$ISSUE_NUM" \
+    --labels "$LABELS" \
+    --body-callout "$ISSUE_BODY")
+
+WORKTREE_DIR=$("$PLATFORM_DIR/scripts/derive-worktree-path" --branch "$BRANCH" --repo "$REPO")
+```
+
+Note the `LABELS` format: the script accepts CSV via `--labels`, so the
+handler joins the JSON array (whereas the original inline code iterated
+newline-separated names).
+
+### Slash command
+
+This repo's `.claude/commands/mika.md` resolves `SCRIPTS_DIR` via walk-up
+from `$PWD` (not via `git rev-parse --git-common-dir`, which from inside a
+sub-repo returns the sub-repo's `.git`, not the meta-repo's):
+
+```bash
+SCRIPTS_DIR=""
+d="$(pwd)"
+while [ "$d" != "/" ]; do
+  if [ -x "$d/scripts/derive-branch-name" ]; then SCRIPTS_DIR="$d/scripts"; break; fi
+  d=$(dirname "$d")
+done
+[ -z "$SCRIPTS_DIR" ] && { echo "Error: could not locate mika-platform scripts/" >&2; exit 1; }
+```
+
+Walk-up works for both `<meta>/mika/` (main checkout) and
+`<meta>/.claude/worktrees/<slug>/mika/` (worktree).
+
+### Two correctness lessons surfaced by CE review on this PR
+
+1. **Post-refactor dangling references.** Collapsing the inline derivation
+   block (lines 218-248) into a subprocess call left `${SANITIZED}` dangling
+   at line 310 (dry-run cleanup). Under `set -e` (no `-u`), the variable
+   expanded to empty and `rmdir` silently targeted the worktrees ROOT.
+   Fixed by using `derive-worktree-path --no-repo` for the parent dir.
+   General rule: after a collapse, grep every variable defined in the
+   removed block and audit each surviving reference. Adding `set -u` to
+   the handler would catch this class at runtime.
+
+2. **CLI exit-code contract.** Both `derive-*` scripts originally had a
+   `shift 2` silent-exit-1 bug under `set -e` when a value-consuming flag
+   appeared as the last argv entry. Outside the documented {0, 2, 3}
+   contract that this handler parses for HANDLER CRASH reports. Fixed
+   upstream in mika-platform with a `require_value` guard and regression
+   tests; relevant here because the handler relies on the contract.
+
+## Why This Matters
+
+Reinstating inline derivation here — even temporarily — recreates the drift
+class the centralization eliminated. The invariant is structurally enforced
+only when every caller invokes the same shared computation; one inline
+recovery defeats the property. The dev-pilot handler is the highest-risk
+site because it creates real branches; protecting that surface is what made
+the centralization load-bearing.
+
+## When to Apply
+
+- Editing `skills/bundled/dev-pilot/handlers/run.sh` to add new dispatch
+  paths or change branch/worktree resolution.
+- Editing `.claude/commands/mika.md` to add new slash-command entry points.
+- Adding any future skill or handler that needs branch derivation or
+  worktree-path computation — invoke the scripts via subprocess, do not
+  reimplement.
+- Reviewing PRs that touch slug derivation: confirm they invoke the
+  canonical scripts rather than reintroducing inline recipes.
+
+## Sources & References
+
+- **Canonical compound (full pattern):** `mika-platform/docs/solutions/cross-repo-patterns/centralized-derivation-load-bearing-invariant-2026-04-28.md`
+- **Origin issue:** [senara-solutions/mika-platform#58](https://github.com/senara-solutions/mika-platform/issues/58)
+- **Drift symptom:** [senara-solutions/mika#844](https://github.com/senara-solutions/mika/issues/844) — dispatch exit 128
+- **Related closure-bound enforcement:** [senara-solutions/mika#841](https://github.com/senara-solutions/mika/issues/841) — positive-consent gate
+- **Companion plan (this repo):** `docs/plans/2026-04-28-001-refactor-dev-pilot-derive-scripts-companion-plan.md`
+- **Plan-on-branch contract:** `docs/solutions/best-practices/plan-on-branch-load-bearing-contract-2026-04-26.md`

--- a/skills/bundled/dev-pilot/handlers/run.sh
+++ b/skills/bundled/dev-pilot/handlers/run.sh
@@ -205,30 +205,19 @@ if [ -n "$REPO" ] && [ -n "$ISSUE_NUM" ]; then
         exit 1
     fi
 
-    # Check issue body for a pre-committed branch callout (from planning sessions).
-    # Format: > - **Branch:** `feat/687/domain-graph-builder`
-    # This takes priority over title-derived branch names so claude-pilot lands
-    # on the branch where the plan file was committed.
+    # Branch-name derivation is centralized in mika-platform/scripts/derive-branch-name.
+    # The script enforces priority order (body callout > conventional-commit prefix in
+    # title > label override > default feat) and the canonical 40-char truncation.
+    # See senara-solutions/mika-platform#58 for context on the drift class this eliminates.
     ISSUE_BODY=$(printf '%s' "$ISSUE_JSON" | jq -r '.body // empty')
-    CALLOUT_BRANCH=$(printf '%s' "$ISSUE_BODY" | grep -oP '>\s*-?\s*\*\*Branch:\*\*\s*`\K[^`]+' | head -1)
+    ISSUE_TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title')
+    LABELS=$(printf '%s' "$ISSUE_JSON" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
 
-    if [ -n "$CALLOUT_BRANCH" ]; then
-        BRANCH="$CALLOUT_BRANCH"
-    else
-        # Derive branch type from labels
-        LABELS=$(printf '%s' "$ISSUE_JSON" | jq -r '.labels[].name' 2>/dev/null)
-        BRANCH_TYPE="feat"
-        if printf '%s' "$LABELS" | grep -qi '^bug$'; then
-            BRANCH_TYPE="fix"
-        elif printf '%s' "$LABELS" | grep -qi '^chore$'; then
-            BRANCH_TYPE="chore"
-        fi
-
-        # Derive branch name: type/number/kebab-title
-        ISSUE_TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title')
-        KEBAB_TITLE=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
-        BRANCH="${BRANCH_TYPE}/${ISSUE_NUM}/${KEBAB_TITLE}"
-    fi
+    BRANCH=$("$PLATFORM_DIR/scripts/derive-branch-name" \
+        --title "$ISSUE_TITLE" \
+        --issue "$ISSUE_NUM" \
+        --labels "$LABELS" \
+        --body-callout "$ISSUE_BODY")
 
     # Sync main before branching to avoid stale worktrees.
     # Use plain `fetch origin main` (not the `main:main` refspec form) because the
@@ -243,9 +232,9 @@ if [ -n "$REPO" ] && [ -n "$ISSUE_NUM" ]; then
     # `origin/main` below and get the latest merged tip.
     git -C "$SUB_REPO_DIR" fetch origin main 2>/dev/null || true
 
-    # Create worktree
-    SANITIZED=$(printf '%s' "$BRANCH" | tr '/' '-')
-    WORKTREE_DIR="${PLATFORM_DIR}/.claude/worktrees/${SANITIZED}/${REPO}"
+    # Worktree path is centralized in mika-platform/scripts/derive-worktree-path —
+    # enforces the invariant `worktree_path_slug == sanitize(branch_ref)` in one line.
+    WORKTREE_DIR=$("$PLATFORM_DIR/scripts/derive-worktree-path" --branch "$BRANCH" --repo "$REPO")
 
     # Reuse existing worktree if valid
     if [ -d "$WORKTREE_DIR" ] && git -C "$WORKTREE_DIR" rev-parse --git-dir >/dev/null 2>&1; then

--- a/skills/bundled/dev-pilot/handlers/run.sh
+++ b/skills/bundled/dev-pilot/handlers/run.sh
@@ -307,7 +307,7 @@ Resolve manually before re-dispatching ${REPO}#${ISSUE_NUM}."
             --arg worktree "$WORKTREE_DIR" --arg prompt "$PROMPT" \
             '{dry_run:true, repo:$repo, issue:$issue, branch:$branch, worktree_dir:$worktree, prompt:$prompt}'
         git -C "$SUB_REPO_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
-        PARENT_DIR="${PLATFORM_DIR}/.claude/worktrees/${SANITIZED}"
+        PARENT_DIR=$("$PLATFORM_DIR/scripts/derive-worktree-path" --branch "$BRANCH" --no-repo)
         rmdir "$PARENT_DIR" 2>/dev/null || true
         exit 0
     fi


### PR DESCRIPTION
## Summary

Companion to senara-solutions/mika-platform#59 — switches the dev-pilot handler from inline branch-slug + worktree-path derivation to subprocess calls into the centralized `mika-platform/scripts/derive-branch-name` and `derive-worktree-path`. Same change for this repo's `/mika` slash command.

The dev-pilot handler is the runtime authority for autonomous dispatch — it creates real branches that get pushed to GitHub. After this PR, it derives via the canonical scripts; the drift class that produced the mika#844 dispatch failure on 2026-04-28 cannot recur because the dispatcher and the slash commands now derive from the same source.

## Changes

- `skills/bundled/dev-pilot/handlers/run.sh` — replace 22-line inline derivation block (lines 218-248 pre-edit) with subprocess calls. CSV-formatted labels via `jq -r '[.labels[].name] | join(",")'` to match the script's `--labels` API.
- `skills/bundled/dev-pilot/handlers/run.sh` — fix dangling `${SANITIZED}` reference at line 310 in dry-run cleanup (CE review P0). Replaced with `derive-worktree-path --no-repo` for the parent dir.
- `.claude/commands/mika.md` — replace inline 45-char recipe in this repo's `/mika` slash command with a walk-up SCRIPTS_DIR resolution and subprocess calls.

## Companion PR

- senara-solutions/mika-platform#59 — introduces the scripts these changes depend on. Land it first (or together).

## Test plan

- [x] `sh -n` syntax check on edited handler PASSES.
- [x] Smoke test from dev-pilot context: cross-script invariant `WORKTREE_DIR == \$PLATFORM_DIR/.claude/worktrees/sanitize(BRANCH)/\$REPO` holds.
- [x] Build a mental cross-repo end-to-end: `make deploy` after both PRs merge will install scripts into `~/workspace/mika-platform/scripts/`, dev-pilot handler will find them via `\$PLATFORM_DIR/scripts/`.

Refs senara-solutions/mika-platform#58

🤖 Generated with [Claude Code](https://claude.com/claude-code)