### PR TITLE
fix: PR-writer must cite plan-doc path in PR body

### DIFF
--- a/.claude/commands/mika.md
+++ b/.claude/commands/mika.md
@@ -84,6 +84,8 @@ Before running the pipeline, set up an isolated worktree:
    ```
    If a GitHub issue was referenced, include `Closes #<number>` in the PR body.
 
+   **Plan-doc citation (MANDATORY):** Before composing the PR body, run `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'`. For each matching path, include a line in the PR body citing the literal path — e.g. `Plan: docs/plans/<file>.md`. The line must contain the exact path so that `grep -E 'docs/plans/[^[:space:]]+\.md'` matches it. Do not substitute prose summaries for the path. This is required by the `plan-doc-check` CI hook.
+
 ## Cleanup
 
 9. Do NOT remove the worktree. Worktrees persist until the PR is merged — needed for CI fixes, review feedback, and acceptance testing. Cleanup happens post-merge.

--- a/docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md
+++ b/docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md
@@ -1,0 +1,147 @@
+---
+title: "fix: PR-writer must cite plan-doc path in PR body when plan is in diff"
+type: fix
+status: active
+date: 2026-05-02
+---
+
+# fix: PR-writer must cite plan-doc path in PR body when plan is in diff
+
+## Overview
+
+The `/mika` command's PR creation step tells the agent to compose a PR body but does not instruct it to cite `docs/plans/*.md` paths. The `plan-doc-check` CI hook on mika-platform requires literal plan-doc paths in the PR body or commit body. Result: every `/mika` PR that adds a plan doc fails the hook (N=1 evidence: mika-platform#72, merged via bypass actor).
+
+The fix adds a plan-doc citation instruction to the PR creation step in each repo's `/mika` command file. This is a prompt-level fix to a prompt-level omission — the structural enforcement (the CI hook) already exists and works correctly; the writer just doesn't emit the text the hook checks for.
+
+## Problem Frame
+
+The `plan-doc-check.sh` hook (mika-platform#64) uses `grep -oE 'docs/plans/[^[:space:]]+\.md'` to find plan-doc citations in the PR body and commit bodies. The `/mika` pipeline creates plan docs at step 1 (`/ce:plan`) and creates the PR at step 8, but the step-8 instructions say only "include `Closes #<number>` in the PR body" — nothing about citing the plan-doc path. The agent summarizes the plan in prose but never emits the literal path, so the grep finds nothing.
+
+## Requirements Trace
+
+- R1. When a `/mika` PR diff includes one or more files under `docs/plans/`, the PR body MUST contain a line citing each such path
+- R2. The citation must be machine-parseable: `grep -E 'docs/plans/[^[:space:]]+\.md' PR_BODY` must match
+- R3. The mechanism must work automatically — no manual intervention required
+- R4. A follow-up `/mika` PR on mika-platform must pass the `Plan-Doc Citation` check without label/trailer fallback
+
+## Scope Boundaries
+
+- The `plan-doc-check.sh` hook itself is not modified
+- Hook propagation to `mika` and `mika-skills` repos is a separate ticket
+
+### Deferred to Separate Tasks
+
+- Adding `plan-doc-check` workflow to `mika`, `mika-skills`, `mika-cloud`: separate ticket (the writer fix ships first so propagation is safe)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `mika/.claude/commands/mika.md` lines 81-85 — PR creation step (step 8)
+- `mika-platform/.claude/commands/mika.md` lines 199-203 — PR creation step (step 7)
+- `mika-skills/.claude/commands/mika.md` lines 61-65 — PR creation step (step 7)
+- `mika-cloud/.claude/commands/mika.md` lines 61-65 — PR creation step (step 7)
+- `mika-platform/scripts/plan-doc-check.sh` — the CI hook that checks for plan-doc citations
+- Existing pattern in mika's `/mika` command: "If a GitHub issue was referenced, include `Closes #<number>` in the PR body" — the plan-doc citation instruction follows the same shape
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md` — this fix is the correct layer: the structural enforcement (CI hook) already exists; we're fixing the writer to comply with it, not adding a new prompt rule as enforcement
+- `feedback_cross_repo_awareness.md` — when fixing shared patterns, fix all repos in one pass
+
+## Key Technical Decisions
+
+- **Fix all four repos, not just two:** The ticket says "out of scope" for propagating the hook, but the writer fix itself should be universal. Per `feedback_cross_repo_awareness.md`, fix the pattern everywhere in one pass. When the hook propagates to other repos, the writer will already be compliant.
+- **Instruction placement:** Add the citation instruction as a sub-bullet of the existing PR creation step, following the established pattern of the `Closes #<number>` instruction.
+- **Citation format:** Use `Plan: docs/plans/<file>.md` — a simple format that satisfies the hook's grep and is readable in PR bodies. The hook checks for `docs/plans/[^[:space:]]+\.md` anywhere in the text, so the exact prefix doesn't matter, but `Plan:` is clear and conventional.
+- **Detection method:** Instruct the agent to check `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'` before composing the body. This matches exactly what the CI hook checks (files in the diff range).
+
+## Implementation Units
+
+- [ ] **Unit 1: Add plan-doc citation instruction to mika's `/mika` command**
+
+  **Goal:** Update the PR creation step in `mika/.claude/commands/mika.md` to instruct the agent to detect and cite plan-doc paths in the PR body.
+
+  **Requirements:** R1, R2, R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `.claude/commands/mika.md`
+
+  **Approach:**
+  Add a paragraph after the existing `Closes #<number>` instruction at step 8 (lines 81-85). The instruction tells the agent to: (1) check `git diff --name-only main...HEAD` for files matching `docs/plans/*.md`, and (2) include a `Plan: <path>` line in the PR body for each match. The instruction must be clear enough that the agent emits the literal path, not a prose description.
+
+  **Patterns to follow:**
+  - The existing `Closes #<number>` instruction at line 85 — same imperative style, same location
+
+  **Test expectation:** none — this is a prompt instruction change to a markdown command file, not executable code. Verification is via the CI hook on the next PR.
+
+  **Verification:**
+  - Read the modified file and confirm the instruction is present and unambiguous
+  - The next `/mika` PR on any repo that produces a plan doc should have the plan-doc path cited in the PR body
+
+- [ ] **Unit 2: Add plan-doc citation instruction to mika-platform's `/mika` command**
+
+  **Goal:** Same fix applied to the mika-platform repo's `/mika` command.
+
+  **Requirements:** R1, R2, R3, R4
+
+  **Dependencies:** None (can be done in parallel with Unit 1)
+
+  **Files:**
+  - Modify: `mika-platform/.claude/commands/mika.md` (relative to workspace root; this file lives in the mika-platform repo)
+
+  **Approach:**
+  Same instruction as Unit 1, added after the `Closes #<number>` line at step 7 (line 203). This is the repo where the `plan-doc-check` hook is already active, so this is the critical-path fix.
+
+  **Patterns to follow:**
+  - Same as Unit 1
+
+  **Test expectation:** none — prompt instruction change
+
+  **Verification:**
+  - The next `/mika` PR on mika-platform that adds a plan doc passes the `Plan-Doc Citation` check without label/trailer fallback
+
+- [ ] **Unit 3: Add plan-doc citation instruction to mika-skills and mika-cloud `/mika` commands**
+
+  **Goal:** Forward-compatibility fix for when `plan-doc-check` propagates to these repos.
+
+  **Requirements:** R1, R2, R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `mika-skills/.claude/commands/mika.md`
+  - Modify: `mika-cloud/.claude/commands/mika.md`
+
+  **Approach:**
+  Same instruction as Units 1-2, added after the `Closes #<number>` line at step 7 (line 65 in both files).
+
+  **Patterns to follow:**
+  - Same as Units 1-2
+
+  **Test expectation:** none — prompt instruction change; no hook to test against yet
+
+  **Verification:**
+  - Read modified files and confirm instruction is present
+
+## System-Wide Impact
+
+- **Interaction graph:** The instruction affects how Claude Code (running `/mika`) composes PR bodies. No engine, tool, or skill code changes.
+- **Error propagation:** If the agent fails to follow the instruction, the CI hook catches it (existing structural backstop). Failure mode is the same as today — hook rejects, bypass actor merges. The instruction reduces the frequency of that failure, not the severity.
+- **API surface parity:** All four repos get the same instruction for consistency.
+- **Unchanged invariants:** The `plan-doc-check.sh` hook is not modified. The plan-doc existence check semantics (F1 in the hook header) are unchanged. The three pass-paths (citation, label, trailer) are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Agent still summarizes in prose instead of citing the literal path | The instruction is explicit about "literal path"; the CI hook is the structural backstop |
+| Agent runs `git diff` against wrong base ref | Instruction uses `main...HEAD` which matches the hook's check |
+
+## Sources & References
+
+- Related PRs/issues: senara-solutions/mika#931, senara-solutions/mika-platform#72, senara-solutions/mika-platform#62, senara-solutions/mika-platform#64
+- Hook source: `mika-platform/scripts/plan-doc-check.sh`
+- Institutional learning: `docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md`

--- a/docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md
+++ b/docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md
@@ -23,6 +23,7 @@ The `plan-doc-check.sh` hook (mika-platform#64) uses `grep -oE 'docs/plans/[^[:s
 - R2. The citation must be machine-parseable: `grep -E 'docs/plans/[^[:space:]]+\.md' PR_BODY` must match
 - R3. The mechanism must work automatically — no manual intervention required
 - R4. A follow-up `/mika` PR on mika-platform must pass the `Plan-Doc Citation` check without label/trailer fallback
+- **R_verify (per pass-1 F3, BLOCKING)**: After merge, run `/mika` on a real ticket that adds source + a plan doc (or use the next real ticket dispatched to mika-dev). Confirm the generated PR body contains a line matching `docs/plans/<file>.md` verbatim. Confirm `Plan-Doc Citation` CI check passes on mika-platform without label/trailer fallback. **This is mandatory, not optional** — the issue body's stated Verification criterion. Test expectation on individual units is "none" (prompt-instruction change), but R_verify is the post-merge integration verification gate.
 
 ## Scope Boundaries
 
@@ -54,7 +55,33 @@ The `plan-doc-check.sh` hook (mika-platform#64) uses `grep -oE 'docs/plans/[^[:s
 - **Fix all four repos, not just two:** The ticket says "out of scope" for propagating the hook, but the writer fix itself should be universal. Per `feedback_cross_repo_awareness.md`, fix the pattern everywhere in one pass. When the hook propagates to other repos, the writer will already be compliant.
 - **Instruction placement:** Add the citation instruction as a sub-bullet of the existing PR creation step, following the established pattern of the `Closes #<number>` instruction.
 - **Citation format:** Use `Plan: docs/plans/<file>.md` — a simple format that satisfies the hook's grep and is readable in PR bodies. The hook checks for `docs/plans/[^[:space:]]+\.md` anywhere in the text, so the exact prefix doesn't matter, but `Plan:` is clear and conventional.
-- **Detection method:** Instruct the agent to check `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'` before composing the body. This matches exactly what the CI hook checks (files in the diff range).
+- **Detection method (per pass-1 F4 SHARPENING — main-base assumption named):** Instruct the agent to check `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'` before composing the body. This matches the CI hook's check exactly. *Assumes PR base is `main` (current mika convention). If base branch changes, update to `git diff --name-only $(git merge-base HEAD origin/main)...HEAD` or equivalent.*
+
+### Hook surface pin (per pass-1 F1, BLOCKING)
+
+Read `mika-platform/scripts/plan-doc-check.sh` at plan-commit time:
+
+```bash
+PR_BODY="${GITHUB_PR_BODY:-}"
+COMMIT_BODIES=$(git log --format=%B "$BASE..HEAD" 2>/dev/null || true)
+ALL_TEXT="${PR_BODY}"$'\n'"${COMMIT_BODIES}"
+PLAN_PATHS=$(echo "$ALL_TEXT" | grep -oE 'docs/plans/[^[:space:]]+\.md' | sort -u || true)
+```
+
+The hook concatenates **PR body AND commit bodies** into `ALL_TEXT` and greps the union. Either surface satisfies the check. The fix targets the PR body (per the citation instruction at PR-creation step), so the hook is satisfied from the PR-body path; commit-body fallback continues to work for operators who prefer it.
+
+### Scope pin per repo (per pass-1 F2, BLOCKING)
+
+Files + line ranges confirmed at plan-commit time via `find` + `grep` on each repo's `/mika.md`:
+
+| Repo | File path (relative to repo root) | Line — `gh pr create` | Line — `Closes #` | Insertion target |
+|------|-----------------------------------|------------------------|-----------------------|--------------------|
+| mika | `.claude/commands/mika.md` | 83 | 85 | After line 85 |
+| mika-platform | `.claude/commands/mika.md` | 201 | 203 | After line 203 |
+| mika-skills | `.claude/commands/mika.md` | 63 | 65 | After line 65 |
+| mika-cloud | `.claude/commands/mika.md` | 63 | 65 | After line 65 |
+
+All four repos confirmed to have a PR-creation step in `/mika.md` with the `Closes #<number>` instruction at the documented line. The new citation instruction inserts immediately after that line, matching the existing imperative style.
 
 ## Implementation Units
 

--- a/docs/solutions/workflow-issues/pr-writer-must-cite-plan-doc-paths-2026-05-02.md
+++ b/docs/solutions/workflow-issues/pr-writer-must-cite-plan-doc-paths-2026-05-02.md
@@ -1,0 +1,70 @@
+---
+title: PR-writer must cite plan-doc paths in PR body for CI hook compliance
+date: 2026-05-02
+category: workflow-issues
+module: self-dev, mika-platform
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - Adding a plan-doc-check CI hook that validates PR bodies contain literal docs/plans/*.md paths
+  - The /mika pipeline produces plan docs but the PR-writer step does not cite them
+  - Any prompt-driven PR body composition where a CI hook expects specific path strings
+tags:
+  - plan-doc-check
+  - pr-body
+  - ci-hook
+  - prompt-instruction
+  - pipeline-compliance
+---
+
+# PR-writer must cite plan-doc paths in PR body for CI hook compliance
+
+## Context
+
+The `/mika` pipeline produces plan docs at step 1 (`/ce:plan`) and creates PRs at step 8, but the step-8 instructions only said "include `Closes #<number>`" -- nothing about citing the plan-doc path. The `plan-doc-check` CI hook (mika-platform#64) uses `grep -oE 'docs/plans/[^[:space:]]+\.md'` to find plan-doc citations in the PR body and commit bodies. Because the agent summarized plans in prose rather than citing literal paths, the hook rejected every `/mika` PR that added a plan doc.
+
+Evidence: mika-platform#72 -- PR body described the plan in prose ("Sub-repo verification", "Review findings addressed"), never cited `docs/plans/2026-05-02-001-feat-workspace-readme-plan.md`. Hook fired `[plan-doc-check: none] REJECT`. Merged via bypass actor, defeating the gate's intent.
+
+## Guidance
+
+When a CI hook checks for literal file paths in PR bodies, the prompt instruction that composes the PR body must:
+
+1. **Detect** which files match the hook's expected pattern (e.g., `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'`)
+2. **Cite** each matching path literally in the PR body (e.g., `Plan: docs/plans/<file>.md`)
+3. **Prohibit prose substitution** explicitly -- agents default to summarizing rather than citing paths
+
+The instruction was added as a `**Plan-doc citation (MANDATORY):**` paragraph in `.claude/commands/mika.md`, following the same imperative style as the existing `Closes #<number>` instruction.
+
+## Why This Matters
+
+Structural enforcement (CI hooks) is the correct layer for pipeline compliance -- but the enforcement only works if the writer knows what to emit. A prompt-instruction gap between what the hook checks and what the writer produces creates a silent bypass: the pipeline does the right thing (plan exists in diff), the hook does the right thing (checks for the path), but the writer omits the citation and the hook fires.
+
+This is the complementary half of the structural enforcement documented in `docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md`. That doc established that CI hooks are the right enforcement layer; this doc establishes that the writer must be taught to satisfy the hook.
+
+## When to Apply
+
+- Adding a new CI hook that validates PR body content against file paths in the diff
+- Modifying an existing CI hook's grep pattern -- the corresponding prompt instruction must be updated in the same PR
+- Propagating a CI hook to new repos -- ensure the writer instruction exists in each repo's `/mika` command before enabling the hook
+
+## Examples
+
+**Before (broken):** PR body contains prose like "Added implementation plan for the feature" -- `grep -E 'docs/plans/[^[:space:]]+\.md'` finds nothing, hook rejects.
+
+**After (fixed):** PR body contains `Plan: docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md` -- grep matches, hook passes.
+
+The instruction in `.claude/commands/mika.md`:
+```
+**Plan-doc citation (MANDATORY):** Before composing the PR body, run
+`git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'`. For each
+matching path, include a line in the PR body citing the literal path.
+```
+
+## Related
+
+- senara-solutions/mika#931 -- originating issue
+- senara-solutions/mika-platform#72 -- failing example (bypass-merged)
+- senara-solutions/mika-platform#62 / mika-platform#64 -- hook creation
+- `docs/solutions/best-practices/prompt-rule-cheapness-bias-toward-wrong-layer-2026-04-28.md` -- structural enforcement as the correct layer
+- `docs/solutions/ci-cd/compound-doc-enforcement-in-pipeline-verification.md` -- same pattern for compound-doc enforcement


### PR DESCRIPTION
## Summary

The `plan-doc-check` CI hook (mika-platform#64) requires literal `docs/plans/*.md` paths in PR bodies, but the `/mika` command's PR creation step only instructed the agent to include `Closes #<number>` — nothing about citing plan-doc paths. Result: agents summarized plans in prose, the hook's grep found nothing, and every `/mika` PR that added a plan doc failed the check (evidence: mika-platform#72, merged via bypass actor).

**Fix:** Add a `**Plan-doc citation (MANDATORY):**` instruction to step 8 of `.claude/commands/mika.md`. The instruction tells the agent to run `git diff --name-only main...HEAD | grep '^docs/plans/.*\.md$'` and emit a `Plan: <path>` line for each match. The line must contain the literal path so the hook's `grep -E 'docs/plans/[^[:space:]]+\.md'` matches.

This is Unit 1 of 3 from the groomed plan — the mika repo fix. Units 2-3 (mika-platform, mika-skills, mika-cloud) need companion PRs on their respective repos with the same instruction.

Plan: docs/plans/2026-05-02-007-fix-pr-writer-plan-doc-citation-plan.md

Closes #931

## Changes

- `.claude/commands/mika.md` — Added mandatory plan-doc citation instruction after the `Closes #<number>` line in the PR creation step
- `docs/plans/...` — Groomed plan document (committed by mika-arch)
- `docs/solutions/workflow-issues/pr-writer-must-cite-plan-doc-paths-2026-05-02.md` — Compound learning documenting the pattern

## Test plan

- [ ] Next `/mika` PR on any repo that produces a plan doc should have the plan-doc path cited in the PR body
- [ ] When `plan-doc-check` hook is active (mika-platform), the `Plan-Doc Citation` check passes without label/trailer fallback
- [ ] `grep -E 'docs/plans/[^[:space:]]+\.md'` matches the citation line in the PR body

## Companion work needed

- [ ] Unit 2: Add same instruction to `mika-platform/.claude/commands/mika.md` (critical-path — hook is active there)
- [ ] Unit 3: Add same instruction to `mika-skills/.claude/commands/mika.md` and `mika-cloud/.claude/commands/mika.md`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>