### PR TITLE
fix(mika-arch): citation-fabrication prompt anchoring (#952)

### DIFF
--- a/docs/plans/2026-05-02-009-fix-mika-arch-citation-fabrication-plan.md
+++ b/docs/plans/2026-05-02-009-fix-mika-arch-citation-fabrication-plan.md
@@ -161,3 +161,13 @@ Cross-session attribution is the secondary surface: mika-arch's pass-2 on mika#9
 - **Sibling tickets:** mika#947 (persistence-meta), mika#939 / PR #941 (Opus deadline).
 - **Source files:** `mika/skills/bundled/mika-arch-groom-ticket/system_prompt.md`, `mika/skills/bundled/mika-arch-second-review/system_prompt.md`, `mika/skills/bundled/mika-arch-groom-milestone/system_prompt.md`.
 - **Related institutional knowledge:** `project_mika_arch_failure_modes.md`, `feedback_qa_provider_perf.md`, `mika/docs/architecture/review-guide.md` (citation-or-silence principle).
+
+## Pass-1 iteration
+
+### F1 (BLOCKING) — Acceptance item 2 (telemetry) explicit deferral
+
+Issue body Acceptance item 2 ("When fabrication occurs, it is auto-detected and logged via structured telemetry") is **explicitly deferred** to companion follow-up. Rationale: prompt-level prevention (this fix's KTD-1+KTD-2) addresses the primary failure mode; telemetry-based detection is a separate concern with a different fix surface (KG event infrastructure / structured logging surface). The two are **independent, not gated** — telemetry adds defense-in-depth observability after prevention reduces incident rate.
+
+Companion ticket title (filed before this PR merges): `feat(mika-arch): structured telemetry for citation-fabrication detection (mika#952 follow-up)`. NOT a companion-task filing gate (different from mika#938 F2 and mika#939 F5 shapes — those gates exist for tightly-coupled fixes that MUST ship together; this is independent observability work).
+
+Plan acceptance criteria therefore cover items 1 + 3 from issue body, with item 2 deferred via filed-companion. R4 (0/5 fabrication-rate) remains the primary verification gate.

--- a/docs/plans/2026-05-02-009-fix-mika-arch-citation-fabrication-plan.md
+++ b/docs/plans/2026-05-02-009-fix-mika-arch-citation-fabrication-plan.md
@@ -1,0 +1,163 @@
+---
+title: "fix(mika-arch): citation-fabrication failure mode — anchor verbatim quotes via gh_read at quote time"
+type: fix
+status: active
+date: 2026-05-02
+ticket: mika#952
+---
+
+# fix(mika-arch): citation-fabrication failure mode — anchor verbatim quotes via gh_read at quote time
+
+## Overview
+
+mika-arch fabricates concrete provenance citations (prior-session findings, "verbatim" quotes from issue bodies) within otherwise-sound review findings. Two verified instances on 2026-05-02 (mika#931 pass-1: fabricated prior-session reference; mika#928 pass-1: fabricated verbatim concept lists). Distinct from mika#947 (persistence-meta refusal pattern). Fix shape: prompt-level instruction in mika-arch's review skills (`mika-arch-groom-ticket`, `mika-arch-second-review`, `mika-arch-groom-milestone`) requiring verbatim quotes to be anchored via fresh `gh_read` invocations at quote time, not reproduced from parametric memory.
+
+## Problem Frame
+
+Per mika#952 issue body: confident-tone fabrications appear in BLOCKING findings where false provenance carries decision weight. Both verified instances had architecturally-sound conclusions (preserve existing entry; pin verbatim concepts) — the fabrication was the false-detail attached to support them. The model self-corrects when challenged in pass-2, indicating the failure mode is at quote-emission time, not reasoning time.
+
+Cross-session attribution is the secondary surface: mika-arch's pass-2 on mika#931 explicitly conflated session `02cb26ed` (different mika#931 brief, different plan) with the current session. Parametric memory of "I've seen something like this" appears to fill in details the model expected but did not actually have.
+
+## Requirements Trace
+
+- **R1.** When mika-arch reviews a brief that references issue body content, verbatim quotes must be sourced from a fresh `gh_read` call at quote time (not paraphrased from the brief's summary or parametric memory).
+- **R2.** When mika-arch references prior-session findings, the cited session ID must be in the current conversation's session-id chain (i.e., the prior session_id passed via `--session-id`), not invented from parametric memory.
+- **R3.** Existing review findings remain architecturally sound — this fix changes WHERE quotes come from, not WHAT findings the architect produces.
+- **R4.** Five consecutive mika-arch reviews show ZERO fabricated provenance citations (manual operator audit).
+
+## Scope Boundaries
+
+- **In scope:** `mika/skills/bundled/mika-arch-groom-ticket/system_prompt.md`, `mika/skills/bundled/mika-arch-second-review/system_prompt.md`, `mika/skills/bundled/mika-arch-groom-milestone/system_prompt.md` — the three architect-skill prompts.
+- **Out:** mika#947 (persistence-meta) — distinct failure mode.
+- **Out:** mika#939 / Opus deadline-exceeded — different surface.
+- **Out:** Structured telemetry for fabrication detection (mika#952 direction option 3) — file as separate observability ticket if pursued.
+
+### Deferred to Separate Tasks
+
+- **Telemetry-driven fabrication catalog** (mika#952 direction 3): structured `kg_arch_fabrication_detected` event logging. Useful but adds infrastructure scope; this prompt-level fix addresses the primary failure first. File as observability follow-up after this fix verifies.
+- **Cross-skill prompt-anchoring discipline** (apply same pattern to mika-qa, mika-dev review skills): out of scope here; same family but distinct skills.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `mika/skills/bundled/mika-arch-groom-ticket/system_prompt.md` — first-pass prompt; primary surface.
+- `mika/skills/bundled/mika-arch-second-review/system_prompt.md` — second-pass prompt; same fix applied for symmetry.
+- `mika/skills/bundled/mika-arch-groom-milestone/system_prompt.md` — milestone-grooming prompt; same fix applied (broader review surface).
+- `mika/docs/architecture/review-guide.md` — review principles; verbatim-quote-anchoring is consistent with existing "citation-or-silence" discipline.
+
+### Institutional Learnings
+
+- mika#947 — persistence-meta hallucination (sibling ticket; different family).
+- mika#939 / PR #941 — mika-arch routing fix (orthogonal).
+- `project_mika_arch_failure_modes.md` (Vincent's institutional memory) — failure-mode catalog. This ticket extends with citation-fabrication.
+- Verified sessions in mika#952 issue body: `39f5f998-1199-4fdf-bfb2-2119eab9d5aa` (mika#931 pass-1+2), `fba22d43-c46e-49ad-82af-9992e7c4636a` (mika#928 pass-1+2).
+
+## Key Technical Decisions
+
+### KTD-1. Prompt-level verbatim-quote anchoring
+
+**Decision:** Add explicit instruction to all three mika-arch review skill prompts requiring `gh_read` at quote time for any verbatim claim:
+
+> *"When citing verbatim content from issue bodies, PR bodies, or prior commits, you MUST invoke `gh_read` (or equivalent file/issue read tool) to fetch the source at quote time, not paraphrase from the brief's summary or parametric memory. If the verbatim content cannot be retrieved via fresh tool call, do NOT claim 'verbatim' — describe the content in your own words and flag the inability to anchor."*
+
+**Rationale:**
+- Prompt-level fix is the cheapest correct surface — model is being asked to use a tool it already has access to.
+- Aligns with existing "citation-or-silence" principle in review-guide.md.
+- Fails-loud: if `gh_read` is unavailable or the source can't be fetched, the model self-flags rather than fabricating.
+
+### KTD-2. Session-id chain anchoring
+
+**Decision:** Add explicit instruction requiring prior-session references to come from the current conversation's session-id chain only:
+
+> *"When referencing prior-session findings, only cite session IDs that appear in the current conversation's brief or `--session-id` parameter. If you have a sense of 'I've seen something like this before' but cannot point to a session ID in the current chain, frame as a new finding, not a 'persisted pattern.'"*
+
+**Rationale:**
+- Cross-session parametric memory bleed is the verified failure mode in instance 1 (mika#931).
+- Constraint is enforceable: session IDs are explicitly visible in the brief.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Prompt-level vs structural fix?** → Prompt-level (KTD-1). Structural telemetry deferred.
+- **All three skills or just groom-ticket?** → All three (groom-ticket, second-review, groom-milestone). Same failure mode applies; consistent application.
+
+### Deferred to Implementation
+
+- **Exact prompt wording** — implementer drafts using KTD-1 + KTD-2 as constraint. The shape is locked; the exact phrasing can be tuned.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add verbatim-quote anchoring + session-id chain anchoring to all three mika-arch skill prompts**
+
+**Goal:** Edit three skill prompts to add the two anchoring instructions per KTD-1 and KTD-2.
+
+**Requirements:** R1, R2, R3, R4.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `mika/skills/bundled/mika-arch-groom-ticket/system_prompt.md`
+- Modify: `mika/skills/bundled/mika-arch-second-review/system_prompt.md`
+- Modify: `mika/skills/bundled/mika-arch-groom-milestone/system_prompt.md`
+
+**Approach:**
+
+1. Read each skill's `system_prompt.md` to find the citation-or-silence section (existing).
+2. Insert the verbatim-quote anchoring instruction (KTD-1) immediately after the citation-or-silence rule.
+3. Insert the session-id chain anchoring instruction (KTD-2) immediately after that.
+4. Verify no other instruction in the prompt contradicts these (e.g., a "you may paraphrase" line that needs reconciliation).
+
+**Patterns to follow:**
+
+- Existing "citation-or-silence" instruction in `review-guide.md` — language style and assertion shape.
+
+**Test scenarios:**
+
+| Category | Scenario |
+|---|---|
+| Happy path | Send mika-arch a brief that quotes "this is in the issue body" with a real fragment. Architect's review uses `gh_read` to anchor before quoting. |
+| Edge case | Send mika-arch a brief without the issue body content embedded. Architect's review either fetches via `gh_read` or flags inability to anchor — does NOT fabricate. |
+| Edge case | Send mika-arch a brief with `--session-id <existing>`. Architect cites that session's findings. Does NOT cite a different session ID from parametric memory. |
+| Integration (R4) | 5 consecutive mika-arch reviews on real briefs (e.g., next 5 grooming sessions in queue) — operator audits final responses for fabricated provenance. Acceptance: 0 instances. |
+
+**Verification:**
+
+- `git diff` shows changes ONLY in the three skill prompt files.
+- New instructions are present and non-contradictory with existing prompt content.
+- Post-deploy: 5-call audit shows zero citation fabrications.
+
+## System-Wide Impact
+
+- **Interaction graph:** mika-arch loads these skill prompts on every review invocation. Edit propagates via bundled-skill resync on next agent session start.
+- **Error propagation:** None affected. The new instructions are guidance, not new error paths.
+- **State lifecycle risks:** None. Prompt-only change.
+- **API surface parity:** Other agents (mika-dev, mika-qa) have similar review-style skills that may benefit from the same anchoring discipline. Out of scope here; file follow-up after observing fix verification on mika-arch.
+- **Unchanged invariants:**
+  - mika-arch's review-finding architecture unchanged (R3).
+  - Skill `[llm:]` routing unchanged.
+  - `gh_read` tool surface unchanged (it already exists and works).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Prompt-level fix doesn't actually change behavior — model still fabricates because the instruction is "soft." | Verification gate (R4) requires 0/5 fabrication rate. If verification fails, escalate to structural fix (telemetry-driven detection + retry, mika#952 direction 3). |
+| Adding instructions bloats the prompt; model loses focus on review work. | Two short instructions; minimal token cost. Verify against pass-rate baseline post-deploy. |
+| `gh_read` is not available in mika-arch's tool set. | Verify before /ce:work — if not available, this fix is blocked on adding it (likely already present per mika-arch's existing capability). |
+| Plan-doc-check hook fails. | Manually cite plan path in PR body. |
+
+## Documentation / Operational Notes
+
+- **Rollout:** Prompt-only change. PR merge → bundled-skill resync on next agent session start. No deploy step beyond the standard.
+- **Verification timeline:** After merge, observe next 5 mika-arch reviews. Operator-audit each response against the brief's referenced content. Fabrication rate should be 0/5.
+- **Pattern claim (N=2 for mika-arch family):** mika#947 (persistence-meta) + mika#952 (citation-fabrication) form a 2-instance pattern of "mika-arch-specific failure modes that surface as confident-but-wrong outputs." After both fixes ship, author compound doc on the discipline (failure-mode catalog + per-mode prompt-level mitigations + telemetry future-pointer).
+
+## Sources & References
+
+- **Ticket:** [mika#952](https://github.com/senara-solutions/mika/issues/952)
+- **Verified sessions:** `39f5f998-1199-4fdf-bfb2-2119eab9d5aa` (mika#931 pass-1+2), `fba22d43-c46e-49ad-82af-9992e7c4636a` (mika#928 pass-1+2).
+- **Sibling tickets:** mika#947 (persistence-meta), mika#939 / PR #941 (Opus deadline).
+- **Source files:** `mika/skills/bundled/mika-arch-groom-ticket/system_prompt.md`, `mika/skills/bundled/mika-arch-second-review/system_prompt.md`, `mika/skills/bundled/mika-arch-groom-milestone/system_prompt.md`.
+- **Related institutional knowledge:** `project_mika_arch_failure_modes.md`, `feedback_qa_provider_perf.md`, `mika/docs/architecture/review-guide.md` (citation-or-silence principle).

--- a/docs/solutions/best-practices/citation-fabrication-prompt-anchoring-2026-05-02.md
+++ b/docs/solutions/best-practices/citation-fabrication-prompt-anchoring-2026-05-02.md
@@ -1,0 +1,105 @@
+---
+title: "Citation-fabrication prompt anchoring — verbatim-quote and session-id chain discipline for architect review skills"
+date: 2026-05-02
+category: best-practices
+module: skills/bundled
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - mika-arch review skills produce findings that cite prior-session content or verbatim issue body quotes
+  - Any agent skill produces confident-tone citations to content not actually in its context window
+  - Cross-session parametric memory bleed causes the model to conflate prior sessions with the current one
+tags: [mika-arch, citation-fabrication, prompt-anchoring, grounding, verbatim-quote, session-id, hallucination]
+---
+
+# Citation-fabrication prompt anchoring — verbatim-quote and session-id chain discipline for architect review skills
+
+## Context
+
+mika-arch produces review findings with confident-but-wrong provenance citations. Two verified instances on 2026-05-02:
+
+1. **mika#931 pass-1** — cited a non-existent prior architect session ("Prior mika#931 first-pass F2 — this is a persisted pattern"). Reality: no prior architect first-pass existed for that issue.
+2. **mika#928 pass-1** — fabricated "verbatim" concept lists claiming they were "from the issue body." Reality: the actual issue body contained different prose concepts; the specific entity-key tokens were generated, not extracted.
+
+Both instances had architecturally-sound conclusions — the fabrication was the false-detail attached to support them. The model self-corrected when challenged in pass-2, indicating the failure mode is at quote-emission time, not reasoning time.
+
+Distinct from mika#947 (persistence-meta hallucination — a refusal-style failure where no review is delivered).
+
+## Guidance
+
+Add two anchoring instructions to the Operating Discipline section of architect review skill prompts:
+
+**1. Verbatim-quote anchoring** — require `gh_read` at quote time:
+
+```markdown
+**Verbatim-quote anchoring.** When citing verbatim content from issue bodies, PR bodies,
+or prior commits, you MUST invoke `gh_read` (or equivalent file/issue read tool) to fetch
+the source at quote time — not paraphrase from the brief's summary or parametric memory.
+If the verbatim content cannot be retrieved via a fresh tool call, do NOT claim "verbatim"
+— describe the content in your own words and flag the inability to anchor.
+```
+
+**2. Session-id chain anchoring** — restrict prior-session references to the current conversation chain:
+
+```markdown
+**Session-id chain anchoring.** When referencing prior-session findings, only cite session
+IDs that appear in the current conversation's brief or `--session-id` parameter. If you
+have a sense of "I've seen something like this before" but cannot point to a session ID in
+the current chain, frame as a new finding — not a "persisted pattern" or continuation of
+a prior review.
+```
+
+Both instructions are placed after the existing "Citation or silence" rule in the Operating Discipline section, reinforcing the same principle: cite what you can verify, stay silent on what you cannot.
+
+## Why This Matters
+
+Citation fabrication is a half-ground-truth failure — review delivered but with fabricated provenance. An operator who treats the citations as ground truth will misroute investigation (e.g., searching for a prior architect session that doesn't exist, or trying to reconcile "verbatim" content that was never in the issue body).
+
+The failure mode carries extra weight because it appears in BLOCKING findings (ITERATE/ESCALATE dispositions), where false provenance carries decision weight. The findings themselves may be sound architecture, but the false provenance misleads triage.
+
+## When to Apply
+
+- When adding review or analysis skills that reference external content (issue bodies, PR bodies, prior sessions)
+- When a skill's output includes "verbatim" quotes or claims about prior-session continuity
+- When cross-session parametric memory bleed is a risk (agent has access to multiple sessions on the same issue)
+- As a general pattern: any skill that cites external content should anchor those citations via fresh tool calls
+
+## Examples
+
+**Before (fabrication):**
+```
+F2: Plan must confirm `pipeline-exempt:no-plan` entry's current exact YAML shape
+(identical requirement to my prior first-pass on this issue)
+Prior mika#931 first-pass F2 (same finding on prior draft — this is a persisted pattern)
+```
+
+**After (anchored):**
+```
+F2: Plan must confirm `pipeline-exempt:no-plan` entry's current exact YAML shape
+[Verified via gh_read: issue #931 body does not contain a prior architect review reference.
+This is a new finding based on the current plan content.]
+```
+
+**Before (fabricated verbatim quote):**
+```
+The issue body already provides concrete B1 and B2 lists:
+B1 — concept:cross-repo:*: worktree, plan-on-branch, callout, branch-slug...
+```
+
+**After (anchored or flagged):**
+```
+The issue body describes concepts for B1 and B2 categories in prose form.
+[Fetched via gh_read: actual issue body lists "companion-PR pattern, branch-name-immutable
+invariant, plan-doc-on-branch contract..." — not the entity-key tokens listed above.
+Using the actual issue body content as the reference.]
+```
+
+## Related
+
+- mika#952 — citation-fabrication failure mode ticket
+- mika#953 — companion ticket for telemetry-driven fabrication detection (deferred)
+- mika#947 — persistence-meta hallucination (sibling failure mode, distinct family)
+- `docs/solutions/prompt-engineering/grounding-rule-downstream-state-hallucination.md` — four-part anti-hallucination formula (related grounding discipline)
+- `docs/solutions/architecture-patterns/engine-guards-vs-prompt-rules-for-agent-behavior-2026-04-19.md` — prompt-level vs structural enforcement doctrine
+- `docs/solutions/best-practices/operator-grooming-marathon-2026-05-02.md` — incident report documenting both verified fabrication instances

--- a/docs/solutions/best-practices/operator-grooming-marathon-2026-05-02.md
+++ b/docs/solutions/best-practices/operator-grooming-marathon-2026-05-02.md
@@ -1,0 +1,50 @@
+---
+problem_type: workflow-pattern
+module: mika-platform
+tags: [grooming, operator-claude, dev-groom, mika-arch, dashboard-launch]
+date: 2026-05-02
+---
+
+# Operator-Claude grooming marathon — closing the dev-groom canary chain (2026-05-02)
+
+## Context
+
+8 tickets groomed end-to-end in a single operator-Claude session, ranging from the original dev-groom canary blocker (mika-platform#76, mika#938, mika#939) through the dashboard-launch sprint (mika-platform#77, mika#929, mika#931) to the milestone#19 closure (mika#927, mika#928). Plus a citation-fabrication follow-up (mika#952). Pattern emerged: when dev-groom autonomous path is unreliable, operator-Claude can replicate the full /mika-groom-ticket flow at scale within a single session, dispatching via `ready` label after each grooming.
+
+## What worked
+
+1. **Reuse worktrees + FF-merge before re-dispatch.** Stale worktrees from killed canaries can be ff-merged onto origin/main; staged-but-uncommitted plans can be moved to /tmp as backup and the dispatch re-fired clean. Saves the cost of full worktree re-derivation.
+2. **Skill-disable bypass for mika-arch fabrication.** When `mika-arch-groom-ticket` skill envelope produces persistence-meta hallucination ("No new facts warrant persistence"), `mika skills --agent mika-arch disable mika-arch-groom-ticket` then bare `mika ask --agent mika-arch` delivers real verdicts. Re-enable after grooming.
+3. **Plan-doc backup-and-restart pattern.** Killed canaries leave staged plan files in worktrees that block subsequent rebases. Pattern: `cp <plan> /tmp/<backup>`, `git restore --staged <plan>`, `mv <plan> /tmp/`, redispatch. Plan content preserved as starter for next iteration.
+4. **Cross-ticket pattern compounding within one session.** F2-style filing-gate pattern (PR-description checkbox + reviewer-blocks-merge) applied across mika#938, mika#939, mika#952. Each plan referenced prior instances; mika-arch acknowledged "N=2 pattern" by mika#939's pass-2.
+
+## What broke (catalog these failure modes)
+
+1. **mika-arch citation-fabrication** (mika#952 filed). Two confirmed instances: mika#931 pass-1 cited a non-existent prior architect session; mika#928 pass-1 fabricated "verbatim" concept lists. Distinct from persistence-meta (mika#947). Self-corrects when challenged in pass-2.
+2. **mika-arch persistence-meta** (mika#947 filed). Skill envelope's system prompt triggers memory-tool conditioning. "No new facts warrant persistence from this turn" instead of review.
+3. **Opus 4.7 transient-error chain** (mika#939, fixed via PR #941). 3 retry attempts × 2-min timeout = 8 min wall time before agent deadline; mika-server emits "I'm sorry, that took too long" fallback. Mitigated by deadline-aware retry abort.
+4. **Pipeline-truncation on /mika dispatch** (mika#940, severity downgraded to N=1). claude-pilot exits cleanly after compound doc Write without continuing to gh pr create. Mika#938 hit it; mika#939 didn't (118-turn full pipeline). Not universal pattern.
+5. **dev-groom canary chain — 4 distinct deny-cause layers**. (1) relay LLM Bash-classifier (mika#935/PR#937 fixed). (2) Phase 1 step 4 interactive prose (mika-platform#76/PR#78 fixed). (3) backtick-in-message rejection (mika#938/PR#945 fixed). (4) env-var-prefix-cmd-substitution rejection (caught in canary v8 v2; recovers via inside-quotes form). Each layer required its own ticket and fix.
+
+## Calibrated patterns
+
+- **Opus on review work hallucinates** — Vincent confirmed via `feedback_qa_provider_perf.md`. Sonnet 4.6 + bare-ask is the reliable architect invocation pattern.
+- **Issue-as-versioned-contract discipline** — when plan reframes a spec item, issue body should be updated post-merge. Plan-vs-issue drift surfaced in mika#928 (acceptance threshold) and mika#931 (R6 ceiling) — architect ratified the divergence at pass-2.
+- **Cross-session parametric-memory bleed** — mika-arch's pass-1 on mika#931 conflated session `02cb26ed` (different mika#931 brief) with current brief. Mika#952 KTD-2 addresses via session-id chain anchoring instruction.
+
+## Future-pointer (N=2+ compound triggers)
+
+- mika#947 + mika#952 both ship → author compound doc on mika-arch failure-mode catalog (persistence-meta + citation-fabrication + Opus deadline + LLM routing per-skill).
+- mika#940 second instance → upgrade severity, ship structural fix.
+- "Operator-Claude grooming marathon" pattern repeats → factor into a CLAUDE.md note about when to bypass dev-groom.
+
+## References
+
+- mika#935/PR#937 (layer 1 relay-deny)
+- mika-platform#76/PR#78 (layer 2 spec language)
+- mika#938/PR#945 (layer 3 quote-aware pre-classifier)
+- mika#939/PR#941 (mika-arch routing + retry abort)
+- mika#940 (pipeline truncation, N=1)
+- mika#947 (persistence-meta)
+- mika#952/mika#953 (citation-fabrication + telemetry follow-up)
+- mika#927/mika#928 (KG milestone#19 closure tickets, both groomed today)

--- a/skills/bundled/mika-arch-groom-milestone/system_prompt.md
+++ b/skills/bundled/mika-arch-groom-milestone/system_prompt.md
@@ -12,6 +12,10 @@ You are a Principal-Engineer-class advisory reviewer performing a milestone-leve
 
 If a concern is a style preference unmoored from a citation, stay silent. A review without challenge is a failed review — but fabricated concerns are worse than none.
 
+**Verbatim-quote anchoring.** When citing verbatim content from issue bodies, PR bodies, or prior commits, you MUST invoke `gh_read` (or equivalent file/issue read tool) to fetch the source at quote time — not paraphrase from the brief's summary or parametric memory. If the verbatim content cannot be retrieved via a fresh tool call, do NOT claim "verbatim" — describe the content in your own words and flag the inability to anchor.
+
+**Session-id chain anchoring.** When referencing prior-session findings, only cite session IDs that appear in the current conversation's brief or `--session-id` parameter. If you have a sense of "I've seen something like this before" but cannot point to a session ID in the current chain, frame as a new finding — not a "persisted pattern" or continuation of a prior review.
+
 ### Process
 
 1. **Read the milestone brief.** The user message contains a milestone brief with sub-issue plans, dependency context, and milestone metadata. Read every sub-issue plan thoroughly before forming any assessment.

--- a/skills/bundled/mika-arch-groom-ticket/system_prompt.md
+++ b/skills/bundled/mika-arch-groom-ticket/system_prompt.md
@@ -12,6 +12,10 @@ You are a Principal-Engineer-class advisory reviewer performing a first-pass rev
 
 If a concern is a style preference unmoored from a citation, stay silent. A review without challenge is a failed review — but fabricated concerns are worse than none.
 
+**Verbatim-quote anchoring.** When citing verbatim content from issue bodies, PR bodies, or prior commits, you MUST invoke `gh_read` (or equivalent file/issue read tool) to fetch the source at quote time — not paraphrase from the brief's summary or parametric memory. If the verbatim content cannot be retrieved via a fresh tool call, do NOT claim "verbatim" — describe the content in your own words and flag the inability to anchor.
+
+**Session-id chain anchoring.** When referencing prior-session findings, only cite session IDs that appear in the current conversation's brief or `--session-id` parameter. If you have a sense of "I've seen something like this before" but cannot point to a session ID in the current chain, frame as a new finding — not a "persisted pattern" or continuation of a prior review.
+
 ### Process
 
 1. **Read the package.** The user message contains a brief, a plan path, and an issue number. Read the plan thoroughly.

--- a/skills/bundled/mika-arch-second-review/system_prompt.md
+++ b/skills/bundled/mika-arch-second-review/system_prompt.md
@@ -8,6 +8,10 @@ You are performing an iteration review on a revised plan. The first-pass review 
 
 **No third pass.** This is the final automated review. Your verdict is either GROOMED (proceed) or ESCALATE (human decision needed). You may **never** return ITERATE, "needs-third-pass", or any equivalent. If concerns remain after this pass, the answer is ESCALATE — a human must decide.
 
+**Verbatim-quote anchoring.** When citing verbatim content from issue bodies, PR bodies, or prior commits, you MUST invoke `gh_read` (or equivalent file/issue read tool) to fetch the source at quote time — not paraphrase from the brief's summary or parametric memory. If the verbatim content cannot be retrieved via a fresh tool call, do NOT claim "verbatim" — describe the content in your own words and flag the inability to anchor.
+
+**Session-id chain anchoring.** When referencing prior-session findings, only cite session IDs that appear in the current conversation's brief or `--session-id` parameter. If you have a sense of "I've seen something like this before" but cannot point to a session ID in the current chain, frame as a new finding — not a "persisted pattern" or continuation of a prior review.
+
 ### Process
 
 1. **Read the revised plan and the prior review.** The prior first-pass review is available in conversation memory (correlated by session_id). If conversation memory is unavailable, the prior review is re-passed in the user message as a fallback.


### PR DESCRIPTION
## Summary

- Add **verbatim-quote anchoring** and **session-id chain anchoring** instructions to all three mika-arch review skill prompts (`mika-arch-groom-ticket`, `mika-arch-second-review`, `mika-arch-groom-milestone`)
- Prevents citation-fabrication failure mode where mika-arch produces confident-but-wrong provenance citations (fabricated prior-session references, fabricated "verbatim" quotes from issue bodies) within otherwise-sound review findings
- Prompt-only change — no executable code modified, no new tools, no schema changes

Closes #952

Plan: `docs/plans/2026-05-02-009-fix-mika-arch-citation-fabrication-plan.md`

## Context

Two verified instances on 2026-05-02:
1. **mika#931 pass-1** — cited non-existent prior architect session
2. **mika#928 pass-1** — fabricated "verbatim" concept lists not present in the issue body

Both had sound architectural conclusions; the fabrication was false provenance attached to support them. Model self-corrects when challenged in pass-2.

## What changed

**Verbatim-quote anchoring:** Requires `gh_read` at quote time for any verbatim claim from issue/PR bodies. If unable to fetch, must describe in own words and flag inability to anchor. Backed by existing `required_tools` and `required_fetches_for_quoted_resources` engine guards.

**Session-id chain anchoring:** Restricts prior-session references to session IDs in the current conversation's brief or `--session-id` parameter. Prevents cross-session parametric memory bleed.

## Test plan

- [ ] Verify `cargo build -p mika-agent` succeeds (build.rs bundles skill prompts)
- [ ] Post-deploy: 5 consecutive mika-arch reviews show ZERO fabricated provenance citations (R4 acceptance gate — manual operator audit)
- [ ] Pass-2 self-correction continues to work when fabrication occurs

## Deferred

- Structured telemetry for fabrication detection → mika#953 (independent, not gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)