### PR TITLE
chore(cli): make tasks and reminders verb-orthogonal with sibling surfaces

### DIFF
--- a/crates/mika-cli/CLAUDE.md
+++ b/crates/mika-cli/CLAUDE.md
@@ -18,6 +18,12 @@ TUI CLI binary (`mika`): ratatui chat interface with clap subcommands.
 - `mika setup --mode compose` — Generate `.env` for docker-compose in current directory
 - `mika setup --mode oauth` — Authorize Mika with Claude Pro/Max subscription via PKCE
 - `mika teams log <name>` — shows full run UUIDs (copyable for `--run-id`), supports `--format text|json` and `-n/--limit` (default 10)
+- `mika tasks list` — List active tasks (pending, in_progress, recurring_active). Bare `mika tasks` is an alias. Supports `--format text|json`.
+- `mika tasks get <id>` — Show full details for a single task. Supports `--format text|json`.
+- `mika tasks cancel <id>` — Cancel a task and kill its process if running.
+- `mika reminders list` — List pending reminders. Bare `mika reminders` is an alias. Supports `--format text|json`.
+- `mika reminders get <id>` — Show full details for a single reminder. Validates the task is a reminder (trigger_type: time/recurring). Supports `--format text|json`.
+- `mika reminders cancel <id>` — Cancel a reminder by ID.
 
 ### `mika ask`
 
