### PR TITLE
fix(executor): validate required fields before skill tool execution (#955)

### DIFF
--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -100,6 +100,90 @@ pub struct LongRunningContext {
     pub dispatch_count: AtomicU32,
 }
 
+/// Validate that all top-level `required` fields declared in the tool's JSON
+/// Schema `input_schema` are present and non-null in the supplied `input`.
+///
+/// Returns `Some(ToolOutput::error(...))` with a structured JSON error on
+/// validation failure, or `None` if all required fields are present.
+///
+/// Scope: top-level `required` only. Does NOT validate `enum` constraints,
+/// `type` assertions, or nested `properties`. Defensively handles malformed
+/// schemas (missing `required` key, non-array, non-string elements) by
+/// degrading to an empty required list with a warning.
+fn validate_required_fields(
+    skill_tool: &ResolvedSkillTool,
+    input: &serde_json::Value,
+) -> Option<ToolOutput> {
+    let required_fields: Vec<&str> = skill_tool
+        .definition
+        .input_schema
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect())
+        .unwrap_or_default();
+
+    if required_fields.is_empty() {
+        // Check if `required` exists but isn't an array — indicates malformed schema
+        if skill_tool
+            .definition
+            .input_schema
+            .get("required")
+            .is_some_and(|v| !v.is_array())
+        {
+            warn!(
+                tool = %skill_tool.definition.name,
+                "skill_tool_malformed_schema_skipped_validation: \
+                 'required' field exists but is not a JSON array"
+            );
+        }
+        return None;
+    }
+
+    let input_obj = input.as_object();
+    for field in &required_fields {
+        let is_present = input_obj
+            .and_then(|obj| obj.get(*field))
+            .is_some_and(|v| !v.is_null());
+
+        if !is_present {
+            warn!(
+                tool = %skill_tool.definition.name,
+                field = %field,
+                "skill_tool_missing_required_field: \
+                 required field not provided in tool call input"
+            );
+
+            // Collect valid_values from the field's `enum` constraint, if any
+            let valid_values: Option<Vec<&str>> = skill_tool
+                .definition
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.get(*field))
+                .and_then(|f| f.get("enum"))
+                .and_then(serde_json::Value::as_array)
+                .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect());
+
+            let mut error = serde_json::json!({
+                "error": "missing_required_field",
+                "tool": skill_tool.definition.name,
+                "field": field,
+                "reason": format!(
+                    "The '{}' field is required by the tool schema but was not provided in the tool call.",
+                    field
+                )
+            });
+
+            if let Some(values) = valid_values {
+                error["valid_values"] = serde_json::json!(values);
+            }
+
+            return Some(ToolOutput::error(error.to_string()));
+        }
+    }
+
+    None
+}
+
 /// Execute a skill tool with the appropriate handler.
 ///
 /// Applies a per-skill timeout wrapping the inner execution.
@@ -112,6 +196,13 @@ pub async fn execute_skill_tool(
     long_running_ctx: Option<&LongRunningContext>,
     github_token: Option<&str>,
 ) -> ToolOutput {
+    // Validate required fields from tool schema before any execution (#955).
+    // Catches the bug class where the LLM omits a required field — the subprocess
+    // never spawns, and the LLM gets a structured retry signal in the same turn.
+    if let Some(error) = validate_required_fields(skill_tool, &input) {
+        return error;
+    }
+
     // Check for long-running exec handler
     if let ToolHandler::Exec {
         command,
@@ -842,7 +933,29 @@ async fn execute_long_running(
         ))),
         action_type: action_type::RESUME_AGENT.to_string(),
         action_config: "{}".to_string(),
-        input_context: Some(serde_json::to_string(&input).unwrap_or_default()),
+        input_context: Some({
+            let serialized = serde_json::to_string(&input).unwrap_or_default();
+            // Belt-and-suspenders (#955): validate_required_fields is the runtime
+            // guard, but assert that required fields survived serialization as a
+            // development-time safety net.
+            debug_assert!(
+                {
+                    let required: Vec<&str> = skill_tool
+                        .definition
+                        .input_schema
+                        .get("required")
+                        .and_then(serde_json::Value::as_array)
+                        .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect())
+                        .unwrap_or_default();
+                    required
+                        .iter()
+                        .all(|f| input.get(f).is_some_and(|v| !v.is_null()))
+                },
+                "dispatch record serialized without required fields — \
+                 validate_required_fields should have caught this"
+            );
+            serialized
+        }),
         created_by_session: Some(ctx.session_id.clone()),
         created_trace_id: Some(ctx.trace_id.clone()),
         reference_url: None,
