### PR TITLE
docs: refresh README for accuracy (test count, providers, crates, KG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ CLI Mode (local)                    Hosted Mode (containers)
   +---------+                       +------+-------+
        |                                   |
   +----v--------+            +-------------+-------------+
-  |  Claude API |            |             |             |
+  |   LLM API  |            |             |             |
   +-------------+     +------v---+  +------v---+  +------v---+
                       | Agent A  |  | Agent B  |  | Agent C  |
                       | +SQLite  |  | +SQLite  |  | +SQLite  |
                       +----+-----+  +----+-----+  +----+-----+
                            |             |             |
                       +----v-------------v-------------v----+
-                      |            Claude API               |
+                      |            LLM API (multi-provider) |
                       +-------------------------------------+
 ```
 
@@ -39,9 +39,10 @@ Each customer gets an isolated container with their own SQLite database. No cust
 - **Skills system** -- Extensible filesystem-based tool registry with Git-based marketplace (`mika skills install`)
 - **Proactive heartbeat** -- Check-ins via silent agent loop with rate limiting
 - **Reminders** -- Time-based reminders with recovery on restart
+- **Knowledge Graph** -- Three-layer KG (domain/lexical/subject) in SQLite with LLM-based entity extraction, resolution, and graph traversal for self-knowledge queries
 - **Conversation compaction** -- Automatic summarization of old messages
 - **Slash commands** -- 20 client-side commands with shell-like Tab completion and argument completers
-- **Multi-channel** -- CLI (local) and Telegram (hosted) with WhatsApp planned
+- **Multi-channel** -- CLI (local), Telegram, and GitHub webhooks (hosted) with WhatsApp planned
 - **Per-customer isolation** -- One container per customer
 
 ## Quick Start
@@ -73,21 +74,27 @@ On first run, Mika creates `~/.mika/` with default configuration, personality, a
 | Component | Technology |
 |-----------|-----------|
 | Language | Rust (edition 2024) |
-| LLM | Claude (Sonnet 4.6 default) via direct API |
+| LLM | Multi-provider via `LlmProvider` trait — Anthropic, OpenAI, OpenRouter, Groq, Ollama, Mistral, Google, DeepSeek, Kimi, MiniMax, Qwen (11 providers) |
 | Database | SQLite via rusqlite (per-customer) |
 | HTTP server | Axum 0.8 with tower-http |
 | TUI | ratatui + tui-textarea + crossterm |
 | Async runtime | tokio |
+| MCP client | rmcp (official Rust MCP SDK) — stdio and Streamable HTTP transports |
+| Telemetry | OpenTelemetry + tracing (feature-gated OTLP export, Langfuse-compatible) |
 | Config | config-rs with `MIKA_` env prefix |
 
 ## Project Structure
 
 ```
 crates/
-  mika-common/     Shared: config, Claude API client, logging, home directory
+  mika-common/     Shared: config, LLM providers, OAuth, GitHub App auth, telemetry
   mika-agent/      Agent: SQLite DB, agent loop, tools, skills, HTTP server (mika-server)
-  mika-gateway/    Telegram webhook router: Postgres customer registry, message routing
+  mika-a2a/        A2A (Agent-to-Agent) protocol v0.3: JSON-RPC types, task state machine, SSE streaming
+  mika-gateway/    Telegram + GitHub webhook router: Postgres customer registry, message routing, A2A proxy
   mika-cli/        TUI CLI (mika): ratatui chat, clap subcommands, slash commands
+dashboard/         React observability dashboard (TypeScript + Vite + Tailwind CSS v4)
+packages/ui/       @senara-solutions/ui shared React component library
+skills/bundled/    Engine-coupled skills discovered at build time (self-dev, qa-review, etc.)
 ```
 
 ## Tools
@@ -109,7 +116,7 @@ The agent has 23 builtin tools and 6 conditional management tools:
 
 ```bash
 cargo build          # Build all crates
-cargo test           # Run tests (~1169 tests)
+cargo test           # Run tests (~3500 tests)
 cargo clippy         # Lint
 cargo fmt            # Format
 cargo run --bin mika # Run TUI CLI

--- a/docs/plans/922-refresh-readme-accuracy.md
+++ b/docs/plans/922-refresh-readme-accuracy.md
@@ -1,0 +1,36 @@
+# Plan: Refresh README for accuracy (#922)
+
+## Problem
+
+`README.md` has multiple factual drifts vs current state:
+1. Claims "~1169 tests" — actual count is ~3512 (from `cargo test` output)
+2. Claims "Claude (Sonnet 4.6 default) via direct API" — engine is multi-provider via `LlmProvider` trait with 11 providers
+3. Project structure section omits: `mika-a2a` crate, `dashboard/`, `packages/ui/`, `skills/bundled/`
+4. No mention of the Knowledge Graph subsystem
+
+## Changes
+
+### 1. Tech Stack table (line 76)
+- Replace "Claude (Sonnet 4.6 default) via direct API" with accurate multi-provider description naming the `LlmProvider` trait and listing providers
+
+### 2. Project Structure section (lines 85-91)
+- Add `mika-a2a/` crate
+- Add `dashboard/` directory
+- Add `packages/ui/` directory
+- Add `skills/bundled/` directory
+
+### 3. Development section (line 112)
+- Update test count from ~1169 to ~3500 (sourced from `cargo test` output: 3512 passed)
+
+### 4. Features section
+- Add Knowledge Graph bullet point with brief description
+
+### 5. Tools table
+- Verify tool count accuracy (will check during implementation)
+
+## Verification
+
+- Test count: `cargo test` output → 3512 passed
+- Providers: `ProviderKind` enum in `crates/mika-common/src/llm/mod.rs` → 11 variants (Anthropic, OpenAI, OpenRouter, Groq, Ollama, Mistral, Google, DeepSeek, Kimi, MiniMax, Qwen)
+- Crates: `ls crates/` → mika-a2a, mika-agent, mika-cli, mika-common, mika-gateway
+- Top-level dirs: `ls` → dashboard/, packages/ui/, skills/bundled/ all present

--- a/docs/solutions/922-readme-accuracy-refresh-2026-05-02.md
+++ b/docs/solutions/922-readme-accuracy-refresh-2026-05-02.md
@@ -1,0 +1,29 @@
+---
+module: docs
+tags: [readme, accuracy, documentation-drift]
+problem_type: documentation-drift
+category: best-practices
+---
+
+# README Accuracy Refresh
+
+## Problem
+
+README.md had drifted significantly from reality:
+- Test count was ~1169 (actual: ~3500)
+- LLM described as single-provider "Claude (Sonnet 4.6 default) via direct API" (actual: 11 providers via `LlmProvider` trait)
+- Project structure omitted `mika-a2a`, `dashboard/`, `packages/ui/`, `skills/bundled/`
+- Knowledge Graph subsystem (a major feature surface) was not mentioned
+
+## Solution
+
+Updated all factual claims with verifiable sources:
+- Test count sourced from `cargo test` output (3512 passed)
+- Provider list sourced from `ProviderKind` enum in `crates/mika-common/src/llm/mod.rs`
+- Directory listing sourced from `ls crates/` and `ls .`
+
+## Lessons
+
+1. **Cite sources for counts.** README numbers like test counts rot fast. Always cite the source command in PR body so reviewers can verify.
+2. **Audit on milestone boundaries.** README drift accumulates silently — adding a periodic README audit to milestone checklists would catch this earlier.
+3. **Architecture diagrams should use generic labels.** "Claude API" → "LLM API" is more stable against provider changes.


### PR DESCRIPTION
## Summary

- Update test count from ~1169 to ~3500 (verified: `cargo test` → 3512 passed)
- Replace single-provider "Claude" claim with multi-provider `LlmProvider` trait listing all 11 providers
- Add missing project structure entries: `mika-a2a`, `dashboard/`, `packages/ui/`, `skills/bundled/`
- Add Knowledge Graph feature description
- Add MCP client and telemetry to tech stack table
- Update architecture diagram labels from "Claude API" to "LLM API"

## Verification sources

| Claim | Source |
|-------|--------|
| ~3500 tests | `cargo test` output: 3512 passed, 14 ignored |
| 11 providers | `ProviderKind` enum in `crates/mika-common/src/llm/mod.rs` (Anthropic, OpenAI, OpenRouter, Groq, Ollama, Mistral, Google, DeepSeek, Kimi, MiniMax, Qwen) |
| Crate list | `ls crates/` → mika-a2a, mika-agent, mika-cli, mika-common, mika-gateway |
| Top-level dirs | `ls .` → dashboard/, packages/ui/, skills/bundled/ all present |
| KG subsystem | Three-layer KG documented in CLAUDE.md Knowledge Graph section |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Cross-check test count hasn't changed significantly since PR creation

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)