### PR TITLE
feat(dashboard): add CostTrendChart time-series visualization

### DIFF
--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -2028,6 +2028,13 @@ impl AsyncDatabase {
             .await
     }
 
+    pub async fn query_cost_trend(
+        &self,
+        filters: crate::db::CostTrendFilters,
+    ) -> Result<crate::db::CostTrendResponse> {
+        self.with_db(move |db| db.query_cost_trend(&filters)).await
+    }
+
     pub async fn query_tool_calls(
         &self,
         filters: crate::db::ToolCallFilters,

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -5714,11 +5714,7 @@ impl Database {
                 }
             }
 
-            let agent_key = if filters.agent_id.is_some() {
-                None
-            } else {
-                Some(agent_id)
-            };
+            let agent_key = Some(agent_id);
             let entry = aggregated.entry((bucket_ts, agent_key)).or_default();
             entry.0 += cost;
             entry.1 += input;

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -511,6 +511,33 @@ pub struct LlmCallFilters {
     pub to: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct CostTrendBucket {
+    pub timestamp: String,
+    pub cost_usd: f64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub call_count: u64,
+    pub agent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CostTrendResponse {
+    pub buckets: Vec<CostTrendBucket>,
+    pub bucket_size: String,
+    pub has_estimated_pricing: bool,
+    pub estimated_models: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CostTrendFilters {
+    pub agent_id: Option<String>,
+    pub model: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub bucket: Option<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ToolCallFilters {
     pub agent_id: Option<String>,
@@ -5565,6 +5592,162 @@ impl Database {
             )?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok((rows, total))
+    }
+
+    pub fn query_cost_trend(&self, filters: &CostTrendFilters) -> Result<CostTrendResponse> {
+        use std::collections::BTreeMap;
+
+        // Determine effective from/to.
+        let effective_from = filters
+            .from
+            .clone()
+            .unwrap_or_else(|| timestamp::now_minus(Duration::hours(24)));
+        let effective_to = filters.to.clone().unwrap_or_else(timestamp::now);
+
+        // Determine bucket size.
+        let bucket_size = match filters.bucket.as_deref() {
+            Some("hour") => "hour",
+            Some("day") => "day",
+            Some("auto") | None => {
+                let from_dt = timestamp::parse(&effective_from)
+                    .unwrap_or_else(|_| Utc::now() - Duration::hours(24));
+                let to_dt = timestamp::parse(&effective_to).unwrap_or_else(|_| Utc::now());
+                let span_secs = (to_dt - from_dt).num_seconds();
+                if span_secs < 259_200 { "hour" } else { "day" }
+            }
+            _ => "hour",
+        };
+
+        let bucket_expr = if bucket_size == "hour" {
+            "substr(created_at, 1, 13) || ':00:00Z'"
+        } else {
+            "substr(created_at, 1, 10) || 'T00:00:00Z'"
+        };
+
+        // Build WHERE clause.
+        let mut where_clauses = Vec::new();
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        params_vec.push(Box::new(effective_from));
+        where_clauses.push(format!("created_at >= ?{}", params_vec.len()));
+
+        params_vec.push(Box::new(effective_to));
+        where_clauses.push(format!("created_at <= ?{}", params_vec.len()));
+
+        if let Some(ref agent_id) = filters.agent_id {
+            params_vec.push(Box::new(agent_id.clone()));
+            where_clauses.push(format!("agent_id = ?{}", params_vec.len()));
+        }
+        if let Some(ref model) = filters.model {
+            params_vec.push(Box::new(model.clone()));
+            where_clauses.push(format!("model = ?{}", params_vec.len()));
+        }
+
+        let where_sql = format!("WHERE {}", where_clauses.join(" AND "));
+
+        let sql = format!(
+            "SELECT {bucket_expr} as bucket_ts,
+                    agent_id, provider, model,
+                    SUM(input_tokens) as total_input,
+                    SUM(output_tokens) as total_output,
+                    SUM(COALESCE(cache_read_tokens, 0)) as total_cache_read,
+                    SUM(COALESCE(cache_write_tokens, 0)) as total_cache_write,
+                    COUNT(*) as call_count
+             FROM llm_calls
+             {where_sql}
+             GROUP BY bucket_ts, agent_id, provider, model
+             ORDER BY bucket_ts ASC"
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(params_vec.iter().map(|p| p.as_ref())),
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?, // bucket_ts
+                    row.get::<_, String>(1)?, // agent_id
+                    row.get::<_, String>(2)?, // provider
+                    row.get::<_, String>(3)?, // model
+                    row.get::<_, u64>(4)?,    // total_input
+                    row.get::<_, u64>(5)?,    // total_output
+                    row.get::<_, u64>(6)?,    // total_cache_read
+                    row.get::<_, u64>(7)?,    // total_cache_write
+                    row.get::<_, u64>(8)?,    // call_count
+                ))
+            },
+        )?;
+
+        // Aggregate by (bucket_ts, agent_id), applying per-model pricing.
+        let mut has_estimated = false;
+        let mut estimated_models: Vec<String> = Vec::new();
+
+        // Key: (bucket_ts, agent_id) -> (cost_usd, input_tokens, output_tokens, call_count)
+        type BucketKey = (String, Option<String>);
+        type BucketValue = (f64, u64, u64, u64);
+        let mut aggregated: BTreeMap<BucketKey, BucketValue> = BTreeMap::new();
+
+        for row in rows {
+            let (
+                bucket_ts,
+                agent_id,
+                provider,
+                model,
+                input,
+                output,
+                cache_read,
+                cache_write,
+                count,
+            ) = row?;
+            let pricing = crate::pricing::get_pricing(&provider, &model);
+            let cost = crate::pricing::estimate_call_cost(
+                &pricing,
+                input,
+                output,
+                Some(cache_read),
+                Some(cache_write),
+            );
+            if crate::pricing::is_fallback_pricing(&pricing) {
+                has_estimated = true;
+                let model_key = format!("{provider}/{model}");
+                if !estimated_models.contains(&model_key) {
+                    estimated_models.push(model_key);
+                }
+            }
+
+            let agent_key = if filters.agent_id.is_some() {
+                None
+            } else {
+                Some(agent_id)
+            };
+            let entry = aggregated.entry((bucket_ts, agent_key)).or_default();
+            entry.0 += cost;
+            entry.1 += input;
+            entry.2 += output;
+            entry.3 += count;
+        }
+
+        let buckets = aggregated
+            .into_iter()
+            .map(
+                |((ts, agent_id), (cost_usd, input_tokens, output_tokens, call_count))| {
+                    CostTrendBucket {
+                        timestamp: ts,
+                        cost_usd,
+                        input_tokens,
+                        output_tokens,
+                        call_count,
+                        agent_id,
+                    }
+                },
+            )
+            .collect();
+
+        Ok(CostTrendResponse {
+            buckets,
+            bucket_size: bucket_size.to_string(),
+            has_estimated_pricing: has_estimated,
+            estimated_models,
+        })
     }
 
     pub fn query_tool_calls(

--- a/crates/mika-agent/src/lib.rs
+++ b/crates/mika-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod github_graphql;
 pub mod kg;
 pub mod mcp;
 pub mod messaging;
+pub mod pricing;
 pub mod prompt;
 pub mod rewind;
 pub mod secret_scrubber;

--- a/crates/mika-agent/src/pricing.rs
+++ b/crates/mika-agent/src/pricing.rs
@@ -1,0 +1,475 @@
+//! LLM API cost estimation from token counts and model identity.
+//!
+//! Provides approximate pricing data for major LLM providers and a cost
+//! estimation function. Prices are per million tokens and may drift from
+//! actual provider pricing — treat as estimates for dashboard display.
+
+/// Per-model pricing rates (USD per million tokens).
+#[derive(Debug, Clone)]
+pub struct ModelPricing {
+    /// Cost per million input tokens.
+    pub input_per_mtok: f64,
+    /// Cost per million output tokens.
+    pub output_per_mtok: f64,
+    /// Multiplier applied to input rate for cache-read tokens (e.g. 0.1 for Anthropic).
+    pub cache_read_multiplier: f64,
+    /// Multiplier applied to input rate for cache-write tokens (e.g. 1.25 for Anthropic).
+    pub cache_write_multiplier: f64,
+}
+
+/// Fallback pricing used when the model is not recognized.
+const FALLBACK_PRICING: ModelPricing = ModelPricing {
+    input_per_mtok: 1.0,
+    output_per_mtok: 5.0,
+    cache_read_multiplier: 1.0,
+    cache_write_multiplier: 1.0,
+};
+
+/// Zero-cost pricing for local models (Ollama).
+const ZERO_PRICING: ModelPricing = ModelPricing {
+    input_per_mtok: 0.0,
+    output_per_mtok: 0.0,
+    cache_read_multiplier: 1.0,
+    cache_write_multiplier: 1.0,
+};
+
+/// Anthropic cache multipliers.
+const ANTHROPIC_CACHE_READ: f64 = 0.1;
+const ANTHROPIC_CACHE_WRITE: f64 = 1.25;
+
+struct PricingEntry {
+    /// Model name prefixes to match (lowercase).
+    models: &'static [&'static str],
+    input_per_mtok: f64,
+    output_per_mtok: f64,
+}
+
+const ANTHROPIC_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["claude-opus-4", "claude-opus-4-0520"],
+        input_per_mtok: 15.0,
+        output_per_mtok: 75.0,
+    },
+    PricingEntry {
+        models: &[
+            "claude-sonnet-4",
+            "claude-sonnet-4-0514",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-6-20250514",
+        ],
+        input_per_mtok: 3.0,
+        output_per_mtok: 15.0,
+    },
+    PricingEntry {
+        models: &["claude-haiku-4-5", "claude-haiku-4-5-20251022"],
+        input_per_mtok: 0.80,
+        output_per_mtok: 4.0,
+    },
+];
+
+const OPENAI_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["gpt-4o", "gpt-4o-2024-08-06"],
+        input_per_mtok: 2.50,
+        output_per_mtok: 10.0,
+    },
+    PricingEntry {
+        models: &["gpt-4o-mini"],
+        input_per_mtok: 0.15,
+        output_per_mtok: 0.60,
+    },
+    PricingEntry {
+        models: &["o3-mini"],
+        input_per_mtok: 1.10,
+        output_per_mtok: 4.40,
+    },
+];
+
+const DEEPSEEK_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["deepseek-chat", "deepseek-v3"],
+        input_per_mtok: 0.27,
+        output_per_mtok: 1.10,
+    },
+    PricingEntry {
+        models: &["deepseek-reasoner", "deepseek-r1"],
+        input_per_mtok: 0.55,
+        output_per_mtok: 2.19,
+    },
+];
+
+const GOOGLE_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["gemini-2.5-flash"],
+        input_per_mtok: 0.15,
+        output_per_mtok: 0.60,
+    },
+    PricingEntry {
+        models: &["gemini-2.5-pro"],
+        input_per_mtok: 1.25,
+        output_per_mtok: 10.0,
+    },
+];
+
+const GROQ_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["llama-3.3-70b-versatile"],
+        input_per_mtok: 0.59,
+        output_per_mtok: 0.79,
+    },
+    PricingEntry {
+        models: &["llama-3.1-8b-instant"],
+        input_per_mtok: 0.05,
+        output_per_mtok: 0.08,
+    },
+];
+
+const MISTRAL_MODELS: &[PricingEntry] = &[
+    PricingEntry {
+        models: &["mistral-large-latest"],
+        input_per_mtok: 2.0,
+        output_per_mtok: 6.0,
+    },
+    PricingEntry {
+        models: &["mistral-small-latest"],
+        input_per_mtok: 0.10,
+        output_per_mtok: 0.30,
+    },
+];
+
+/// Provider name to pricing table mapping.
+struct ProviderPricing {
+    name: &'static str,
+    entries: &'static [PricingEntry],
+    cache_read_multiplier: f64,
+    cache_write_multiplier: f64,
+}
+
+const PROVIDERS: &[ProviderPricing] = &[
+    ProviderPricing {
+        name: "anthropic",
+        entries: ANTHROPIC_MODELS,
+        cache_read_multiplier: ANTHROPIC_CACHE_READ,
+        cache_write_multiplier: ANTHROPIC_CACHE_WRITE,
+    },
+    ProviderPricing {
+        name: "openai",
+        entries: OPENAI_MODELS,
+        cache_read_multiplier: 1.0,
+        cache_write_multiplier: 1.0,
+    },
+    ProviderPricing {
+        name: "deepseek",
+        entries: DEEPSEEK_MODELS,
+        cache_read_multiplier: 1.0,
+        cache_write_multiplier: 1.0,
+    },
+    ProviderPricing {
+        name: "google",
+        entries: GOOGLE_MODELS,
+        cache_read_multiplier: 1.0,
+        cache_write_multiplier: 1.0,
+    },
+    ProviderPricing {
+        name: "groq",
+        entries: GROQ_MODELS,
+        cache_read_multiplier: 1.0,
+        cache_write_multiplier: 1.0,
+    },
+    ProviderPricing {
+        name: "mistral",
+        entries: MISTRAL_MODELS,
+        cache_read_multiplier: 1.0,
+        cache_write_multiplier: 1.0,
+    },
+];
+
+/// Look up pricing for a (provider, model) pair.
+///
+/// Normalizes provider prefixes (e.g. `openrouter/anthropic/` routes to
+/// Anthropic pricing) and performs case-insensitive matching. Returns
+/// [`FALLBACK_PRICING`] for unknown models.
+pub fn get_pricing(provider: &str, model: &str) -> ModelPricing {
+    let provider_lower = provider.to_lowercase();
+    let model_lower = model.to_lowercase();
+
+    // Ollama / local models are always zero cost.
+    if provider_lower == "ollama" || provider_lower.starts_with("ollama/") {
+        return ZERO_PRICING;
+    }
+
+    // Resolve effective provider. For compound providers like "openrouter",
+    // try to extract the real provider from the model string (e.g.
+    // "anthropic/claude-sonnet-4.6" → provider "anthropic", model "claude-sonnet-4.6").
+    let (effective_provider, effective_model) =
+        resolve_provider_and_model(&provider_lower, &model_lower);
+
+    // Find the provider's pricing table.
+    if let Some(pp) = PROVIDERS.iter().find(|pp| pp.name == effective_provider)
+        && let Some(entry) = find_model_in_entries(pp.entries, effective_model)
+    {
+        return ModelPricing {
+            input_per_mtok: entry.input_per_mtok,
+            output_per_mtok: entry.output_per_mtok,
+            cache_read_multiplier: pp.cache_read_multiplier,
+            cache_write_multiplier: pp.cache_write_multiplier,
+        };
+    }
+
+    FALLBACK_PRICING
+}
+
+/// Estimate the cost of a single LLM call in USD.
+///
+/// Formula:
+/// ```text
+/// effective_input = input_tokens - cache_read
+/// cost = effective_input * input_rate
+///      + cache_read * (input_rate * cache_read_multiplier)
+///      + cache_write * (input_rate * cache_write_multiplier)
+///      + output_tokens * output_rate
+/// ```
+///
+/// All rates are per-million-token, so final result is divided by 1,000,000.
+pub fn estimate_call_cost(
+    pricing: &ModelPricing,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: Option<u64>,
+    cache_write_tokens: Option<u64>,
+) -> f64 {
+    let cache_read = cache_read_tokens.unwrap_or(0) as f64;
+    let cache_write = cache_write_tokens.unwrap_or(0) as f64;
+    let input = input_tokens as f64;
+    let output = output_tokens as f64;
+
+    let effective_input = (input - cache_read).max(0.0);
+
+    let cost = effective_input * pricing.input_per_mtok
+        + cache_read * (pricing.input_per_mtok * pricing.cache_read_multiplier)
+        + cache_write * (pricing.input_per_mtok * pricing.cache_write_multiplier)
+        + output * pricing.output_per_mtok;
+
+    cost / 1_000_000.0
+}
+
+/// Returns `true` if the pricing matches the fallback (unknown model).
+pub fn is_fallback_pricing(pricing: &ModelPricing) -> bool {
+    pricing.input_per_mtok == FALLBACK_PRICING.input_per_mtok
+        && pricing.output_per_mtok == FALLBACK_PRICING.output_per_mtok
+        && pricing.cache_read_multiplier == FALLBACK_PRICING.cache_read_multiplier
+        && pricing.cache_write_multiplier == FALLBACK_PRICING.cache_write_multiplier
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a compound provider string into (effective_provider, effective_model).
+///
+/// Examples:
+/// - ("openrouter", "anthropic/claude-sonnet-4.6") → ("anthropic", "claude-sonnet-4.6")
+/// - ("openrouter", "deepseek/deepseek-chat") → ("deepseek", "deepseek-chat")
+/// - ("anthropic", "claude-sonnet-4.6") → ("anthropic", "claude-sonnet-4.6")
+fn resolve_provider_and_model<'a>(provider: &'a str, model: &'a str) -> (&'a str, &'a str) {
+    // If the provider is a known direct provider, use it as-is.
+    if PROVIDERS.iter().any(|pp| pp.name == provider) {
+        return (provider, model);
+    }
+
+    // For compound providers (e.g. "openrouter"), try to extract the real
+    // provider from the model string: "anthropic/claude-sonnet-4.6".
+    if let Some(slash_pos) = model.find('/') {
+        let candidate_provider = &model[..slash_pos];
+        let remainder = &model[slash_pos + 1..];
+        if PROVIDERS.iter().any(|pp| pp.name == candidate_provider) {
+            return (candidate_provider, remainder);
+        }
+    }
+
+    // Try the last segment of the provider itself (e.g. "openrouter/anthropic").
+    if let Some(slash_pos) = provider.rfind('/') {
+        let last_segment = &provider[slash_pos + 1..];
+        if PROVIDERS.iter().any(|pp| pp.name == last_segment) {
+            return (last_segment, model);
+        }
+    }
+
+    (provider, model)
+}
+
+/// Find a model in a pricing table. Tries exact match first, then prefix match.
+fn find_model_in_entries<'a>(entries: &'a [PricingEntry], model: &str) -> Option<&'a PricingEntry> {
+    // Exact match.
+    for entry in entries {
+        for &name in entry.models {
+            if name == model {
+                return Some(entry);
+            }
+        }
+    }
+
+    // Prefix match: the model string starts with a known name.
+    // This handles versioned suffixes like "claude-sonnet-4-6-20250514" matching
+    // "claude-sonnet-4-6" and also dotted variants like "claude-sonnet-4.6".
+    //
+    // Sort candidates by length descending so longer (more specific) prefixes win.
+    let mut candidates: Vec<(&PricingEntry, &str)> = Vec::new();
+    for entry in entries {
+        for &name in entry.models {
+            if model.starts_with(name) {
+                candidates.push((entry, name));
+            }
+        }
+    }
+    candidates.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    if let Some((entry, _)) = candidates.first() {
+        return Some(entry);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_sonnet_46_basic_cost() {
+        let pricing = get_pricing("anthropic", "claude-sonnet-4-6");
+        assert_eq!(pricing.input_per_mtok, 3.0);
+        assert_eq!(pricing.output_per_mtok, 15.0);
+
+        let cost = estimate_call_cost(&pricing, 1000, 500, None, None);
+        // (1000 * 3.0 + 500 * 15.0) / 1_000_000 = (3000 + 7500) / 1_000_000 = 0.0000105
+        let expected = (1000.0 * 3.0 + 500.0 * 15.0) / 1_000_000.0;
+        assert!(
+            (cost - expected).abs() < 1e-12,
+            "cost={cost}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn full_four_component_cost_with_cache() {
+        let pricing = get_pricing("anthropic", "claude-sonnet-4-6");
+        let cost = estimate_call_cost(&pricing, 1000, 500, Some(500), Some(200));
+        // effective_input = 1000 - 500 = 500
+        // cost = 500 * 3.0                       (regular input)
+        //      + 500 * (3.0 * 0.1)               (cache read)
+        //      + 200 * (3.0 * 1.25)              (cache write)
+        //      + 500 * 15.0                       (output)
+        //      = 1500 + 150 + 750 + 7500 = 9900
+        // 9900 / 1_000_000 = 0.0000099
+        let expected = (500.0 * 3.0 + 500.0 * 0.3 + 200.0 * 3.75 + 500.0 * 15.0) / 1_000_000.0;
+        assert!(
+            (cost - expected).abs() < 1e-12,
+            "cost={cost}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn zero_tokens_zero_cost() {
+        let pricing = get_pricing("anthropic", "claude-sonnet-4-6");
+        let cost = estimate_call_cost(&pricing, 0, 0, None, None);
+        assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn unknown_model_returns_fallback() {
+        let pricing = get_pricing("unknown-provider", "some-custom-model");
+        assert!(is_fallback_pricing(&pricing));
+        assert_eq!(pricing.input_per_mtok, 1.0);
+        assert_eq!(pricing.output_per_mtok, 5.0);
+    }
+
+    #[test]
+    fn openrouter_prefix_resolves_to_anthropic() {
+        let pricing = get_pricing("openrouter", "anthropic/claude-sonnet-4.6");
+        assert_eq!(pricing.input_per_mtok, 3.0);
+        assert_eq!(pricing.output_per_mtok, 15.0);
+        assert_eq!(pricing.cache_read_multiplier, ANTHROPIC_CACHE_READ);
+        assert!(!is_fallback_pricing(&pricing));
+    }
+
+    #[test]
+    fn cache_read_none_treated_as_zero() {
+        let pricing = get_pricing("anthropic", "claude-sonnet-4-6");
+        let cost_none = estimate_call_cost(&pricing, 1000, 500, None, None);
+        let cost_zero = estimate_call_cost(&pricing, 1000, 500, Some(0), Some(0));
+        assert!((cost_none - cost_zero).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ollama_provider_zero_cost() {
+        let pricing = get_pricing("ollama", "llama3:latest");
+        assert_eq!(pricing.input_per_mtok, 0.0);
+        assert_eq!(pricing.output_per_mtok, 0.0);
+
+        let cost = estimate_call_cost(&pricing, 10000, 5000, None, None);
+        assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn known_anthropic_model_not_fallback() {
+        let pricing = get_pricing("anthropic", "claude-opus-4");
+        assert!(!is_fallback_pricing(&pricing));
+        assert_eq!(pricing.input_per_mtok, 15.0);
+        assert_eq!(pricing.output_per_mtok, 75.0);
+    }
+
+    #[test]
+    fn openrouter_deepseek_resolves() {
+        let pricing = get_pricing("openrouter", "deepseek/deepseek-v3");
+        assert_eq!(pricing.input_per_mtok, 0.27);
+        assert_eq!(pricing.output_per_mtok, 1.10);
+        assert!(!is_fallback_pricing(&pricing));
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        let pricing = get_pricing("Anthropic", "Claude-Sonnet-4-6");
+        assert_eq!(pricing.input_per_mtok, 3.0);
+        assert!(!is_fallback_pricing(&pricing));
+    }
+
+    #[test]
+    fn versioned_model_prefix_match() {
+        // A model string with a date suffix should still match.
+        let pricing = get_pricing("anthropic", "claude-haiku-4-5-20251022");
+        assert_eq!(pricing.input_per_mtok, 0.80);
+        assert_eq!(pricing.output_per_mtok, 4.0);
+    }
+
+    #[test]
+    fn google_gemini_flash() {
+        let pricing = get_pricing("google", "gemini-2.5-flash");
+        assert_eq!(pricing.input_per_mtok, 0.15);
+        assert_eq!(pricing.output_per_mtok, 0.60);
+        assert!(!is_fallback_pricing(&pricing));
+    }
+
+    #[test]
+    fn groq_llama_model() {
+        let pricing = get_pricing("groq", "llama-3.3-70b-versatile");
+        assert_eq!(pricing.input_per_mtok, 0.59);
+        assert_eq!(pricing.output_per_mtok, 0.79);
+    }
+
+    #[test]
+    fn mistral_models() {
+        let large = get_pricing("mistral", "mistral-large-latest");
+        assert_eq!(large.input_per_mtok, 2.0);
+        assert_eq!(large.output_per_mtok, 6.0);
+
+        let small = get_pricing("mistral", "mistral-small-latest");
+        assert_eq!(small.input_per_mtok, 0.10);
+        assert_eq!(small.output_per_mtok, 0.30);
+    }
+
+    #[test]
+    fn non_anthropic_cache_multipliers_are_one() {
+        let pricing = get_pricing("openai", "gpt-4o");
+        assert_eq!(pricing.cache_read_multiplier, 1.0);
+        assert_eq!(pricing.cache_write_multiplier, 1.0);
+    }
+}

--- a/crates/mika-agent/src/server/dashboard.rs
+++ b/crates/mika-agent/src/server/dashboard.rs
@@ -881,6 +881,36 @@ pub async fn handle_llm_calls(
     .into_response()
 }
 
+// ===== Cost Trend =====
+
+#[derive(Debug, Deserialize)]
+pub struct CostTrendQuery {
+    pub agent_id: Option<String>,
+    pub model: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub bucket: Option<String>,
+}
+
+/// GET /api/v1/llm-calls/cost-trend — cost over time aggregation.
+pub async fn handle_cost_trend(
+    State(state): State<AppState>,
+    Query(q): Query<CostTrendQuery>,
+) -> impl IntoResponse {
+    let filters = db::CostTrendFilters {
+        agent_id: q.agent_id,
+        model: q.model,
+        from: q.from,
+        to: q.to,
+        bucket: q.bucket,
+    };
+
+    match state.dashboard_db.query_cost_trend(filters).await {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => internal_error(e).into_response(),
+    }
+}
+
 // ===== Tool Calls =====
 
 #[derive(Debug, Deserialize)]

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -145,6 +145,7 @@ fn build_router(state: AppState) -> Router {
         )
         // Observability: LLM calls and tool calls
         .route("/llm-calls", get(dashboard::handle_llm_calls))
+        .route("/llm-calls/cost-trend", get(dashboard::handle_cost_trend))
         .route("/llm-calls/{id}", get(dashboard::handle_llm_call_detail))
         .route(
             "/llm-calls/{id}/tool-calls",

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -24,6 +24,8 @@ This Dashboard is currently undergoing the first of three ecosystem-wide design 
 
 Event Timeline, Agents, Sessions, Traces, Tasks (+ detail), Team Runs, LLM Calls (+ detail), Tool Calls (+ detail), Dev Runs (+ detail). Auth via `VITE_MIKA_DASHBOARD_TOKEN` env var. Bearer token. Imports shared components from `@senara-solutions/ui`. All list pages expose `<TimeRangeFilter />` with URL-reflected `?from=...&to=...` state (mika#659).
 
+**LLM Calls page (mika#660):** `<CostTrendChart>` time-series visualization above the table, showing estimated cost over time aggregated from `llm_calls` token counts. Two variants: total (single line) and stacked-by-agent. Uses recharts. Backed by `GET /api/v1/llm-calls/cost-trend` with auto-bucketing (hourly <3d, daily ≥3d). Server defaults to last 24h when no `from` param. Pricing is estimated server-side via `crates/mika-agent/src/pricing.rs`.
+
 **Agent Detail page (mika#656):** Tabbed Core Memory panel with three views — Sections (expandable blocks with `<TokenBudgetBar />` thresholds and per-section timestamps), Facts (paginated structured facts from people/commitments/preferences/events tables), and History (core memory edit audit trail filtered to `update_core_memory` events). Facts served via `GET /api/v1/agents/:id/facts`. Structured content (WORKFLOWS JSON) auto-detected and rendered as definition lists; non-JSON rendered via `<MarkdownContent />`.
 
 ## `packages/ui/`

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "^7.6.3"
+    "react-router": "^7.6.3",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/dashboard/src/api/llmCalls.ts
+++ b/dashboard/src/api/llmCalls.ts
@@ -73,3 +73,37 @@ export function useLlmCallToolCalls(llmCallId: string | undefined) {
     enabled: !!llmCallId,
   })
 }
+
+// Cost trend types and hook
+
+export interface CostTrendBucket {
+  timestamp: string
+  cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  call_count: number
+  agent_id: string | null
+}
+
+export interface CostTrendResponse {
+  buckets: CostTrendBucket[]
+  bucket_size: string
+  has_estimated_pricing: boolean
+  estimated_models: string[]
+}
+
+export interface CostTrendFilters {
+  agent_id?: string
+  model?: string
+  from?: string
+  to?: string
+  bucket?: string
+}
+
+export function useCostTrend(filters: CostTrendFilters) {
+  return useQuery<CostTrendResponse>({
+    queryKey: ['cost-trend', filters],
+    queryFn: () =>
+      apiFetch('/llm-calls/cost-trend', filters as Record<string, string | undefined>),
+  })
+}

--- a/dashboard/src/components/CostTrendChart.test.tsx
+++ b/dashboard/src/components/CostTrendChart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import CostTrendChart, { type CostTrendBucket } from './CostTrendChart.tsx'
+import CostTrendChart, { type CostTrendBucket, type ChartVariant } from './CostTrendChart.tsx'
 
 // Mock recharts to avoid rendering issues in jsdom
 vi.mock('recharts', () => ({
@@ -19,76 +19,57 @@ const mockBuckets: CostTrendBucket[] = [
   { timestamp: '2026-05-05T11:00:00Z', cost_usd: 0.35, input_tokens: 120000, output_tokens: 6000, call_count: 4, agent_id: 'mika-dev' },
 ]
 
+function renderChart(overrides: Partial<{
+  data: CostTrendBucket[] | undefined
+  variant: ChartVariant
+  onVariantChange: (v: ChartVariant) => void
+  bucketSize: string
+  isLoading: boolean
+  error: Error | null
+  onRetry: () => void
+  hasEstimatedPricing: boolean
+  defaultRange: string
+}> = {}) {
+  const defaults = {
+    data: mockBuckets,
+    variant: 'total' as ChartVariant,
+    onVariantChange: vi.fn(),
+    bucketSize: 'hour',
+    isLoading: false,
+    error: null,
+    onRetry: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<CostTrendChart {...defaults} />), ...defaults }
+}
+
 describe('CostTrendChart', () => {
   it('renders chart with data in total variant', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
+    renderChart()
     expect(screen.getByTestId('area-chart')).toBeTruthy()
     expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
     expect(screen.getByText('Cost Trend')).toBeTruthy()
   })
 
   it('renders stacked areas per agent in agent variant', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
-    // Switch to agent variant
-    fireEvent.click(screen.getByText('By Agent'))
+    renderChart({ variant: 'agent' })
     expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
     expect(screen.getByTestId('area-mika-qa')).toBeTruthy()
   })
 
   it('renders EmptyState when data is empty', () => {
-    render(
-      <CostTrendChart
-        data={[]}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
+    renderChart({ data: [] })
     expect(screen.getByText('No cost data for this time range')).toBeTruthy()
   })
 
   it('renders LoadingState when loading', () => {
-    render(
-      <CostTrendChart
-        data={undefined}
-        bucketSize="hour"
-        isLoading={true}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
-    // LoadingState renders skeleton elements with aria-label
+    renderChart({ data: undefined, isLoading: true })
     expect(screen.getByLabelText(/loading/i)).toBeTruthy()
   })
 
   it('renders ErrorState with retry on error', () => {
     const onRetry = vi.fn()
-    render(
-      <CostTrendChart
-        data={undefined}
-        bucketSize="hour"
-        isLoading={false}
-        error={new Error('Network error')}
-        onRetry={onRetry}
-      />
-    )
+    renderChart({ data: undefined, error: new Error('Network error'), onRetry })
     const retryButton = screen.getByText('Retry')
     expect(retryButton).toBeTruthy()
     fireEvent.click(retryButton)
@@ -99,78 +80,33 @@ describe('CostTrendChart', () => {
     const single: CostTrendBucket[] = [
       { timestamp: '2026-05-05T10:00:00Z', cost_usd: 0.42, input_tokens: 150000, output_tokens: 8000, call_count: 5, agent_id: 'mika-dev' },
     ]
-    render(
-      <CostTrendChart
-        data={single}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
+    renderChart({ data: single })
     expect(screen.getByTestId('area-chart')).toBeTruthy()
   })
 
-  it('toggles between total and agent variants', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
-    // Initially total mode
-    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+  it('calls onVariantChange when toggling variants', () => {
+    const onVariantChange = vi.fn()
+    renderChart({ variant: 'total', onVariantChange })
 
-    // Switch to agent
     fireEvent.click(screen.getByText('By Agent'))
-    expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
+    expect(onVariantChange).toHaveBeenCalledWith('agent')
 
-    // Switch back to total
     fireEvent.click(screen.getByText('Total'))
-    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+    expect(onVariantChange).toHaveBeenCalledWith('total')
   })
 
   it('shows estimated pricing footnote', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-        hasEstimatedPricing={true}
-      />
-    )
+    renderChart({ hasEstimatedPricing: true })
     expect(screen.getByText(/estimated from token counts/i)).toBeTruthy()
   })
 
   it('shows default range label when provided', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-        defaultRange="last 24 hours"
-      />
-    )
+    renderChart({ defaultRange: 'last 24 hours' })
     expect(screen.getByText('Showing last 24 hours')).toBeTruthy()
   })
 
   it('renders accessible data table for screen readers', () => {
-    render(
-      <CostTrendChart
-        data={mockBuckets}
-        bucketSize="hour"
-        isLoading={false}
-        error={null}
-        onRetry={() => {}}
-      />
-    )
+    renderChart()
     expect(screen.getByLabelText('Cost trend data')).toBeTruthy()
   })
 })

--- a/dashboard/src/components/CostTrendChart.test.tsx
+++ b/dashboard/src/components/CostTrendChart.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CostTrendChart, { type CostTrendBucket } from './CostTrendChart.tsx'
+
+// Mock recharts to avoid rendering issues in jsdom
+vi.mock('recharts', () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: ({ dataKey, name }: { dataKey: string; name?: string }) => <div data-testid={`area-${dataKey}`} data-name={name} />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+}))
+
+const mockBuckets: CostTrendBucket[] = [
+  { timestamp: '2026-05-05T10:00:00Z', cost_usd: 0.42, input_tokens: 150000, output_tokens: 8000, call_count: 5, agent_id: 'mika-dev' },
+  { timestamp: '2026-05-05T10:00:00Z', cost_usd: 0.07, input_tokens: 20000, output_tokens: 2000, call_count: 2, agent_id: 'mika-qa' },
+  { timestamp: '2026-05-05T11:00:00Z', cost_usd: 0.35, input_tokens: 120000, output_tokens: 6000, call_count: 4, agent_id: 'mika-dev' },
+]
+
+describe('CostTrendChart', () => {
+  it('renders chart with data in total variant', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    expect(screen.getByTestId('area-chart')).toBeTruthy()
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+    expect(screen.getByText('Cost Trend')).toBeTruthy()
+  })
+
+  it('renders stacked areas per agent in agent variant', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    // Switch to agent variant
+    fireEvent.click(screen.getByText('By Agent'))
+    expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
+    expect(screen.getByTestId('area-mika-qa')).toBeTruthy()
+  })
+
+  it('renders EmptyState when data is empty', () => {
+    render(
+      <CostTrendChart
+        data={[]}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    expect(screen.getByText('No cost data for this time range')).toBeTruthy()
+  })
+
+  it('renders LoadingState when loading', () => {
+    render(
+      <CostTrendChart
+        data={undefined}
+        bucketSize="hour"
+        isLoading={true}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    // LoadingState renders skeleton elements with aria-label
+    expect(screen.getByLabelText(/loading/i)).toBeTruthy()
+  })
+
+  it('renders ErrorState with retry on error', () => {
+    const onRetry = vi.fn()
+    render(
+      <CostTrendChart
+        data={undefined}
+        bucketSize="hour"
+        isLoading={false}
+        error={new Error('Network error')}
+        onRetry={onRetry}
+      />
+    )
+    const retryButton = screen.getByText('Retry')
+    expect(retryButton).toBeTruthy()
+    fireEvent.click(retryButton)
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it('renders single bucket without crash', () => {
+    const single: CostTrendBucket[] = [
+      { timestamp: '2026-05-05T10:00:00Z', cost_usd: 0.42, input_tokens: 150000, output_tokens: 8000, call_count: 5, agent_id: 'mika-dev' },
+    ]
+    render(
+      <CostTrendChart
+        data={single}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    expect(screen.getByTestId('area-chart')).toBeTruthy()
+  })
+
+  it('toggles between total and agent variants', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    // Initially total mode
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+
+    // Switch to agent
+    fireEvent.click(screen.getByText('By Agent'))
+    expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
+
+    // Switch back to total
+    fireEvent.click(screen.getByText('Total'))
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+  })
+
+  it('shows estimated pricing footnote', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+        hasEstimatedPricing={true}
+      />
+    )
+    expect(screen.getByText(/estimated from token counts/i)).toBeTruthy()
+  })
+
+  it('shows default range label when provided', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+        defaultRange="last 24 hours"
+      />
+    )
+    expect(screen.getByText('Showing last 24 hours')).toBeTruthy()
+  })
+
+  it('renders accessible data table for screen readers', () => {
+    render(
+      <CostTrendChart
+        data={mockBuckets}
+        bucketSize="hour"
+        isLoading={false}
+        error={null}
+        onRetry={() => {}}
+      />
+    )
+    expect(screen.getByLabelText('Cost trend data')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/CostTrendChart.tsx
+++ b/dashboard/src/components/CostTrendChart.tsx
@@ -1,0 +1,378 @@
+import { useMemo, useState } from 'react'
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts'
+import { LoadingState, ErrorState, EmptyState, formatApiError } from '@senara-solutions/ui'
+
+export interface CostTrendBucket {
+  timestamp: string
+  cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  call_count: number
+  agent_id: string | null
+}
+
+interface CostTrendChartProps {
+  data: CostTrendBucket[] | undefined
+  bucketSize: string
+  isLoading: boolean
+  error: Error | null
+  onRetry: () => void
+  hasEstimatedPricing?: boolean
+  defaultRange?: string
+}
+
+/**
+ * Deterministic hex color palette for chart series.
+ * Mirrors the hue order of agentColors.ts (blue, emerald, purple, amber, pink,
+ * cyan, orange, indigo, rose, teal) but as hex values for recharts fills.
+ */
+const CHART_PALETTE = [
+  '#60a5fa', // blue-400
+  '#34d399', // emerald-400
+  '#a78bfa', // purple-400
+  '#fbbf24', // amber-400
+  '#f472b6', // pink-400
+  '#22d3ee', // cyan-400
+  '#fb923c', // orange-400
+  '#818cf8', // indigo-400
+  '#fb7185', // rose-400
+  '#2dd4bf', // teal-400
+]
+
+function hashString(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = ((hash << 5) - hash + char) | 0
+  }
+  return Math.abs(hash)
+}
+
+function getAgentHex(agentName: string): string {
+  return CHART_PALETTE[hashString(agentName) % CHART_PALETTE.length]
+}
+
+/** Primary accent color for total cost line. */
+const ACCENT = '#7c6af7'
+
+function formatXAxis(ts: string, bucketSize: string): string {
+  try {
+    const d = new Date(ts)
+    if (bucketSize === 'hour') {
+      return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    }
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  } catch {
+    return ts.slice(0, 10)
+  }
+}
+
+function formatCost(v: number): string {
+  if (v >= 1) return `$${v.toFixed(2)}`
+  if (v >= 0.01) return `$${v.toFixed(3)}`
+  if (v >= 0.001) return `$${v.toFixed(4)}`
+  if (v === 0) return '$0.00'
+  return `$${v.toExponential(1)}`
+}
+
+function formatTokensCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+interface TooltipEntry {
+  name: string
+  value: number
+  color: string
+}
+
+function CustomTooltip({ active, payload, label, bucketSize }: {
+  active?: boolean
+  payload?: TooltipEntry[]
+  label?: string
+  bucketSize: string
+}) {
+  if (!active || !payload?.length) return null
+
+  const totalCost = payload.reduce((sum, entry) => sum + (entry.value || 0), 0)
+
+  return (
+    <div className="bg-bg-card border border-white/[0.08] rounded-lg px-3 py-2 shadow-lg">
+      <p className="text-xs text-muted/60 mb-1">
+        {label ? formatXAxis(String(label), bucketSize) : ''}
+      </p>
+      {payload.length === 1 ? (
+        <p className="text-sm text-heading font-medium">{formatCost(payload[0].value)}</p>
+      ) : (
+        <>
+          <p className="text-sm text-heading font-medium mb-1">{formatCost(totalCost)} total</p>
+          <div className="space-y-0.5">
+            {payload.map((entry) => (
+              <div key={entry.name} className="flex items-center gap-2 text-xs">
+                <span
+                  className="w-2 h-2 rounded-full shrink-0"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="text-muted">{entry.name}</span>
+                <span className="text-muted/60 ml-auto">{formatCost(entry.value)}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+type ChartVariant = 'total' | 'agent'
+
+export default function CostTrendChart({
+  data,
+  bucketSize,
+  isLoading,
+  error,
+  onRetry,
+  hasEstimatedPricing,
+  defaultRange,
+}: CostTrendChartProps) {
+  const [variant, setVariant] = useState<ChartVariant>('total')
+
+  // Transform data for recharts
+  const { chartData, agentIds } = useMemo(() => {
+    if (!data?.length) return { chartData: [], agentIds: [] as string[] }
+
+    if (variant === 'total') {
+      // Aggregate across agents per timestamp
+      const byTimestamp = new Map<string, { cost_usd: number; input_tokens: number; output_tokens: number; call_count: number }>()
+      for (const b of data) {
+        const existing = byTimestamp.get(b.timestamp)
+        if (existing) {
+          existing.cost_usd += b.cost_usd
+          existing.input_tokens += b.input_tokens
+          existing.output_tokens += b.output_tokens
+          existing.call_count += b.call_count
+        } else {
+          byTimestamp.set(b.timestamp, {
+            cost_usd: b.cost_usd,
+            input_tokens: b.input_tokens,
+            output_tokens: b.output_tokens,
+            call_count: b.call_count,
+          })
+        }
+      }
+      return {
+        chartData: Array.from(byTimestamp.entries()).map(([ts, v]) => ({
+          timestamp: ts,
+          cost_usd: v.cost_usd,
+          input_tokens: v.input_tokens,
+          output_tokens: v.output_tokens,
+          call_count: v.call_count,
+        })),
+        agentIds: [] as string[],
+      }
+    }
+
+    // Stacked by agent: pivot to { timestamp, agent1: cost, agent2: cost, ... }
+    const agents = new Set<string>()
+    const byTimestamp = new Map<string, Record<string, number>>()
+    for (const b of data) {
+      const agentKey = b.agent_id ?? 'unknown'
+      agents.add(agentKey)
+      const existing = byTimestamp.get(b.timestamp) ?? {}
+      existing[agentKey] = (existing[agentKey] ?? 0) + b.cost_usd
+      byTimestamp.set(b.timestamp, existing)
+    }
+
+    const sortedAgents = Array.from(agents).sort()
+    return {
+      chartData: Array.from(byTimestamp.entries()).map(([ts, costs]) => ({
+        timestamp: ts,
+        ...costs,
+      })),
+      agentIds: sortedAgents,
+    }
+  }, [data, variant])
+
+  const hasData = chartData.length > 0
+
+  return (
+    <div className="bg-bg-card rounded-xl p-6 mb-4" role="img" aria-label={`Cost trend chart showing ${bucketSize}ly cost data`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h3 className="text-heading text-sm font-semibold">Cost Trend</h3>
+          {defaultRange && (
+            <p className="text-[10px] text-muted/40 mt-0.5">Showing {defaultRange}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1 bg-bg rounded-lg p-0.5">
+          <button
+            onClick={() => setVariant('total')}
+            className={`px-3 py-1 rounded-md text-xs transition-colors ${
+              variant === 'total'
+                ? 'bg-accent/15 text-accent-light font-medium'
+                : 'text-muted/60 hover:text-muted'
+            }`}
+          >
+            Total
+          </button>
+          <button
+            onClick={() => setVariant('agent')}
+            className={`px-3 py-1 rounded-md text-xs transition-colors ${
+              variant === 'agent'
+                ? 'bg-accent/15 text-accent-light font-medium'
+                : 'text-muted/60 hover:text-muted'
+            }`}
+          >
+            By Agent
+          </button>
+        </div>
+      </div>
+
+      {/* Chart body */}
+      {isLoading ? (
+        <div className="h-[200px] flex items-center justify-center">
+          <LoadingState variant="list" rows={3} />
+        </div>
+      ) : error ? (
+        <div className="h-[200px] flex items-center justify-center">
+          <ErrorState message={formatApiError(error)} retry={onRetry} />
+        </div>
+      ) : !hasData ? (
+        <div className="h-[200px] flex items-center justify-center">
+          <EmptyState message="No cost data for this time range" />
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <defs>
+              {variant === 'total' ? (
+                <linearGradient id="costGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={ACCENT} stopOpacity={0.3} />
+                  <stop offset="100%" stopColor={ACCENT} stopOpacity={0} />
+                </linearGradient>
+              ) : (
+                agentIds.map((id) => (
+                  <linearGradient key={id} id={`gradient-${id}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={getAgentHex(id)} stopOpacity={0.3} />
+                    <stop offset="100%" stopColor={getAgentHex(id)} stopOpacity={0.05} />
+                  </linearGradient>
+                ))
+              )}
+            </defs>
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(v) => formatXAxis(v, bucketSize)}
+              tick={{ fill: '#a0a8b8', fontSize: 10 }}
+              axisLine={false}
+              tickLine={false}
+              minTickGap={40}
+            />
+            <YAxis
+              tickFormatter={(v) => formatCost(v)}
+              tick={{ fill: '#a0a8b8', fontSize: 10 }}
+              axisLine={false}
+              tickLine={false}
+              width={55}
+            />
+            <Tooltip
+              content={<CustomTooltip bucketSize={bucketSize} />}
+              cursor={{ stroke: '#a0a8b8', strokeOpacity: 0.2 }}
+            />
+            {variant === 'total' ? (
+              <Area
+                type="monotone"
+                dataKey="cost_usd"
+                stroke={ACCENT}
+                strokeWidth={2}
+                fill="url(#costGradient)"
+                dot={chartData.length === 1}
+                name="Cost"
+              />
+            ) : (
+              agentIds.map((id) => (
+                <Area
+                  key={id}
+                  type="monotone"
+                  dataKey={id}
+                  stackId="agents"
+                  stroke={getAgentHex(id)}
+                  strokeWidth={1.5}
+                  fill={`url(#gradient-${id})`}
+                  name={id}
+                />
+              ))
+            )}
+            {variant === 'agent' && agentIds.length > 1 && (
+              <Legend
+                iconType="circle"
+                iconSize={8}
+                wrapperStyle={{ fontSize: 11, color: '#a0a8b8', paddingTop: 8 }}
+              />
+            )}
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+
+      {/* Footnotes */}
+      {hasEstimatedPricing && hasData && (
+        <p className="text-[10px] text-muted/30 mt-2">
+          Cost is estimated from token counts. Some models use approximate pricing.
+        </p>
+      )}
+
+      {/* Screen reader data table */}
+      {hasData && (
+        <table className="sr-only" aria-label="Cost trend data">
+          <thead>
+            <tr>
+              <th>Time</th>
+              {variant === 'total' ? (
+                <>
+                  <th>Cost (USD)</th>
+                  <th>Input tokens</th>
+                  <th>Output tokens</th>
+                  <th>Calls</th>
+                </>
+              ) : (
+                agentIds.map((id) => <th key={id}>{id} cost (USD)</th>)
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {chartData.map((row, i) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const r = row as any
+              return (
+                <tr key={i}>
+                  <td>{row.timestamp}</td>
+                  {variant === 'total' ? (
+                    <>
+                      <td>{formatCost(r.cost_usd ?? 0)}</td>
+                      <td>{formatTokensCompact(r.input_tokens ?? 0)}</td>
+                      <td>{formatTokensCompact(r.output_tokens ?? 0)}</td>
+                      <td>{r.call_count ?? 0}</td>
+                    </>
+                  ) : (
+                    agentIds.map((id) => (
+                      <td key={id}>{formatCost(r[id] ?? 0)}</td>
+                    ))
+                  )}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/CostTrendChart.tsx
+++ b/dashboard/src/components/CostTrendChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
   AreaChart,
   Area,
@@ -19,8 +19,12 @@ export interface CostTrendBucket {
   agent_id: string | null
 }
 
+export type ChartVariant = 'total' | 'agent'
+
 interface CostTrendChartProps {
   data: CostTrendBucket[] | undefined
+  variant: ChartVariant
+  onVariantChange: (variant: ChartVariant) => void
   bucketSize: string
   isLoading: boolean
   error: Error | null
@@ -133,10 +137,10 @@ function CustomTooltip({ active, payload, label, bucketSize }: {
   )
 }
 
-type ChartVariant = 'total' | 'agent'
-
 export default function CostTrendChart({
   data,
+  variant,
+  onVariantChange,
   bucketSize,
   isLoading,
   error,
@@ -144,7 +148,6 @@ export default function CostTrendChart({
   hasEstimatedPricing,
   defaultRange,
 }: CostTrendChartProps) {
-  const [variant, setVariant] = useState<ChartVariant>('total')
 
   // Transform data for recharts
   const { chartData, agentIds } = useMemo(() => {
@@ -216,7 +219,7 @@ export default function CostTrendChart({
         </div>
         <div className="flex items-center gap-1 bg-bg rounded-lg p-0.5">
           <button
-            onClick={() => setVariant('total')}
+            onClick={() => onVariantChange('total')}
             className={`px-3 py-1 rounded-md text-xs transition-colors ${
               variant === 'total'
                 ? 'bg-accent/15 text-accent-light font-medium'
@@ -226,7 +229,7 @@ export default function CostTrendChart({
             Total
           </button>
           <button
-            onClick={() => setVariant('agent')}
+            onClick={() => onVariantChange('agent')}
             className={`px-3 py-1 rounded-md text-xs transition-colors ${
               variant === 'agent'
                 ? 'bg-accent/15 text-accent-light font-medium'

--- a/dashboard/src/pages/LlmCalls.test.tsx
+++ b/dashboard/src/pages/LlmCalls.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import LlmCalls from './LlmCalls.tsx'
+
+// Mock recharts to avoid rendering issues in jsdom
+vi.mock('recharts', () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: ({ dataKey }: { dataKey: string }) => <div data-testid={`area-${dataKey}`} />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+}))
+
+const mockCostTrendData = {
+  buckets: [
+    { timestamp: '2026-05-05T10:00:00Z', cost_usd: 0.42, input_tokens: 150000, output_tokens: 8000, call_count: 5, agent_id: 'mika-dev' },
+    { timestamp: '2026-05-05T11:00:00Z', cost_usd: 0.35, input_tokens: 120000, output_tokens: 6000, call_count: 4, agent_id: 'mika-dev' },
+  ],
+  bucket_size: 'hour',
+  has_estimated_pricing: false,
+  estimated_models: [],
+}
+
+const mockLlmCallsData = {
+  data: [],
+  total: 0,
+  page: 1,
+  per_page: 50,
+}
+
+// Track which query keys were used
+const queryFnCalls: Array<{ queryKey: unknown[] }> = []
+
+vi.mock('../api/llmCalls.ts', () => ({
+  useLlmCalls: () => ({
+    data: mockLlmCallsData,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useCostTrend: (filters: Record<string, unknown>) => {
+    queryFnCalls.push({ queryKey: ['cost-trend', filters] })
+    return {
+      data: mockCostTrendData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    }
+  },
+}))
+
+vi.mock('../api/agents.ts', () => ({
+  useAgents: () => ({ data: ['mika-dev', 'mika-qa'] }),
+}))
+
+function renderPage(initialEntries: string[] = ['/llm-calls']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <LlmCalls />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('LlmCalls page — CostTrendChart integration', () => {
+  beforeEach(() => {
+    queryFnCalls.length = 0
+  })
+
+  it('renders the cost trend chart on the page', () => {
+    renderPage()
+    expect(screen.getByText('Cost Trend')).toBeTruthy()
+    expect(screen.getByTestId('area-chart')).toBeTruthy()
+  })
+
+  it('defaults to total variant when no chart URL param', () => {
+    renderPage()
+    // Total variant renders a single area with dataKey="cost_usd"
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+  })
+
+  it('reads agent variant from chart URL param', () => {
+    renderPage(['/llm-calls?chart=agent'])
+    // Agent variant renders per-agent areas
+    expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
+  })
+
+  it('variant toggle updates URL param', () => {
+    renderPage()
+    // Initially total
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+
+    // Click "By Agent" — switches to agent variant
+    fireEvent.click(screen.getByText('By Agent'))
+    expect(screen.getByTestId('area-mika-dev')).toBeTruthy()
+
+    // Click "Total" — switches back
+    fireEvent.click(screen.getByText('Total'))
+    expect(screen.getByTestId('area-cost_usd')).toBeTruthy()
+  })
+
+  it('propagates filter state from page to chart', () => {
+    renderPage(['/llm-calls?agent_id=mika-dev&from=2026-05-01T00:00:00Z&to=2026-05-05T00:00:00Z'])
+    // The useCostTrend mock captures the filters passed to it
+    const costCall = queryFnCalls.find(c =>
+      JSON.stringify(c.queryKey).includes('cost-trend'),
+    )
+    expect(costCall).toBeTruthy()
+    const filters = costCall!.queryKey[1] as Record<string, unknown>
+    expect(filters.agent_id).toBe('mika-dev')
+    expect(filters.from).toBe('2026-05-01T00:00:00Z')
+    expect(filters.to).toBe('2026-05-05T00:00:00Z')
+  })
+
+  it('propagates undefined filters when no URL params set', () => {
+    renderPage()
+    const costCall = queryFnCalls.find(c =>
+      JSON.stringify(c.queryKey).includes('cost-trend'),
+    )
+    expect(costCall).toBeTruthy()
+    const filters = costCall!.queryKey[1] as Record<string, unknown>
+    expect(filters.agent_id).toBeUndefined()
+    expect(filters.from).toBeUndefined()
+    expect(filters.to).toBeUndefined()
+  })
+
+  it('shows default range label when no from param', () => {
+    renderPage()
+    expect(screen.getByText('Showing last 24 hours')).toBeTruthy()
+  })
+
+  it('does not show default range label when from param is set', () => {
+    renderPage(['/llm-calls?from=2026-05-01T00:00:00Z'])
+    expect(screen.queryByText('Showing last 24 hours')).toBeNull()
+  })
+})

--- a/dashboard/src/pages/LlmCalls.tsx
+++ b/dashboard/src/pages/LlmCalls.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Link, useNavigate } from 'react-router'
 import { useLlmCalls, useCostTrend, type LlmCallsFilters, type CostTrendFilters } from '../api/llmCalls.ts'
 import { useAgents } from '../api/agents.ts'
@@ -43,18 +42,11 @@ export default function LlmCalls() {
   const { data, isLoading, error, refetch } = useLlmCalls(filters)
   const { data: agents } = useAgents()
 
-  // Cost trend chart: defaults to last 24h when no time range is set.
-  // Memoize the default "from" to avoid calling Date.now() during render (React purity).
-  const chartDefaultFrom = useMemo(
-    () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
-    // Re-compute when the user sets/clears the from filter
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filters.from],
-  )
+  // Cost trend chart: the server defaults to last 24h when no `from` is provided.
   const costTrendFilters: CostTrendFilters = {
     agent_id: filters.agent_id,
     model: filters.model,
-    from: filters.from ?? chartDefaultFrom,
+    from: filters.from,
     to: filters.to,
   }
   const { data: costTrend, isLoading: costLoading, error: costError, refetch: costRefetch } = useCostTrend(costTrendFilters)

--- a/dashboard/src/pages/LlmCalls.tsx
+++ b/dashboard/src/pages/LlmCalls.tsx
@@ -1,10 +1,12 @@
+import { useMemo } from 'react'
 import { Link, useNavigate } from 'react-router'
-import { useLlmCalls, type LlmCallsFilters } from '../api/llmCalls.ts'
+import { useLlmCalls, useCostTrend, type LlmCallsFilters, type CostTrendFilters } from '../api/llmCalls.ts'
 import { useAgents } from '../api/agents.ts'
 import { Pagination, EmptyState, LoadingState, ErrorState, formatApiError, StatusBadge, ListRow, AgentFilter, TimeRangeFilter, formatTimestamp } from '@senara-solutions/ui'
 import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import { useSearchParamsFilter } from '../hooks/useSearchParamsFilter.ts'
 import { Search } from 'lucide-react'
+import CostTrendChart from '../components/CostTrendChart.tsx'
 
 function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
@@ -40,6 +42,22 @@ export default function LlmCalls() {
 
   const { data, isLoading, error, refetch } = useLlmCalls(filters)
   const { data: agents } = useAgents()
+
+  // Cost trend chart: defaults to last 24h when no time range is set.
+  // Memoize the default "from" to avoid calling Date.now() during render (React purity).
+  const chartDefaultFrom = useMemo(
+    () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    // Re-compute when the user sets/clears the from filter
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filters.from],
+  )
+  const costTrendFilters: CostTrendFilters = {
+    agent_id: filters.agent_id,
+    model: filters.model,
+    from: filters.from ?? chartDefaultFrom,
+    to: filters.to,
+  }
+  const { data: costTrend, isLoading: costLoading, error: costError, refetch: costRefetch } = useCostTrend(costTrendFilters)
 
   return (
     <div>
@@ -89,6 +107,17 @@ export default function LlmCalls() {
           )}
         </div>
       </div>
+
+      {/* Cost Trend Chart */}
+      <CostTrendChart
+        data={costTrend?.buckets}
+        bucketSize={costTrend?.bucket_size ?? 'hour'}
+        isLoading={costLoading}
+        error={costError}
+        onRetry={() => costRefetch()}
+        hasEstimatedPricing={costTrend?.has_estimated_pricing}
+        defaultRange={!filters.from ? 'last 24 hours' : undefined}
+      />
 
       {/* Table */}
       {isLoading ? (

--- a/dashboard/src/pages/LlmCalls.tsx
+++ b/dashboard/src/pages/LlmCalls.tsx
@@ -5,7 +5,7 @@ import { Pagination, EmptyState, LoadingState, ErrorState, formatApiError, Statu
 import type { StatusBadgeVariant } from '@senara-solutions/ui'
 import { useSearchParamsFilter } from '../hooks/useSearchParamsFilter.ts'
 import { Search } from 'lucide-react'
-import CostTrendChart from '../components/CostTrendChart.tsx'
+import CostTrendChart, { type ChartVariant } from '../components/CostTrendChart.tsx'
 
 function llmStatusVariant(status: string): { variant: StatusBadgeVariant; label: string } {
   switch (status) {
@@ -41,6 +41,19 @@ export default function LlmCalls() {
 
   const { data, isLoading, error, refetch } = useLlmCalls(filters)
   const { data: agents } = useAgents()
+
+  // Chart variant from URL param (default: total)
+  const chartVariantParam = searchParams.get('chart')
+  const chartVariant: ChartVariant = chartVariantParam === 'agent' ? 'agent' : 'total'
+  const setChartVariant = (v: ChartVariant) => {
+    const next = new URLSearchParams(searchParams)
+    if (v === 'total') {
+      next.delete('chart')
+    } else {
+      next.set('chart', v)
+    }
+    setSearchParams(next)
+  }
 
   // Cost trend chart: the server defaults to last 24h when no `from` is provided.
   const costTrendFilters: CostTrendFilters = {
@@ -103,6 +116,8 @@ export default function LlmCalls() {
       {/* Cost Trend Chart */}
       <CostTrendChart
         data={costTrend?.buckets}
+        variant={chartVariant}
+        onVariantChange={setChartVariant}
         bucketSize={costTrend?.bucket_size ?? 'hour'}
         isLoading={costLoading}
         error={costError}

--- a/docs/plans/2026-05-05-007-feat-dashboard-cost-trend-chart-plan.md
+++ b/docs/plans/2026-05-05-007-feat-dashboard-cost-trend-chart-plan.md
@@ -144,7 +144,7 @@ AgentFilter ────(agent_id URL param)────►      │
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add pricing module (Rust)**
+- [x] **Unit 1: Add pricing module (Rust)**
 
 **Goal:** Create a production pricing module that computes estimated LLM call cost from token counts and model identity.
 
@@ -183,7 +183,7 @@ AgentFilter ────(agent_id URL param)────►      │
 
 ---
 
-- [ ] **Unit 2: Add cost-trend aggregation query (Rust DB layer)**
+- [x] **Unit 2: Add cost-trend aggregation query (Rust DB layer)**
 
 **Goal:** Add a SQL aggregation query that returns cost-over-time buckets from the `llm_calls` table, with the pricing module applied per-row.
 
@@ -226,7 +226,7 @@ AgentFilter ────(agent_id URL param)────►      │
 
 ---
 
-- [ ] **Unit 3: Add cost-trend HTTP endpoint (Rust server)**
+- [x] **Unit 3: Add cost-trend HTTP endpoint (Rust server)**
 
 **Goal:** Wire the cost-trend query into an Axum handler at `GET /api/v1/llm-calls/cost-trend`.
 
@@ -258,7 +258,7 @@ AgentFilter ────(agent_id URL param)────►      │
 
 ---
 
-- [ ] **Unit 4: Add recharts dependency and CostTrendChart component (Frontend)**
+- [x] **Unit 4: Add recharts dependency and CostTrendChart component (Frontend)**
 
 **Goal:** Create the `<CostTrendChart>` React component with single-line and stacked-by-agent variants, styled for Midnight Obsidian.
 
@@ -307,7 +307,7 @@ AgentFilter ────(agent_id URL param)────►      │
 
 ---
 
-- [ ] **Unit 5: Add cost-trend API hook and integrate on LLM Calls page (Frontend)**
+- [x] **Unit 5: Add cost-trend API hook and integrate on LLM Calls page (Frontend)**
 
 **Goal:** Wire the chart into the LLM Calls page with data fetching and filter integration.
 

--- a/docs/plans/2026-05-05-007-feat-dashboard-cost-trend-chart-plan.md
+++ b/docs/plans/2026-05-05-007-feat-dashboard-cost-trend-chart-plan.md
@@ -1,0 +1,369 @@
+---
+title: "feat: Add CostTrendChart time-series visualization to dashboard"
+type: feat
+status: active
+date: 2026-05-05
+issue: 660
+---
+
+# feat: Add CostTrendChart time-series visualization to dashboard
+
+## Overview
+
+Add the first time-series chart to the Mika observability dashboard — a `<CostTrendChart>` component that visualizes LLM API cost over time, aggregated from the `llm_calls` SQLite table. The chart supports two variants: single-line (total cost) and stacked-by-agent. This is the lead deliverable for the (C) Hybrid stance decided in #660: 2-3 charts that earn their pixels, not full Grafana.
+
+## Problem Frame
+
+The dashboard is entirely table-based. For an observability platform, cost-over-time trends are the highest-signal chart — they answer "am I spending more or less than usual?" at a glance, which tables cannot. The same chart shape will be reused later for tool-failure-rate-over-time (separate ticket).
+
+## Requirements Trace
+
+- R1. Render a cost-over-time line chart on the LLM Calls page
+- R2. Support two variants: single-line (total) and stacked-by-agent
+- R3. Aggregate cost server-side from `llm_calls` token counts with model pricing
+- R4. Account for cache tokens (cache_read at ~10% input rate, cache_write at ~125%)
+- R5. Auto-select time bucket granularity (hourly for <3d, daily for ≥3d)
+- R6. Integrate with existing `<TimeRangeFilter>` and `<AgentFilter>` URL params
+- R7. Follow Luminescent Core / Midnight Obsidian design system
+- R8. Use lifecycle state primitives (`LoadingState`, `ErrorState`, `EmptyState`) from `@senara-solutions/ui`
+- R9. Provide ARIA-accessible data fallback
+
+## Scope Boundaries
+
+- **Out of scope:** Token-totals chart, latency p50/p95/p99, agent activity heatmap, dev-run outcome trend (per issue decision)
+- **Out of scope:** New "Overview" landing page — chart integrates on the existing LLM Calls page
+- **Out of scope:** Real-time polling / auto-refresh — chart follows existing stale-time pattern
+- **Out of scope:** Design system rulebook extension for chart grammar — the rulebook is owned by Vincent and updated via direct commits; this PR applies existing token vocabulary to charts
+
+### Deferred to Separate Tasks
+
+- Tool-failure-rate-over-time chart: reuses the same chart shape, file separately
+- Comprehensive model pricing database: initial implementation covers major providers with a generous fallback; expanding to all models is iterative
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/server/dashboard.rs` — handler pattern: `Query<T>` deserialization → `resolve_pagination` → filters struct → `state.dashboard_db.<method>().await` → `Json(response)`
+- `crates/mika-agent/src/db.rs` — `LlmCallRow` (line ~456), `LlmCallFilters` (line ~505), `llm_calls` CREATE TABLE (line ~1439)
+- `crates/mika-agent/src/async_db.rs` — `AsyncDatabase` closure-based dispatch pattern
+- `dashboard/src/api/client.ts` — `apiFetch<T>(path, params)` with auth token injection
+- `dashboard/src/api/llmCalls.ts` — existing `useLlmCalls` hook pattern
+- `dashboard/src/pages/LlmCalls.tsx` — target page for chart integration
+- `packages/ui/src/components/TimeRangeFilter.tsx` — ISO 8601 emission, URL-state friendly
+- `packages/ui/src/utils/agentColors.ts` — stable agent color mapping
+- `packages/ui/src/theme.css` — design tokens (bg: `#0d0f12`, card: `#151820`, accent: `#7c6af7`, muted: `#a0a8b8`)
+- Index: `idx_llm_calls_agent_created ON llm_calls(agent_id, created_at)` — usable for filtered queries
+
+### Institutional Learnings
+
+- **SQLite datetime format** (`docs/solutions/database-issues/sqlite-datetime-format-mismatch.md`): Use `substr(created_at, 1, N)` for bucketing, not `strftime()`, to avoid the `T` vs space format mismatch
+- **Dashboard time-range filter pattern** (`docs/solutions/best-practices/dashboard-time-range-filter-full-stack-pattern-2026-04-27.md`): `from`/`to` as ISO 8601 TEXT, lexicographic WHERE comparison
+- **DB scoping** (`docs/solutions/656-core-memory-actionable-dashboard-patterns.md`): Use `state.dashboard_db` for cross-agent queries — the cost-trend endpoint is cross-agent by nature
+- **Column selection** (`docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md`): Use explicit column selection in aggregation queries, not `SELECT *`
+- **Filter primitives** (`docs/solutions/655-filter-primitives-unification.md`): Never hand-roll filters; use `@senara-solutions/ui` primitives
+
+### External References
+
+- [recharts documentation](https://recharts.org/en-US/) — React charting library, composable, dark-theme friendly
+- Anthropic cache pricing: cache_read at 10% of input rate, cache_write at 125% of input rate
+
+## Key Technical Decisions
+
+- **Server-side cost computation**: Cost computed in the Rust aggregation query, not client-side. Single source of truth for pricing, no pricing data shipped to browser. Backend returns `cost_usd` per bucket.
+- **Pricing module placement**: New `crates/mika-agent/src/pricing.rs` module with a `ModelPricing` struct and `estimate_cost()` function. Covers major Anthropic, OpenAI, DeepSeek, Google, Mistral, and Groq models. Unknown models use a conservative fallback ($1.00/$5.00 per MTok). The response signals which models used fallback pricing.
+- **Cache token handling**: Full 4-component cost formula: `(input_tokens - cache_read_tokens) * input_rate + cache_read_tokens * (input_rate * 0.1) + cache_write_tokens * (input_rate * 1.25) + output_tokens * output_rate`. Provider-specific multipliers where known.
+- **recharts as charting library**: Added to `dashboard/package.json`. Chosen for: React-native composable API, good dark theme support via props, tree-shakeable, no separate CSS. ~55KB gzipped for AreaChart/LineChart. Alternatives (visx, d3, lightweight-charts) rejected: visx requires more boilerplate for basic charts; d3 is not React-native; lightweight-charts is finance-focused.
+- **Chart on LLM Calls page, not a new page**: Avoids adding a new route/nav item for a single chart. The chart sits in a card above the table. Natural home — cost is a property of LLM calls.
+- **Auto-bucket server-side**: The backend computes bucket granularity from the `from`/`to` span. `<3 days → hourly`, `≥3 days → daily`. Response includes `bucket_size` so the frontend can label the x-axis. Client may override with `bucket=hour|day`.
+- **Chart default time range**: When `from` is unset, the chart endpoint defaults to last 24 hours. This is independent of the table filter (table continues to show all data paginated). A subtle label on the chart indicates the effective range.
+- **Non-paginated response**: The cost-trend endpoint returns a flat array (not `PaginatedResponse<T>`). Time-series data is pre-aggregated; bucket counts are bounded by the time range (max ~720 hourly buckets for 30 days).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does the pricing table live?** → New `crates/mika-agent/src/pricing.rs` production module. The test-only `cost.rs` in `tests/eval/` is not suitable for runtime use.
+- **How should cache tokens factor into cost?** → Full 4-component formula with provider-specific multipliers. Labeled "estimated" since pricing evolves.
+- **Should the chart auto-refresh?** → No. Follows existing TanStack React Query stale-time pattern. Users can manually refresh.
+- **Agent names vs IDs in legend?** → Use `agent_id` directly — already human-readable in this system (e.g., `mika-dev`, `mika-qa`).
+- **Single data point rendering?** → recharts handles single points fine (renders a dot). The tooltip still works.
+
+### Deferred to Implementation
+
+- Exact set of models in the pricing table — expand iteratively based on providers observed in real data
+- Whether a compound SQL index is needed for stacked-by-agent performance — test with real data volume first; existing `idx_llm_calls_agent_created` may suffice
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    LLM Calls Page                                │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Filter Bar: [AgentFilter] [ModelFilter] [TimeRange] [...]│  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ CostTrendChart Card                                       │  │
+│  │  ┌─ header: "Cost Trend" + variant toggle ──────────────┐│  │
+│  │  │ [Total ▪] [By Agent ▪]                               ││  │
+│  │  ├──────────────────────────────────────────────────────┤│  │
+│  │  │          ╱\                                          ││  │
+│  │  │        ╱    \      ╱──\                              ││  │
+│  │  │  ──╱\/        ╲╱╱      \──                           ││  │
+│  │  │  Mon   Tue   Wed   Thu   Fri                         ││  │
+│  │  └──────────────────────────────────────────────────────┘│  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Existing LLM Calls Table                                  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Data flow:**
+
+```
+TimeRangeFilter ──(from/to URL params)──► useCostTrend hook
+AgentFilter ────(agent_id URL param)────►      │
+                                                ▼
+                                    GET /api/v1/llm-calls/cost-trend
+                                           ?from=...&to=...&agent_id=...
+                                                │
+                                                ▼
+                                    dashboard.rs handler
+                                    → db.rs: query_cost_trend()
+                                    → pricing.rs: estimate_cost()
+                                                │
+                                                ▼
+                                    { buckets: [...], bucket_size, pricing_info }
+                                                │
+                                                ▼
+                                    <CostTrendChart data={...} variant="total|agent" />
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add pricing module (Rust)**
+
+**Goal:** Create a production pricing module that computes estimated LLM call cost from token counts and model identity.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `crates/mika-agent/src/pricing.rs`
+- Modify: `crates/mika-agent/src/lib.rs` (add `pub mod pricing;`)
+- Test: `crates/mika-agent/src/pricing.rs` (inline `#[cfg(test)] mod tests`)
+
+**Approach:**
+- `ModelPricing` struct: `input_per_mtok`, `output_per_mtok`, `cache_read_multiplier` (default 0.1), `cache_write_multiplier` (default 1.25)
+- `get_pricing(provider: &str, model: &str) -> ModelPricing` — lookup by `(provider, model)` with normalization (strip provider prefixes, case-insensitive). Returns `FALLBACK_PRICING` for unknown models.
+- `estimate_call_cost(pricing: &ModelPricing, input_tokens: u64, output_tokens: u64, cache_read_tokens: Option<u64>, cache_write_tokens: Option<u64>) -> f64` — the 4-component formula
+- Cover Anthropic (Opus 4, Sonnet 4/4.6, Haiku 4.5), OpenAI (GPT-4o, GPT-4o-mini, o3-mini), DeepSeek (v3, R1), Google (Gemini 2.5 Flash/Pro), Groq (Llama 3.x), Mistral (Large, Small). Ollama/local models get zero cost.
+- `FALLBACK_PRICING`: `$1.00/$5.00` per MTok. `is_fallback_pricing()` helper for frontend signaling.
+
+**Patterns to follow:**
+- `crates/mika-agent/tests/eval/kg_provider_eval/cost.rs` for the lookup pattern (but this is the production version with full coverage)
+- Standalone module pattern like `crates/mika-agent/src/timestamp.rs`
+
+**Test scenarios:**
+- Happy path: Anthropic Sonnet 4.6 with known pricing returns expected cost
+- Happy path: Full 4-component cost with cache tokens returns correct amount
+- Edge case: Zero tokens returns $0.00
+- Edge case: Unknown model returns fallback pricing and `is_fallback_pricing` is true
+- Edge case: Provider prefix normalization — `openrouter/anthropic/claude-sonnet-4.6` resolves to Anthropic pricing
+- Edge case: cache_read_tokens = None treated as 0
+- Edge case: Ollama/local provider returns zero cost
+
+**Verification:**
+- `cargo test -p mika-agent pricing` passes
+- `cargo clippy` clean
+
+---
+
+- [ ] **Unit 2: Add cost-trend aggregation query (Rust DB layer)**
+
+**Goal:** Add a SQL aggregation query that returns cost-over-time buckets from the `llm_calls` table, with the pricing module applied per-row.
+
+**Requirements:** R3, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs` (add `CostTrendBucket`, `CostTrendFilters`, `query_cost_trend()`)
+- Modify: `crates/mika-agent/src/async_db.rs` (add async wrapper `query_cost_trend()`)
+- Test: `crates/mika-agent/src/db.rs` (inline tests)
+
+**Approach:**
+- `CostTrendFilters`: `agent_id: Option<String>`, `model: Option<String>`, `from: Option<String>`, `to: Option<String>`, `bucket: Option<String>` (hour/day/auto, default auto)
+- SQL query selects: `substr(created_at, 1, 13) || ':00:00Z'` for hourly buckets, `substr(created_at, 1, 10) || 'T00:00:00Z'` for daily. GROUP BY bucket, agent_id. Returns raw token columns per group.
+- Rust-side post-processing: apply `pricing::estimate_call_cost()` per row, aggregate into `CostTrendBucket` structs
+- `CostTrendBucket`: `timestamp: String`, `cost_usd: f64`, `input_tokens: u64`, `output_tokens: u64`, `call_count: u64`, `agent_id: Option<String>` (None for total mode)
+- `CostTrendResponse`: `buckets: Vec<CostTrendBucket>`, `bucket_size: String`, `has_estimated_pricing: bool`, `estimated_models: Vec<String>`
+- Auto-bucket logic: if `from` and `to` span < 3 days → hourly; otherwise → daily. If no `from`, default to `now - 24h`.
+- Use `dashboard_db` (cross-agent), not per-agent DB
+- Explicit column selection: only `created_at, agent_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens`
+
+**Patterns to follow:**
+- `query_llm_calls()` in `db.rs` for the WHERE clause construction pattern with optional filters
+- `query_timeline()` for the non-paginated response pattern
+
+**Test scenarios:**
+- Happy path: 3 rows across 2 hourly buckets → 2 buckets with correct aggregated cost
+- Happy path: Stacked by agent — 2 agents in same bucket → 2 rows per bucket
+- Edge case: No rows matching filters → empty buckets array
+- Edge case: Auto-bucket selects hourly for 2-day range, daily for 7-day range
+- Edge case: No `from` → defaults to last 24h
+- Edge case: `from` without `to` → `to` defaults to now
+- Edge case: Unknown model in data → `has_estimated_pricing: true`, model listed in `estimated_models`
+- Integration: `substr()` bucketing produces valid ISO 8601 timestamps
+
+**Verification:**
+- `cargo test -p mika-agent` passes (DB tests)
+- Query returns correct aggregation against test data
+
+---
+
+- [ ] **Unit 3: Add cost-trend HTTP endpoint (Rust server)**
+
+**Goal:** Wire the cost-trend query into an Axum handler at `GET /api/v1/llm-calls/cost-trend`.
+
+**Requirements:** R3, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/dashboard.rs` (add `CostTrendQuery`, `handle_cost_trend()`)
+- Modify: `crates/mika-agent/src/server/mod.rs` (add route `.route("/llm-calls/cost-trend", get(dashboard::handle_cost_trend))`)
+
+**Approach:**
+- `CostTrendQuery` deserializes: `agent_id`, `model`, `from`, `to`, `bucket`
+- Handler builds `CostTrendFilters`, calls `state.dashboard_db.query_cost_trend()`, returns `Json(CostTrendResponse)`
+- Route must be registered BEFORE the `/llm-calls/{id}` wildcard route to avoid path conflict
+
+**Patterns to follow:**
+- `handle_llm_calls()` handler pattern in `dashboard.rs`
+- Route ordering precedent: "Static route MUST come before wildcard" comment in `mod.rs`
+
+**Test scenarios:**
+- Happy path: GET with `from`/`to` returns JSON with `buckets` array and `bucket_size`
+- Edge case: No query params → defaults applied (last 24h, auto bucket)
+- Error path: DB error returns 500 with error message
+
+**Verification:**
+- `cargo build` succeeds
+- Route is accessible (verified in integration or manual test)
+
+---
+
+- [ ] **Unit 4: Add recharts dependency and CostTrendChart component (Frontend)**
+
+**Goal:** Create the `<CostTrendChart>` React component with single-line and stacked-by-agent variants, styled for Midnight Obsidian.
+
+**Requirements:** R1, R2, R7, R8, R9
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `dashboard/package.json` (add `recharts` dependency)
+- Create: `dashboard/src/components/CostTrendChart.tsx`
+- Create: `dashboard/src/components/CostTrendChart.test.tsx`
+
+**Approach:**
+- Add `recharts` to `dashboard/package.json` dependencies
+- Component props: `data: CostTrendBucket[]`, `variant: 'total' | 'agent'`, `bucketSize: string`, `isLoading: boolean`, `error: Error | null`, `onRetry: () => void`, `hasEstimatedPricing?: boolean`
+- **Total variant**: `<AreaChart>` with single area using `accent` color (`#7c6af7`), gradient fill fading to transparent
+- **Agent variant**: `<AreaChart>` with stacked areas, one per unique `agent_id`, colors from `agentColors` utility
+- Tooltip: dark-themed custom tooltip showing timestamp, cost formatted as `$X.XX`, token counts
+- X-axis: formatted timestamps (hour or date based on `bucketSize`)
+- Y-axis: cost in USD with `$` prefix
+- Card wrapper: `bg-bg-card rounded-xl p-6` (no 1px borders per luminescent-core "No-Line Rule")
+- Header: "Cost Trend" title with variant toggle (two small buttons)
+- Lifecycle states: `isLoading ? <LoadingState variant="list" /> : error ? <ErrorState ... /> : empty ? <EmptyState ... /> : chart`
+- Estimated pricing footnote when `hasEstimatedPricing` is true
+- ARIA: `role="img"` with `aria-label` describing the data range; hidden `<table>` for screen readers
+
+**Patterns to follow:**
+- `packages/ui/src/theme.css` design tokens for colors
+- `packages/ui/src/utils/agentColors.ts` for agent color mapping
+- Lifecycle state pattern from `packages/ui/CLAUDE.md`
+
+**Test scenarios:**
+- Happy path: Renders AreaChart with data in total variant
+- Happy path: Renders stacked areas per agent in agent variant
+- Edge case: Empty data array renders `<EmptyState>`
+- Edge case: Loading state renders `<LoadingState>`
+- Edge case: Error state renders `<ErrorState>` with retry button
+- Edge case: Single bucket renders without crash
+- Happy path: Variant toggle switches between total and agent views
+- Happy path: Estimated pricing footnote visible when `hasEstimatedPricing` is true
+
+**Verification:**
+- `npm run test --prefix dashboard` passes
+- Component renders in dev server without errors
+- Chart uses design system colors, not default recharts palette
+
+---
+
+- [ ] **Unit 5: Add cost-trend API hook and integrate on LLM Calls page (Frontend)**
+
+**Goal:** Wire the chart into the LLM Calls page with data fetching and filter integration.
+
+**Requirements:** R1, R6, R8
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `dashboard/src/api/llmCalls.ts` (add `CostTrendResponse`, `CostTrendBucket`, `useCostTrend` hook)
+- Modify: `dashboard/src/pages/LlmCalls.tsx` (add chart above table)
+
+**Approach:**
+- `useCostTrend(filters: { agent_id?, model?, from?, to? })` — `useQuery` wrapping `apiFetch('/llm-calls/cost-trend', filters)` with query key `['cost-trend', filters]`
+- Chart reads `from`/`to`/`agent_id` from existing URL search params (same source as the table)
+- Chart variant state stored in URL param `chart` (`total` | `agent`, default `total`)
+- Chart card placed between the filter bar and the table
+- When no `from` param is set, the chart query passes `from` as 24h ago (chart-specific default), while the table query remains unfiltered
+
+**Patterns to follow:**
+- `useLlmCalls` hook pattern in `dashboard/src/api/llmCalls.ts`
+- `useSearchParamsFilter` hook for URL-state management
+- Page composition pattern from existing list pages
+
+**Test scenarios:**
+- Happy path: LLM Calls page renders chart above table
+- Happy path: Changing time range filter updates both chart and table
+- Happy path: Selecting an agent filters chart data
+- Edge case: No `from` param → chart defaults to 24h, table shows all
+- Happy path: Chart variant toggle persists in URL param
+
+**Verification:**
+- LLM Calls page loads with chart visible in dev server
+- Filters control both chart and table
+- URL reflects chart variant state
+
+## System-Wide Impact
+
+- **Interaction graph:** Chart data flows through the same `dashboard_db` connection as existing list queries. The periodic WAL checkpoint (every 60s) ensures fresh data. No new write paths.
+- **Error propagation:** Chart fetch failures are isolated to the chart card — the table continues to work independently (separate `useQuery`). `<ErrorState>` with retry.
+- **State lifecycle risks:** None — chart is read-only, no mutations. The `useCostTrend` query is independent of the `useLlmCalls` pagination query.
+- **API surface parity:** The new endpoint follows the same auth pattern (dashboard or internal token). It does not affect existing endpoints.
+- **Unchanged invariants:** Existing `/api/v1/llm-calls` endpoint, `LlmCallRow` type, `LlmCallFilters`, and all other dashboard pages are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| recharts bundle size (~55KB gzip) increases dashboard load | Tree-shake via Vite; only import AreaChart, XAxis, YAxis, Tooltip, ResponsiveContainer — not the full library |
+| Pricing estimates diverge from actual provider billing | Label as "estimated cost"; surface `has_estimated_pricing` flag; expand pricing table iteratively |
+| SQLite `substr()` bucketing performance on large datasets | Existing `idx_llm_calls_agent_created` index covers agent-filtered queries; unfiltered queries over 100K+ rows may need a dedicated index — defer until measured |
+| Route ordering conflict: `/llm-calls/cost-trend` vs `/llm-calls/{id}` | Register the static route before the wildcard, following the existing precedent in `mod.rs` |
+
+## Sources & References
+
+- Related issue: #660
+- Related milestone: #13 (Dashboard improvements)
+- Stitch designs: project `6562713725762717689`, screens `5b65fb5f76dd4edaa3e4e72a9c00ee13` and `2443ccdf05d44295ade2f7c17574d7c3`
+- Design system: `docs/design/luminescent-core.md`, `docs/design/north-star.md`
+- Pricing reference: Anthropic API pricing page, OpenAI API pricing page

--- a/docs/solutions/660-dashboard-cost-trend-chart-time-series.md
+++ b/docs/solutions/660-dashboard-cost-trend-chart-time-series.md
@@ -1,0 +1,76 @@
+---
+module: dashboard
+tags: [chart, time-series, recharts, cost, pricing, llm-calls, aggregation, sqlite]
+problem_type: feature
+category: dashboard
+date: 2026-05-05
+issue: 660
+---
+
+# Dashboard Cost Trend Chart — Time-Series Visualization
+
+## Problem
+
+The Mika observability dashboard was entirely table-based with zero charts. For an operator monitoring LLM API spend, cost-over-time trends are the highest-signal visualization — they answer "am I spending more or less than usual?" at a glance, which tables cannot.
+
+## Solution
+
+Added a `<CostTrendChart>` component to the LLM Calls page with:
+
+### Backend (Rust)
+
+1. **Pricing module** (`crates/mika-agent/src/pricing.rs`): Server-side cost estimation from token counts using a per-provider/model pricing table. Covers Anthropic, OpenAI, DeepSeek, Google, Groq, Mistral, and Ollama (zero-cost). 4-component cost formula accounting for cache read tokens (10% input rate for Anthropic) and cache write tokens (125% input rate).
+
+2. **Aggregation endpoint** (`GET /api/v1/llm-calls/cost-trend`): SQL query groups `llm_calls` by time bucket + agent_id + provider + model, then applies pricing per row in Rust. Returns `CostTrendResponse` with pre-aggregated buckets, bucket size, and estimated-pricing metadata.
+
+3. **Auto-bucketing**: Server determines granularity from the from/to span: hourly for <3 days, daily for >=3 days. Defaults to last 24h when no `from` param.
+
+### Frontend (React + TypeScript)
+
+4. **CostTrendChart component** (`dashboard/src/components/CostTrendChart.tsx`): recharts `<AreaChart>` with two variants:
+   - **Total**: Single accent-colored area with gradient fill
+   - **By Agent**: Stacked areas with deterministic agent color palette
+
+5. **Integration**: Chart sits above the table on the LLM Calls page, sharing the same `from`/`to`/`agent_id` URL params as the table filter.
+
+## Key Patterns
+
+### SQLite Time-Bucket Aggregation
+
+Use `substr()` instead of `strftime()` for bucketing ISO 8601 timestamps stored as TEXT:
+
+```sql
+-- Hourly: substr(created_at, 1, 13) || ':00:00Z'  → "2026-05-05T10:00:00Z"
+-- Daily:  substr(created_at, 1, 10) || 'T00:00:00Z' → "2026-05-05T00:00:00Z"
+```
+
+This avoids the `T` vs space format mismatch with SQLite's `strftime()` function (see `docs/solutions/database-issues/sqlite-datetime-format-mismatch.md`).
+
+### Server-Side Cost Computation
+
+Cost is computed server-side, not client-side, because:
+- Single source of truth for pricing data
+- No pricing tables shipped to the browser
+- Backend can signal which models used fallback pricing (`has_estimated_pricing`)
+- Aggregation at the SQL+Rust layer keeps response payloads small (buckets, not raw rows)
+
+### Non-Paginated Response for Time-Series
+
+The cost-trend endpoint returns a flat `CostTrendResponse` (not `PaginatedResponse<T>`) because time-series data is pre-aggregated — bucket counts are bounded by the time range (max ~720 hourly buckets for 30 days).
+
+### Route Ordering for Static vs Wildcard
+
+`/llm-calls/cost-trend` must be registered BEFORE `/llm-calls/{id}` in `mod.rs` to avoid the wildcard capturing "cost-trend" as an ID parameter. This follows the existing precedent documented in the route registration code.
+
+## Pitfalls
+
+1. **Agent key erasure bug**: Initially, the aggregation query erased `agent_id` to `None` when an `agent_id` filter was active, causing the "By Agent" chart to show all costs as "unknown". Fix: always preserve `agent_id` in the bucket key — let the frontend decide whether to show the toggle.
+
+2. **React purity with Date.now()**: Computing a default `from` using `Date.now()` inside render violates React's purity rule (eslint `react-hooks/purity`). Fix: let the server handle the default — the endpoint already defaults to 24h when `from` is omitted.
+
+3. **recharts + dark theme**: recharts doesn't natively consume CSS custom properties. Chart colors must be hardcoded hex values matching the design system tokens, not Tailwind classes. The chart palette (`CHART_PALETTE`) mirrors the hue order of `agentColors.ts` but as hex values.
+
+## Dependencies
+
+- `recharts` added to `dashboard/package.json` — first charting library in the dashboard
+- No Rust dependency changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router": "^7.6.3"
+        "react-router": "^7.6.3",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -158,6 +159,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -507,6 +509,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -530,6 +533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1429,6 +1433,42 @@
         "resolve": "~1.22.2"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.6.tgz",
+      "integrity": "sha512-uwrF08UBQfxk49i9WcUeCx045wjB1zXEHNJmbYHPVVspxmjwSeWCoKbB8DEIvs3XkBJV6lcRAyLaWJ2+u3MMCw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1933,6 +1973,18 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2293,8 +2345,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2351,6 +2402,69 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -2429,6 +2543,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2447,6 +2562,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2494,6 +2615,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -2993,6 +3115,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3083,7 +3206,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3200,6 +3322,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3362,6 +3485,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3462,6 +3594,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -3505,6 +3758,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -3584,8 +3843,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -3627,6 +3885,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -3698,6 +3966,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3960,6 +4229,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4338,6 +4613,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4390,6 +4675,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -5026,7 +5320,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6241,7 +6534,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6257,7 +6549,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6307,6 +6598,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6316,6 +6608,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6327,7 +6620,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -6358,6 +6650,30 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -6366,6 +6682,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {
@@ -6380,6 +6726,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -6458,6 +6820,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6495,6 +6863,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6790,7 +7159,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -6805,6 +7175,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -6965,6 +7341,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7149,6 +7526,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -7177,12 +7563,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7551,6 +7960,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- Add the first time-series chart to the Mika observability dashboard — a `<CostTrendChart>` component showing LLM API cost over time
- New server-side pricing module (`pricing.rs`) with per-provider/model cost estimation covering Anthropic, OpenAI, DeepSeek, Google, Groq, Mistral, and Ollama
- New `GET /api/v1/llm-calls/cost-trend` aggregation endpoint with auto-bucketing (hourly <3d, daily ≥3d)
- Two chart variants: total cost (single accent line) and stacked-by-agent
- Integrated on the LLM Calls page above the existing table, sharing filter state via URL params

Closes #660

Plan: docs/plans/2026-05-05-007-feat-dashboard-cost-trend-chart-plan.md

## Key decisions

- **Server-side cost computation**: Pricing estimated in Rust, not shipped to browser. Response signals fallback pricing.
- **4-component cost formula**: Accounts for cache read (10% input rate) and cache write (125%) tokens
- **recharts**: First charting library in the dashboard (~55KB gzip). Tree-shaken via Vite.
- **No new page**: Chart lives on the existing LLM Calls page in a card above the table

## Test plan

- [x] 15 Rust pricing module tests (all providers, cache tokens, normalization, edge cases)
- [x] 10 React component tests (variants, loading/error/empty states, toggle, ARIA)
- [x] All 42 dashboard tests pass
- [x] `cargo check` + `cargo clippy` clean
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [x] lefthook pre-commit hooks pass (fmt, clippy, lint, typecheck, secrets, large files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)