### PR TITLE
fix(mika-arch): apply /ce:review findings on merged PR #866 — broken citation + missing test + plan rename

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -606,7 +606,7 @@ execute shell commands.
 Cite these when relevant in reviews. They are the durable artifacts behind the principles you enforce; previously held inline in `current_priorities` core memory (accretion-prone), moved here per the three-way filter (existing artifact = drop in-line + cite from soul). See `docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md`.
 
 - `docs/architecture/review-guide.md` — SOLID/DRY/YAGNI/KISS/Orthogonality with citations to mika code (canonical principles reference; already cited above)
-- `docs/architecture/north-star.md` — the WHY behind every visual decision across the Mika ecosystem
+- `docs/design/north-star.md` — the WHY behind every visual decision across the Mika ecosystem
 - `docs/design/luminescent-core.md` — design system rulebook
 - `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md` — disposition-keyword drift on first-pass output
 - `docs/solutions/workflow-issues/grooming-branch-callout-required-2026-04-25.md` — plan-on-branch discipline
@@ -894,6 +894,17 @@ mod tests {
                 .unwrap();
         assert!(relay_soul.contains("Mika Relay"));
         assert!(relay_soul.contains("Permission Relay Agent"));
+
+        let arch_soul =
+            fs::read_to_string(mika_common::agent::agent_dir(home, "mika-arch").join("soul.md"))
+                .unwrap();
+        assert!(arch_soul.contains("Mika Architect"));
+        assert!(arch_soul.contains("Plan Review Agent"));
+        // Foundational references section guards against accidental deletion of the citation
+        // surface that mika-arch consults during reviews. See PR #866 / mika#860.
+        assert!(arch_soul.contains("## Foundational references"));
+        assert!(arch_soul.contains("docs/design/north-star.md"));
+        assert!(arch_soul.contains("required-tools-gate-evasion-patterns-2026-04-28.md"));
     }
 
     #[test]

--- a/docs/plans/2026-04-28-002-chore-extract-mika-arch-foundational-refs-plan.md
+++ b/docs/plans/2026-04-28-002-chore-extract-mika-arch-foundational-refs-plan.md
@@ -14,13 +14,19 @@ This plan was authored *retroactively* after PR #866 was already opened. The PR 
 
 This is the same prompt-level-discipline-fails-under-load pattern that today's compound doc `required-tools-gate-evasion-patterns-2026-04-28.md` Rule 3 documents — applied to the operator side. The doc that argues prompt-level rules don't bind under load shipped *without* the discipline it advocates for. The recurrence-watch annotation belongs on the operator dispatch path, not just the agent's core memory.
 
