### PR TITLE
feat(dashboard): task tree visualization on Dev Runs detail (#661)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -411,7 +411,7 @@ Axum-based with two auth layers: mutation endpoints require `MIKA_INTERNAL_TOKEN
 
 **Mutation endpoints:** `/message` (202 async, 10MB limit), `/tasks/{id}/complete` (200 sync, 100KB cap), `/tasks/{id}/cancel` (200 sync), `/api/v1/rewind/*`, `/a2a/*`.
 
-**Dashboard API:** `/api/v1/*` — timeline, agents, sessions, messages, traces, investigate, tasks (+ detail/children/sessions), team-runs (+ summary), llm-calls (+ detail), tool-calls (+ detail), dev-runs (+ detail), github proxy endpoints. CORS scoped to `MIKA_CORS_ORIGIN`.
+**Dashboard API:** `/api/v1/*` — timeline, agents, sessions, messages, traces, investigate, tasks (+ detail/children/descendants/sessions), team-runs (+ summary), llm-calls (+ detail), tool-calls (+ detail), dev-runs (+ detail), github proxy endpoints. CORS scoped to `MIKA_CORS_ORIGIN`.
 
 **Time-range filtering (#659):** All list endpoints (timeline, sessions, llm-calls, tool-calls, team-runs, tasks, dev-runs) accept `from`/`to` ISO 8601 string query params for server-side filtering against the surface's primary timestamp column (`created_at` or `started_at`). String comparison is correct because ISO 8601 ordering matches chronological ordering. Frontend emits via `<TimeRangeFilter />` from `@senara-solutions/ui`.
 

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -529,6 +529,11 @@ impl AsyncDatabase {
         self.with_db(move |db| db.get_child_tasks(&p)).await
     }
 
+    pub async fn get_task_descendants(&self, root_task_id: &str) -> Result<Vec<Task>> {
+        let r = root_task_id.to_owned();
+        self.with_db(move |db| db.get_task_descendants(&r)).await
+    }
+
     pub async fn has_active_callback_tasks_excluding(
         &self,
         excluded_parent_id: &str,

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -5095,6 +5095,31 @@ impl Database {
         Ok(rows)
     }
 
+    /// Get all descendant tasks for a given root task (recursive).
+    /// Returns all tasks in the subtree below root_task_id, excluding the root itself.
+    /// No agent_id filter — team task trees have children with different agent_ids.
+    /// Depth guard (depth <= 3) mirrors the CHECK constraint as defense-in-depth.
+    pub fn get_task_descendants(&self, root_task_id: &str) -> Result<Vec<Task>> {
+        let sql = format!(
+            "WITH RECURSIVE descendant_ids(id) AS (
+                 SELECT id FROM tasks WHERE parent_task_id = ?1
+                 UNION ALL
+                 SELECT t.id FROM tasks t
+                 JOIN descendant_ids d ON t.parent_task_id = d.id
+                 WHERE t.depth <= 3
+             )
+             SELECT {cols} FROM tasks
+             WHERE id IN (SELECT id FROM descendant_ids)
+             ORDER BY created_at ASC",
+            cols = Self::TASK_COLUMNS,
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params![root_task_id], Self::row_to_task)?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(rows)
+    }
+
     /// Check if any active callback tasks exist for a task OTHER than the excluded one.
     ///
     /// Returns `Some((parent_task_id, callback_task_id))` if an active callback task exists
@@ -8081,20 +8106,15 @@ impl Database {
         Ok(count as u64)
     }
 
-    /// Get all sessions linked to a task tree (the given task + its direct children).
+    /// Get all sessions linked to a task tree (the given task + all descendants).
     /// Returns sessions where `task_id` (or legacy `json_extract(metadata, '$.task_id')`)
     /// matches any task ID in the tree. Includes message count for display.
     pub fn get_sessions_for_task_tree(&self, root_task_id: &str) -> Result<Vec<TaskSessionRow>> {
-        // Collect all task IDs in the tree: root + direct children
+        // Collect all task IDs in the tree: root + all descendants
         let mut task_ids = vec![root_task_id.to_string()];
         {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT id FROM tasks WHERE parent_task_id = ?1")?;
-            let children: Vec<String> = stmt
-                .query_map(params![root_task_id], |r| r.get(0))?
-                .collect::<rusqlite::Result<_>>()?;
-            task_ids.extend(children);
+            let descendants = self.get_task_descendants(root_task_id)?;
+            task_ids.extend(descendants.into_iter().map(|t| t.id));
         }
 
         let placeholders: String = (1..=task_ids.len())
@@ -9806,6 +9826,102 @@ mod tests {
     }
 
     #[test]
+    fn test_get_task_descendants_three_levels() {
+        let db = db();
+        let root_id = db.create_task(&make_task("root")).unwrap();
+
+        let mut child = make_task("child");
+        child.parent_task_id = Some(root_id.clone());
+        child.depth = 1;
+        let child_id = db.create_task(&child).unwrap();
+
+        let mut grandchild = make_task("grandchild");
+        grandchild.parent_task_id = Some(child_id.clone());
+        grandchild.depth = 2;
+        let grandchild_id = db.create_task(&grandchild).unwrap();
+
+        let mut great_grandchild = make_task("great-grandchild");
+        great_grandchild.parent_task_id = Some(grandchild_id.clone());
+        great_grandchild.depth = 3;
+        db.create_task(&great_grandchild).unwrap();
+
+        let descendants = db.get_task_descendants(&root_id).unwrap();
+        assert_eq!(descendants.len(), 3);
+        // Verify all descendants are present (ordering depends on created_at which may be identical)
+        let labels: Vec<&str> = descendants.iter().map(|t| t.label.as_str()).collect();
+        assert!(labels.contains(&"child"));
+        assert!(labels.contains(&"grandchild"));
+        assert!(labels.contains(&"great-grandchild"));
+    }
+
+    #[test]
+    fn test_get_task_descendants_excludes_root() {
+        let db = db();
+        let root_id = db.create_task(&make_task("root")).unwrap();
+
+        let mut child = make_task("child");
+        child.parent_task_id = Some(root_id.clone());
+        child.depth = 1;
+        db.create_task(&child).unwrap();
+
+        let descendants = db.get_task_descendants(&root_id).unwrap();
+        assert_eq!(descendants.len(), 1);
+        assert!(descendants.iter().all(|t| t.id != root_id));
+    }
+
+    #[test]
+    fn test_get_task_descendants_no_children() {
+        let db = db();
+        let root_id = db.create_task(&make_task("root")).unwrap();
+
+        let descendants = db.get_task_descendants(&root_id).unwrap();
+        assert!(descendants.is_empty());
+    }
+
+    #[test]
+    fn test_get_task_descendants_multi_branch() {
+        let db = db();
+        let root_id = db.create_task(&make_task("root")).unwrap();
+
+        // 3 children, each with 2 grandchildren = 9 descendants total
+        for i in 0..3 {
+            let mut child = make_task(&format!("child-{i}"));
+            child.parent_task_id = Some(root_id.clone());
+            child.depth = 1;
+            let child_id = db.create_task(&child).unwrap();
+
+            for j in 0..2 {
+                let mut gc = make_task(&format!("gc-{i}-{j}"));
+                gc.parent_task_id = Some(child_id.clone());
+                gc.depth = 2;
+                db.create_task(&gc).unwrap();
+            }
+        }
+
+        let descendants = db.get_task_descendants(&root_id).unwrap();
+        assert_eq!(descendants.len(), 9);
+    }
+
+    #[test]
+    fn test_get_task_descendants_cross_agent() {
+        let db = Database::open_in_memory().unwrap();
+        db.register_agent("mika", "Mika", "/tmp").unwrap();
+        db.register_agent("other-agent", "Other", "/tmp").unwrap();
+
+        let root_id = db.create_task(&make_task("root")).unwrap();
+
+        let mut child = make_task("child");
+        child.parent_task_id = Some(root_id.clone());
+        child.depth = 1;
+        child.agent_id = "other-agent".to_string();
+        db.create_task(&child).unwrap();
+
+        let descendants = db.get_task_descendants(&root_id).unwrap();
+        assert_eq!(descendants.len(), 1);
+        assert_eq!(descendants[0].agent_id, "other-agent");
+    }
+
+    #[test]
     fn test_count_pending_callback_tasks_by_team_run() {
         let db = Database::open_in_memory().unwrap();
         db.register_agent("mika", "Mika", "/tmp").unwrap();
@@ -11170,6 +11286,48 @@ mod tests {
         let sessions = db.get_sessions_for_task_tree(&task_id).unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "legacy-sess");
+    }
+
+    #[test]
+    fn test_sessions_for_task_tree_includes_deep_descendants() {
+        let db = db();
+
+        // Create a 3-level tree: root → child → grandchild
+        let root_id = db
+            .create_task(&new_task("mika", "root-task", "manual", "none"))
+            .unwrap();
+        let mut child = new_task("mika", "child-task", "callback", "resume_agent");
+        child.parent_task_id = Some(root_id.clone());
+        child.depth = 1;
+        let child_id = db.create_task(&child).unwrap();
+        let mut grandchild = new_task("mika", "grandchild-task", "callback", "resume_agent");
+        grandchild.parent_task_id = Some(child_id.clone());
+        grandchild.depth = 2;
+        let grandchild_id = db.create_task(&grandchild).unwrap();
+
+        // Sessions at each level
+        db.create_session_with_parent("sess-root", "mika", "cli", None, None, Some(&root_id))
+            .unwrap();
+        db.create_session_with_parent("sess-child", "mika", "system", None, None, Some(&child_id))
+            .unwrap();
+        db.create_session_with_parent(
+            "sess-grandchild",
+            "mika",
+            "system",
+            None,
+            None,
+            Some(&grandchild_id),
+        )
+        .unwrap();
+        // Unrelated session
+        db.create_session("sess-unrelated", "mika", "cli").unwrap();
+
+        let sessions = db.get_sessions_for_task_tree(&root_id).unwrap();
+        assert_eq!(sessions.len(), 3);
+        let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+        assert!(ids.contains(&"sess-root"));
+        assert!(ids.contains(&"sess-child"));
+        assert!(ids.contains(&"sess-grandchild"));
     }
 
     #[test]

--- a/crates/mika-agent/src/server/dashboard.rs
+++ b/crates/mika-agent/src/server/dashboard.rs
@@ -742,6 +742,23 @@ pub async fn handle_task_children(
     }
 }
 
+/// GET /api/v1/tasks/:id/descendants — all descendant tasks (recursive tree).
+pub async fn handle_task_descendants(
+    State(state): State<AppState>,
+    Path(task_id): Path<String>,
+) -> impl IntoResponse {
+    match state.dashboard_db.get_task_descendants(&task_id).await {
+        Ok(descendants) => Json(
+            descendants
+                .into_iter()
+                .map(TaskResponse::from)
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => internal_error(e).into_response(),
+    }
+}
+
 // ===== Task Sessions =====
 
 /// Response type for sessions linked to a task tree.

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -127,6 +127,10 @@ fn build_router(state: AppState) -> Router {
             get(dashboard::handle_task_children),
         )
         .route(
+            "/tasks/{task_id}/descendants",
+            get(dashboard::handle_task_descendants),
+        )
+        .route(
             "/tasks/{task_id}/sessions",
             get(dashboard::handle_task_sessions),
         )

--- a/dashboard/src/api/tasks.ts
+++ b/dashboard/src/api/tasks.ts
@@ -91,16 +91,18 @@ export function useTaskChildren(parentTaskId: string | undefined) {
 
 const TERMINAL_STATUSES = new Set(['completed', 'delivered', 'failed', 'cancelled'])
 
-export function useTaskDescendants(rootTaskId: string | undefined) {
+export function useTaskDescendants(rootTaskId: string | undefined, parentStatus?: string) {
   return useQuery<TaskItem[]>({
     queryKey: ['task-descendants', rootTaskId],
     queryFn: () => apiFetch(`/tasks/${rootTaskId}/descendants`),
     enabled: !!rootTaskId,
     refetchInterval: (query) => {
       const data = query.state.data
-      if (!data || data.length === 0) return false
+      const parentIsActive = !!parentStatus && !TERMINAL_STATUSES.has(parentStatus)
+      // Keep polling when parent is active even if descendants are empty (children may not exist yet)
+      if (!data || data.length === 0) return parentIsActive ? 15_000 : false
       const hasActive = data.some((t) => !TERMINAL_STATUSES.has(t.status))
-      return hasActive ? 15_000 : false
+      return hasActive || parentIsActive ? 15_000 : false
     },
   })
 }

--- a/dashboard/src/api/tasks.ts
+++ b/dashboard/src/api/tasks.ts
@@ -89,6 +89,22 @@ export function useTaskChildren(parentTaskId: string | undefined) {
   })
 }
 
+const TERMINAL_STATUSES = new Set(['completed', 'delivered', 'failed', 'cancelled'])
+
+export function useTaskDescendants(rootTaskId: string | undefined) {
+  return useQuery<TaskItem[]>({
+    queryKey: ['task-descendants', rootTaskId],
+    queryFn: () => apiFetch(`/tasks/${rootTaskId}/descendants`),
+    enabled: !!rootTaskId,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      if (!data || data.length === 0) return false
+      const hasActive = data.some((t) => !TERMINAL_STATUSES.has(t.status))
+      return hasActive ? 15_000 : false
+    },
+  })
+}
+
 /** Session linked to a task tree — returned by GET /api/v1/tasks/:id/sessions. */
 export interface TaskSession {
   id: string

--- a/dashboard/src/components/TaskTree.tsx
+++ b/dashboard/src/components/TaskTree.tsx
@@ -1,0 +1,180 @@
+import { useState, useMemo, type ReactNode } from 'react'
+import { Link } from 'react-router'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { TaskStatusBadge, formatRelativeTime } from '@senara-solutions/ui'
+import type { TaskItem } from '../api/tasks.ts'
+
+interface TaskTreeProps {
+  tasks: TaskItem[]
+  rootTaskId: string
+}
+
+/** Build a lookup from parent_task_id → children. */
+function buildChildrenMap(tasks: TaskItem[]): Map<string, TaskItem[]> {
+  const map = new Map<string, TaskItem[]>()
+  for (const task of tasks) {
+    if (task.parent_task_id) {
+      const siblings = map.get(task.parent_task_id)
+      if (siblings) {
+        siblings.push(task)
+      } else {
+        map.set(task.parent_task_id, [task])
+      }
+    }
+  }
+  return map
+}
+
+/** Compute which nodes to expand by default (direct children of root). */
+function defaultExpanded(tasks: TaskItem[], rootTaskId: string): Set<string> {
+  const expanded = new Set<string>()
+  for (const task of tasks) {
+    if (task.parent_task_id === rootTaskId) {
+      expanded.add(task.id)
+    }
+  }
+  return expanded
+}
+
+function TaskTreeNode({
+  task,
+  childrenMap,
+  expanded,
+  onToggle,
+  indentLevel,
+}: {
+  task: TaskItem
+  childrenMap: Map<string, TaskItem[]>
+  expanded: Set<string>
+  onToggle: (id: string) => void
+  indentLevel: number
+}) {
+  const children = childrenMap.get(task.id)
+  const hasChildren = !!children && children.length > 0
+  const isExpanded = expanded.has(task.id)
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 py-1.5 hover:bg-white/[0.02] transition-colors rounded-lg"
+        style={{ paddingLeft: `${indentLevel * 24}px` }}
+      >
+        {/* Expand/collapse chevron */}
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => onToggle(task.id)}
+            className="flex items-center justify-center w-5 h-5 shrink-0"
+            aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5 text-muted/40 transition-transform" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-muted/40 transition-transform" />
+            )}
+          </button>
+        ) : (
+          <span className="w-5 shrink-0" />
+        )}
+
+        {/* Status badge */}
+        <TaskStatusBadge status={task.status} />
+
+        {/* Label link */}
+        <Link
+          to={`/tasks/${task.id}`}
+          className="text-accent text-xs hover:text-accent-light transition-colors truncate"
+        >
+          {task.label}
+        </Link>
+
+        {/* Right side metadata */}
+        <div className="flex items-center gap-2 ml-auto shrink-0">
+          {/* Trigger type badge */}
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-white/[0.06] text-muted/60">
+            {task.trigger_type}
+          </span>
+
+          {/* Session link */}
+          {task.created_by_session && (
+            <Link
+              to={`/sessions/${task.created_by_session}`}
+              className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-white/[0.06] text-accent hover:text-accent-light transition-colors"
+            >
+              SESSION
+            </Link>
+          )}
+
+          {/* Trace link */}
+          {task.execution_trace_id && (
+            <Link
+              to={`/traces/${task.execution_trace_id}`}
+              className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-white/[0.06] text-accent hover:text-accent-light transition-colors"
+            >
+              TRACE
+            </Link>
+          )}
+
+          {/* Timing */}
+          <span className="text-muted/40 text-xs">
+            {formatRelativeTime(task.created_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Render children if expanded */}
+      {hasChildren && isExpanded && (
+        children.map((child) => (
+          <TaskTreeNode
+            key={child.id}
+            task={child}
+            childrenMap={childrenMap}
+            expanded={expanded}
+            onToggle={onToggle}
+            indentLevel={indentLevel + 1}
+          />
+        ))
+      )}
+    </>
+  )
+}
+
+export function TaskTree({ tasks, rootTaskId }: TaskTreeProps): ReactNode {
+  const childrenMap = useMemo(() => buildChildrenMap(tasks), [tasks])
+
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    defaultExpanded(tasks, rootTaskId),
+  )
+
+  const onToggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  // Top-level nodes: direct children of the root task
+  const topLevel = childrenMap.get(rootTaskId) ?? []
+
+  if (topLevel.length === 0) return null
+
+  return (
+    <div className="space-y-0">
+      {topLevel.map((task) => (
+        <TaskTreeNode
+          key={task.id}
+          task={task}
+          childrenMap={childrenMap}
+          expanded={expanded}
+          onToggle={onToggle}
+          indentLevel={0}
+        />
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/components/TaskTree.tsx
+++ b/dashboard/src/components/TaskTree.tsx
@@ -25,7 +25,7 @@ function buildChildrenMap(tasks: TaskItem[]): Map<string, TaskItem[]> {
   return map
 }
 
-/** Compute which nodes to expand by default (direct children of root). */
+/** Mark direct children of root as expanded so their subtrees are visible on first render. */
 function defaultExpanded(tasks: TaskItem[], rootTaskId: string): Set<string> {
   const expanded = new Set<string>()
   for (const task of tasks) {

--- a/dashboard/src/pages/DevRunDetail.tsx
+++ b/dashboard/src/pages/DevRunDetail.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useParams, Link } from 'react-router'
 import { useDevRun } from '../api/devRuns.ts'
 import { useGitHubIssue, useGitHubPull, type GitHubReview } from '../api/github.ts'
-import { useTaskSessions, useTaskChildren } from '../api/tasks.ts'
+import { useTaskSessions, useTaskDescendants } from '../api/tasks.ts'
 import { useSessionMessages, type Message } from '../api/sessions.ts'
 import {
   TaskStatusBadge,
@@ -17,6 +17,7 @@ import {
 import { MetadataRow } from '../components/MetadataRow.tsx'
 import { CollapsibleCard } from '../components/CollapsibleCard.tsx'
 import { PipelineTimeline, type PipelineStep } from '../components/PipelineTimeline.tsx'
+import { TaskTree } from '../components/TaskTree.tsx'
 import { parseGitHubUrl } from '../utils/github.ts'
 import {
   Clock,
@@ -279,7 +280,7 @@ export default function DevRunDetail() {
 
   // Fetch sessions and children
   const { data: taskSessions } = useTaskSessions(taskId)
-  const { data: children } = useTaskChildren(taskId)
+  const { data: descendants, isLoading: descendantsLoading } = useTaskDescendants(taskId)
 
   if (isLoading) {
     return <LoadingState variant="detail" />
@@ -510,46 +511,18 @@ export default function DevRunDetail() {
         </div>
       )}
 
-      {/* ===== Child Tasks ===== */}
-      {children && children.length > 0 && (
+      {/* ===== Task Tree ===== */}
+      {descendantsLoading && (
+        <div className="bg-bg-card border border-white/[0.05] rounded-2xl p-5 mb-4">
+          <LoadingState variant="list" rows={3} />
+        </div>
+      )}
+      {descendants && descendants.length > 0 && taskId && (
         <div className="bg-bg-card border border-white/[0.05] rounded-2xl p-5 mb-4">
           <h3 className="text-heading text-sm font-medium mb-3">
-            Child Tasks ({children.length})
+            Task Tree ({descendants.length})
           </h3>
-          <div className="space-y-2">
-            {children.map((child) => (
-              <div key={child.id} className="flex items-center gap-3 py-1.5">
-                <TaskStatusBadge status={child.status} />
-                <Link
-                  to={`/tasks/${child.id}`}
-                  className="text-accent text-xs hover:text-accent-light transition-colors"
-                >
-                  {child.label}
-                </Link>
-                <div className="flex items-center gap-2 ml-auto">
-                  {child.created_by_session && (
-                    <Link
-                      to={`/sessions/${child.created_by_session}`}
-                      className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-white/[0.06] text-accent hover:text-accent-light transition-colors"
-                    >
-                      SESSION
-                    </Link>
-                  )}
-                  {child.execution_trace_id && (
-                    <Link
-                      to={`/traces/${child.execution_trace_id}`}
-                      className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-white/[0.06] text-accent hover:text-accent-light transition-colors"
-                    >
-                      TRACE
-                    </Link>
-                  )}
-                  <span className="text-muted/40 text-xs font-mono">
-                    {child.action_type}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
+          <TaskTree tasks={descendants} rootTaskId={taskId} />
         </div>
       )}
 

--- a/dashboard/src/pages/DevRunDetail.tsx
+++ b/dashboard/src/pages/DevRunDetail.tsx
@@ -280,7 +280,7 @@ export default function DevRunDetail() {
 
   // Fetch sessions and children
   const { data: taskSessions } = useTaskSessions(taskId)
-  const { data: descendants, isLoading: descendantsLoading } = useTaskDescendants(taskId)
+  const { data: descendants, isLoading: descendantsLoading } = useTaskDescendants(taskId, run?.status)
 
   if (isLoading) {
     return <LoadingState variant="detail" />

--- a/docs/plans/2026-05-05-008-feat-dashboard-task-tree-visualization-plan.md
+++ b/docs/plans/2026-05-05-008-feat-dashboard-task-tree-visualization-plan.md
@@ -1,0 +1,302 @@
+---
+title: "feat: Add task tree visualization to Dev Runs detail page"
+type: feat
+status: active
+date: 2026-05-05
+issue: 661
+---
+
+# feat: Add task tree visualization to Dev Runs detail page
+
+## Overview
+
+Replace the flat "Child Tasks" list on the Dev Runs detail page with a collapsible task tree that reveals the full hierarchy of descendants beneath the root dev run task. The root task itself is already rendered as the page header (title, status badge, stats row); the tree visualizes everything below it: Issue → long_running callback → downstream tasks. Add a recursive descendants backend endpoint (bounded by the existing depth 0-3 CHECK constraint) and a dashboard-local `<TaskTree />` component.
+
+## Problem Frame
+
+Dev Runs have a tree-shaped execution structure (milestone → issue → run_claude_pilot callback → build/deploy tasks), but the detail page renders children as a flat list using `GET /api/v1/tasks/:id/children` (direct children only). Operators must mentally reconstruct the hierarchy by cross-referencing the Child Tasks, Agent Activity, and Claude Pilot Metadata sections. This makes it hard to trace failures through the dispatch chain.
+
+## Requirements Trace
+
+- R1. Dev Runs detail page renders child tasks as a collapsible tree with expand/collapse
+- R2. Tree shows the full lineage: milestone → issue → long_running → callbacks → build/deploy
+- R3. Each tree node shows: label, status badge (via `<TaskStatusBadge />`), trigger_type, timing, link to detail
+- R4. Top-level children expanded by default; deeper levels collapsed
+- R5. Agent Activity sessions section covers the full task tree (all descendants), not just root + direct children
+
+## Scope Boundaries
+
+- No real-time WebSocket push — polling via `refetchInterval` when the tree has non-terminal tasks
+- No drag-and-drop or tree manipulation — read-only visualization
+- No generic `<TreeView />` in `@senara-solutions/ui` — the tree component starts as a dashboard-local component per the stitch-map workflow agreement ("primitives used by only one surface stay local"); promote when Cloud Console or another surface needs it
+
+### Deferred to Separate Tasks
+
+- `<TaskTree />` extraction to `@senara-solutions/ui`: separate PR when a second consumer surfaces
+- Back-navigation context preservation (e.g., `?from=/dev-runs/:id` on task links): general dashboard UX improvement, not specific to this tree
+- Team Runs detail tree adoption: follow-up ticket after #652 lands
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/db.rs:5084` — `get_child_tasks()`: direct children only, `WHERE parent_task_id = ?1`, no agent_id filter
+- `crates/mika-agent/src/db.rs:8087` — `get_sessions_for_task_tree()`: collects root + direct children task IDs only
+- `crates/mika-agent/src/server/dashboard.rs:728` — `handle_task_children()` handler
+- `crates/mika-agent/src/server/mod.rs:126` — route registration for `/tasks/{task_id}/children`
+- `dashboard/src/pages/DevRunDetail.tsx:513-554` — current flat Child Tasks section
+- `dashboard/src/api/tasks.ts:84-90` — `useTaskChildren()` hook
+- `dashboard/src/components/CollapsibleCard.tsx` — expand/collapse pattern used throughout
+- `packages/ui/src/components/ListRow.tsx` — `<ListRow variant="expandable">` with chevron, keyboard a11y, `isTargetRow()` guard
+- Tasks DB: `depth` column has `CHECK (depth BETWEEN 0 AND 3)` — max 4 levels, recursion is inherently bounded
+
+### Institutional Learnings
+
+- `docs/solutions/dashboard-issues/task-session-bidirectional-linking.md` — `get_sessions_for_task_tree()` is shallow (root + direct children only); needs extending for full tree
+- `docs/solutions/best-practices/design-system-listrow-extraction-2026-04-27.md` — `<ListRow variant="expandable">` auto-injects chevron; static rows need `<td className="w-8" />` spacer for alignment
+- `docs/solutions/best-practices/design-system-status-pill-migration-2026-04-27.md` — hand-rolled status pills are review fails; use `<TaskStatusBadge />`
+- `docs/solutions/best-practices/design-system-state-catalog-extraction-2026-04-27.md` — use `<LoadingState />`, `<ErrorState />`, `<EmptyState />` from `@senara-solutions/ui`
+- `docs/solutions/dashboard-issues/dev-runs-source-filter-too-restrictive.md` — descendants query must not filter by single source
+- `docs/solutions/database-issues/sql-column-mismatch-trace-detail-view.md` — use centralized column constants for SQL queries
+
+### Design References
+
+- Stitch screen #8 (`abe0ec4a059d459f94220fad9404149a`) — Team Run Debug Detail: "The Iteration Timeline IS the answer to #661 task-tree visualization"
+- Stitch variant `e7cd46efd53b4c0d91e689edff4fa877` — expanded-node detail rendering (editorial typography, prominent labels)
+
+## Key Technical Decisions
+
+- **Recursive CTE with depth guard:** SQLite `WITH RECURSIVE` is safe here — max depth is 3 (DB-enforced), so worst-case recursion is 4 levels. Include `WHERE t.depth <= 3` in the CTE as defense-in-depth against any data anomalies. No row LIMIT — the depth constraint naturally bounds results (typical tree: ~90 nodes for a 30-issue milestone; depth 0-3 makes unbounded growth impossible).
+- **Root task excluded from descendants:** The root dev run task is already rendered as the page header (title, status badge, stats). The descendants endpoint returns only the subtree below it. The `<TaskTree />` component renders these descendants with indentation relative to the root, not using absolute DB `depth` values.
+- **Depth is absolute in DB, relative in rendering:** The `depth` column stores absolute tree depth (0-3, set at creation as `parent.depth + 1`). The tree component computes visual indentation as `node.depth - minDepthInResults` to handle cases where the root is not at depth 0.
+- **Single endpoint, flat response with parent_task_id:** Return all descendants as a flat array with `parent_task_id` references. Frontend builds the tree client-side using a simple `Map<parentId, children[]>` grouping. This is simpler than returning a nested JSON tree and reuses the existing `TaskResponse` DTO.
+- **Replace `useTaskChildren` with `useTaskDescendants` on DevRunDetail:** The descendants response is a superset of children. No need to call both endpoints.
+- **Update `get_sessions_for_task_tree` to use all descendant IDs:** Extends the ID collection to include all descendants. The root task's own sessions are still included (root ID added first, then descendant IDs appended — same pattern as current code, just with more IDs). Ensures the Agent Activity section shows sessions for the entire tree.
+- **Dashboard-local tree component:** Per stitch-map workflow agreement, start local in `dashboard/src/components/TaskTree.tsx`. No `@senara-solutions/ui` extraction until a second consumer surfaces.
+- **Conditional polling:** `useTaskDescendants` enables `refetchInterval: 15000` when any descendant has a non-terminal status. Stops when all tasks reach terminal state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Row limit on descendants?** No LIMIT needed. The depth 0-3 CHECK constraint bounds the tree at 4 levels; a large milestone produces ~90 nodes. Depth constraint makes unbounded growth structurally impossible.
+- **Should sessions query also go recursive?** Yes — `get_sessions_for_task_tree()` already collects task IDs and queries sessions; we extend the ID collection to include all descendants. Root task sessions are still included.
+- **Default expand state for deeper levels?** Direct children of the root task expanded by default. Deeper descendants collapsed. Expand logic uses relative depth (distance from root in tree), not absolute DB `depth` column, to handle cases where the root is not at depth 0.
+
+### Deferred to Implementation
+
+- Exact CSS indentation per depth level — implement and tune visually
+- Whether trigger_type badges need different colors — use existing badge chip styling first, adjust if unclear
+
+## Implementation Units
+
+- [x] **Unit 1: Backend — recursive descendants query**
+
+  **Goal:** Add `get_task_descendants()` to the DB layer that returns all descendants of a task using a recursive CTE.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/db.rs`
+  - Modify: `crates/mika-agent/src/async_db.rs`
+  - Test: `crates/mika-agent/src/db.rs` (inline `#[cfg(test)] mod tests`)
+
+  **Approach:**
+  - Add `get_task_descendants(root_task_id: &str) -> Result<Vec<Task>>` using `WITH RECURSIVE` CTE
+  - CTE anchor: `SELECT ... FROM tasks WHERE parent_task_id = ?1` (direct children of root, not root itself)
+  - Recursive step: `UNION ALL SELECT t.* FROM tasks t JOIN descendants d ON t.parent_task_id = d.id WHERE t.depth <= 3`
+  - No row LIMIT — depth CHECK (0-3) structurally bounds the result set
+  - Reuse `Self::TASK_COLUMNS` and `Self::row_to_task` — same pattern as `get_child_tasks()`
+  - No agent_id filter (same as `get_child_tasks` — team trees have cross-agent children)
+  - Add async wrapper `AsyncDatabase::get_task_descendants()`
+
+  **Patterns to follow:**
+  - `get_child_tasks()` at db.rs:5084 — same column set, same row mapper, same no-agent-id design
+  - `AsyncDatabase` closure-based dispatch pattern
+
+  **Test scenarios:**
+  - Happy path: create a 3-level tree (root → child → grandchild → great-grandchild), verify all 3 descendants returned in creation order
+  - Happy path: verify root task is NOT included in results (only descendants)
+  - Edge case: task with no children returns empty vec
+  - Edge case: task with children at only one level returns only direct children (same as `get_child_tasks`)
+  - Edge case: multi-branch tree (root with 3 children, each with 2 grandchildren) returns all 9 descendants
+  - Edge case: cross-agent children included (parent agent_id="a", child agent_id="b")
+
+  **Verification:**
+  - `cargo test -p mika-agent get_task_descendants` passes
+  - Query returns descendants ordered by `created_at ASC`
+
+- [x] **Unit 2: Backend — descendants API endpoint**
+
+  **Goal:** Expose `GET /api/v1/tasks/:id/descendants` returning all descendants as a flat `TaskResponse[]`.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/server/dashboard.rs`
+  - Modify: `crates/mika-agent/src/server/mod.rs`
+
+  **Approach:**
+  - Add `handle_task_descendants()` handler following the exact pattern of `handle_task_children()` at dashboard.rs:728
+  - Map `Vec<Task>` → `Vec<TaskResponse>` using existing `TaskResponse::from()`
+  - Register route at `/tasks/{task_id}/descendants` in `mod.rs` alongside the existing `/tasks/{task_id}/children` route
+
+  **Patterns to follow:**
+  - `handle_task_children()` at dashboard.rs:728 — same State/Path extraction, same error handling, same `TaskResponse::from()` mapping
+
+  **Test scenarios:**
+  - Happy path: endpoint returns 200 with array of TaskResponse objects for a task with descendants
+  - Edge case: endpoint returns 200 with empty array for a task with no descendants
+  - Edge case: endpoint returns 200 with empty array for a non-existent task ID (consistent with `get_child_tasks` behavior)
+
+  **Verification:**
+  - Endpoint accessible via `curl http://localhost:8080/api/v1/tasks/<id>/descendants` with auth token
+  - Response shape matches existing `GET /api/v1/tasks/:id/children`
+
+- [x] **Unit 3: Backend — extend sessions-for-task-tree to include all descendants**
+
+  **Goal:** Update `get_sessions_for_task_tree()` to collect sessions for the root task AND all its descendants (not just direct children).
+
+  **Requirements:** R5
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/db.rs`
+  - Test: `crates/mika-agent/src/db.rs` (inline tests)
+
+  **Approach:**
+  - Replace the direct-children-only task ID collection (db.rs:8088-8098) with a call to `get_task_descendants()` to get all descendant task IDs
+  - Root task ID is still added first (same as current code at line 8089: `let mut task_ids = vec![root_task_id.to_string()]`), then all descendant IDs appended. Root's own sessions are preserved.
+  - Rest of the function (session query with `COALESCE` for backward compat) stays unchanged
+
+  **Patterns to follow:**
+  - Current `get_sessions_for_task_tree()` at db.rs:8087 — preserve the session query structure and backward-compat COALESCE
+
+  **Test scenarios:**
+  - Happy path: sessions linked to grandchild tasks (depth 2) are now returned
+  - Integration: existing test `test_get_sessions_for_task_tree` still passes (root + direct children sessions found)
+  - Edge case: sessions linked to depth-3 tasks are found
+
+  **Verification:**
+  - Existing `test_get_sessions_for_task_tree` and `test_sessions_for_task_tree_backfill_compat` still pass
+  - New test with deeper tree hierarchy confirms sessions at all levels are returned
+
+- [x] **Unit 4: Frontend — `useTaskDescendants` hook**
+
+  **Goal:** Add a TanStack React Query hook to fetch the full descendants tree from the new endpoint, with conditional polling.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `dashboard/src/api/tasks.ts`
+
+  **Approach:**
+  - Add `useTaskDescendants(taskId: string | undefined)` hook returning `TaskItem[]`
+  - Follow `useTaskChildren` pattern exactly: `useQuery` with `enabled: !!taskId`, query key `['task-descendants', taskId]`
+  - Add `refetchInterval` callback that checks response data: return `15_000` if any task has non-terminal status (`pending`, `in_progress`, `blocked`, `suspended`), return `false` otherwise
+
+  **Patterns to follow:**
+  - `useTaskChildren` at tasks.ts:84-90
+
+  **Test expectation:** none — hook is a thin fetch wrapper with no logic beyond the polling gate
+
+  **Verification:**
+  - Hook returns the same shape as `useTaskChildren` (same `TaskItem` type)
+  - Browser network tab confirms polling stops when all tasks are terminal
+
+- [x] **Unit 5: Frontend — TaskTree component**
+
+  **Goal:** Build a collapsible tree component that renders task descendants as an indented hierarchy with expand/collapse controls.
+
+  **Requirements:** R1, R2, R3, R4
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Create: `dashboard/src/components/TaskTree.tsx`
+
+  **Approach:**
+  - Props: `{ tasks: TaskItem[], rootTaskId: string }` — receives flat array, builds tree client-side
+  - Build tree structure: `Map<string | null, TaskItem[]>` grouping by `parent_task_id`, then render recursively
+  - Each node renders: indent per depth, chevron (if has children), `<TaskStatusBadge />`, label as `<Link to={/tasks/${id}}>`, trigger_type badge, timing (relative time from `created_at`), optional SESSION/TRACE links
+  - Expand/collapse state: `Set<string>` of expanded node IDs. Initialize by expanding all direct children of `rootTaskId` (nodes whose `parent_task_id === rootTaskId`), deeper levels collapsed. Uses tree-structural relationship, not absolute DB `depth` column
+  - Chevron uses `ChevronRight`/`ChevronDown` from lucide-react (same pattern as `SessionRow` in DevRunDetail.tsx)
+  - Indentation via `paddingLeft` calculated from depth relative to root (e.g., `(node.depth - rootDepth) * 24px`)
+  - Use `<div>` structure (not `<table>`) — the tree is not tabular data; the existing child tasks section uses divs too
+
+  **Patterns to follow:**
+  - `SessionRow` in DevRunDetail.tsx (lines 162-203) — expand/collapse with ChevronDown rotation animation
+  - Child Tasks section (lines 521-553) — row layout with status badge, link, SESSION/TRACE chips, action_type badge
+  - Dashboard card styling: `bg-bg-card border border-white/[0.05] rounded-2xl p-5`
+
+  **Test expectation:** none — presentational React component with local state only; behavior verified via manual visual inspection and dashboard dev server
+
+  **Verification:**
+  - Component renders a multi-level tree with correct indentation
+  - Clicking a chevron expands/collapses that node's children
+  - Depth-1 nodes start expanded, deeper nodes start collapsed
+  - Uses `<TaskStatusBadge />` for status (not hand-rolled pills)
+  - Leaf nodes (no children) render without a chevron
+
+- [x] **Unit 6: Frontend — integrate TaskTree into DevRunDetail**
+
+  **Goal:** Replace the flat "Child Tasks" section with the new `<TaskTree />` component, wired to `useTaskDescendants`.
+
+  **Requirements:** R1, R2, R3, R4, R5
+
+  **Dependencies:** Unit 4, Unit 5
+
+  **Files:**
+  - Modify: `dashboard/src/pages/DevRunDetail.tsx`
+
+  **Approach:**
+  - Replace `useTaskChildren(taskId)` import and call with `useTaskDescendants(taskId)`
+  - Replace the "Child Tasks" section (lines 513-554) with `<TaskTree tasks={descendants} rootTaskId={taskId} />`
+  - Add loading/empty state handling: `<LoadingState variant="list" />` while descendants load, hide section when empty (same pattern as current)
+  - Update section header from "Child Tasks (N)" to "Task Tree (N)" with descendant count
+  - Remove `useTaskChildren` import (no longer used on this page)
+
+  **Patterns to follow:**
+  - Current "Agent Activity" section (lines 492-511) — conditional rendering when data exists, section header with count
+
+  **Test scenarios:**
+  - Happy path: DevRunDetail page renders TaskTree when descendants exist
+  - Edge case: section hidden when no descendants
+  - Edge case: loading state shown while descendants fetch is in flight
+  - Integration: clicking a task link in the tree navigates to `/tasks/:id`
+
+  **Verification:**
+  - Dev Runs detail page shows a collapsible tree instead of a flat list
+  - Tree matches the full hierarchy depth visible in the tasks DB
+  - Agent Activity section now shows sessions for all descendants (via Unit 3)
+
+## System-Wide Impact
+
+- **Interaction graph:** The new descendants endpoint is consumed only by DevRunDetail. The existing children endpoint remains for TaskDetail and any other consumers.
+- **Error propagation:** Recursive CTE errors surface as 500 via the standard `internal_error()` handler, rendered by `<ErrorState />` on the frontend.
+- **State lifecycle risks:** No write operations. Read-only query with bounded recursion (depth 0-3 CHECK constraint + CTE depth guard + 200 row LIMIT).
+- **API surface parity:** The children endpoint stays unchanged. The descendants endpoint is additive.
+- **Integration coverage:** Sessions-for-task-tree change means the Agent Activity section will show more sessions than before — existing users may notice new sessions appearing that were previously hidden (deeper tree sessions). This is correct behavior.
+- **Unchanged invariants:** `get_child_tasks()` and `handle_task_children()` are untouched. `TaskResponse` DTO is unchanged. The `useTaskChildren` hook remains available for other pages.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Recursive CTE performance on large trees | Bounded by depth CHECK (0-3); worst case is ~100 rows, trivially fast for SQLite |
+| Circular parent_task_id references | CTE depth guard (`WHERE t.depth <= 3`) prevents runaway recursion; SQLite's default 1000-recursion limit is a second backstop |
+| Breaking existing sessions behavior | Unit 3 extends the existing ID collection but preserves the session query structure; existing tests still pass |
+| TaskTree component complexity | Component is div-based with local state only; no complex state management needed for 4-level bounded trees |
+
+## Sources & References
+
+- Related issues: #661 (this), #657 (StatusPill), #651 (Dev Runs detail), #652 (Team Runs detail), #13 (milestone)
+- Design: Stitch screen #8 (`abe0ec4a059d459f94220fad9404149a`), variant `e7cd46efd53b4c0d91e689edff4fa877`
+- Design docs: `docs/design/dashboard-stitch-map.md`

--- a/docs/solutions/dashboard-issues/661-task-tree-visualization-recursive-descendants-2026-05-05.md
+++ b/docs/solutions/dashboard-issues/661-task-tree-visualization-recursive-descendants-2026-05-05.md
@@ -1,0 +1,112 @@
+---
+title: "Task tree visualization with recursive descendants endpoint"
+date: 2026-05-05
+category: dashboard-issues
+module: dashboard, mika-agent
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding hierarchical/tree visualization to dashboard pages
+  - Querying multi-level task relationships (parent → children → grandchildren)
+  - Replacing flat list sections with collapsible tree components
+tags: [dashboard, task-tree, recursive-cte, collapsible, tree-visualization, descendants, react, sqlite]
+---
+
+# Task tree visualization with recursive descendants endpoint
+
+## Context
+
+The Dev Runs detail page displayed child tasks as a flat list using `GET /api/v1/tasks/:id/children` (direct children only). The actual execution hierarchy is tree-shaped (milestone -> issue -> callback -> downstream tasks, up to depth 3), but operators had to mentally reconstruct it by cross-referencing the Child Tasks, Agent Activity, and Claude Pilot Metadata sections.
+
+## Guidance
+
+### Backend: Recursive CTE for bounded trees
+
+Use `WITH RECURSIVE` CTE when the tree depth is structurally bounded (here by `CHECK (depth BETWEEN 0 AND 3)`). Collect IDs in the CTE, then SELECT full columns via `WHERE id IN (SELECT id FROM cte)` to avoid column-prefix issues with multi-line `TASK_COLUMNS` constants:
+
+```sql
+WITH RECURSIVE descendant_ids(id) AS (
+    SELECT id FROM tasks WHERE parent_task_id = ?1
+    UNION ALL
+    SELECT t.id FROM tasks t
+    JOIN descendant_ids d ON t.parent_task_id = d.id
+    WHERE t.depth <= 3
+)
+SELECT {TASK_COLUMNS} FROM tasks
+WHERE id IN (SELECT id FROM descendant_ids)
+ORDER BY created_at ASC
+```
+
+Key decisions:
+- **No row LIMIT needed** when depth is CHECK-constrained (max ~100 nodes for a 30-issue milestone)
+- **No agent_id filter** — team task trees have cross-agent children (documented convention from `get_child_tasks`)
+- **Root excluded from results** — the root task is already rendered as the page header; descendants fill the tree below it
+
+### Frontend: Flat array + client-side tree building
+
+Return descendants as a flat `TaskItem[]` array (reuses existing `TaskResponse` DTO). Build the tree client-side with a `Map<parentId, children[]>` grouping:
+
+```typescript
+function buildChildrenMap(tasks: TaskItem[]): Map<string, TaskItem[]> {
+  const map = new Map<string, TaskItem[]>()
+  for (const task of tasks) {
+    if (task.parent_task_id) {
+      const siblings = map.get(task.parent_task_id)
+      if (siblings) siblings.push(task)
+      else map.set(task.parent_task_id, [task])
+    }
+  }
+  return map
+}
+```
+
+### Polling: Parent-status-aware refetch
+
+A critical edge case: when the first descendants fetch returns an empty array (children haven't been created yet), polling must continue if the parent task is still active. Without this, the tree section stays permanently empty until page reload.
+
+```typescript
+export function useTaskDescendants(rootTaskId: string | undefined, parentStatus?: string) {
+  return useQuery<TaskItem[]>({
+    queryKey: ['task-descendants', rootTaskId],
+    queryFn: () => apiFetch(`/tasks/${rootTaskId}/descendants`),
+    enabled: !!rootTaskId,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      const parentIsActive = !!parentStatus && !TERMINAL_STATUSES.has(parentStatus)
+      if (!data || data.length === 0) return parentIsActive ? 15_000 : false
+      const hasActive = data.some((t) => !TERMINAL_STATUSES.has(t.status))
+      return hasActive || parentIsActive ? 15_000 : false
+    },
+  })
+}
+```
+
+### Expand state: Structural, not absolute
+
+Use tree-structural relationships (nodes whose `parent_task_id === rootTaskId`) to determine default expand state, not the absolute `depth` DB column. This handles cases where the root task is not at depth 0.
+
+## Why This Matters
+
+- Operators can trace failures through the full dispatch chain without mental reconstruction
+- The recursive CTE pattern is safe for SQLite when depth is structurally bounded
+- The flat-array-with-client-side-grouping pattern avoids nested JSON response complexity and reuses existing DTOs
+- The polling fix prevents a class of "empty section" bugs that occur when children are created after the initial page load
+
+## When to Apply
+
+- Adding any hierarchical visualization to dashboard pages (Team Runs tree, Tasks page tree)
+- Needing recursive parent-child traversal in the tasks table
+- Building collapsible tree UIs that consume polling data
+
+## Examples
+
+The `get_sessions_for_task_tree()` function was also updated to use descendants instead of direct children, ensuring the Agent Activity section shows sessions linked to tasks at all depth levels.
+
+## Related
+
+- `docs/solutions/dashboard-issues/add-restful-detail-pages-pattern.md` — 4-layer pattern (DB → async → handler → route)
+- `docs/solutions/dashboard-issues/task-session-bidirectional-linking.md` — sessions.task_id and get_sessions_for_task_tree
+- `docs/solutions/best-practices/design-system-listrow-extraction-2026-04-27.md` — ListRow expandable variant patterns
+- mika#661 — Dashboard task tree visualization
+- mika#652 — Team Runs detail (future consumer of tree pattern)


### PR DESCRIPTION
## Summary

- Add recursive `GET /api/v1/tasks/:id/descendants` endpoint using `WITH RECURSIVE` CTE (depth-guarded, bounded by schema CHECK constraint depth 0-3)
- Build collapsible `<TaskTree />` component with expand/collapse per node, direct children of root expanded by default
- Replace flat "Child Tasks" section on Dev Runs detail page with hierarchical task tree
- Extend `get_sessions_for_task_tree()` to include sessions for all descendants (not just direct children)
- Add parent-status-aware polling: continues fetching when parent run is active even if descendants are empty

Closes #661

Plan: `docs/plans/2026-05-05-008-feat-dashboard-task-tree-visualization-plan.md`

## Test plan

- [x] `cargo test -p mika-agent --lib -- descendants` — 5 tests for recursive CTE (3-level tree, excludes root, no children, multi-branch, cross-agent)
- [x] `cargo test -p mika-agent --lib -- task_tree` — 3 tests for sessions-for-task-tree (existing + deep descendants)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] ESLint passes
- [ ] Manual: navigate to Dev Runs detail page with a multi-level task hierarchy, verify tree renders with correct indentation and expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>