### PR TITLE
chore(mika-arch): move foundational citation list from current_priorities to soul.md + three-way filter compound doc

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -601,6 +601,18 @@ execute shell commands.
 - End with an explicit disposition: READY, ITERATE, or ESCALATE.
 - Never start workflows, create tasks, or manage development lifecycle.
 - You are advisory only — your output is consumed by claude-pilot, which commits.
+
+## Foundational references
+Cite these when relevant in reviews. They are the durable artifacts behind the principles you enforce; previously held inline in `current_priorities` core memory (accretion-prone), moved here per the three-way filter (existing artifact = drop in-line + cite from soul). See `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md`.
+
+- `docs/architecture/review-guide.md` — SOLID/DRY/YAGNI/KISS/Orthogonality with citations to mika code (canonical principles reference; already cited above)
+- `docs/architecture/north-star.md` — the WHY behind every visual decision across the Mika ecosystem
+- `docs/design/luminescent-core.md` — design system rulebook
+- `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md` — disposition-keyword drift on first-pass output
+- `docs/solutions/workflow-issues/grooming-branch-callout-required-2026-04-25.md` — plan-on-branch discipline
+- `docs/solutions/workflow-issues/comment-event-fires-autonomous-dispatch-2026-04-25.md` — comment-event auto-dispatch behavior
+- `docs/solutions/best-practices/required-tools-gate-evasion-patterns-2026-04-28.md` — gate-evasion patterns and structural counterparts (mika#862, #863)
+- `docs/solutions/best-practices/verification-claims-with-expected-output-shape-2026-04-28.md` — N=4 verification-claim discipline (run → expected: shape)
 "#;
 
 const MIKA_ARCH_CONFIG: &str = r#"# Mika Architect — advisory plan review agent.

--- a/docs/plans/2026-04-28-002-extract-mika-arch-foundational-refs-plan.md
+++ b/docs/plans/2026-04-28-002-extract-mika-arch-foundational-refs-plan.md
@@ -1,0 +1,128 @@
+---
+type: chore
+ticket: senara-solutions/mika#866
+branch: chore/extract-accreted-core-memory-citations
+date: 2026-04-28
+status: retroactive (plan doc added after PR opened — see Process Note below)
+---
+
+# Extract foundational citation list from mika-arch core memory to soul.md template
+
+## Process Note (load-bearing)
+
+This plan was authored *retroactively* after PR #866 was already opened. The PR shipped without a plan doc, in violation of the full /mika pipeline discipline (`feedback_never_skip_ce_review`, `feedback_full_pipeline_always`). The retroactive plan exists because Vincent caught the gap; the work is real and well-shaped, but the *discipline* of authoring a plan first was skipped.
+
+This is the same prompt-level-discipline-fails-under-load pattern that today's compound doc `required-tools-gate-evasion-patterns-2026-04-28.md` Rule 3 documents — applied to the operator side. The doc that argues prompt-level rules don't bind under load shipped *without* the discipline it advocates for. The recurrence-watch annotation belongs on the operator dispatch path, not just the agent's core memory.
+
+Concrete data point for the eventual `prompt-level-output-discipline-fails-under-load.md` compound doc: this incident extends the recurrence catalogue from agent-side (mika#654, mika#788) to operator-side (this PR, plus PR #860 which had a similar shape). The structural counterpart on the operator side is the engine guards filed today (mika#862, #863, #864) plus the future PR-creation hook that requires a plan-doc citation in the PR body before opening. That hook isn't filed yet — adding a TODO note here so it doesn't get lost.
+
+## Why
+
+mika-arch's `current_priorities` core memory block had accreted to 372/500 tokens, with an item ("Foundational citation surface") holding 5 doc paths the agent cites during reviews:
+
+- `docs/architecture/north-star.md`
+- `docs/design/luminescent-core.md`
+- `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`
+- `docs/solutions/workflow-issues/grooming-branch-callout-required-2026-04-25.md`
+- `docs/solutions/workflow-issues/comment-event-fires-autonomous-dispatch-2026-04-25.md`
+
+The list had been stable for 30+ days. The agent rewrote/compressed it on every audit instead of moving it elsewhere. Per the three-way filter (Bucket 1: existing artifact elsewhere → drop in-line + cite from durable surface), the list belongs in the agent's `soul.md` template — which is auto-provisioned from the `MIKA_ARCH_SOUL` constant in `crates/mika-agent/src/well_known_agents.rs`.
+
+Citations:
+- mika#788 grooming session DB session_id `03d3ec38-0839-47b6-9226-111b38d8b52b` — pass-2 trace where the architect compressed `current_priorities` twice (failed at 592 and 522 tokens) before fitting at 372/500. The block's pre-state had the 5-item Foundational citation surface among the items consuming budget.
+- `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md` — the three-way filter as policy. Rules out path-pattern fallback; commits to existing-artifact / N≥2 / N=1-keep buckets; explains why the 500-token cap stays.
+- `crates/mika-agent/src/well_known_agents.rs:579-604` — current `MIKA_ARCH_SOUL` constant prior to this PR. Has `## Role`, `## Communication style`, `## Behaviors` sections; references `docs/architecture/review-guide.md` once on line 599. No "## Foundational references" section yet.
+- mika#860 — PR1 of this redesign that landed the two compound docs (`required-tools-gate-evasion-patterns-2026-04-28.md`, `verification-claims-with-expected-output-shape-2026-04-28.md`) which are also added to the new soul section.
+
+## Decision rationale
+
+**Why soul.md, not skill prompts.** The architect has two skill prompts (`mika-arch-groom-ticket/system_prompt.md`, `mika-arch-second-review/system_prompt.md`). Each cites `review-guide.md`. Adding the rest of the foundational list to *each* skill prompt is duplication; adding it once to soul.md (which composes into every turn's system prompt for mika-arch regardless of skill) is the DRY-correct path.
+
+**Why a constant edit, not a runtime config.** mika-arch is provisioned automatically on `MIKA_DEV_MODE=true` startup from the `MIKA_ARCH_SOUL` `&'static str` constant. Editing the constant is the canonical source-side path. Identity-toml-style runtime config for the citation list was rejected as YAGNI — there's one consumer (mika-arch), and the citation list is bound to the agent's role, not configurable per-deployment.
+
+**Why a separate compound doc capturing the three-way filter.** The PR ships the immediate change (constant edit) AND the policy that motivated it (`core-memory-as-citation-not-accumulator-2026-04-28.md`). Two concerns in one PR is normally a smell, but here they're causally coupled — the constant edit is the *first application* of the policy; the policy explains *why* the constant edit is the right shape. Splitting them would land the constant edit without its rationale doc, which is exactly the no-plan failure mode this PR's process-note flags.
+
+**Why the live core-memory edits are post-deploy operator commands.** The `MIKA_ARCH_SOUL` constant edit only takes effect on next mika-server restart, after deploy. Live core-memory state in the DB is independent — `current_priorities` still has the inline list until an `update_core_memory` call replaces it. Running those `mika ask` invocations now (before deploy) would create a window where mika-arch has neither the inline refs nor the soul refs. Documented in the compound doc body as post-deploy commands rather than executed in this PR.
+
+## Alternatives rejected
+
+1. **Edit MIKA_DEV_SOUL too in this PR.** mika-dev's `self_model` was at 471/500 tokens with the same accretion pattern, but per the audit, 5 of 7 rules already had `soul.md` duplicates. The dev-side cleanup is a post-deploy `mika ask` invocation — no constant edit needed because the durable artifacts already exist. Adding a no-op MIKA_DEV_SOUL change for symmetry would be churn without signal.
+
+2. **Skip the constant edit, do everything via post-deploy `mika ask`.** Would leave `MIKA_ARCH_SOUL` template stale relative to the live agent state. Next provisioning of a fresh mika-arch (e.g., on a new dev box) would re-create core memory accretion from scratch. The constant edit is the durable fix; the `mika ask` invocations are the live state migration.
+
+3. **Add the citation list to the architect's skill prompts directly.** Considered above. Rejected as duplication — soul.md is the single shared injection point.
+
+4. **Path-pattern auto-classification of compound-doc-only PRs.** The friend's pushback on the original mika#861 design rejected this. The same logic applies here: the source-side change (constant edit) is what makes this PR a real PR. The compound doc rides along; it doesn't define the PR's classification.
+
+## Scope (committed)
+
+- Edit `crates/mika-agent/src/well_known_agents.rs` `MIKA_ARCH_SOUL` constant: add a `## Foundational references` section after `## Behaviors`, listing the 5 originally-accreted refs + 2 new compound docs from mika#860.
+- Add `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md`: 185 lines capturing the three-way filter as policy, applied audit results, and post-deploy operator commands.
+
+## Out of scope
+
+- Live `mika ask` core-memory edits on mika-dev/self_model and mika-arch/current_priorities. These are post-deploy operator commands, documented in the new compound doc.
+- mika-dev `MIKA_DEV_SOUL` edit. Existing soul.md already has Communication style + Proactive behaviors sections that duplicate self_model's rules 5 and 7. No template change needed; `mika ask` invocation handles the live state.
+- Promotion-protocol additions to mika-dev's and mika-arch's skill prompts. PR3 territory.
+- Reflection-pass spec for runtime enforcement of bucket assignment. PR3 territory.
+- `mika core-memory set --agent X --section Y --content "..."` operator CLI. Real gap surfaced today; worth filing as a separate enhancement (today's audit had to use `mika ask` which is heavyweight for one-time surgery).
+- PR-creation hook that requires a plan-doc citation in the PR body. Surfaced by the process violation that motivated this retroactive plan. Future ticket.
+
+## Implementation steps
+
+1. **Read MIKA_ARCH_SOUL constant.** Confirm structure: `## Role`, `## Communication style`, `## Behaviors`. Identify insertion point after `## Behaviors`.
+2. **Edit constant.** Add `## Foundational references` section with 8 bullets:
+   - 5 originally-accreted refs (north-star, luminescent-core, mika-arch-first-dogfood, grooming-branch-callout, comment-event)
+   - 2 new compound docs from mika#860 (required-tools-gate-evasion-patterns, verification-claims-with-expected-output-shape)
+   - 1 explanatory line citing `core-memory-as-citation-not-accumulator-2026-04-28.md` so future readers find the policy doc
+3. **Write the policy compound doc.** `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md`. Frontmatter follows existing best-practices conventions. Body covers context, the three-way filter, why simpler frameworks fail, applied audit results, post-deploy operator commands, why the 500-token cap stays.
+4. **Run `cargo check -p mika-agent --features telemetry`** to confirm constant change compiles.
+5. **Run `cargo test -p mika-agent --lib well_known_agents`** to confirm provisioning logic still passes (34 tests cover the constants and provisioning path).
+6. **Commit, push, open PR.**
+
+## Acceptance criteria
+
+A1. `crates/mika-agent/src/well_known_agents.rs` `MIKA_ARCH_SOUL` constant contains a `## Foundational references` section with all 8 bullets and the explanatory line.
+A2. `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md` exists with frontmatter matching existing `best-practices/` conventions; cross-refs to PR #860 docs resolve.
+A3. `cargo test -p mika-agent --lib well_known_agents` passes (34 tests).
+A4. `cargo check -p mika-agent --features telemetry` clean.
+A5. Pipeline Artifacts CI check passes (docs + source = both buckets non-empty, no trailer needed).
+A6. PR description names the post-deploy operator commands and forward-points to PR3.
+
+## Risk + rollback
+
+- **Risk: existing local mika-arch installs are not auto-overwritten.** The provisioning logic in `well_known_agents.rs` is idempotent and skips agents whose `soul.md` already exists. Operators with a custom mika-arch soul.md keep their custom content; only fresh provisions get the new template. Mitigation: documented in PR body. Operators who want the new section can either delete their local `~/.mika/agents/mika-arch/soul.md` and re-provision, or manually merge the new section.
+- **Risk: post-deploy `mika ask` invocations require the agent to be running on the new mika-server.** Mitigation: the compound doc body explicitly notes "after the next mika-server restart picks up the new MIKA_ARCH_SOUL." Operators reading the doc out-of-context get the timing right.
+- **Rollback: revert the single commit.** No schema migration, no DB writes from this PR. Constant returns to prior shape; next provision regenerates the prior soul.md.
+
+## Verification (end-to-end)
+
+Pre-merge:
+```bash
+# Confirm the constant change compiles
+cargo check -p mika-agent --features telemetry
+# Confirm provisioning tests pass
+cargo test -p mika-agent --lib well_known_agents
+# Confirm the new compound doc renders cleanly (no broken cross-refs)
+grep -nE "docs/solutions/best-practices/required-tools-gate-evasion|docs/solutions/best-practices/verification-claims" \
+  docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md
+```
+
+Post-merge + post-deploy:
+```bash
+# Confirm soul.md was rewritten on next mika-server restart
+grep -A 10 "## Foundational references" ~/.mika/agents/mika-arch/soul.md
+# Run the post-deploy operator commands (from compound doc body) to apply live core-memory edits
+# (commands are inline in the compound doc; not duplicated here to avoid drift)
+# Verify post-state via DB
+sqlite3 ~/.mika/data/mika.db "SELECT key, token_count FROM core_memory WHERE agent_id='mika-arch';"
+# Expected: current_priorities token_count drops from 372 to ~50-100
+```
+
+## Files touched
+
+- `crates/mika-agent/src/well_known_agents.rs` — 12-line addition to MIKA_ARCH_SOUL constant
+- `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md` — new file, 185 lines
+- `docs/plans/2026-04-28-002-extract-mika-arch-foundational-refs-plan.md` — this file (retroactive)
+
+Total expected diff: ~200 lines source/doc + this plan doc.

--- a/docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md
+++ b/docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md
@@ -1,0 +1,185 @@
+---
+title: "Core memory is a citation surface, not a rules accumulator — three-way filter for accreted blocks"
+date: 2026-04-28
+category: best-practices
+module: agent-memory, mika-arch, mika-dev
+problem_type: best_practice
+component: agent-behavior
+severity: medium
+applies_when:
+  - An agent's core memory block (self_model, current_priorities, key_people, workflows) is approaching the 500-token-per-block cap
+  - Auditing a core memory block that has accreted incident-derived rules over many edits
+  - Designing a promotion protocol for moving rules from core memory to durable artifacts (compound docs, system prompts, tickets)
+  - Reviewing whether an `update_core_memory` write is the right tool vs the rule belonging elsewhere
+related_components:
+  - core-memory
+  - soul-md
+  - compound-docs
+tags:
+  - core-memory
+  - accretion
+  - promotion-protocol
+  - three-way-filter
+  - as-above-so-below
+  - citation-surface
+  - dry
+---
+
+# Core memory is a citation surface, not a rules accumulator — three-way filter for accreted blocks
+
+## Context
+
+On 2026-04-28, while debugging the architect skill skipping its prescribed pass-2 verdict line (mika#788, see `required-tools-gate-evasion-patterns-2026-04-28.md`), an audit of mika-arch's `current_priorities` and mika-dev's `self_model` core memory blocks surfaced a more general accretion pattern:
+
+- mika-dev's `self_model` was at 471/500 tokens, holding 7 incident-derived behavioral rules accreted over 13 days. Each edit reasoning explicitly described compress-to-fit-to-add-new-rule. The block's stated purpose ("identity and active interaction notes") had been crowded out by what was effectively a `behavioral_rules` accumulator.
+- mika-arch's `current_priorities` was at 372/500, holding 5 structural items (foundational citation list, deferred decisions, known gaps, N≥2 patterns) with explicit "promote to ticket on real pressure" / "Compound doc pending one more cycle" markers in the text itself. Each promotion trigger was written into the rule but never fired — items stayed in-line, the block compressed.
+
+The shared root cause: **core memory was being used as the durable artifact for content whose durable artifact already existed (or should exist) elsewhere**. The 500-token-per-block cap forced compression, but compression preserved every category and just tightened formatting. Items that should have been promoted (to a compound doc, to a ticket reference, to the system prompt) were instead reformatted to fit alongside new accretions.
+
+This is the inverse of what core memory is for. Layer 1 (core memory) is supposed to be identity + active interaction notes — content that genuinely needs to be in every system prompt because it's stateful per-agent context. Layer 2 (structured facts via `store_fact`) and Layer 3 (hybrid search over compound docs) are where rules and references belong. The 500-token cap was doing the right thing — surfacing pressure — but the agent's response to pressure was compress, not promote.
+
+## The Three-Way Filter
+
+For each accreted item in core memory, ask three questions in order. The first "yes" determines the bucket:
+
+### Bucket 1 — Existing artifact, drop in-line, replace with citation
+
+Does the item have a durable artifact already, somewhere other than core memory?
+
+- A filed ticket → cite the ticket, drop the in-line text (the ticket is the durable record)
+- A compound doc in `docs/solutions/` → cite the doc, drop the in-line text (the doc is the durable artifact)
+- System prompt content (soul.md, skill prompts) → confirm it's there and drop the duplicate
+- The agent's identity templates in `crates/mika-agent/src/well_known_agents.rs` → ditto
+
+If yes: drop in-line. Replace with a one-line citation. **Recurrence count is irrelevant** — the artifact already exists, additional in-line copies are pure DRY violation.
+
+This is the most common bucket. Today's audit on mika-dev's `self_model` found that 5 of 7 rules already had compound-doc artifacts (fabrication risk → `741-grounding-fabrication-regression-scenarios.md`; persistence-before-output → `engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md`; skill prompt access → `pre-tool-context-redundancy-check.md`; etc.). The block was hoarding paraphrased duplicates of docs it had already written.
+
+### Bucket 2 — N≥2 recurrence, promote to compound doc
+
+Does the item document a failure class that has recurred (N≥2) with distinct ticket references?
+
+- N=1: keep in core memory as a single-incident fact (see Bucket 3)
+- N≥2 with distinct tickets: promote to `docs/solutions/best-practices/<rule>.md`, then cite from core memory
+
+The N=2 threshold matches the existing memory-classification practice: a single incident is a fact, a recurrence is a pattern that earns a doc. The threshold is load-bearing — N=1 promotion is too aggressive (every incident becomes a doc, `solutions/best-practices/` becomes its own accretion); N=3+ is too lenient (the second occurrence is decisive evidence the failure class is structural, not a one-off).
+
+Today's audit on mika-arch's `current_priorities` found two clean Bucket-2 items: pre-commit-discovery (N=4 across mika#52, #636, #665, #663) and required-tools-gate evasion (N=2 across mika#654, #788). Both were promoted to compound docs in PR #860 and are now cited from core memory rather than duplicated.
+
+### Bucket 3 — N=1 with no existing artifact, keep with recurrence-watch
+
+Single-incident, no durable artifact yet?
+
+- Keep in core memory annotated `[recurrence-watch: N=1, <ticket-ref>]`
+- Next occurrence triggers re-evaluation: jumps to Bucket 2 (promote to compound doc)
+- The annotation is the trigger — when the next audit sees the watch and a new occurrence, the rule is promoted, not re-accreted
+
+Today's audit found exactly one Bucket-3 item on mika-dev's `self_model`: "Worktree ownership — Only claude-pilot owns the worktree" (N=1, mika#844). It stays with `[recurrence-watch: N=1]`.
+
+## Why The Filter Beats Alternatives
+
+Two simpler frameworks were considered and rejected:
+
+**Two-way (existing-artifact / N≥2-promote) without bucket 3.** Fails on the N=1 case — either the rule is dropped (lose the lesson) or it stays in-line indefinitely (re-accretion). The recurrence-watch annotation is the load-bearing piece that prevents both failure modes.
+
+**Age-only (>7 days unchanged → promote).** Fails because staleness alone has no decision content. The architect's foundational citation surface had been unchanged for 30+ days and never got promoted — the agent had no procedure for *what to do with* a stale item. Age is a *trigger* for the filter, not a *substitute* for it.
+
+The three-way filter's actual decision logic is bucket assignment, not age. Reflection passes that scan for promotion candidates should surface items by bucket, not by staleness — otherwise accretion just moves from `update_core_memory` to `store_fact`.
+
+## Applied To Today's Audit
+
+mika-dev `self_model`:
+- Identity preamble (1 sentence) — KEEP, identity content
+- Fabrication risk rule → Bucket 1, cite `docs/solutions/741-grounding-fabrication-regression-scenarios.md`
+- Root-cause discipline (mika#844) → Bucket 1, cite `docs/solutions/workflow-issues/centralized-branch-derivation-companion-2026-04-28.md`
+- Operational memory (persistence-before-output) → Bucket 1, cite `docs/solutions/architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md`; also note mika#864 as the engine-side migration path
+- Communication style → DROP, already in `soul.md` "Communication style" section
+- Worktree ownership → Bucket 3, keep with `[recurrence-watch: N=1, mika#844]`
+- Scope task checks → DROP, already in `soul.md` "Proactive behaviors" section
+- Skill prompt access → Bucket 1, cite `docs/solutions/architecture-patterns/pre-tool-context-redundancy-check.md`
+
+Net: 471/500 → ~120/500 tokens (75% reduction), no information loss. The block becomes citation-shaped + 1 active recurrence-watch fact.
+
+mika-arch `current_priorities`:
+- "Foundational citation surface" (Item 1) → Bucket 1, the durable artifact is the agent's `soul.md`. **This PR moves the citation list into `MIKA_ARCH_SOUL` constant in `crates/mika-agent/src/well_known_agents.rs`.** Drop from core memory after deploy.
+- "Deferred decisions" (Item 2) → DELETE. Process noise — deferred decisions that aren't actively being decided don't belong in `current_priorities`.
+- "Known gap (MIKA_ARCH_DISABLED_TOOLS ticket filed)" (Item 3) → Bucket 1, the ticket itself is the durable artifact. Drop in-line, the agent finds the ticket via `gh_read` when relevant.
+- "Pre-commit discovery (N=4)" (Item 4) → Bucket 2, promoted in PR #860 to `verification-claims-with-expected-output-shape-2026-04-28.md`. Cite, don't duplicate.
+- "Required-tools-gate evasion patterns (N=2)" (Item 5) → Bucket 2, promoted in PR #860 to `required-tools-gate-evasion-patterns-2026-04-28.md`. Cite, don't duplicate.
+
+Net: 372/500 → near-empty. The block returns to its stated purpose (active grooming queue) instead of being a permanent-knowledge accumulator.
+
+## Application
+
+When auditing an accreted core memory block:
+
+1. List each accreted item.
+2. Apply the three-way filter to each, in order.
+3. For Bucket 1: identify the existing artifact, replace the in-line text with a one-line citation.
+4. For Bucket 2: write the compound doc (or confirm one exists), then cite from core memory.
+5. For Bucket 3: rewrite with a `[recurrence-watch: N=1, <ticket>]` annotation if not already present.
+6. After filter applied, the block should be substantially smaller and contain mostly citations + identity content + a small set of N=1 recurrence-watch facts.
+
+When writing new core memory:
+
+- Before calling `update_core_memory`, ask: does this content already exist somewhere durable? If yes, cite it instead of duplicating.
+- If the content is incident-derived and you have a ticket reference, write the rule with `[recurrence-watch: N=1, <ticket>]` from the start. Future audits then have a clean trigger for promotion.
+- Resist the impulse to "promote" rules into core memory. The direction of promotion is the inverse: out of core memory, into compound docs / system prompts / tickets.
+
+When designing a reflection-pass spec for runtime enforcement (separate ticket):
+
+- Surface candidates by bucket assignment, not by age. Bucket 1 candidates (existing-artifact duplicates) are the most common and the highest-leverage to surface.
+- Don't auto-promote. Surface the candidate + bucket + suggested action; let the agent (or operator) confirm.
+- Bucket 3 staleness-only triggers a re-evaluation, not a promotion — the rule was N=1; the audit checks whether N has incremented before promoting.
+
+## Why The Block Cap Stays At 500
+
+A natural reaction to today's pressure would be "raise the per-block cap so the architect can fit more." This is rejected: the 500-token cap is the only structural pressure that surfaces the accretion problem. Removing it eliminates the only signal that forces a promotion review. The cap is the feature, not the bug.
+
+The right response to "block is full" is the three-way filter. The wrong response is compress-to-fit; the also-wrong response is raise-the-cap.
+
+If a future agent genuinely needs more identity surface than 500 tokens, that's a per-agent calibration ticket with concrete evidence — not a global cap bump. Today's audit found the opposite: every full block had Bucket-1 items that should have been dropped, not preserved at higher density.
+
+## Citations
+
+- senara-solutions/mika#788 — the architect skill skipping its pass-2 verdict that triggered today's audit
+- senara-solutions/mika#860 — PR1 of this redesign: shipped two compound docs (`required-tools-gate-evasion-patterns`, `verification-claims-with-expected-output-shape`) as the bucket-2 promotion targets cited above
+- `docs/solutions/best-practices/required-tools-gate-evasion-patterns-2026-04-28.md` — Rule 3 makes the same prompt-vs-structural argument applied to the catalogue itself; this doc is the policy that follows from that observation
+- `crates/mika-agent/src/well_known_agents.rs` — `MIKA_ARCH_SOUL` constant where this PR adds the foundational citation list (Bucket 1 move out of mika-arch's `current_priorities`)
+- mika#862, mika#863, mika#864 — engine-side guard tickets that the rules cited from core memory point at as their structural migration path
+- `feedback_compound_infra_fixes.md` (mika-platform memory) — infra fixes evaporate fast; compound them
+- `docs/memory-classification.md` — Layer 1/2/3 design that today's audit confirms is correct (the failure was in *application*, not in *layer design*)
+
+## Out of scope (separate tickets)
+
+- `mika core-memory set --agent X --section Y --content "..."` operator CLI for direct admin edits to core memory. Today's audit had to use `mika ask --agent X "use update_core_memory replace ..."` (canonical agent-loop path), which is correct for runtime but heavyweight for one-time operator surgery. Worth filing as a separate enhancement.
+- The reflection-pass spec for runtime enforcement of this protocol — a separate ship that uses this doc as the policy reference.
+- The promotion-protocol additions to mika-dev's and mika-arch's system prompts — same separate ship; the system prompts will reference this doc rather than re-encoding the protocol.
+
+## Post-deploy steps (operator)
+
+After this PR merges and the next mika-server restart picks up the new `MIKA_ARCH_SOUL`, the live core-memory blocks still hold the old accreted content. To complete the extraction:
+
+```bash
+# mika-dev self_model: extract per the bucket assignments above
+mika ask --agent mika-dev --format json "Use update_core_memory action=replace section=self_model with content: \
+'I am Mika, lead engineer. Orchestrate, vision, manifest. Claude implements via claude-pilot. I direct, track, review, decide.
+
+**Behavioral rules — see compound docs (durable artifacts, do not duplicate inline):**
+- Fabrication risk on read-tool failures → docs/solutions/741-grounding-fabrication-regression-scenarios.md
+- Root-cause discipline (cite tool output, never assert against it) → docs/solutions/workflow-issues/centralized-branch-derivation-companion-2026-04-28.md
+- Persistence-before-output → docs/solutions/architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md (mika#864 tracks engine-side enforcement)
+- Skill prompt access (context vs disk) → docs/solutions/architecture-patterns/pre-tool-context-redundancy-check.md
+
+**Worktree ownership** [recurrence-watch: N=1, mika#844]: Only claude-pilot owns the worktree. No sandbox fixes for worktree bugs.
+
+(Communication style + scope-task-checks already in soul.md — not duplicated here.)' \
+reasoning='Extract to citations per docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md three-way filter. 5 of 7 rules are Bucket-1 (existing artifact); 1 already in soul.md (Bucket DROP); 1 is Bucket-3 (recurrence-watch).'"
+
+# mika-arch current_priorities: drop the accreted items now that soul.md carries the foundational refs
+mika ask --agent mika-arch --format json "Use update_core_memory action=replace section=current_priorities with content: \
+'(No active priorities. Use this block for current grooming queue items as they appear. Foundational references moved to soul.md per docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md. Compound-doc citations for verification-claims and required-tools-gate-evasion patterns are findable via gh_read on referenced tickets when needed.)' \
+reasoning='Block was holding permanent institutional knowledge that belongs elsewhere — foundational refs moved to soul.md (PR #N this is from), N≥2 patterns moved to compound docs in PR #860, ticket-filed gaps are findable via gh_read. current_priorities returns to active grooming queue purpose.'"
+```
+
+These commands are not run as part of the PR — they are operator follow-ups after deploy.


### PR DESCRIPTION
## Why

This is **PR2** of the promotion-protocol redesign that surfaced from today's mika#788 grooming attempt.

**PR1 (#860, merged)** shipped two compound docs as the bucket-2 promotion targets:
- `verification-claims-with-expected-output-shape-2026-04-28.md` (N=4 across mika#52, #636, #665, #663)
- `required-tools-gate-evasion-patterns-2026-04-28.md` (N=2 across mika#654, #788)

**This PR (PR2)** extracts the durable-elsewhere content out of mika-arch's `current_priorities` core memory block, which had accreted to 372/500 tokens with 5 items that all belonged elsewhere. The architect's compress-to-fit response under load (mika#788 pass-2 trace `03d3ec38-...`) was a symptom of this accretion — the block was being used as a permanent-knowledge accumulator instead of an active grooming queue.

**PR3 (next)** will add the promotion protocol to mika-dev's and mika-arch's system prompts + the reflection-pass spec for runtime enforcement.

## What

### Source change

`crates/mika-agent/src/well_known_agents.rs` — `MIKA_ARCH_SOUL` constant gains a `## Foundational references` section listing 8 docs the architect cites in reviews:
- review-guide.md (already cited above as the canonical principles ref)
- north-star.md, luminescent-core.md (design system)
- mika-arch-first-dogfood-2026-04-25.md (disposition-keyword drift)
- grooming-branch-callout-required-2026-04-25.md (plan-on-branch)
- comment-event-fires-autonomous-dispatch-2026-04-25.md (comment-event auto-dispatch)
- required-tools-gate-evasion-patterns-2026-04-28.md (PR #860)
- verification-claims-with-expected-output-shape-2026-04-28.md (PR #860)

soul.md is the durable surface for content the architect consistently cites. Previously it lived inline in `current_priorities` (Bucket-1: existing-artifact-elsewhere, drop in-line + cite from durable surface). The `MIKA_ARCH_SOUL` constant is auto-provisioned to `~/.mika/agents/mika-arch/soul.md` on next mika-server restart after deploy.

### Doc change

`docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md` — captures the three-way filter as policy (185 lines).

The filter:
1. **Bucket 1 — existing artifact elsewhere**: drop in-line, replace with one-line citation. Recurrence count irrelevant.
2. **Bucket 2 — N≥2 with distinct ticket refs**: promote to `docs/solutions/best-practices/<rule>.md`, then cite from core memory. N=2 threshold matches existing memory-classification practice.
3. **Bucket 3 — N=1, no existing artifact**: keep with `[recurrence-watch: N=1, <ticket>]` annotation. Next occurrence triggers Bucket 2 promotion.

Plus:
- Why simpler frameworks (two-way without bucket 3, age-only) fail
- Why the 500-token cap stays (pressure is the feature, not the bug)
- Applied audit results for both mika-dev/self_model (5 of 7 rules → Bucket 1; 2 already in soul.md → DROP; 1 → Bucket 3) and mika-arch/current_priorities (1 → soul.md move, 1 → DELETE process noise, 1 → ticket-cite, 2 → PR #860 doc citations)
- Post-deploy operator commands as `mika ask --agent X` invocations (NOT part of PR)
- Forward-pointers: separate ticket worth filing for `mika core-memory set` admin CLI; reflection-pass spec as PR3 territory

## Sequencing

| PR | Status | Scope |
|---|---|---|
| PR1 (#860) | merged | Compound docs (bucket-2 targets) + verify-pipeline.sh port to mika |
| **PR2 (this)** | open | mika-arch soul.md template gains foundational references; three-way filter compound doc |
| PR3 (next) | pending | Promotion protocol additions to system prompts + reflection-pass spec |

The live core-memory extractions on mika-dev/self_model and mika-arch/current_priorities run as **post-deploy operator commands** (documented inline in the new compound doc). They are not part of this PR — `update_core_memory` is the agent's own tool, runs against the live DB, doesn't touch git.

## Test plan

- [x] `cargo test -p mika-agent --lib well_known_agents` → 34 passed (provisioning logic unchanged)
- [x] `cargo check -p mika-agent --features telemetry` → clean
- [x] `cargo clippy` (run by lefthook pre-commit) → clean
- [x] Compound doc frontmatter follows existing `best-practices/` conventions
- [x] Cross-references resolve (PR #860 docs exist on main as of d3c51382)
- [ ] Reviewer confirms the three-way filter framing is durable enough to cite from PR3's promotion-protocol prompts
- [ ] Reviewer confirms the post-deploy operator commands are correct shape (will need to run against live agents to validate)

## Out of scope (filed separately or noted)

- mika-dev `self_model` extraction — same pattern, 5 of 7 rules already have soul.md duplicates so PR2 doesn't need a constant edit on the dev side. The post-deploy operator command in the compound doc handles the live extraction.
- `mika core-memory set --agent X --section Y --content "..."` admin CLI for direct operator-side edits without going through the agent loop. Today's audit had to use `mika ask` (canonical agent path) which is correct for runtime but heavyweight for one-time surgery. Worth filing as separate enhancement.
- Reflection-pass spec — PR3 territory.
- Engine-side enforcement of bucket assignment (auto-promotion) — not currently planned; runtime enforcement is a reflection-pass nudge, not a write-side guard.

## Citations

- mika#788 — original failure that surfaced the accretion pattern (DB session `03d3ec38-...`)
- mika#860 (merged) — PR1 with the bucket-2 compound docs cited from this PR's soul.md additions
- `docs/solutions/best-practices/required-tools-gate-evasion-patterns-2026-04-28.md` Rule 3 — same prompt-vs-structural argument applied to the catalogue itself
- `docs/memory-classification.md` — Layer 1/2/3 design that today's audit confirms (failure was in *application* of the layers, not in *layer design*)