@@ -1095,6 +1208,221 @@ mod tests {
             },
             skill_dir: skill_dir.to_path_buf(),
         }
+    }
+
+    // --- validate_required_fields tests (#955) ---
+
+    #[test]
+    fn test_validate_required_fields_missing_field_returns_error() {
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "Dispatch claude-pilot".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["skill", "prompt", "task_id"],
+                    "properties": {
+                        "skill": {
+                            "type": "string",
+                            "enum": ["dev-pilot", "dev-groom"]
+                        },
+                        "prompt": { "type": "string" },
+                        "task_id": { "type": "string" }
+                    }
+                }),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: true,
+                estimated_duration_secs: Some(3600),
+            },
+            skill_dir: PathBuf::from("/tmp"),
+        };
+
+        // Missing `skill` field entirely
+        let input = serde_json::json!({"prompt": "mika#928", "task_id": "abc-123"});
+        let result = validate_required_fields(&tool, &input);
+        assert!(
+            result.is_some(),
+            "expected error for missing required field"
+        );
+        let output = result.unwrap();
+        assert!(output.is_error);
+        assert!(output.content.contains("missing_required_field"));
+        assert!(output.content.contains("skill"));
+        assert!(output.content.contains("dev-pilot"));
+        assert!(output.content.contains("dev-groom"));
+    }
+
+    #[test]
+    fn test_validate_required_fields_null_field_returns_error() {
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "Dispatch claude-pilot".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["skill"],
+                    "properties": {
+                        "skill": { "type": "string" }
+                    }
+                }),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: false,
+                estimated_duration_secs: None,
+            },
+            skill_dir: PathBuf::from("/tmp"),
+        };
+
+        // `skill` present but null
+        let input = serde_json::json!({"skill": null});
+        let result = validate_required_fields(&tool, &input);
+        assert!(result.is_some(), "expected error for null required field");
+        let output = result.unwrap();
+        assert!(output.is_error);
+        assert!(output.content.contains("missing_required_field"));
+    }
+
+    #[test]
+    fn test_validate_required_fields_all_present_passes() {
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "Dispatch claude-pilot".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["skill", "prompt"],
+                    "properties": {
+                        "skill": { "type": "string" },
+                        "prompt": { "type": "string" }
+                    }
+                }),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: false,
+                estimated_duration_secs: None,
+            },
+            skill_dir: PathBuf::from("/tmp"),
+        };
+
+        let input = serde_json::json!({"skill": "dev-pilot", "prompt": "mika#928"});
+        let result = validate_required_fields(&tool, &input);
+        assert!(
+            result.is_none(),
+            "expected no error when all required fields present"
+        );
+    }
+
+    #[test]
+    fn test_validate_required_fields_no_required_key_passes() {
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "test_tool".to_string(),
+                description: "Test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: false,
+                estimated_duration_secs: None,
+            },
+            skill_dir: PathBuf::from("/tmp"),
+        };
+
+        let input = serde_json::json!({"anything": "goes"});
+        let result = validate_required_fields(&tool, &input);
+        assert!(result.is_none(), "no required fields = no validation error");
+    }
+
+    #[test]
+    fn test_validate_required_fields_malformed_schema_degrades_gracefully() {
+        // `required` is a string, not an array — malformed
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "bad_tool".to_string(),
+                description: "Tool with bad schema".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": "skill"
+                }),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: false,
+                estimated_duration_secs: None,
+            },
+            skill_dir: PathBuf::from("/tmp"),
+        };
+
+        let input = serde_json::json!({});
+        let result = validate_required_fields(&tool, &input);
+        assert!(
+            result.is_none(),
+            "malformed schema should degrade to no validation"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_execute_skill_tool_rejects_missing_required_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_script(
+            &tmp.path().join("handler.sh"),
+            "#!/bin/sh\necho 'should not run'",
+        );
+
+        let tool = ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "Dispatch claude-pilot".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "required": ["skill", "prompt", "task_id"],
+                    "properties": {
+                        "skill": {
+                            "type": "string",
+                            "enum": ["dev-pilot", "dev-groom"]
+                        },
+                        "prompt": { "type": "string" },
+                        "task_id": { "type": "string" }
+                    }
+                }),
+            },
+            handler: ToolHandler::Exec {
+                command: "handler.sh".to_string(),
+                long_running: false,
+                estimated_duration_secs: None,
+            },
+            skill_dir: tmp.path().to_path_buf(),
+        };
+
+        // Call with missing `skill` — should get rejected before the handler runs
+        let output = execute_skill_tool(
+            &tool,
+            serde_json::json!({"prompt": "mika#928", "task_id": "abc-123"}),
+            30,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(output.is_error, "expected error: {}", output.content);
+        assert!(
+            output.content.contains("missing_required_field"),
+            "expected structured error, got: {}",
+            output.content
+        );
+        assert!(
+            output.content.contains("skill"),
+            "error should name the missing field"
+        );
+        // The handler should NOT have run
+        assert!(
+            !output.content.contains("should not run"),
+            "handler should not execute when required field is missing"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/plans/2026-05-05-001-fix-run-claude-pilot-missing-skill-plan.md
+++ b/docs/plans/2026-05-05-001-fix-run-claude-pilot-missing-skill-plan.md
@@ -1,0 +1,106 @@
+# Plan: fix(self-dev) run_claude_pilot dispatch record missing skill argument crashes handler
+
+**Ticket:** mika issue#955
+**Type:** fix
+**Branch:** `fix/955/self-dev-run-claude-pilot-dispatch`
+
+## Problem Summary
+
+`run_claude_pilot` dispatch crashed at 2026-05-02 because the LLM emitted a tool call without the `skill` field. The tool's JSON schema declares `skill` as required, but the Rust executor does not validate tool inputs against the schema before spawning the subprocess. The handler script (`_shared/dispatch-lib.sh`) catches the missing field and exits with code 1, which triggers the exit trap and delivers a `"HANDLER CRASH (exit code 1)"` callback — but this generic crash string leaves the parent task in `blocked` status with no actionable error for mika-dev.
+
+## Root Cause Analysis
+
+Three layers failed:
+
+1. **No schema enforcement at the Rust boundary.** `execute_long_running()` in `crates/mika-agent/src/skills/executor.rs` takes `input: serde_json::Value` and passes it directly to the subprocess. The `tools.json` schema is used only for LLM tool-array construction (telling the model what parameters exist), not for runtime validation of the model's actual output.
+
+2. **Handler validation exits before structured callback delivery.** The `_validate_inputs()` function in `dispatch-lib.sh` (line 113) writes to stderr and calls `exit 1`. The exit trap captures the stderr and delivers it as a callback. However, the callback result string is free-form text (`"HANDLER CRASH (exit code 1). Script failed before building result.\n\nStderr (last 10KB):\nError: missing required argument 'skill'..."`), not structured JSON that the verdict handler or task-health system can parse into an actionable next-step.
+
+3. **Parent task receives opaque crash.** mika-dev's callback turn sees a crash string but has no structured signal to distinguish "LLM forgot a required field" (retry-safe) from "handler has a real bug" (escalate). The result: task stuck in `blocked`.
+
+## Fix Strategy
+
+Three orthogonal fixes matching the ticket's three investigation surfaces:
+
+### Fix 1: Rust-level required-field validation before spawn (primary fix)
+
+**File:** `crates/mika-agent/src/skills/executor.rs`
+
+Add a `validate_required_fields()` check at the top of `execute_long_running()`, before task creation. Parse `skill_tool.definition.input_schema` for the `required` array, verify each required field is present and non-null in the input JSON. On failure, return `ToolOutput::error()` with a structured JSON error (same pattern as `task_not_dispatchable`):
+
+```json
+{
+  "error": "missing_required_field",
+  "tool": "run_claude_pilot",
+  "field": "skill",
+  "valid_values": ["dev-pilot", "dev-groom"],
+  "reason": "The 'skill' field is required by the tool schema but was not provided in the tool call."
+}
+```
+
+This prevents the subprocess from ever spawning with invalid input, catches the bug at the cheapest possible point (no task creation, no subprocess, no callback needed), and gives the LLM a clear retry signal in the same turn.
+
+**Why `execute_long_running` specifically:** Only long-running exec handlers have the cascade problem (task creation → subprocess spawn → crash → opaque callback). Short-lived exec handlers fail in the same turn and the error is visible immediately. The cost of schema validation is negligible relative to subprocess spawn + callback lifecycle.
+
+**Scope limitation:** Validate only `required` fields (presence + non-null). Do NOT validate `enum` constraints or `type` assertions at this layer — that would duplicate logic better left to the handler. The goal is to prevent the "field entirely missing" class of failures that produce opaque crashes.
+
+### Fix 2: Structured error in handler validation path (defense-in-depth)
+
+**File:** `skills/bundled/_shared/dispatch-lib.sh`
+
+When `_validate_inputs()` detects a missing required field, format the exit message as a structured JSON object before exiting. The exit trap already captures stderr — make the stderr parseable:
+
+```bash
+if [ -z "$SKILL" ]; then
+    printf '{"error":"missing_required_field","field":"skill","valid_values":["dev-pilot","dev-groom"]}\n' >&2
+    exit 1
+fi
+```
+
+The exit trap delivers this as the callback result. Downstream consumers (mika-dev's callback turn) can then `jq` the result and decide to retry vs escalate.
+
+**Additionally:** Add a prefix marker to the callback result when it originates from input validation failure (not a runtime crash). Modify the exit trap to detect the structured-error pattern and tag the result:
+
+```
+DISPATCH_VALIDATION_ERROR: {"error":"missing_required_field","field":"skill",...}
+```
+
+This lets the `ci_failure_handler` and verdict handler distinguish validation failures from runtime crashes without parsing free-form text.
+
+### Fix 3: Fail-loud at dispatch-record insert time (belt-and-suspenders)
+
+**File:** `crates/mika-agent/src/skills/executor.rs`
+
+After Fix 1, the input_context stored in the callback task row will always contain required fields. But as belt-and-suspenders for any future code path that writes `input_context` directly:
+
+Add a post-condition assertion after `serde_json::to_string(&input)` on line 845: if the tool's schema declares required fields, assert they exist in the serialized input. This is a `debug_assert!` (development-only) rather than a runtime check — Fix 1 is the runtime guard.
+
+## Implementation Order
+
+1. Fix 1 (Rust validation) — the primary fix. Prevents the bug class entirely.
+2. Fix 2 (structured handler errors) — defense-in-depth. Makes any future bypass of Fix 1 produce actionable errors.
+3. Fix 3 (debug assertion) — development-time safety net.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/skills/executor.rs` | Add `validate_required_fields()` before `execute_long_running` body; add `debug_assert!` after input serialization |
+| `skills/bundled/_shared/dispatch-lib.sh` | Structured JSON stderr in `_validate_inputs()`; exit-trap detection of validation-origin errors |
+
+## Testing
+
+1. **Unit test:** Add test in `executor.rs` tests module — call `execute_long_running` (or `execute_skill_tool`) with input missing `skill`, verify `ToolOutput::error` contains `missing_required_field`.
+2. **Integration test:** Add eval scenario — mock LLM emits `run_claude_pilot` without `skill` field, verify agent receives structured error and can retry.
+3. **Manual verification:** Confirm the dispatch-readiness guard still rejects appropriately when the validation passes but other guards fail.
+
+## Risk Assessment
+
+- **Low risk.** Fix 1 adds a pre-check that returns early with an error. No existing working code paths are affected (they always provide `skill`). The validation only fires when the LLM omits a required field — which is already a broken state.
+- **No breaking changes.** The handler script's structured error is backward-compatible — the exit trap still captures it and delivers as a callback string. Old consumers see a slightly different crash message format; new consumers can parse the JSON prefix.
+
+## Out of Scope
+
+- Generalizing schema validation to all tool types (future work, separate ticket).
+- Retry logic in mika-dev for validation errors (separate concern — mika-dev already retries on tool errors).
+- claude-pilot changes (this bug occurs before claude-pilot is invoked).

--- a/docs/plans/2026-05-05-001-fix-run-claude-pilot-missing-skill-plan.md
+++ b/docs/plans/2026-05-05-001-fix-run-claude-pilot-missing-skill-plan.md
@@ -22,11 +22,16 @@ Three layers failed:
 
 Three orthogonal fixes matching the ticket's three investigation surfaces:
 
-### Fix 1: Rust-level required-field validation before spawn (primary fix)
+### Fix 1: Rust-level required-field validation at executor entry point (primary fix)
 
 **File:** `crates/mika-agent/src/skills/executor.rs`
 
-Add a `validate_required_fields()` check at the top of `execute_long_running()`, before task creation. Parse `skill_tool.definition.input_schema` for the `required` array, verify each required field is present and non-null in the input JSON. On failure, return `ToolOutput::error()` with a structured JSON error (same pattern as `task_not_dispatchable`):
+Add a `validate_required_fields()` check at the top of `execute_skill_tool()` — before the long-running/short-lived branch. This provides:
+- **Single policy enforcement** — one place where Rust asserts the JSON Schema contract
+- **Consistent error structure** — `ToolOutput::error { missing_required_field }` for both paths
+- **Easier testing** — one validation unit covers all handlers
+
+On failure, return `ToolOutput::error()` with a structured JSON error (same pattern as `task_not_dispatchable`):
 
 ```json
 {
@@ -40,9 +45,21 @@ Add a `validate_required_fields()` check at the top of `execute_long_running()`,
 
 This prevents the subprocess from ever spawning with invalid input, catches the bug at the cheapest possible point (no task creation, no subprocess, no callback needed), and gives the LLM a clear retry signal in the same turn.
 
-**Why `execute_long_running` specifically:** Only long-running exec handlers have the cascade problem (task creation → subprocess spawn → crash → opaque callback). Short-lived exec handlers fail in the same turn and the error is visible immediately. The cost of schema validation is negligible relative to subprocess spawn + callback lifecycle.
+**Why unified entry-point (per mika-arch first-pass review):** The plan originally scoped to `execute_long_running` only because short-lived handlers fail visibly. The architect correctly identified that the key distinction isn't speed of visibility — it's failure mode consistency. Two different error paths for the same violation is architecturally incomplete. The cost of validation on short-lived handlers is negligible (one array scan of `required` fields per tool call).
 
-**Scope limitation:** Validate only `required` fields (presence + non-null). Do NOT validate `enum` constraints or `type` assertions at this layer — that would duplicate logic better left to the handler. The goal is to prevent the "field entirely missing" class of failures that produce opaque crashes.
+**Defensive schema parsing:** The `input_schema` is not guaranteed to have a well-formed `required` array. Defensive pattern:
+
+```rust
+let required_fields: Vec<&str> = skill_tool.definition.input_schema
+    .get("required")
+    .and_then(Value::as_array)
+    .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+    .unwrap_or_default();
+```
+
+On malformed schema (missing `required` key, non-array, non-string elements): gracefully degrade to empty required list. Emit `warn!` event (`skill_tool_malformed_schema_skipped_validation`) so operators know a tool definition is malformed, but don't crash the dispatcher.
+
+**Scope limitation:** Validate only **top-level** `required` fields (presence + non-null). Do NOT validate `enum` constraints, `type` assertions, or nested `properties` objects with their own `required` arrays. Nested required fields are handler-side concerns. This prevents scope creep while being explicit about coverage boundaries.
 
 ### Fix 2: Structured error in handler validation path (defense-in-depth)
 
@@ -77,7 +94,7 @@ Add a post-condition assertion after `serde_json::to_string(&input)` on line 845
 
 ## Implementation Order
 
-1. Fix 1 (Rust validation) — the primary fix. Prevents the bug class entirely.
+1. Fix 1 (Rust validation at `execute_skill_tool` entry) — the primary fix. Prevents the bug class entirely for both long-running and short-lived handlers.
 2. Fix 2 (structured handler errors) — defense-in-depth. Makes any future bypass of Fix 1 produce actionable errors.
 3. Fix 3 (debug assertion) — development-time safety net.
 
@@ -90,9 +107,10 @@ Add a post-condition assertion after `serde_json::to_string(&input)` on line 845
 
 ## Testing
 
-1. **Unit test:** Add test in `executor.rs` tests module — call `execute_long_running` (or `execute_skill_tool`) with input missing `skill`, verify `ToolOutput::error` contains `missing_required_field`.
-2. **Integration test:** Add eval scenario — mock LLM emits `run_claude_pilot` without `skill` field, verify agent receives structured error and can retry.
-3. **Manual verification:** Confirm the dispatch-readiness guard still rejects appropriately when the validation passes but other guards fail.
+1. **Unit test:** Add test in `executor.rs` tests module — call `execute_skill_tool` with input missing a required field, verify `ToolOutput::error` contains `missing_required_field`.
+2. **Unit test (malformed schema):** Call `execute_skill_tool` with a tool whose `input_schema` has no `required` key or a non-array `required` — verify graceful degradation (no error, passes through to handler).
+3. **Integration test:** Add eval scenario — mock LLM emits `run_claude_pilot` without `skill` field, verify agent receives structured error and can retry.
+4. **Manual verification:** Confirm the dispatch-readiness guard still rejects appropriately when the validation passes but other guards fail.
 
 ## Risk Assessment
 

--- a/docs/solutions/best-practices/skill-tool-required-field-validation-2026-05-05.md
+++ b/docs/solutions/best-practices/skill-tool-required-field-validation-2026-05-05.md
@@ -1,0 +1,75 @@
+---
+title: "Skill tool required-field validation — three-layer defense against LLM-omitted fields in dispatch"
+date: 2026-05-05
+category: best-practices
+module: crates/mika-agent/src/skills/executor.rs
+problem_type: best_practice
+component: executor
+severity: high
+applies_when:
+  - Adding a new skill tool with required fields in its JSON Schema
+  - Debugging a handler crash where the subprocess received malformed input
+  - A long-running dispatch record is persisted without expected fields
+tags: [executor, validation, dispatch, run_claude_pilot, required-fields, skill-tools, defense-in-depth]
+---
+
+# Skill tool required-field validation — three-layer defense against LLM-omitted fields in dispatch
+
+## Context
+
+On 2026-05-02, `run_claude_pilot` dispatch crashed during mika#928 redispatch because the LLM emitted a tool call without the `skill` field. The JSON Schema declared `skill` as required, but the Rust executor passed the input directly to the subprocess without schema validation. The handler script caught the missing field and exited with code 1, but the resulting error was an opaque crash string ("HANDLER CRASH (exit code 1)") that left the parent task `blocked` with no actionable retry signal.
+
+Three layers failed: (1) no schema enforcement at the Rust boundary, (2) handler validation produced free-form text instead of structured errors, (3) the parent task received an unparseable crash message.
+
+## Solution
+
+Three orthogonal fixes at decreasing cost levels:
+
+### Layer 1: Rust-level `validate_required_fields()` (primary)
+
+Added at the top of `execute_skill_tool()` — runs before both the long-running and short-lived handler paths. Checks all top-level `required` fields from the tool's `input_schema` for presence and non-null values. On failure, returns `ToolOutput::error()` with structured JSON:
+
+```json
+{
+  "error": "missing_required_field",
+  "tool": "run_claude_pilot",
+  "field": "skill",
+  "valid_values": ["dev-pilot", "dev-groom"],
+  "reason": "The 'skill' field is required by the tool schema but was not provided."
+}
+```
+
+The LLM sees this in the same turn and can retry with the correct fields. No subprocess is spawned, no task is created, no callback is needed.
+
+**Scope limitation:** Validates only top-level `required` fields (presence + non-null). Does NOT validate `enum` constraints, `type` assertions, or nested `properties`. This is intentional — nested validation is a handler-side concern.
+
+**Defensive schema parsing:** If `required` is missing, non-array, or contains non-string elements, the validation degrades gracefully to an empty required list with a `warn!` event (`skill_tool_malformed_schema_skipped_validation`).
+
+### Layer 2: Structured handler errors (defense-in-depth)
+
+`dispatch-lib.sh` `_validate_inputs()` now emits structured JSON with a `DISPATCH_VALIDATION_ERROR:` prefix:
+
+```
+DISPATCH_VALIDATION_ERROR: {"error":"missing_required_field","field":"skill","valid_values":["dev-pilot","dev-groom"]}
+```
+
+The exit trap captures this to stderr and delivers it as the callback result. Downstream consumers can `jq` the result after the prefix to distinguish validation failures from runtime crashes.
+
+### Layer 3: `debug_assert!` in dispatch record (development-time)
+
+After `serde_json::to_string(&input)` in `execute_long_running`, a `debug_assert!` verifies that required fields survived serialization. Fires only in debug builds — Layer 1 is the runtime guard.
+
+## Key Decisions
+
+1. **Unified entry-point validation:** The validation runs for both long-running and short-lived handlers. The mika-arch first-pass review correctly identified that two different error paths for the same violation is architecturally incomplete.
+
+2. **First missing field reported:** The validation returns on the first missing field rather than collecting all missing fields. This matches the LLM retry pattern — the model will retry with the one field, and if it misses another, the next call catches it. Avoids complex multi-error formatting.
+
+3. **`valid_values` from enum:** When the missing field has an `enum` constraint in the schema, the error includes the valid values. This gives the LLM maximum information for a successful retry.
+
+## References
+
+- mika#955 (this fix)
+- mika#932 (sibling: `run_claude_pilot` tool collision — different code path)
+- `crates/mika-agent/src/skills/executor.rs` — `validate_required_fields()`, `execute_skill_tool()`
+- `skills/bundled/_shared/dispatch-lib.sh` — `_validate_inputs()`

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -110,8 +110,12 @@ _parse_input_json() {
 }
 
 _validate_inputs() {
+    # Structured validation errors (#955): emit parseable JSON to stderr so that
+    # the exit trap delivers an actionable error (not a generic crash string).
+    # Downstream consumers (mika-dev's callback turn) can `jq` the result to
+    # distinguish "LLM forgot a required field" (retry-safe) from "handler bug" (escalate).
     if [ -z "$SKILL" ]; then
-        echo "Error: missing required argument 'skill'; valid values: [\"dev-pilot\", \"dev-groom\"]" >&2
+        printf 'DISPATCH_VALIDATION_ERROR: {"error":"missing_required_field","field":"skill","valid_values":["dev-pilot","dev-groom"],"reason":"The skill field is required but was not provided in the tool call."}\n' >&2
         exit 1
     fi
 
@@ -119,12 +123,12 @@ _validate_inputs() {
     # which derives ENTRY_COMMAND from SKILL. Unknown skills exit 1 there.
 
     if [ -z "$PROMPT" ]; then
-        echo "Error: prompt is required" >&2
+        printf 'DISPATCH_VALIDATION_ERROR: {"error":"missing_required_field","field":"prompt","reason":"The prompt field is required but was not provided in the tool call."}\n' >&2
         exit 1
     fi
 
     if [ -z "$USER_TASK_ID" ]; then
-        echo "Error: task_id is required" >&2
+        printf 'DISPATCH_VALIDATION_ERROR: {"error":"missing_required_field","field":"task_id","reason":"The task_id field is required but was not provided in the tool call."}\n' >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- Add `validate_required_fields()` at `execute_skill_tool()` entry point — validates top-level required JSON Schema fields before any subprocess spawn, returning structured JSON errors for LLM retry
- Structured `DISPATCH_VALIDATION_ERROR:` JSON errors in `dispatch-lib.sh` `_validate_inputs()` for defense-in-depth parsability
- `debug_assert!` on dispatch record serialization as development-time safety net

## Problem

`run_claude_pilot` dispatch crashed during mika#928 redispatch because the LLM omitted the `skill` field. The tool's JSON Schema declared `skill` as required, but the Rust executor passed input directly to the subprocess without validation. The handler caught it but produced an opaque "HANDLER CRASH" string, leaving the parent task `blocked` with no actionable error.

## Approach

Three-layer defense matching the ticket's three investigation surfaces:
1. **Rust entry-point validation** (primary) — prevents subprocess spawn entirely, gives LLM structured retry signal in same turn
2. **Structured handler errors** (defense-in-depth) — if Layer 1 is ever bypassed, the handler produces parseable JSON
3. **Debug assertion** (development-time) — catches regressions in debug builds

Plan: docs/plans/2026-05-05-001-fix-run-claude-pilot-missing-skill-plan.md

## Test plan

- [x] 5 unit tests for `validate_required_fields()` (missing field, null field, all present, no required key, malformed schema)
- [x] 1 integration test for `execute_skill_tool()` rejecting missing required field before handler runs
- [x] All 75 executor tests pass
- [x] Clippy clean, `cargo fmt` clean
- [x] Pre-commit hooks pass (lefthook: no-secrets, no-large-files, rust-fmt, rust-clippy)

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)