### PR TITLE
feat(dashboard): surface telemetry on Team Runs detail page

### DIFF
--- a/dashboard/src/components/TraceIdWidget.tsx
+++ b/dashboard/src/components/TraceIdWidget.tsx
@@ -4,8 +4,8 @@ import { Activity } from 'lucide-react'
 
 interface TraceIdWidgetProps {
   traceId: string
-  /** Optional count shown as a mini badge (e.g., LLM call count) */
-  callCount?: number
+  /** Optional LLM call count shown as a mini badge */
+  llmCallCount?: number
   className?: string
 }
 
@@ -13,7 +13,7 @@ interface TraceIdWidgetProps {
  * Trace ID chip — displays a truncated trace ID with copy + link affordances.
  * Uses CopyButton from @senara-solutions/ui per mika#665 AC3 constraint.
  */
-export default function TraceIdWidget({ traceId, callCount, className = '' }: TraceIdWidgetProps) {
+export default function TraceIdWidget({ traceId, llmCallCount, className = '' }: TraceIdWidgetProps) {
   return (
     <div className={`inline-flex items-center gap-1.5 bg-white/[0.04] border border-white/[0.08] rounded-md px-2 py-1 ${className}`}>
       <Activity size={12} className="text-accent/70 shrink-0" />
@@ -24,9 +24,9 @@ export default function TraceIdWidget({ traceId, callCount, className = '' }: Tr
       >
         {traceId.slice(0, 12)}...
       </Link>
-      {callCount !== undefined && callCount > 0 && (
+      {llmCallCount !== undefined && llmCallCount > 0 && (
         <span className="text-[10px] text-muted/60 bg-white/[0.06] rounded px-1">
-          {callCount}
+          {llmCallCount}
         </span>
       )}
       <CopyButton text={traceId} title="Copy trace ID" className="shrink-0" />

--- a/dashboard/src/components/TraceIdWidget.tsx
+++ b/dashboard/src/components/TraceIdWidget.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router'
+import { CopyButton } from '@senara-solutions/ui'
+import { Activity } from 'lucide-react'
+
+interface TraceIdWidgetProps {
+  traceId: string
+  /** Optional count shown as a mini badge (e.g., LLM call count) */
+  callCount?: number
+  className?: string
+}
+
+/**
+ * Trace ID chip — displays a truncated trace ID with copy + link affordances.
+ * Uses CopyButton from @senara-solutions/ui per mika#665 AC3 constraint.
+ */
+export default function TraceIdWidget({ traceId, callCount, className = '' }: TraceIdWidgetProps) {
+  return (
+    <div className={`inline-flex items-center gap-1.5 bg-white/[0.04] border border-white/[0.08] rounded-md px-2 py-1 ${className}`}>
+      <Activity size={12} className="text-accent/70 shrink-0" />
+      <Link
+        to={`/traces/${traceId}`}
+        className="text-xs font-mono text-accent hover:text-accent-light transition-colors truncate max-w-[120px]"
+        title={traceId}
+      >
+        {traceId.slice(0, 12)}...
+      </Link>
+      {callCount !== undefined && callCount > 0 && (
+        <span className="text-[10px] text-muted/60 bg-white/[0.06] rounded px-1">
+          {callCount}
+        </span>
+      )}
+      <CopyButton text={traceId} title="Copy trace ID" className="shrink-0" />
+    </div>
+  )
+}

--- a/dashboard/src/pages/TeamRunDetail.tsx
+++ b/dashboard/src/pages/TeamRunDetail.tsx
@@ -10,7 +10,7 @@ import { useTraceLlmCalls, type LlmCallRow } from '../api/llmCalls.ts'
 import { useTraceToolCalls, type ToolCallRow } from '../api/toolCalls.ts'
 import { TaskStatusBadge, CopyButton, EmptyState, LoadingState, ErrorState, formatApiError, MarkdownContent, formatRelativeTime } from '@senara-solutions/ui'
 import TraceIdWidget from '../components/TraceIdWidget.tsx'
-import { ChevronDown, ChevronRight, Clock, Cpu, Wrench, Users } from 'lucide-react'
+import { ChevronDown, ChevronRight, Clock, Cpu, Wrench, Users, DollarSign, MessageSquare } from 'lucide-react'
 
 // ===== Helpers =====
 
@@ -35,6 +35,54 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
   return String(n)
+}
+
+/**
+ * Estimate cost in USD from LLM calls using simplified per-model pricing.
+ * Same approach as DevRunDetail — input_tokens * input_rate + output_tokens * output_rate.
+ * Rates are per million tokens. Conservative estimates for unknown models.
+ */
+function estimateCostUsd(llmCalls: LlmCallRow[]): number {
+  // Rates per million tokens [input, output]
+  const MODEL_RATES: Record<string, [number, number]> = {
+    'claude-sonnet-4-20250514': [3.0, 15.0],
+    'claude-3-5-sonnet-20241022': [3.0, 15.0],
+    'claude-3-5-haiku-20241022': [0.8, 4.0],
+    'claude-3-haiku-20240307': [0.25, 1.25],
+    'claude-opus-4-20250514': [15.0, 75.0],
+    'claude-3-opus-20240229': [15.0, 75.0],
+    'gpt-4o': [2.5, 10.0],
+    'gpt-4o-mini': [0.15, 0.6],
+    'deepseek-chat': [0.14, 0.28],
+    'deepseek/deepseek-chat': [0.14, 0.28],
+  }
+  const DEFAULT_RATES: [number, number] = [3.0, 15.0] // Conservative fallback
+
+  let totalCost = 0
+  for (const call of llmCalls) {
+    const rates = MODEL_RATES[call.model] ?? DEFAULT_RATES
+    const inputCost = (call.input_tokens / 1_000_000) * rates[0]
+    const outputCost = (call.output_tokens / 1_000_000) * rates[1]
+    totalCost += inputCost + outputCost
+  }
+  return totalCost
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return '<$0.01'
+  return `$${usd.toFixed(2)}`
+}
+
+/**
+ * Compute turn count — number of distinct agent loop turns across all sessions.
+ * A turn is one (session_id, step) pair in the LLM calls data.
+ */
+function computeTurnCount(llmCalls: LlmCallRow[]): number {
+  const turns = new Set<string>()
+  for (const call of llmCalls) {
+    turns.add(`${call.session_id}:${call.step}`)
+  }
+  return turns.size
 }
 
 // ===== Sub-components =====
@@ -73,6 +121,7 @@ interface AgentTelemetry {
   totalOutputTokens: number
   totalCacheReadTokens: number
   totalLatencyMs: number
+  costUsd: number
   toolSuccessCount: number
   models: Map<string, number>
   topTools: Map<string, number>
@@ -94,6 +143,7 @@ function computeAgentTelemetry(
         totalOutputTokens: 0,
         totalCacheReadTokens: 0,
         totalLatencyMs: 0,
+        costUsd: 0,
         toolSuccessCount: 0,
         models: new Map(),
         topTools: new Map(),
@@ -111,6 +161,12 @@ function computeAgentTelemetry(
       agent.totalCacheReadTokens += call.cache_read_tokens ?? 0
       agent.totalLatencyMs += call.latency_ms
       agent.models.set(call.model, (agent.models.get(call.model) ?? 0) + 1)
+    }
+    // Compute per-agent cost after aggregating all calls
+    for (const agent of map.values()) {
+      agent.costUsd = estimateCostUsd(
+        llmCalls.filter((c) => c.agent_id === agent.agentId),
+      )
     }
   }
 
@@ -405,6 +461,8 @@ export default function TeamRunDetail() {
   const totalLlmCalls = llmCalls?.length ?? 0
   const totalToolCalls = toolCalls?.length ?? 0
   const totalTokens = llmCalls?.reduce((sum, c) => sum + c.input_tokens + c.output_tokens, 0) ?? 0
+  const totalCostUsd = llmCalls ? estimateCostUsd(llmCalls) : 0
+  const turnCount = llmCalls ? computeTurnCount(llmCalls) : 0
 
   // Iteration indicator logic
   const capturedIterations = displayIterations.length
@@ -446,7 +504,7 @@ export default function TeamRunDetail() {
         {/* Trace ID Widget */}
         {run.trace_id && (
           <div className="flex items-center gap-4 mt-3 pt-3 border-t border-white/[0.05]">
-            <TraceIdWidget traceId={run.trace_id} callCount={totalLlmCalls} />
+            <TraceIdWidget traceId={run.trace_id} llmCallCount={totalLlmCalls} />
           </div>
         )}
 
@@ -456,11 +514,17 @@ export default function TeamRunDetail() {
             {durationMs !== null && (
               <StatBadge icon={Clock} label="Duration" value={formatDurationMs(durationMs)} />
             )}
+            {totalCostUsd > 0 && (
+              <StatBadge icon={DollarSign} label="Cost" value={formatCost(totalCostUsd)} />
+            )}
             {totalLlmCalls > 0 && (
               <StatBadge icon={Cpu} label="LLM Calls" value={`${totalLlmCalls} calls`} />
             )}
             {totalToolCalls > 0 && (
               <StatBadge icon={Wrench} label="Tool Calls" value={`${totalToolCalls} tools`} />
+            )}
+            {turnCount > 0 && (
+              <StatBadge icon={MessageSquare} label="Turns" value={`${turnCount} turns`} />
             )}
             {agentTelemetry.length > 0 && (
               <StatBadge icon={Users} label="Agents" value={`${agentTelemetry.length} agents`} />

--- a/dashboard/src/pages/TeamRunDetail.tsx
+++ b/dashboard/src/pages/TeamRunDetail.tsx
@@ -6,13 +6,238 @@ import {
   useTeamWorkspace,
   type TeamWorkspaceEntry,
 } from '../api/teams.ts'
+import { useTraceLlmCalls, type LlmCallRow } from '../api/llmCalls.ts'
+import { useTraceToolCalls, type ToolCallRow } from '../api/toolCalls.ts'
 import { TaskStatusBadge, CopyButton, EmptyState, LoadingState, ErrorState, formatApiError, MarkdownContent, formatRelativeTime } from '@senara-solutions/ui'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import TraceIdWidget from '../components/TraceIdWidget.tsx'
+import { ChevronDown, ChevronRight, Clock, Cpu, Wrench, Users } from 'lucide-react'
+
+// ===== Helpers =====
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const totalSecs = Math.floor(ms / 1000)
+  if (totalSecs < 60) return `${totalSecs}s`
+  const mins = Math.floor(totalSecs / 60)
+  const secs = totalSecs % 60
+  if (mins < 60) return `${mins}m ${secs}s`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return `${hours}h ${remMins}m`
+}
+
+function computeDurationMs(startedAt: string, endedAt: string | null): number | null {
+  if (!endedAt) return null
+  return new Date(endedAt).getTime() - new Date(startedAt).getTime()
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+// ===== Sub-components =====
+
+function StatBadge({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string; size?: number }>
+  label: string
+  value: string
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-muted/60 text-xs" title={label}>
+      <Icon className="h-3.5 w-3.5" size={14} />
+      <span>{value}</span>
+    </div>
+  )
+}
 
 function DarkContainer({ children, className = '' }: { children: React.ReactNode; className?: string }) {
   return (
     <div className={`bg-bg rounded-xl p-4 border border-white/[0.04] ${className}`}>
       {children}
+    </div>
+  )
+}
+
+/** Agent telemetry summary computed from LLM/tool calls. */
+interface AgentTelemetry {
+  agentId: string
+  llmCallCount: number
+  toolCallCount: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalCacheReadTokens: number
+  totalLatencyMs: number
+  toolSuccessCount: number
+  models: Map<string, number>
+  topTools: Map<string, number>
+}
+
+function computeAgentTelemetry(
+  llmCalls: LlmCallRow[] | undefined,
+  toolCalls: ToolCallRow[] | undefined,
+): AgentTelemetry[] {
+  const map = new Map<string, AgentTelemetry>()
+
+  const getOrCreate = (agentId: string): AgentTelemetry => {
+    if (!map.has(agentId)) {
+      map.set(agentId, {
+        agentId,
+        llmCallCount: 0,
+        toolCallCount: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCacheReadTokens: 0,
+        totalLatencyMs: 0,
+        toolSuccessCount: 0,
+        models: new Map(),
+        topTools: new Map(),
+      })
+    }
+    return map.get(agentId)!
+  }
+
+  if (llmCalls) {
+    for (const call of llmCalls) {
+      const agent = getOrCreate(call.agent_id)
+      agent.llmCallCount++
+      agent.totalInputTokens += call.input_tokens
+      agent.totalOutputTokens += call.output_tokens
+      agent.totalCacheReadTokens += call.cache_read_tokens ?? 0
+      agent.totalLatencyMs += call.latency_ms
+      agent.models.set(call.model, (agent.models.get(call.model) ?? 0) + 1)
+    }
+  }
+
+  if (toolCalls) {
+    for (const call of toolCalls) {
+      const agent = getOrCreate(call.agent_id)
+      agent.toolCallCount++
+      if (call.success) agent.toolSuccessCount++
+      agent.topTools.set(call.tool_name, (agent.topTools.get(call.tool_name) ?? 0) + 1)
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.llmCallCount - a.llmCallCount)
+}
+
+function AgentTelemetrySection({ agents }: { agents: AgentTelemetry[] }) {
+  const [expandedAgent, setExpandedAgent] = useState<string | null>(null)
+
+  if (agents.length === 0) {
+    return <EmptyState message="No telemetry data available for this trace" />
+  }
+
+  return (
+    <div className="space-y-1">
+      {agents.map((agent) => {
+        const isExpanded = expandedAgent === agent.agentId
+        const successRate = agent.toolCallCount > 0
+          ? Math.round((agent.toolSuccessCount / agent.toolCallCount) * 100)
+          : 0
+        const topModels = Array.from(agent.models.entries())
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, 3)
+        const topTools = Array.from(agent.topTools.entries())
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, 5)
+
+        return (
+          <div key={agent.agentId} className="border border-white/[0.04] rounded-lg overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setExpandedAgent(isExpanded ? null : agent.agentId)}
+              className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-white/[0.02] transition-colors"
+            >
+              {isExpanded ? (
+                <ChevronDown size={14} className="text-muted/40 shrink-0" />
+              ) : (
+                <ChevronRight size={14} className="text-muted/40 shrink-0" />
+              )}
+              <Link
+                to={`/agents/${agent.agentId}`}
+                onClick={(e) => e.stopPropagation()}
+                className="text-accent text-xs font-medium hover:text-accent-light transition-colors"
+              >
+                {agent.agentId}
+              </Link>
+              <div className="flex items-center gap-4 ml-auto text-muted/40 text-xs">
+                <span>{agent.llmCallCount} LLM calls</span>
+                <span>{agent.toolCallCount} tools ({successRate}%)</span>
+                <span>{formatTokens(agent.totalInputTokens + agent.totalOutputTokens)} tokens</span>
+              </div>
+            </button>
+
+            {isExpanded && (
+              <div className="px-3 pb-3 pt-1 border-t border-white/[0.04] space-y-3">
+                {/* Models */}
+                {topModels.length > 0 && (
+                  <div>
+                    <h5 className="text-[10px] text-muted/50 uppercase tracking-wider mb-1">Models</h5>
+                    <div className="flex flex-wrap gap-1.5">
+                      {topModels.map(([model, count]) => (
+                        <span key={model} className="text-xs text-muted bg-white/[0.04] rounded px-1.5 py-0.5">
+                          {model} <span className="text-muted/40">({count})</span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Token breakdown */}
+                <div>
+                  <h5 className="text-[10px] text-muted/50 uppercase tracking-wider mb-1">Tokens</h5>
+                  <div className="grid grid-cols-3 gap-2 text-xs">
+                    <div>
+                      <span className="text-muted/40">Input: </span>
+                      <span className="text-muted">{formatTokens(agent.totalInputTokens)}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted/40">Output: </span>
+                      <span className="text-muted">{formatTokens(agent.totalOutputTokens)}</span>
+                    </div>
+                    <div>
+                      <span className="text-muted/40">Cache read: </span>
+                      <span className="text-muted">{formatTokens(agent.totalCacheReadTokens)}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Latency */}
+                <div>
+                  <h5 className="text-[10px] text-muted/50 uppercase tracking-wider mb-1">Latency</h5>
+                  <span className="text-xs text-muted">{formatDurationMs(agent.totalLatencyMs)} total</span>
+                  {agent.llmCallCount > 0 && (
+                    <span className="text-xs text-muted/40 ml-2">
+                      (avg {formatDurationMs(Math.round(agent.totalLatencyMs / agent.llmCallCount))})
+                    </span>
+                  )}
+                </div>
+
+                {/* Top tools */}
+                {topTools.length > 0 && (
+                  <div>
+                    <h5 className="text-[10px] text-muted/50 uppercase tracking-wider mb-1">Top Tools</h5>
+                    <div className="space-y-0.5">
+                      {topTools.map(([tool, count]) => (
+                        <div key={tool} className="flex items-center justify-between text-xs">
+                          <span className="text-muted font-mono">{tool}</span>
+                          <span className="text-muted/40">{count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -135,11 +360,18 @@ function IterationSection({
   )
 }
 
+// ===== Main Page =====
+
 export default function TeamRunDetail() {
   const { runId } = useParams()
   const { data: run, isLoading: runLoading, error: runError, refetch } = useTeamRun(runId)
   const { data: summary } = useTeamRunSummary(runId)
   const { data: workspace } = useTeamWorkspace(runId)
+
+  // Fetch telemetry when trace_id is available
+  const traceId = run?.trace_id ?? ''
+  const { data: llmCalls } = useTraceLlmCalls(traceId)
+  const { data: toolCalls } = useTraceToolCalls(traceId)
 
   if (runLoading) {
     return <LoadingState variant="detail" />
@@ -166,6 +398,19 @@ export default function TeamRunDetail() {
   const displayIterations = iterations.filter(([, entries]) =>
     entries.some((e) => ['assignment', 'agent_response', 'critic'].includes(e.entry_type))
   )
+
+  // Compute telemetry aggregates
+  const agentTelemetry = computeAgentTelemetry(llmCalls, toolCalls)
+  const durationMs = computeDurationMs(run.started_at, run.ended_at)
+  const totalLlmCalls = llmCalls?.length ?? 0
+  const totalToolCalls = toolCalls?.length ?? 0
+  const totalTokens = llmCalls?.reduce((sum, c) => sum + c.input_tokens + c.output_tokens, 0) ?? 0
+
+  // Iteration indicator logic
+  const capturedIterations = displayIterations.length
+  const iterationLabel = capturedIterations < run.max_iterations && capturedIterations < run.iteration
+    ? `Iteration ${run.iteration}/${run.max_iterations} (${capturedIterations} captured)`
+    : `Iteration ${run.iteration}/${run.max_iterations}`
 
   return (
     <div>
@@ -194,21 +439,35 @@ export default function TeamRunDetail() {
           <div className="text-right text-xs text-muted/60 space-y-1">
             <div>Started {formatRelativeTime(run.started_at)}</div>
             {run.ended_at && <div>Ended {formatRelativeTime(run.ended_at)}</div>}
-            <div>
-              Iteration {run.iteration}/{run.max_iterations}
-            </div>
+            <div>{iterationLabel}</div>
           </div>
         </div>
 
-        {/* Links */}
+        {/* Trace ID Widget */}
         {run.trace_id && (
           <div className="flex items-center gap-4 mt-3 pt-3 border-t border-white/[0.05]">
-            <Link
-              to={`/traces/${run.trace_id}`}
-              className="text-accent text-xs hover:text-accent-light transition-colors"
-            >
-              View Trace &rarr;
-            </Link>
+            <TraceIdWidget traceId={run.trace_id} callCount={totalLlmCalls} />
+          </div>
+        )}
+
+        {/* Stats row */}
+        {(durationMs !== null || totalLlmCalls > 0 || totalToolCalls > 0) && (
+          <div className="flex items-center gap-5 mt-3 pt-3 border-t border-white/[0.05]">
+            {durationMs !== null && (
+              <StatBadge icon={Clock} label="Duration" value={formatDurationMs(durationMs)} />
+            )}
+            {totalLlmCalls > 0 && (
+              <StatBadge icon={Cpu} label="LLM Calls" value={`${totalLlmCalls} calls`} />
+            )}
+            {totalToolCalls > 0 && (
+              <StatBadge icon={Wrench} label="Tool Calls" value={`${totalToolCalls} tools`} />
+            )}
+            {agentTelemetry.length > 0 && (
+              <StatBadge icon={Users} label="Agents" value={`${agentTelemetry.length} agents`} />
+            )}
+            {totalTokens > 0 && (
+              <span className="text-muted/40 text-xs">{formatTokens(totalTokens)} tokens</span>
+            )}
           </div>
         )}
 
@@ -246,6 +505,14 @@ export default function TeamRunDetail() {
           </div>
         )}
       </div>
+
+      {/* Agent Telemetry */}
+      {run.trace_id && agentTelemetry.length > 0 && (
+        <div className="bg-bg-card border border-white/[0.05] rounded-xl p-5 mb-5">
+          <h3 className="text-heading text-base font-semibold mb-3">Agent Telemetry</h3>
+          <AgentTelemetrySection agents={agentTelemetry} />
+        </div>
+      )}
 
       {/* Summary: Agent Results & Critic */}
       {summary && (

--- a/docs/plans/2026-05-05-002-feat-team-run-detail-telemetry-plan.md
+++ b/docs/plans/2026-05-05-002-feat-team-run-detail-telemetry-plan.md
@@ -1,0 +1,119 @@
+# Plan: Dashboard Team Runs Detail — Surface Telemetry & Fix Iteration Indicator
+
+**Issue:** mika#652
+**Branch:** `feat/652/dashboard-team-runs-missing-telemetry-no`
+**Scope:** Bug-fix portion only (data-rendering, no design dependency)
+
+## Problem
+
+The Team Runs detail page (`/dashboard/team-runs/:runId`) renders the scaffold (goal, deliverable, status) but is missing actionable operational telemetry that already exists in the database. The `Iteration X/Y` indicator is potentially misleading when fewer iterations are captured. The "View Trace" link is a weak affordance — should be a chip with copy + link.
+
+## Acceptance Criteria
+
+1. **Duration** — Elapsed time displayed (computed from `started_at` / `ended_at`)
+2. **Cost** — Aggregated LLM cost from `llm_calls` by trace_id (same formula as DevRunDetail)
+3. **Agent roster** — List of participating agents with per-agent tool/LLM call counts
+4. **Tool call summary** — Per-agent breakdown table (tool name, count, success rate)
+5. **LLM call summary** — Per-agent breakdown table (model, input/output tokens, cache read, latency)
+6. **Turn count** — Message count across agent sessions
+7. **Iteration indicator accuracy** — Shows `Iteration X/Y` only when Y iterations exist in workspace data; shows `X of Y captured` when fewer exist
+8. **TraceIdWidget** — Shared component using `<CopyButton />` from `@senara-solutions/ui` (per mika#665 AC3 constraint); replaces the plain "View Trace" link
+
+## Architecture
+
+### Data Flow (existing — no backend changes needed)
+
+The backend already serves all necessary telemetry:
+- `GET /api/v1/team-runs/:runId` — returns `TeamRunRow` with `trace_id`, `started_at`, `ended_at`, `iteration`, `max_iterations`
+- `GET /api/v1/traces/:traceId/llm-calls` — returns `LlmCallRow[]` with tokens, latency, model, agent_id
+- `GET /api/v1/traces/:traceId/tool-calls` — returns `ToolCallRow[]` with tool_name, success, agent_id
+- `GET /api/v1/team-runs/:runId/workspace` — returns entries with iteration numbers
+
+No new API endpoints required. All aggregation happens client-side (same pattern as TraceDetail page).
+
+### Implementation Units
+
+#### Unit 1: TraceIdWidget shared component
+
+**File:** `dashboard/src/components/TraceIdWidget.tsx` (new)
+
+A chip that:
+- Displays truncated trace ID (first 12 chars + `...`)
+- Uses `<CopyButton text={traceId} />` from `@senara-solutions/ui` (mika#665 constraint)
+- Links to `/traces/:traceId` on click
+- Optionally shows span count or LLM call count as a mini badge
+
+Props:
+```typescript
+interface TraceIdWidgetProps {
+  traceId: string
+  llmCallCount?: number
+  className?: string
+}
+```
+
+#### Unit 2: Telemetry stats row
+
+**File:** `dashboard/src/pages/TeamRunDetail.tsx` (modify)
+
+Add a stats row below the header (same pattern as DevRunDetail's `StatBadge` components):
+- Duration: compute from `started_at`/`ended_at`
+- Cost: sum `llm_calls` cost (input_tokens * rate + output_tokens * rate — use simplified estimate or just show token totals)
+- LLM calls count
+- Tool calls count
+- Agent count (distinct `agent_id` from tool/llm calls)
+
+Fetch telemetry conditionally when `run.trace_id` exists using existing hooks:
+- `useTraceLlmCalls(run.trace_id)`
+- `useTraceToolCalls(run.trace_id)`
+
+#### Unit 3: Agent roster & per-agent telemetry tables
+
+**File:** `dashboard/src/pages/TeamRunDetail.tsx` (modify)
+
+New collapsible section "Agent Telemetry" below the summary card:
+- Group LLM calls by `agent_id` — show per-agent: model distribution, total tokens, total latency, cost estimate
+- Group tool calls by `agent_id` — show per-agent: tool usage (top tools, success rate)
+- Each agent links to `/agents/:agentId`
+
+Use a compact table layout following TraceDetail patterns. Collapsible per-agent rows.
+
+#### Unit 4: Fix iteration indicator
+
+**File:** `dashboard/src/pages/TeamRunDetail.tsx` (modify)
+
+Current: always shows `Iteration {run.iteration}/{run.max_iterations}` from the DB row.
+
+Fix: Compare `run.iteration`/`run.max_iterations` against actual workspace entries. If `displayIterations.length < run.max_iterations`, show an explanatory note: `"Iteration {run.iteration}/{run.max_iterations} — {displayIterations.length} captured"`. If workspace shows all iterations, show normal `Iteration X/Y`.
+
+#### Unit 5: Replace "View Trace" link with TraceIdWidget
+
+**File:** `dashboard/src/pages/TeamRunDetail.tsx` (modify)
+
+Replace lines 204-213 (the plain "View Trace" link) with `<TraceIdWidget traceId={run.trace_id} llmCallCount={llmCalls?.length} />`.
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `dashboard/src/components/TraceIdWidget.tsx` | NEW — shared trace ID chip component |
+| `dashboard/src/pages/TeamRunDetail.tsx` | MODIFY — add telemetry stats, agent roster, fix iteration, use TraceIdWidget |
+
+## Out of Scope
+
+- Iteration navigation/comparison UI (design-class, requires Stitch)
+- Run Summary panel layout redesign (design-class)
+- Cost calculation precision (we'll show token counts; precise cost needs model-specific pricing tables)
+- Backend API changes (all data already available)
+
+## Testing
+
+- Build verification: `npm run build --prefix dashboard` must pass
+- Visual: navigate to a completed team run with a trace_id and verify all telemetry sections render
+- Edge case: team run without trace_id — telemetry section hidden gracefully
+- Edge case: team run with 0 LLM/tool calls — empty states shown
+
+## Dependencies
+
+- `@senara-solutions/ui` CopyButton (already available)
+- Existing `useTraceLlmCalls` and `useTraceToolCalls` hooks (already in `dashboard/src/api/`)

--- a/docs/solutions/652-team-run-detail-telemetry-surface.md
+++ b/docs/solutions/652-team-run-detail-telemetry-surface.md
@@ -1,0 +1,70 @@
+---
+module: dashboard
+tags: [team-runs, telemetry, trace, observability]
+problem_type: missing-feature
+category: dashboard
+---
+
+# Team Run Detail: Surfacing Telemetry from Existing Trace Endpoints
+
+## Problem
+
+The Team Runs detail page rendered the scaffold (goal, deliverable, status) but
+lacked operational telemetry — no duration, no LLM/tool call counts, no per-agent
+breakdown. The iteration indicator showed `X/Y` without clarifying when fewer
+iterations were actually captured. The "View Trace" link was a weak affordance.
+
+## Root Cause
+
+The backend already served all telemetry data via `GET /traces/:traceId/llm-calls`
+and `GET /traces/:traceId/tool-calls`. The frontend simply wasn't fetching or
+rendering it. Team runs carry a `trace_id` that links to the same trace
+infrastructure used by all other telemetry surfaces.
+
+## Solution
+
+### Approach: Client-side aggregation from existing endpoints
+
+No backend changes needed. The frontend conditionally fetches trace-level data
+when `run.trace_id` is available:
+
+1. **Stats row** — Duration (computed from timestamps), LLM call count, tool call
+   count, agent count, total tokens. Same `StatBadge` pattern as DevRunDetail.
+
+2. **Agent Telemetry section** — Groups LLM/tool calls by `agent_id`, renders
+   expandable per-agent cards with model distribution, token breakdown, latency
+   stats, and top-5 tool usage.
+
+3. **TraceIdWidget** — Shared component (chip with truncated ID, CopyButton from
+   `@senara-solutions/ui`, link to trace detail). Uses CopyButton per mika#665
+   AC3 forward constraint.
+
+4. **Iteration indicator fix** — Compares workspace entries against
+   `max_iterations`; shows "(N captured)" when fewer exist.
+
+### Key pattern: Conditional query enablement
+
+```typescript
+const traceId = run?.trace_id ?? ''
+const { data: llmCalls } = useTraceLlmCalls(traceId)
+// Hook has `enabled: !!traceId` — empty string prevents fetch
+```
+
+This avoids waterfall requests (run must load first to get trace_id) while
+keeping the hook interface clean.
+
+### Key pattern: Client-side aggregation
+
+`computeAgentTelemetry()` groups raw call arrays by agent_id into a typed
+`AgentTelemetry` struct. This is the correct location for aggregation because:
+- The trace endpoints already return all rows (no pagination needed for typical runs)
+- Server-side aggregation would require a new endpoint for marginal benefit
+- The pattern matches how TraceDetail already works
+
+## Applicability
+
+This pattern applies to any detail page that has a `trace_id` and needs to show
+telemetry summaries. The TraceIdWidget component is reusable across:
+- Dev Runs detail (child tasks with execution_trace_id)
+- Session detail pages
+- Any future surface that displays trace IDs


### PR DESCRIPTION
## Summary

- Surface operational telemetry (duration, LLM/tool call counts, per-agent breakdown) on the Team Runs detail page using existing trace-level API endpoints
- Add shared `<TraceIdWidget />` component (truncated ID chip with copy + link) using `<CopyButton />` from `@senara-solutions/ui` per mika#665 AC3 constraint
- Fix iteration indicator to show "(N captured)" when fewer iterations exist in workspace data than `max_iterations`

## Changes

- **`dashboard/src/components/TraceIdWidget.tsx`** — New shared trace ID chip component
- **`dashboard/src/pages/TeamRunDetail.tsx`** — Add stats row, agent telemetry section, fix iteration label, replace "View Trace" link with TraceIdWidget
- **No backend changes** — all telemetry data already served via `GET /traces/:traceId/llm-calls` and `GET /traces/:traceId/tool-calls`

Plan: docs/plans/2026-05-05-002-feat-team-run-detail-telemetry-plan.md

Closes #652

## Test plan

- [ ] Navigate to a completed team run with `trace_id` — verify duration, LLM/tool counts, agent roster render
- [ ] Expand an agent row — verify models, tokens, latency, top tools display
- [ ] Click TraceIdWidget — verify copy works and link navigates to trace detail
- [ ] Navigate to a team run without `trace_id` — verify telemetry section hidden gracefully
- [ ] Verify `npm run build --prefix dashboard` passes
- [ ] Verify iteration indicator shows "(N captured)" when workspace has fewer iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)