@@ -46,7 +52,7 @@ Scoped flags: `--agent <name>` (override active agent, most subcommands), `--tea
 
 ## Other `--format text|json` Commands
 
-`agents validate`, `teams list`, `teams status`, `teams validate`, `skills list`, `skills validate`, `status`, `config list`, `memory search`, `provider`, `model`, `webhook list-dead`, `webhook replay`, `webhook replay-all`, `kg status`, `kg list-agents`, `kg purge`, `kg validate`.
+`agents validate`, `teams list`, `teams status`, `teams validate`, `skills list`, `skills validate`, `status`, `config list`, `memory search`, `provider`, `model`, `tasks list`, `tasks get`, `reminders list`, `reminders get`, `webhook list-dead`, `webhook replay`, `webhook replay-all`, `kg status`, `kg list-agents`, `kg purge`, `kg validate`.
 
 ## Webhook CLI
 

--- a/crates/mika-cli/src/cli.rs
+++ b/crates/mika-cli/src/cli.rs
@@ -577,6 +577,18 @@ pub struct ReminderArgs {
 
 #[derive(Subcommand)]
 pub enum ReminderCommand {
+    /// List pending reminders
+    List {
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Show details for a specific reminder
+    Get {
+        /// Reminder ID
+        id: String,
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
     /// Cancel a reminder by ID (from `mika reminders`)
     Cancel { id: String },
 }
@@ -592,6 +604,18 @@ pub struct TaskArgs {
 
 #[derive(Subcommand)]
 pub enum TaskCommand {
+    /// List active tasks
+    List {
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Show details for a specific task
+    Get {
+        /// Task ID
+        id: String,
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
     /// Cancel a task by ID (from `mika tasks`)
     Cancel { id: String },
 }

--- a/crates/mika-cli/src/commands/reminders.rs
+++ b/crates/mika-cli/src/commands/reminders.rs
@@ -135,3 +135,95 @@ fn reminder_to_json(t: &Task) -> Value {
         "metadata": t.metadata,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_reminder(id: &str, label: &str, trigger_type: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            agent_id: "test-agent".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: label.to_string(),
+            trigger_type: trigger_type.to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: Some("2026-05-06T15:00:00Z".to_string()),
+            timeout_at: None,
+            action_type: "send_message".to_string(),
+            action_config: "Don't forget the meeting".to_string(),
+            status: "pending".to_string(),
+            process_id: None,
+            input_context: None,
+            result: None,
+            created_by_session: None,
+            created_trace_id: None,
+            execution_trace_id: None,
+            created_at: "2026-05-06T09:00:00Z".to_string(),
+            updated_at: "2026-05-06T09:00:00Z".to_string(),
+            fired_at: None,
+            completed_at: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: "issue".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_reminder_to_json_happy_get() {
+        let reminder = make_reminder("rem-001-aaaa", "Team standup", "time");
+        let json = reminder_to_json(&reminder);
+
+        assert_eq!(json["id"], "rem-001-aaaa");
+        assert_eq!(json["label"], "Team standup");
+        assert_eq!(json["status"], "pending");
+        assert_eq!(json["trigger_type"], "time");
+        assert_eq!(json["action_type"], "send_message");
+        assert_eq!(json["action_config"], "Don't forget the meeting");
+        assert_eq!(json["next_fire_at"], "2026-05-06T15:00:00Z");
+    }
+
+    #[test]
+    fn test_reminder_to_json_not_found() {
+        // Verify null optional fields serialize correctly.
+        let reminder = make_reminder("rem-missing-00", "Orphan reminder", "recurring");
+        let json = reminder_to_json(&reminder);
+
+        assert_eq!(json["id"], "rem-missing-00");
+        assert_eq!(json["trigger_type"], "recurring");
+        assert!(json["cron_expr"].is_null());
+        assert!(json["fired_at"].is_null());
+        assert!(json["completed_at"].is_null());
+        assert!(json["metadata"].is_null());
+    }
+
+    #[test]
+    fn test_reminder_to_json_list_serialization() {
+        let reminders = [
+            make_reminder("rem-001-aaaa", "Morning standup", "time"),
+            make_reminder("rem-002-bbbb", "Weekly review", "recurring"),
+        ];
+        let json_reminders: Vec<Value> = reminders.iter().map(reminder_to_json).collect();
+        let output = serde_json::to_string_pretty(&json_reminders).unwrap();
+
+        assert!(output.contains("\"Morning standup\""));
+        assert!(output.contains("\"Weekly review\""));
+        assert!(output.contains("\"time\""));
+        assert!(output.contains("\"recurring\""));
+    }
+
+    #[test]
+    fn test_reminder_to_json_empty_list() {
+        let reminders: Vec<Task> = vec![];
+        let json_reminders: Vec<Value> = reminders.iter().map(reminder_to_json).collect();
+        let output = serde_json::to_string_pretty(&json_reminders).unwrap();
+
+        assert_eq!(output, "[]");
+    }
+}

--- a/crates/mika-cli/src/commands/reminders.rs
+++ b/crates/mika-cli/src/commands/reminders.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use mika_agent::db::format_ts;
+use mika_agent::db::{Task, format_ts};
+use serde_json::{Value, json};
 
-use crate::cli::{ReminderArgs, ReminderCommand};
+use crate::cli::{OutputFormat, ReminderArgs, ReminderCommand};
 use crate::init;
 
 pub async fn run(args: ReminderArgs, agent_name: &str) -> Result<()> {
@@ -9,22 +10,54 @@ pub async fn run(args: ReminderArgs, agent_name: &str) -> Result<()> {
     let db = &ctx.async_db;
 
     match args.command {
-        None => {
+        None | Some(ReminderCommand::List { .. }) => {
+            let format = match &args.command {
+                Some(ReminderCommand::List { format }) => format.clone(),
+                _ => OutputFormat::Text,
+            };
             let reminders = db.get_user_visible_tasks().await?;
-            if reminders.is_empty() {
-                println!("\n  No pending reminders.\n");
-            } else {
-                println!("\n  Pending Reminders ({}):", reminders.len());
-                for t in &reminders {
-                    let short_id = &t.id[..12.min(t.id.len())];
-                    let fire_at = t
-                        .next_fire_at
-                        .as_ref()
-                        .map(|s| format_ts(s))
-                        .unwrap_or_else(|| "unknown".to_string());
-                    println!("    {}: \"{}\" at {}", short_id, t.label, fire_at);
+
+            match format {
+                OutputFormat::Text => {
+                    if reminders.is_empty() {
+                        println!("\n  No pending reminders.\n");
+                    } else {
+                        println!("\n  Pending Reminders ({}):", reminders.len());
+                        for t in &reminders {
+                            print_reminder_summary(t);
+                        }
+                        println!();
+                    }
                 }
-                println!();
+                OutputFormat::Json => {
+                    let json_reminders: Vec<Value> =
+                        reminders.iter().map(reminder_to_json).collect();
+                    println!("{}", serde_json::to_string_pretty(&json_reminders)?);
+                }
+            }
+        }
+        Some(ReminderCommand::Get { id, format }) => {
+            let task = db.get_task(&id).await?;
+            match task {
+                Some(t) => {
+                    // Verify it's actually a reminder (time or recurring trigger)
+                    if t.trigger_type != "time" && t.trigger_type != "recurring" {
+                        println!(
+                            "\n  ID {id} is not a reminder (trigger_type: {}).\n",
+                            t.trigger_type
+                        );
+                        return Ok(());
+                    }
+                    match format {
+                        OutputFormat::Text => print_reminder_detail(&t),
+                        OutputFormat::Json => {
+                            println!("{}", serde_json::to_string_pretty(&reminder_to_json(&t))?);
+                        }
+                    }
+                }
+                None => {
+                    println!("\n  Reminder {id} not found.\n");
+                }
             }
         }
         Some(ReminderCommand::Cancel { id }) => {
@@ -37,6 +70,68 @@ pub async fn run(args: ReminderArgs, agent_name: &str) -> Result<()> {
         }
     }
 
-    // Database shutdown happens automatically via Drop on ctx
     Ok(())
+}
+
+fn print_reminder_summary(t: &Task) {
+    let short_id = &t.id[..12.min(t.id.len())];
+    let fire_at = t
+        .next_fire_at
+        .as_ref()
+        .map(|s| format_ts(s))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("    {}: \"{}\" at {}", short_id, t.label, fire_at);
+}
+
+fn print_reminder_detail(t: &Task) {
+    println!();
+    println!("  Reminder Detail");
+    println!("  ───────────────────────────────────");
+    println!("  ID:            {}", t.id);
+    println!("  Label:         {}", t.label);
+    println!("  Status:        {}", t.status);
+    println!("  Trigger:       {}", t.trigger_type);
+    println!("  Action:        {}", t.action_type);
+    println!("  Agent:         {}", t.agent_id);
+    println!("  Created:       {}", format_ts(&t.created_at));
+    println!("  Updated:       {}", format_ts(&t.updated_at));
+    if let Some(ref v) = t.next_fire_at {
+        println!("  Next fire at:  {}", format_ts(v));
+    }
+    if let Some(ref v) = t.fired_at {
+        println!("  Fired at:      {}", format_ts(v));
+    }
+    if let Some(ref v) = t.completed_at {
+        println!("  Completed at:  {}", format_ts(v));
+    }
+    if let Some(ref v) = t.cron_expr {
+        println!("  Cron:          {v}");
+    }
+    // Show the reminder message text from action_config
+    if !t.action_config.is_empty() {
+        println!("  Message:       {}", t.action_config);
+    }
+    if let Some(ref v) = t.metadata {
+        println!("  Metadata:      {v}");
+    }
+    println!();
+}
+
+fn reminder_to_json(t: &Task) -> Value {
+    json!({
+        "id": t.id,
+        "agent_id": t.agent_id,
+        "label": t.label,
+        "status": t.status,
+        "trigger_type": t.trigger_type,
+        "action_type": t.action_type,
+        "action_config": t.action_config,
+        "cron_expr": t.cron_expr,
+        "next_fire_at": t.next_fire_at,
+        "fired_at": t.fired_at,
+        "completed_at": t.completed_at,
+        "created_at": t.created_at,
+        "updated_at": t.updated_at,
+        "metadata": t.metadata,
+    })
 }

--- a/crates/mika-cli/src/commands/tasks.rs
+++ b/crates/mika-cli/src/commands/tasks.rs
@@ -139,7 +139,10 @@ fn print_task_detail(t: &Task) {
         println!("  Process ID:    {pid}");
     }
     if let Some(ref v) = t.result {
-        let display = if v.len() > 200 { &v[..200] } else { v };
+        let display = match v.char_indices().nth(200) {
+            Some((i, _)) => &v[..i],
+            None => v,
+        };
         println!("  Result:        {display}");
     }
     println!();

--- a/crates/mika-cli/src/commands/tasks.rs
+++ b/crates/mika-cli/src/commands/tasks.rs
@@ -172,3 +172,99 @@ fn task_to_json(t: &Task) -> Value {
         "metadata": t.metadata,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_task(id: &str, label: &str, status: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            agent_id: "test-agent".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: label.to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: Some("2026-05-06T10:00:00Z".to_string()),
+            timeout_at: None,
+            action_type: "send_message".to_string(),
+            action_config: "{}".to_string(),
+            status: status.to_string(),
+            process_id: None,
+            input_context: None,
+            result: None,
+            created_by_session: None,
+            created_trace_id: None,
+            execution_trace_id: None,
+            created_at: "2026-05-06T09:00:00Z".to_string(),
+            updated_at: "2026-05-06T09:00:00Z".to_string(),
+            fired_at: None,
+            completed_at: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: "issue".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_task_to_json_happy_get() {
+        let task = make_task("abc123def456", "Deploy service", "pending");
+        let json = task_to_json(&task);
+
+        assert_eq!(json["id"], "abc123def456");
+        assert_eq!(json["label"], "Deploy service");
+        assert_eq!(json["status"], "pending");
+        assert_eq!(json["type"], "issue");
+        assert_eq!(json["trigger_type"], "manual");
+        assert_eq!(json["action_type"], "send_message");
+        assert_eq!(json["agent_id"], "test-agent");
+        assert_eq!(json["next_fire_at"], "2026-05-06T10:00:00Z");
+    }
+
+    #[test]
+    fn test_task_to_json_not_found() {
+        // When a task is not found, the handler prints a message.
+        // Verify that task_to_json correctly serializes null optional fields.
+        let task = make_task("missing-id-0000", "Orphan task", "in_progress");
+        let json = task_to_json(&task);
+
+        assert_eq!(json["id"], "missing-id-0000");
+        assert!(json["cron_expr"].is_null());
+        assert!(json["fired_at"].is_null());
+        assert!(json["completed_at"].is_null());
+        assert!(json["parent_task_id"].is_null());
+        assert!(json["reference_url"].is_null());
+        assert!(json["result"].is_null());
+        assert!(json["metadata"].is_null());
+    }
+
+    #[test]
+    fn test_task_to_json_list_serialization() {
+        let tasks = [
+            make_task("task-001-aaaa", "First task", "pending"),
+            make_task("task-002-bbbb", "Second task", "in_progress"),
+        ];
+        let json_tasks: Vec<Value> = tasks.iter().map(task_to_json).collect();
+        let output = serde_json::to_string_pretty(&json_tasks).unwrap();
+
+        assert!(output.contains("\"First task\""));
+        assert!(output.contains("\"Second task\""));
+        assert!(output.contains("\"pending\""));
+        assert!(output.contains("\"in_progress\""));
+    }
+
+    #[test]
+    fn test_task_to_json_empty_list() {
+        let tasks: Vec<Task> = vec![];
+        let json_tasks: Vec<Value> = tasks.iter().map(task_to_json).collect();
+        let output = serde_json::to_string_pretty(&json_tasks).unwrap();
+
+        assert_eq!(output, "[]");
+    }
+}

--- a/crates/mika-cli/src/commands/tasks.rs
+++ b/crates/mika-cli/src/commands/tasks.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use mika_agent::db::format_ts;
+use mika_agent::db::{Task, format_ts};
+use serde_json::{Value, json};
 
-use crate::cli::{TaskArgs, TaskCommand};
+use crate::cli::{OutputFormat, TaskArgs, TaskCommand};
 use crate::init;
 
 pub async fn run(args: TaskArgs, agent_name: &str) -> Result<()> {
@@ -9,7 +10,11 @@ pub async fn run(args: TaskArgs, agent_name: &str) -> Result<()> {
     let db = &ctx.async_db;
 
     match args.command {
-        None => {
+        None | Some(TaskCommand::List { .. }) => {
+            let format = match &args.command {
+                Some(TaskCommand::List { format }) => format.clone(),
+                _ => OutputFormat::Text,
+            };
             let tasks = db
                 .get_tasks_by_status(vec![
                     "pending".to_string(),
@@ -18,27 +23,36 @@ pub async fn run(args: TaskArgs, agent_name: &str) -> Result<()> {
                 ])
                 .await?;
 
-            if tasks.is_empty() {
-                println!("\n  No active tasks.\n");
-            } else {
-                println!("\n  Active Tasks ({}):", tasks.len());
-                for t in &tasks {
-                    let short_id = &t.id[..12.min(t.id.len())];
-                    let when = t
-                        .next_fire_at
-                        .as_ref()
-                        .map(|s| format_ts(s))
-                        .unwrap_or_else(|| t.trigger_type.clone());
-                    let pid_info = t
-                        .process_id
-                        .map(|pid| format!(" [PID {pid}]"))
-                        .unwrap_or_default();
-                    println!(
-                        "    {}: [{}] [{}] \"{}\" ({}){pid_info}",
-                        short_id, t.status, t.action_type, t.label, when
-                    );
+            match format {
+                OutputFormat::Text => {
+                    if tasks.is_empty() {
+                        println!("\n  No active tasks.\n");
+                    } else {
+                        println!("\n  Active Tasks ({}):", tasks.len());
+                        for t in &tasks {
+                            print_task_summary(t);
+                        }
+                        println!();
+                    }
                 }
-                println!();
+                OutputFormat::Json => {
+                    let json_tasks: Vec<Value> = tasks.iter().map(task_to_json).collect();
+                    println!("{}", serde_json::to_string_pretty(&json_tasks)?);
+                }
+            }
+        }
+        Some(TaskCommand::Get { id, format }) => {
+            let task = db.get_task(&id).await?;
+            match task {
+                Some(t) => match format {
+                    OutputFormat::Text => print_task_detail(&t),
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&task_to_json(&t))?);
+                    }
+                },
+                None => {
+                    println!("\n  Task {id} not found.\n");
+                }
             }
         }
         Some(TaskCommand::Cancel { id }) => {
@@ -68,4 +82,90 @@ pub async fn run(args: TaskArgs, agent_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_task_summary(t: &Task) {
+    let short_id = &t.id[..12.min(t.id.len())];
+    let when = t
+        .next_fire_at
+        .as_ref()
+        .map(|s| format_ts(s))
+        .unwrap_or_else(|| t.trigger_type.clone());
+    let pid_info = t
+        .process_id
+        .map(|pid| format!(" [PID {pid}]"))
+        .unwrap_or_default();
+    println!(
+        "    {}: [{}] [{}] \"{}\" ({}){pid_info}",
+        short_id, t.status, t.action_type, t.label, when
+    );
+}
+
+fn print_task_detail(t: &Task) {
+    println!();
+    println!("  Task Detail");
+    println!("  ───────────────────────────────────");
+    println!("  ID:            {}", t.id);
+    println!("  Label:         {}", t.label);
+    println!("  Status:        {}", t.status);
+    println!("  Type:          {}", t.r#type);
+    println!("  Trigger:       {}", t.trigger_type);
+    println!("  Action:        {}", t.action_type);
+    println!("  Agent:         {}", t.agent_id);
+    println!("  Created:       {}", format_ts(&t.created_at));
+    println!("  Updated:       {}", format_ts(&t.updated_at));
+    if let Some(ref v) = t.next_fire_at {
+        println!("  Next fire at:  {}", format_ts(v));
+    }
+    if let Some(ref v) = t.fired_at {
+        println!("  Fired at:      {}", format_ts(v));
+    }
+    if let Some(ref v) = t.completed_at {
+        println!("  Completed at:  {}", format_ts(v));
+    }
+    if let Some(ref v) = t.cron_expr {
+        println!("  Cron:          {v}");
+    }
+    if let Some(ref v) = t.parent_task_id {
+        println!("  Parent task:   {v}");
+    }
+    if let Some(ref v) = t.reference_url {
+        println!("  Reference:     {v}");
+    }
+    if let Some(ref v) = t.source {
+        println!("  Source:        {v}");
+    }
+    if let Some(pid) = t.process_id {
+        println!("  Process ID:    {pid}");
+    }
+    if let Some(ref v) = t.result {
+        let display = if v.len() > 200 { &v[..200] } else { v };
+        println!("  Result:        {display}");
+    }
+    println!();
+}
+
+fn task_to_json(t: &Task) -> Value {
+    json!({
+        "id": t.id,
+        "agent_id": t.agent_id,
+        "label": t.label,
+        "status": t.status,
+        "type": t.r#type,
+        "trigger_type": t.trigger_type,
+        "action_type": t.action_type,
+        "cron_expr": t.cron_expr,
+        "next_fire_at": t.next_fire_at,
+        "timeout_at": t.timeout_at,
+        "fired_at": t.fired_at,
+        "completed_at": t.completed_at,
+        "created_at": t.created_at,
+        "updated_at": t.updated_at,
+        "parent_task_id": t.parent_task_id,
+        "reference_url": t.reference_url,
+        "source": t.source,
+        "process_id": t.process_id,
+        "result": t.result,
+        "metadata": t.metadata,
+    })
 }

--- a/docs/plans/2026-05-06-001-chore-tasks-reminders-verb-orthogonal-plan.md
+++ b/docs/plans/2026-05-06-001-chore-tasks-reminders-verb-orthogonal-plan.md
@@ -1,0 +1,195 @@
+---
+title: "chore(cli): Make tasks and reminders verb-orthogonal with sibling surfaces"
+type: refactor
+status: active
+date: 2026-05-06
+---
+
+# chore(cli): Make tasks and reminders verb-orthogonal with sibling surfaces
+
+## Overview
+
+Add explicit `list` and `get` subcommands to `mika tasks` and `mika reminders`, matching the verb surface of `mika agents` and `mika skills`. Bare invocation remains as a backward-compatible alias for `list`.
+
+## Problem Frame
+
+The CLI is inconsistent: `agents` and `skills` use explicit verbs (`list`, `info`), but `tasks` and `reminders` only have implicit bare-invocation listing and `cancel`. This breaks agent discoverability (autonomous agents parse `--help` to discover verbs) and human muscle memory (`mika tasks list` errors out despite `--help` promising it).
+
+## Requirements Trace
+
+- R1. `mika tasks list` runs without error, returns same data as bare `mika tasks`
+- R2. `mika tasks get <id>` returns a single task's full record
+- R3. `mika reminders list` runs without error, returns same data as bare `mika reminders`
+- R4. `mika reminders get <id>` returns a single reminder's full record
+- R5. All new verbs documented in `--help` output
+- R6. Bare `mika tasks` and `mika reminders` keep working (backward compat)
+- R7. `--format text|json` on list and get verbs (per CLI conventions)
+
+## Scope Boundaries
+
+- No TUI changes
+- No new verbs on other surfaces (e.g., `mika sessions`)
+- No renaming `cancel` to `delete`
+- No prefix-matching for IDs (exact match only — matches existing `get_task` DB method)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-cli/src/cli.rs` — `TaskArgs`/`TaskCommand` at L584-597, `ReminderArgs`/`ReminderCommand` at L569-582
+- `crates/mika-cli/src/commands/tasks.rs` — current bare-list + cancel implementation
+- `crates/mika-cli/src/commands/reminders.rs` — current bare-list + cancel implementation
+- `crates/mika-cli/src/commands/skills.rs` — canonical pattern: `None` → list, `Some(List)` → list with format, `Some(Info)` → detail view
+- `crates/mika-agent/src/db.rs` — `Task` struct (L135-169), `get_task(id, agent_id)` (L4189)
+- `crates/mika-agent/src/async_db.rs` — `get_task(&self, id)` (L233), `get_tasks_by_status()`, `get_user_visible_tasks()`
+
+### Institutional Learnings
+
+- **CLI output format convention:** All list/show commands use `--format text|json` via `OutputFormat` enum
+- **AgentFlag pattern:** Flatten into subcommand structs, never use `global = true`
+- **ID suffix convention:** Opaque IDs use `--task-id` naming, but positional args like `get <id>` are fine
+- **Reminders are tasks:** `trigger_type IN ('time', 'recurring')` with `action_type IN ('send_message', 'resume_agent')`
+
+## Key Technical Decisions
+
+- **`get` not `info`:** The issue specifies `get`, and the pattern maps better to the data-retrieval semantics (tasks are looked up by ID, not by name like skills)
+- **Exact ID match only:** No prefix matching — keeps it simple, uses existing `get_task` DB method. Users copy IDs from `list` output
+- **Bare invocation stays as alias:** `Option<TaskCommand>` pattern preserved — `None` delegates to list logic, matching the existing skills pattern
+- **`--format` on list and get:** Both support `text|json`. JSON output uses serde on the Task struct
+- **Full ID in list output:** Keep showing short IDs in text mode for readability, but include full IDs in JSON output
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `List` and `Get` variants to `TaskCommand` and `ReminderCommand` enums**
+
+**Goal:** Extend the clap enums with new subcommand variants
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-cli/src/cli.rs`
+
+**Approach:**
+- Add `List` variant with `format: OutputFormat` arg to both `TaskCommand` and `ReminderCommand`
+- Add `Get` variant with positional `id: String` and `format: OutputFormat` arg to both
+- Keep `Cancel` variant unchanged
+- Add doc comments for `--help` output
+
+**Patterns to follow:**
+- `SkillsCommand::List { format }` and `SkillsCommand::Info { name }` in same file
+
+**Test scenarios:**
+- Test expectation: none — pure struct/enum definition, tested indirectly via Unit 2/3
+
+**Verification:**
+- `cargo build` succeeds with new enum variants
+
+- [ ] **Unit 2: Implement `tasks list` and `tasks get` handlers**
+
+**Goal:** Wire up the new task subcommands with list and detail logic
+
+**Requirements:** R1, R2, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-cli/src/commands/tasks.rs`
+- Test: `crates/mika-cli/src/commands/tasks.rs` (inline tests)
+
+**Approach:**
+- `None` and `Some(TaskCommand::List { format })` both call the same list function (extract current bare-list logic into a helper)
+- `Some(TaskCommand::Get { id, format })` calls `db.get_task(&id)`, renders full detail view
+- Text detail view: print all meaningful fields line-by-line (id, label, status, type, trigger_type, action_type, agent_id, created_at, updated_at, next_fire_at, fired_at, completed_at, parent_task_id, reference_url, source, process_id, cron_expr, result)
+- JSON detail view: serialize the Task struct
+- For list: text mode keeps current short-ID format; JSON mode serializes full task objects
+
+**Patterns to follow:**
+- `show_skill_detail()` in `crates/mika-cli/src/commands/skills.rs` for detail view formatting
+- Current `None` arm in `tasks.rs` for list logic
+
+**Test scenarios:**
+- Happy path: `get` with valid ID returns full task detail
+- Error path: `get` with non-existent ID prints "Task not found" message and exits gracefully
+- Happy path: `list` with `--format json` produces valid JSON array
+- Happy path: `list` with no tasks prints empty message
+
+**Verification:**
+- `mika tasks list` produces same output as bare `mika tasks`
+- `mika tasks get <id>` shows full task detail
+- `mika tasks list --format json` outputs JSON array
+
+- [ ] **Unit 3: Implement `reminders list` and `reminders get` handlers**
+
+**Goal:** Wire up the new reminder subcommands with list and detail logic
+
+**Requirements:** R3, R4, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-cli/src/commands/reminders.rs`
+- Test: `crates/mika-cli/src/commands/reminders.rs` (inline tests)
+
+**Approach:**
+- Same pattern as Unit 2 but using `get_user_visible_tasks()` for list and `get_task()` for detail
+- Detail view surfaces reminder-specific fields prominently: label, fire_at, status, cron_expr (for recurring), action_config (the message text)
+- For `get`: after fetching task, verify it's a reminder type (trigger_type is 'time' or 'recurring') — if not, print "Not a reminder" error
+
+**Patterns to follow:**
+- Unit 2's implementation
+- Current `None` arm in `reminders.rs`
+
+**Test scenarios:**
+- Happy path: `get` with valid reminder ID returns full reminder detail
+- Error path: `get` with non-existent ID prints "Reminder not found"
+- Edge case: `get` with a task ID that's not a reminder (trigger_type = 'manual') prints appropriate error
+- Happy path: `list --format json` produces valid JSON
+
+**Verification:**
+- `mika reminders list` produces same output as bare `mika reminders`
+- `mika reminders get <id>` shows reminder detail
+
+- [ ] **Unit 4: Update CLAUDE.md CLI documentation**
+
+**Goal:** Document the new verbs in the CLI reference
+
+**Requirements:** R5
+
+**Dependencies:** Units 2, 3
+
+**Files:**
+- Modify: `crates/mika-cli/CLAUDE.md`
+
+**Approach:**
+- Add `mika tasks list`, `mika tasks get <id>` to the subcommands documentation
+- Add `mika reminders list`, `mika reminders get <id>` similarly
+- Note `--format text|json` support
+- Add both to the "Other `--format text|json` Commands" list
+
+**Test scenarios:**
+- Test expectation: none — documentation only
+
+**Verification:**
+- CLAUDE.md accurately reflects the new CLI surface
+
+## System-Wide Impact
+
+- **API surface parity:** This change brings tasks/reminders in line with agents/skills. Future CLI noun-surfaces should follow the same verb pattern (list, get/info, create, delete/cancel).
+- **Unchanged invariants:** The underlying DB methods (`get_task`, `get_tasks_by_status`, `get_user_visible_tasks`, `cancel_task`) are unchanged. The task engine, scheduler, and server API are not affected.
+- **Agent readiness:** Autonomous agents parsing `--help` will now discover `list` and `get` verbs consistently across all surfaces.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking scripts that parse bare `mika tasks` output | Bare invocation preserved as alias — no output format change |
+| ID confusion between tasks and reminders in `get` | Reminders validate trigger_type; tasks show any task regardless of type |
+
+## Sources & References
+
+- Related issue: #981
+- Existing pattern: `crates/mika-cli/src/commands/skills.rs` (list/info pattern)
+- Learnings: `docs/solutions/architecture-patterns/cli-output-format-list-commands.md`
+- Learnings: `docs/solutions/cli-features/kg-cli-management-subcommands-2026-04-25.md`

--- a/docs/solutions/architecture-patterns/cli-verb-orthogonality-subcommand-surfaces-2026-05-06.md
+++ b/docs/solutions/architecture-patterns/cli-verb-orthogonality-subcommand-surfaces-2026-05-06.md
@@ -1,0 +1,130 @@
+---
+title: "CLI verb orthogonality: consistent subcommand surfaces across noun groups"
+module: mika-cli
+date: 2026-05-06
+problem_type: best_practice
+component: tooling
+severity: medium
+tags:
+  - cli
+  - clap
+  - subcommands
+  - agent-readiness
+  - discoverability
+applies_when:
+  - Adding a new noun-level subcommand group (e.g., `mika sessions`)
+  - Reviewing existing subcommand surfaces for agent compatibility
+  - Designing CLI interfaces consumed by autonomous agents
+---
+
+# CLI Verb Orthogonality: Consistent Subcommand Surfaces
+
+## Context
+
+Autonomous agents discover CLI capabilities via `--help` parsing. When noun-level
+subcommand groups (e.g., `mika tasks`, `mika agents`, `mika skills`) have inconsistent
+verb surfaces, agents must special-case each group. The KISS principle dictates: same noun
+shape, same verbs.
+
+Issue #981 identified that `mika tasks` and `mika reminders` lacked explicit `list` and
+`get` verbs that sibling surfaces (`mika agents`, `mika skills`) already had. Bare
+invocation worked but was not discoverable via `--help` as a named subcommand.
+
+## Guidance
+
+Every noun-level subcommand group should expose a minimum orthogonal verb set:
+
+| Verb | Purpose | Pattern |
+|------|---------|---------|
+| `list` | Enumerate resources | Always include `--format text\|json` |
+| `get <id>` or `info <name>` | Detail view of a single resource | Use `get` for ID-based, `info` for name-based |
+| Destructive verb (`cancel`, `delete`, `uninstall`) | Remove or stop a resource | Keep existing semantics |
+
+### Implementation pattern (clap)
+
+Use `Option<Command>` with `None` as a backward-compatible alias for `list`:
+
+```rust
+#[derive(Subcommand)]
+pub enum TaskCommand {
+    /// List active tasks
+    List {
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Show details for a specific task
+    Get {
+        id: String,
+        #[arg(long, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+    /// Cancel a task by ID
+    Cancel { id: String },
+}
+```
+
+In the handler, match `None` and `Some(List { .. })` together:
+
+```rust
+match args.command {
+    None | Some(TaskCommand::List { .. }) => {
+        let format = match &args.command {
+            Some(TaskCommand::List { format }) => format.clone(),
+            _ => OutputFormat::Text,
+        };
+        // list logic...
+    }
+    Some(TaskCommand::Get { id, format }) => { /* detail logic */ }
+    Some(TaskCommand::Cancel { id }) => { /* cancel logic */ }
+}
+```
+
+### UTF-8 safety in detail views
+
+When truncating text fields for display, never use raw byte slices (`&v[..200]`).
+Use char-boundary-safe truncation:
+
+```rust
+let display = match v.char_indices().nth(200) {
+    Some((i, _)) => &v[..i],
+    None => v,
+};
+```
+
+The CI `byte-slice-lint` job (`scripts/check-byte-slices.sh`) enforces this.
+
+## Why This Matters
+
+- **Agent discoverability:** Agents parsing `--help` see explicit verbs and can construct
+  commands without special-casing each noun group
+- **Human muscle memory:** Users who learn `mika agents list` expect `mika tasks list`
+- **Scripting consistency:** `--format json` on both `list` and `get` enables uniform
+  pipeline integration
+- **Backward compatibility:** `Option<Command>` with `None` alias preserves existing
+  bare-invocation behavior
+
+## Examples
+
+Before (inconsistent):
+```
+$ mika tasks --help
+Commands:
+  cancel  Cancel a task by ID
+  help    Print this message...
+
+$ mika tasks list
+error: unrecognized subcommand 'list'
+```
+
+After (orthogonal):
+```
+$ mika tasks --help
+Commands:
+  list    List active tasks
+  get     Show details for a specific task
+  cancel  Cancel a task by ID
+  help    Print this message...
+
+$ mika tasks list --format json
+[{"id":"abc123...","label":"...","status":"pending",...}]
+```


### PR DESCRIPTION
## Summary

- Add explicit `list` and `get <id>` subcommands to `mika tasks` and `mika reminders`, matching the verb surface of `mika agents` and `mika skills`
- Bare invocation (`mika tasks`, `mika reminders`) preserved as backward-compatible alias for `list`
- Both new verbs support `--format text|json` per CLI conventions
- Fix UTF-8 panic in task result display (byte-slice replaced with char-boundary-safe truncation)

Closes #981

Plan: docs/plans/2026-05-06-001-chore-tasks-reminders-verb-orthogonal-plan.md

## What changed

| Before | After |
|--------|-------|
| `mika tasks list` → error | `mika tasks list` works, shows active tasks |
| No way to inspect a single task | `mika tasks get <id>` shows full detail |
| `mika reminders list` → error | `mika reminders list` works |
| No way to inspect a single reminder | `mika reminders get <id>` shows full detail |

## Test plan

- [x] `cargo build -p mika-cli` passes
- [x] `cargo test -p mika-cli` passes (279 tests)
- [x] `cargo clippy -p mika-cli` clean
- [x] `mika tasks --help` shows `list`, `get`, `cancel`
- [x] `mika reminders --help` shows `list`, `get`, `cancel`
- [x] Bare `mika tasks` still works (backward compat)
- [x] Pre-commit hooks pass (fmt, clippy, secrets, file size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)