### PR TITLE
docs(solutions): add Example 6 to prompt-rule-cheapness-bias doc — author-side recurrence during doc composition

### DIFF
--- a/docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md
+++ b/docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md
@@ -126,6 +126,14 @@ Reach for this lens when you are about to:
 - **What we shipped:** This doc, framed honestly as a citation handle for human design review — surfacing the bias as a recognizable class so future authors notice the cheap-impulse moment before shipping it. The load-bearing fixes from today's session are the structural tickets filed alongside (mika#864, mika#861, mika#866 + mika#867, mika-platform#62), not this doc.
 - **What that costs us:** Honesty about scope. The doc is worth writing because human reviewers reading it during design review can recognize the pattern and route around it. It is not worth writing if it gets cited in agent prompts as authority for "the agent should ask question 1-4" — that would be the parallel-duplication failure mode it warns against, applied to itself.
 
+### Example 6 — Author-side cheap-impulse during this doc's composition (2026-04-28)
+
+The author of this doc committed it to the in-flight worktree (mika#868's `feat/promotion-protocol-prompts-and-reflection-spec` branch) rather than creating a fresh branch, advancing the branch tip while mika-dev's autonomous pipeline ran from the prior tip (`0683dd8a`). Zero file overlap; recovered cleanly via `resolve_pr_conflicts` post-pipeline (the codebase's designed recovery mechanism for mid-pipeline base advancement, named explicitly in `mika/CLAUDE.md` § "Git discipline").
+
+The cheap impulse: "I have a worktree open, I'll commit there." Worktree-convenience bias toward the wrong commit target — the operator-side analogue of prompt-rule cheapness bias toward the wrong enforcement layer. The structural correlate would be a pre-commit hook that warns when committing to a branch with an in-flight dispatch task on the same ticket; the prep work for that fix is filed (see senara-solutions/mika-platform issue list) at N=2 (Example 4 + Example 6) per the same N=3 promotion threshold this doc names in § "When to Apply".
+
+**Why this is in the doc.** Example 5 was a *prediction* that prompt-level catalogues fail to bind under load, even for actively-engaged readers. Example 6 is the *immediate-occurrence evidence*: the author committed the failure mode while writing the doc, with the doc itself active in working context. The recursive-observation framing in Example 5 said "this will happen"; Example 6 says "this happened, mid-authoring, by the author." That's stronger as evidence than any future Example 7 or 8 reading the doc and recurring would be. The doc warns about a pattern; the doc demonstrates the pattern in its own authoring; the doc names the demonstration. That self-demonstration is the closest a prompt-level artifact can get to structural credibility.
+
 ## Citations
 
 **Foundational meta-rule:**


### PR DESCRIPTION
## Why

Adds Example 6 to `docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md` (shipped in #872). Example 6 captures the author-side recurrence that happened *during the doc's own composition*: the doc was committed to the in-flight worktree of mika#868 (`feat/promotion-protocol-prompts-and-reflection-spec`) rather than a fresh branch, advancing the branch tip while mika-dev's autonomous pipeline ran from the prior tip.

Zero file overlap; recovered cleanly via `resolve_pr_conflicts` post-pipeline (the codebase's designed recovery mechanism for mid-pipeline base advancement, named explicitly in `mika/CLAUDE.md` § "Git discipline"). PR #872 merged with the rebase happening transparently.

External review pushback (the same Claude Chat reviewer who cut sub-task 1 from mika#868) explicitly recommended capturing this as Example 6: *"Example 5 was a prediction that prompt-level catalogues fail to bind under load. Example 6 is the immediate-occurrence evidence: the failure happened mid-authoring, by the author, with the doc active in working context. That's stronger as evidence than any future Example 7 or 8 reading the doc and recurring would be. The doc warns about a pattern; the doc demonstrates the pattern in its own authoring; the doc names the demonstration."*

The commit landed on the feature branch after #872 merged, so this small follow-up PR brings Example 6 to main.

## What

Single 8-line addition to the doc (cherry-picked from `cd50ff95`):
- New § "Example 6 — Author-side cheap-impulse during this doc's composition (2026-04-28)"
- Documents the worktree-convenience bias incident as the operator-side analogue of prompt-rule cheapness bias toward the wrong enforcement layer
- Names the structural correlate (pre-commit hook warning when committing to a branch with an in-flight dispatch task) — filed as senara-solutions/mika-platform#63 (N=2 prep)
- Frames the addition as "Why this is in the doc": Example 5 was a prediction; Example 6 is contemporaneous self-evidence

## Test plan

- [x] `Pipeline-Exempt: docs-only` trailer present in cherry-picked commit (`8d1d0364`)
- [x] Cherry-pick clean (no conflicts; the doc was unchanged on main since #872 merged)
- [x] Pipeline Artifacts CI accepts the trailer

## Citations

- senara-solutions/mika#872 (merged) — original ship of the compound doc
- senara-solutions/mika-platform#63 — N=2 prep ticket for the operator-side worktree-convenience bias structural fix (Example 6's "what we shipped")
- senara-solutions/mika-platform#62 — sibling structural fix for operator-side `/mika` bypass (Example 4's "what we shipped")