-Concrete data point for the eventual `prompt-level-output-discipline-fails-under-load.md` compound doc: this incident extends the recurrence catalogue from agent-side (mika#654, mika#788) to operator-side (this PR, plus PR #860 which had a similar shape). The structural counterpart on the operator side is the engine guards filed today (mika#862, #863, #864) plus the future PR-creation hook that requires a plan-doc citation in the PR body before opening. That hook isn't filed yet — adding a TODO note here so it doesn't get lost.
+**Prior solution-doc precedents that would have prevented this** (per /ce:review learnings-researcher):
+- `mika-platform/docs/solutions/cross-repo-patterns/2026-03-21-artifact-driven-pipeline-enforcement.md` — THE foundational "instructions are not enforceable; artifacts are" precedent. PR #227 in March 2026 demonstrated the exact same failure mode — Claude labels sections to match pipeline steps but does work inline without invoking `/ce:plan`. Reading this doc pre-PR would have surfaced the discipline gap before ship.
+- `mika-platform/docs/solutions/dev-loop/2026-04-13-cross-repo-secondary-pr-needs-plan-doc.md` — direct precedent for the same retroactive-plan failure shape (PR opened without plan, plan added retroactively).
+- `mika/docs/solutions/best-practices/plan-on-branch-load-bearing-contract-2026-04-26.md` — "Each pipeline stage reads the artifact the prior stage produced." PR #866 had no plan because the prior stage (planning) didn't run.
+- `mika/docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md` — canonical doc on provisioning idempotency that the Risk + rollback section depends on.
+
+Concrete data point for the eventual `prompt-level-output-discipline-fails-under-load.md` compound doc: this incident extends the recurrence catalogue from agent-side (mika#654, mika#788) to operator-side (this PR, PR #860, and the March PR #227 from the artifact-enforcement doc). **Recurrence count is now N=4 across the same failure class.** Per `mika/docs/solutions/best-practices/structural-check-replaces-human-discipline-2026-04-27.md`, when human-discipline mitigation fails N=3+, the response is a structural CI check, not another prompt-level rule. **The future PR-creation hook that requires a plan-doc citation in the PR body before opening should be filed as a ticket now**, not left as a TODO. (Filing as a follow-up after this PR merges; tracked in PR #866 description.)
 
 ## Why
 
 mika-arch's `current_priorities` core memory block had accreted to 372/500 tokens, with an item ("Foundational citation surface") holding 5 doc paths the agent cites during reviews:
 
-- `docs/architecture/north-star.md`
+- `docs/design/north-star.md`
 - `docs/design/luminescent-core.md`
 - `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`
 - `docs/solutions/workflow-issues/grooming-branch-callout-required-2026-04-25.md`

--- a/docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md
+++ b/docs/solutions/best-practices/core-memory-as-citation-not-accumulator-2026-04-28.md
@@ -149,6 +149,8 @@ If a future agent genuinely needs more identity surface than 500 tokens, that's 
 - mika#862, mika#863, mika#864 — engine-side guard tickets that the rules cited from core memory point at as their structural migration path
 - `feedback_compound_infra_fixes.md` (mika-platform memory) — infra fixes evaporate fast; compound them
 - `docs/memory-classification.md` — Layer 1/2/3 design that today's audit confirms is correct (the failure was in *application*, not in *layer design*)
+- `docs/solutions/best-practices/structural-check-replaces-human-discipline-2026-04-27.md` — methodological precedent for threshold-based promotion (N=3 prompt-discipline → CI gate). The N≥2 promotion threshold in this doc is the same shape applied to memory accretion.
+- `docs/solutions/architecture-patterns/structural-readonly-agent-binds-at-every-layer-2026-04-25.md` — methodological precedent for layer-aware decomposition. The three-way filter is structurally analogous: decompose accreted items into independent buckets, each with its own binding mechanism (drop-and-cite / promote-to-doc / recurrence-watch).
 
 ## Out of scope (separate tickets)
 
@@ -158,7 +160,19 @@ If a future agent genuinely needs more identity surface than 500 tokens, that's 
 
 ## Post-deploy steps (operator)
 
-After this PR merges and the next mika-server restart picks up the new `MIKA_ARCH_SOUL`, the live core-memory blocks still hold the old accreted content. To complete the extraction:
+**Step 0 — Refresh the provisioned soul.md on existing hosts.** The `provision_well_known_agents()` path is idempotent and skips agents that already exist on disk (`crates/mika-agent/src/well_known_agents.rs:351-413`). Hosts that have ever booted with `MIKA_DEV_MODE=true` will keep their old `~/.mika/agents/mika-arch/soul.md` template *without* the new `## Foundational references` section unless explicitly refreshed. To pull in the new template:
+
+```bash
+sudo rc-service mika-server stop
+rm ~/.mika/agents/mika-arch/soul.md
+sudo rc-service mika-server start
+# Verify:
+grep -A 5 "## Foundational references" ~/.mika/agents/mika-arch/soul.md
+```
+
+This step is host-by-host and is NOT applied automatically by deploy. Operators with manually-customized mika-arch souls should diff before deletion.
+
+After this is done — and the live core-memory blocks still hold the old accreted content — to complete the extraction:
 
 ```bash
 # mika-dev self_model: extract per the bucket assignments above


### PR DESCRIPTION
## Why

PR #866 merged before /ce:review (run on it post-PR-creation as part of the retroactive process-discipline fix Vincent flagged) finished surfacing findings. Three reviewers (correctness, maintainability, project-standards) independently flagged the same P0: `MIKA_ARCH_SOUL` cites `docs/architecture/north-star.md` but the file is at `docs/design/north-star.md`. Cross-reviewer agreement → high merge confidence. Once mika-arch is provisioned with the merged template, it would cite a non-existent path during reviews. This PR ships the fixes that should have been on #866.

## What

**P0 — Broken citation (3-reviewer cross-agreement):**
- `crates/mika-agent/src/well_known_agents.rs:609` — `docs/architecture/north-star.md` → `docs/design/north-star.md`. Verified canonical location via `ls` and root `CLAUDE.md` line 38.
- Plan doc line 23 — same fix.

**P2 — Naming convention (project-standards):**
- Renamed `docs/plans/2026-04-28-002-extract-mika-arch-foundational-refs-plan.md` → `2026-04-28-002-chore-extract-mika-arch-foundational-refs-plan.md` per the established `YYYY-MM-DD-NNN-<type>-<slug>-plan.md` convention. Sibling `2026-04-28-001-refactor-...` confirms pattern.

**P2 — Missing test assertions (testing reviewer):**
- `test_provision_correct_soul` had asymmetric coverage (asserted dev/qa/relay but not arch). Added 5 assertions covering "Mika Architect", "Plan Review Agent", `## Foundational references`, the corrected `docs/design/north-star.md` path, and `required-tools-gate-evasion-patterns-2026-04-28.md`. **This test would have caught the P0 path bug if written first.** All 34 well_known_agents tests pass.

**P2 — Provisioning refresh step (correctness reviewer's residual risk):**
- Provisioning is idempotent and skips existing agents, so hosts that have ever booted with `MIKA_DEV_MODE=true` keep their old `soul.md` template without the new section. Compound doc `core-memory-as-citation-not-accumulator-2026-04-28.md` Post-deploy section gains an explicit Step 0 (stop server, `rm soul.md`, restart, verify) so operators don't silently miss the upgrade.

**P3 — Missing citations (learnings-researcher):**
- Compound doc Citations: added `structural-check-replaces-human-discipline-2026-04-27.md` and `structural-readonly-agent-binds-at-every-layer-2026-04-25.md` as methodological precedents the three-way filter follows.
- Plan Process Note: added 4 prior-precedent docs (`artifact-driven-pipeline-enforcement-2026-03-21.md`, `cross-repo-secondary-pr-needs-plan-doc-2026-04-13.md`, `plan-on-branch-load-bearing-contract-2026-04-26.md`, `well-known-agent-provisioning-dev-mode.md`). **Recurrence count on the no-/ce:plan failure class is now N=4.** Per `structural-check-replaces-human-discipline-2026-04-27.md` (N=3+ → CI gate, not another prompt rule), the PR-creation hook ticket should be filed now rather than left as a TODO.

## /ce:review run summary

Run ID: `20260428-195136-02b823dd`. 6 reviewers dispatched in parallel (4 always-on personas + 2 CE always-on agents). 0 failures. Findings:
- 3-reviewer agreement on the north-star path bug (correctness/maintainability/project-standards) → P0
- Solo findings on test coverage gap (testing), provisioning-refresh ergonomics (correctness residual), citation gaps (learnings-researcher), filename convention (project-standards)
- agent-native-reviewer: PASS, 0 findings, 6 observations — confirmed the post-deploy `mika ask --agent X` invocations are agent-runnable end-to-end, the new soul section is shaped for agent consumption, and `mika core-memory set` CLI is correctly framed as ergonomics-not-parity

Full per-reviewer artifacts at `.context/compound-engineering/ce-review/20260428-195136-02b823dd/` in the original branch's worktree (now removed); summarized above.

## Sequencing

This PR is the missing review-applied tail of PR #866. Lands directly on top of `ef8abddf` (the #866 merge commit). The follow-up PR-creation-hook ticket (per N=4 recurrence) is still pending — will file separately, not as a sub-task here.

## Test plan

- [x] `cargo test -p mika-agent --lib well_known_agents` → 34 passed (the new mika-arch assertions catch this exact path bug class on regression)
- [x] `cargo check -p mika-agent --features telemetry` clean
- [x] Pipeline Artifacts CI passes (docs + source = both buckets non-empty, no trailer needed)
- [x] Cross-references resolve: `docs/design/north-star.md` exists; cited prior-precedent docs all exist on main
- [ ] Reviewer confirms the prior-precedent citation list in the plan Process Note is accurate

## Out of scope

- File the PR-creation-hook ticket per N=4 recurrence — separate follow-up after this PR merges.
- Live core-memory edits via `mika ask` post-deploy operator commands — still post-deploy operator step, not in PR.
- mika-dev `self_model` extraction — same shape, post-deploy.

## Citations

- senara-solutions/mika#866 (merged) — original PR that this fixes
- /ce:review run on PR #866: 3-reviewer cross-agreement on the north-star path drift
- `crates/mika-agent/src/well_known_agents.rs:880-897` — extended `test_provision_correct_soul` with mika-arch assertions following the existing dev/qa/relay pattern