### PR TITLE
obs(logging): document log sink architecture and add `mika logs` command

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -431,6 +431,21 @@ Axum-based with two auth layers: mutation endpoints require `MIKA_INTERNAL_TOKEN
 
 **Session lifecycle:** Silent dispatcher variants call `end_session()` after completion. CLI commands call `end_session()` on all exit paths. `startup_recovery()` prunes old sessions via `prune_old_sessions()`.
 
+### Log Sinks
+
+Two distinct sinks exist for runtime log events. Both emit the same structured JSON with an `agent_id` field on every entry — the difference is the file target and the process that writes to it.
+
+| Sink | Initializer | Process | Path | Rotation |
+|------|-------------|---------|------|----------|
+| **Server log** | `mika_common::logging::init()` (`crates/mika-common/src/logging.rs:208`) | `mika-server` (long-running daemon) | `MIKA_SERVER_LOG_FILE` (e.g. `/var/log/mika/server.log`) | None — single file via `tracing_appender::rolling::never` |
+| **Per-agent CLI log** | `mika_common::logging::init_pretty()` (`crates/mika-common/src/logging.rs:314`) | `mika-cli` (`mika ask`, `mika chat`, `mika team run`, etc.) | `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` (daily) | Daily via `tracing_appender::rolling::daily` |
+
+**Decision tree for operators:** If you want to read the running mika-server's runtime events (skill execution, task engine, callback lifecycle, autonomous-loop wedges), read `MIKA_SERVER_LOG_FILE` filtered by `agent_id`. If you want to read a specific `mika ask` or `mika chat` invocation's events, read `~/.mika/agents/<name>/logs/mika.log.<date>`. Both contain the same `agent_id` field on every entry, so cross-filtering by agent works in either sink.
+
+**Single-sink rationale:** mika-server uses one file with `agent_id`-filtered queries instead of per-agent file appenders because: (a) per-agent appenders would double the disk-write rate per event, (b) they create a sync gap risk if the per-agent appender worker can't keep up, and (c) they duplicate data already correctly addressable via the JSON `agent_id` field. The per-agent CLI sink is correct for its purpose (discrete CLI invocations) and is not a substitute for the server log.
+
+**Common mistake:** Audit tooling that reads `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` for server-mode events will find it nearly empty — only CLI invocations write there. Use `jq 'select(.agent_id == "<name>")' < $MIKA_SERVER_LOG_FILE` for server-mode queries. `mika logs --agent <name>` prints both resolved paths.
+
 ## Audit Log
 
 `audit_events` table tracks all memory mutations per session. All writes include `trace_id`.

--- a/crates/mika-cli/CLAUDE.md
+++ b/crates/mika-cli/CLAUDE.md
@@ -4,7 +4,7 @@ TUI CLI binary (`mika`): ratatui chat interface with clap subcommands.
 
 ## Subcommands
 
-`status`, `memory`, `reminders`, `config`, `setup`, `mcp`, `skills`, `tasks`, `ask`, `doctor`, `dashboard`, `token`, `credential-helper`, `provider`, `model`, `agents`, `teams`, `webhook`, `kg`.
+`status`, `memory`, `reminders`, `config`, `setup`, `mcp`, `skills`, `tasks`, `ask`, `doctor`, `dashboard`, `token`, `credential-helper`, `provider`, `model`, `agents`, `teams`, `webhook`, `kg`, `logs`.
 
 ### Key Commands
 
@@ -79,6 +79,14 @@ Requires `MIKA_GATEWAY_URL` (default: `http://localhost:3001`) and `MIKA_INTERNA
 Exit codes: `status`, `list-agents` always 0. `purge` returns 0 on success, 1 on cancellation or error. `validate` returns 0 iff no Fail checks, 1 otherwise.
 
 See `crates/mika-agent/CLAUDE.md` for KG architecture and schema details.
+
+## Logs CLI
+
+`mika logs` — Show resolved log file paths for an agent. Prints both the server log path (`MIKA_SERVER_LOG_FILE` or `/var/log/mika/server.log` fallback) and the per-agent CLI log path (`~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD`). Includes file existence, size, and a ready-to-use `jq` filter command for querying the server log by agent_id.
+
+Supports `--agent <name>` and `--format text|json`.
+
+See `crates/mika-agent/CLAUDE.md` § Log Sinks for the architectural rationale behind the two-sink design.
 
 ## MCP CLI
 

--- a/crates/mika-cli/src/cli.rs
+++ b/crates/mika-cli/src/cli.rs
@@ -75,6 +75,8 @@ pub enum Commands {
     Webhook(WebhookArgs),
     /// Manage Knowledge Graph state
     Kg(KgArgs),
+    /// Show resolved log file paths for an agent
+    Logs(LogsArgs),
     /// Git credential helper (used by git, not directly by users)
     #[command(name = "credential-helper")]
     CredentialHelper(CredentialHelperArgs),
@@ -97,6 +99,7 @@ impl Commands {
             Commands::Provider(args) => args.agent_flag.agent.as_deref(),
             Commands::Model(args) => args.agent_flag.agent.as_deref(),
             Commands::Kg(args) => args.agent_override(),
+            Commands::Logs(args) => args.agent_flag.agent.as_deref(),
             // No agent override — listed explicitly so adding a new Commands variant
             // produces a compile error, forcing a conscious scoping decision.
             Commands::Setup { .. }
@@ -132,6 +135,7 @@ impl Commands {
             | Commands::Model(_)
             | Commands::Webhook(_)
             | Commands::Kg(_)
+            | Commands::Logs(_)
             | Commands::CredentialHelper(_) => None,
         }
     }
@@ -759,6 +763,16 @@ pub struct ModelArgs {
 
     /// Model name or alias to switch to (omit to list)
     pub name: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub struct LogsArgs {
+    #[command(flatten)]
+    pub agent_flag: AgentFlag,
+
+    /// Output format: text (default) or json
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: OutputFormat,
 }
 
 #[derive(clap::Args)]

--- a/crates/mika-cli/src/commands/logs.rs
+++ b/crates/mika-cli/src/commands/logs.rs
@@ -1,0 +1,110 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::Local;
+
+use crate::cli::OutputFormat;
+
+/// Print the resolved log file paths for the given agent.
+///
+/// Two sinks exist:
+/// - **Server log:** `MIKA_SERVER_LOG_FILE` (or `/var/log/mika/server.log` fallback) — contains
+///   all runtime events from the long-running mika-server daemon, filterable by `agent_id`.
+/// - **Per-agent CLI log:** `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` — contains events
+///   from discrete CLI invocations (`mika ask`, `mika chat`, etc.) for that agent only.
+pub fn run(agent_name: &str, agent_home: &Path, format: &OutputFormat) -> Result<()> {
+    let today = Local::now().format("%Y-%m-%d").to_string();
+
+    // Resolve server log path: env var > fallback
+    let server_log = std::env::var("MIKA_SERVER_LOG_FILE")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/var/log/mika/server.log"));
+
+    // Per-agent CLI log path (daily rotation)
+    let cli_log = agent_home.join("logs").join(format!("mika.log.{today}"));
+
+    let server_log_exists = server_log.exists();
+    let cli_log_exists = cli_log.exists();
+
+    let server_log_size = if server_log_exists {
+        std::fs::metadata(&server_log).map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+    let cli_log_size = if cli_log_exists {
+        std::fs::metadata(&cli_log).map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let obj = serde_json::json!({
+                "agent": agent_name,
+                "server_log": {
+                    "path": server_log.to_string_lossy(),
+                    "exists": server_log_exists,
+                    "size_bytes": server_log_size,
+                    "filter_command": format!("jq 'select(.agent_id == \"{agent_name}\")' {}", server_log.display()),
+                },
+                "cli_log": {
+                    "path": cli_log.to_string_lossy(),
+                    "exists": cli_log_exists,
+                    "size_bytes": cli_log_size,
+                    "date": today,
+                },
+            });
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+        OutputFormat::Text => {
+            println!();
+            println!("  \u{2726} Log Sinks for agent: {agent_name}");
+            println!();
+            println!("  Server log (mika-server runtime events):");
+            println!("    Path:   {}", server_log.display());
+            println!(
+                "    Status: {}",
+                if server_log_exists {
+                    format!("exists ({})", format_size(server_log_size))
+                } else {
+                    "not found".to_string()
+                }
+            );
+            println!(
+                "    Filter: jq 'select(.agent_id == \"{agent_name}\")' {}",
+                server_log.display()
+            );
+            println!();
+            println!("  Per-agent CLI log (mika ask/chat invocations):");
+            println!("    Path:   {}", cli_log.display());
+            println!(
+                "    Status: {}",
+                if cli_log_exists {
+                    format!("exists ({})", format_size(cli_log_size))
+                } else {
+                    "not found (no CLI invocations today)".to_string()
+                }
+            );
+            println!();
+            println!("  Tip: For server-mode runtime events (skill execution, task engine,");
+            println!("  callback lifecycle), always use the server log filtered by agent_id.");
+            println!("  The per-agent CLI log only contains events from discrete CLI calls.");
+            println!();
+        }
+    }
+
+    Ok(())
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes > 1_000_000_000 {
+        format!("{:.1} GB", bytes as f64 / 1_000_000_000.0)
+    } else if bytes > 1_000_000 {
+        format!("{:.1} MB", bytes as f64 / 1_000_000.0)
+    } else if bytes > 1_000 {
+        format!("{:.1} KB", bytes as f64 / 1_000.0)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/crates/mika-cli/src/commands/mod.rs
+++ b/crates/mika-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod credential_helper;
 pub mod dashboard;
 pub mod doctor;
 pub mod kg;
+pub mod logs;
 pub mod mcp;
 pub mod memory;
 pub mod model;

--- a/crates/mika-cli/src/main.rs
+++ b/crates/mika-cli/src/main.rs
@@ -276,6 +276,11 @@ async fn main() -> Result<()> {
         Some(Commands::Model(args)) => commands::model::run(args, &agent_name).await,
         Some(Commands::Webhook(args)) => commands::webhook::run(args.command, &args.format).await,
         Some(Commands::Kg(args)) => commands::kg::run(args).await,
+        Some(Commands::Logs(ref args)) => {
+            let ah = agent_home
+                .ok_or_else(|| anyhow::anyhow!("Could not resolve agent home directory"))?;
+            commands::logs::run(&agent_name, &ah, &args.format)
+        }
         // Handled by early-exit above — unreachable, but listed for exhaustive match.
         Some(Commands::Token(_) | Commands::CredentialHelper(_)) => unreachable!(),
     }

--- a/docs/plans/2026-05-06-003-obs-985-logging-sparseness-plan.md
+++ b/docs/plans/2026-05-06-003-obs-985-logging-sparseness-plan.md
@@ -1,0 +1,105 @@
+---
+ticket: mika#985
+title: "obs(logging): per-agent runtime log file is sparse — sink-architecture clarification"
+type: obs
+status: groomed-pending
+labels: [bug, p1-important]
+branch: obs/985/logging-mika-dev-runtime-log-file-is
+related_tickets: [984]
+---
+
+# Plan — mika#985: per-agent runtime log file is sparse
+
+## Verified state (root cause identified during plan drafting)
+
+The audit ticket framed this as "per-agent log file is sparse despite DB activity," with the implicit assumption that `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` is the sink for the running mika-server's per-agent runtime events. That assumption is false. **This is not a regression — it's an architectural mismatch between two sink targets and a single audit recipe.**
+
+### The two sinks
+
+| Sink | Initializer | Server-side call site | Used by | Path | Rotation |
+|---|---|---|---|---|---|
+| Server log | `mika_common::logging::init()` (`crates/mika-common/src/logging.rs:208`) | `crates/mika-agent/src/bin/mika-server.rs` `main()` startup | `mika-server` (long-running daemon) | `MIKA_SERVER_LOG_FILE` (e.g. `/var/log/mika/server.log`) | None — single file via `tracing_appender::rolling::never` |
+| Per-agent CLI log | `mika_common::logging::init_pretty()` (`crates/mika-common/src/logging.rs:314`) | `crates/mika-cli/src/main.rs:215` (per-agent), `:339` (team), `:367` (chat) | `mika-cli` (`mika ask`, `mika chat`, `mika team run`, etc.) | `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` (per-agent, daily) | Daily via `tracing_appender::rolling::daily` |
+
+### The evidence
+
+- Today's `~/.mika/agents/mika-dev/logs/mika.log.2026-05-05` has only 2 entries — both `GitHub App configured` from `mika_common::github_app`. These correspond to two `mika ask --agent mika-dev ...` CLI invocations (each one fires GitHub App init at startup and exits).
+- `/var/log/mika/server.log` is fully populated (2.5 GB cumulative). The `mika#984` task audit found the relevant runtime events there: `long-running exec exited but task already in terminal state`, `resuming agent for callback task`, `task_engine_reaper: transitioned orphaned parent to failed` — all at `target: mika_agent::skills::executor` / `mika_agent::task_engine::*`.
+- `mika-cli/src/main.rs:164` confirms: `let log_dir = agent_home.as_ref().map(|h| h.join("logs"));` — only the CLI sets a per-agent log dir.
+- `mika-server`'s init path takes `log_file: Option<&Path>` from `MIKA_SERVER_LOG_FILE`, not from a per-agent home dir.
+
+### What this means
+
+The audit's `shared:log-grep` recipe in `/mika-audit` (canonical pattern: `~/.mika/agents/<agent_id>/logs/mika.log.YYYY-MM-DD`) is structurally wrong for server-mode events. It looks at the CLI sink while the runtime events go to the server sink. The DB telemetry is correct because both sinks emit the same events to `tracing` — only the file write target differs.
+
+## Acceptance criteria
+
+1. **Documentation:** `crates/mika-agent/CLAUDE.md` § Observability documents which sink contains which class of event. The decision tree is one paragraph: "If you want to read the running mika-server's runtime events, read `MIKA_SERVER_LOG_FILE`. If you want to read a specific `mika ask` or `mika chat` invocation's events, read `~/.mika/agents/<name>/logs/mika.log.<date>`. Both contain the same `agent_id` field on every entry, so cross-filtering by agent works in either sink."
+2. **Audit recipe correction:** `/mika-audit`'s `shared:log-grep` helper (in `mika-platform/.claude/commands/mika-audit.md`) reads from `MIKA_SERVER_LOG_FILE` filtered by `agent_id`, with a fallback to the per-agent CLI log path. The recipe explicitly notes both sinks and which one to prefer.
+3. **Smoke test (optional, low effort):** add a `mika logs --agent <name>` subcommand or extend `mika status` to print the resolved log paths so operators don't need to remember which sink is which.
+
+## Plan
+
+### Step 1 — Documentation in `crates/mika-agent/CLAUDE.md`
+
+Add a new "Log Sinks" subsection under § Observability with the table from "Verified state" above and the cross-reference rule. Cite `mika_common::logging::init()` vs `init_pretty()` and the server-side call site (`crates/mika-agent/src/bin/mika-server.rs main()`) so future readers can find the source of truth.
+
+**Include the single-sink rationale.** State explicitly that mika-server uses one file with `agent_id`-filtered queries instead of per-agent appenders, because per-agent appenders would (a) double the disk-write rate per event, (b) create a sync gap risk if the per-agent worker can't keep up, and (c) duplicate data already correctly addressable via the JSON `agent_id` field. The rationale belongs next to the table so future edits to the architecture see it without going to the plan archive.
+
+### Step 2 — Update `/mika-audit`'s `shared:log-grep`
+
+Edit `mika-platform/.claude/commands/mika-audit.md` § shared:log-grep:
+- Default sink becomes the server log file. Resolve via `MIKA_SERVER_LOG_FILE` env var (or fall back to `/var/log/mika/server.log` as the documented production default).
+- Filter is now `jq 'select(.agent_id == "<agent_id>" and .timestamp >= "<start>" and .timestamp <= "<end>")'` instead of relying on path-based agent scoping.
+- The per-agent CLI sink stays documented as a fallback for "what did this specific `mika ask` invocation do" — useful for grooming-tool debugging, not for tracing autonomous-loop wedges.
+- Update the rendering header to print which sink was used: `**Log file:** <path> (<size>) | **Sink:** server|cli` so the audit output discloses its source of truth.
+
+### Step 3 — Verify the recipe against today's evidence
+
+After Step 2 lands, re-run `/mika-audit task 0b38a0ec-4d4b-4039-b43b-c05d4e121bb3` (the failed mika#666 dispatch). The audit should now find the `long-running exec exited but task already in terminal state` and `resuming agent for callback task` lines that were invisible to the old recipe. If it doesn't, Step 2's filter is wrong and needs revision.
+
+### Step 4 — Optional `mika logs --agent <name>` subcommand
+
+If Step 3 reveals operators need easier sink discovery, add a thin CLI subcommand that prints both resolved paths and tail the appropriate one. Out-of-scope if Steps 1-3 are sufficient.
+
+## Out of scope (explicit)
+
+- **Per-agent file appender on mika-server.** Adding `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` as a second sink for the running mika-server would make the audit recipe "just work" without doc/recipe changes — but it adds disk writes per event for every per-agent action, doubles log volume, and creates a sync gap (events lost if the per-agent appender's worker can't keep up). Server log + agent_id filter is the cheaper, lossless answer.
+- **Schema change to enrich `agent_id` field on every log line.** All entries already carry `agent_id` in the JSON envelope (verified by spot-check in `/var/log/mika/server.log`). No code change needed.
+- **CLI-mode log routing changes.** The per-agent CLI sink is correct as-is for its purpose (discrete invocations).
+
+## Risk and reversibility
+
+- All three steps are documentation + audit-recipe edits. No production-runtime change. Trivially reversible.
+- Step 4 is optional and additive; if shipped, no removal needed.
+- The "audit was reading the wrong file" framing has zero functional impact on running services — only on operator debugging speed.
+
+## Files touched (estimated)
+
+- `mika/crates/mika-agent/CLAUDE.md` — add § Log Sinks with single-sink rationale (Step 1)
+- `mika-platform/.claude/commands/mika-audit.md` — update shared:log-grep (Step 2)
+- `mika/crates/mika-cli/src/commands/logs.rs` (new, optional) — `mika logs` subcommand (Step 4 if needed)
+- `mika/crates/mika-cli/src/main.rs` — wire subcommand if Step 4 ships
+
+## Delivery shape (cross-repo)
+
+Two PRs per `mika-platform/CLAUDE.md` "primary + direct" cross-repo guidance:
+
+- **Primary PR (mika repo):** Step 1 + Step 3 verification + Step 4 if needed. Largest change, owns the architectural docs.
+- **Secondary PR (mika-platform repo):** Step 2 audit-recipe edit only. Single-file change to `.claude/commands/mika-audit.md`.
+
+Both PRs cross-reference via `Companion PR: senara-solutions/<other-repo>#<n>` in the body. Same branch name (`obs/985/logging-mika-dev-runtime-log-file-is`) across both repos for traceability. Land in any order — they're independent (mika-platform recipe edit doesn't break if mika docs ship later, and vice versa).
+
+## Why P1, not P0
+
+Audit operators currently fall back to the DB telemetry, which has the same fidelity as logs (the events are the same; only the file write target differs). The cost is debugging speed, not correctness. P1 — fix soon, not blocking.
+
+## Cross-cutting note (mika#984)
+
+This ticket was filed today during the mika#984 audit specifically because the `validate_required_fields` warn was expected to surface in the per-agent log file but did not. Once the audit recipe is corrected (Step 2), the same trace becomes immediately visible in the server log. Useful checkpoint for the mika#984 F5 step (Phase 0.5.1 of mika#984's plan): once the trace lands, find it via the corrected recipe, not via the empty per-agent file.
+
+## What this plan deliberately does NOT do
+
+- Does NOT add a third log sink. Two sinks is correct given two execution modes (server daemon vs discrete CLI invocation).
+- Does NOT promote `MIKA_SERVER_LOG_FILE` from "optional" to "required." The default fallback path (`/var/log/mika/server.log` per the deployed gentoo init script) is fine; the env var is the override.
+- Does NOT change log levels or filters. The log content is correct; only the audit recipe pointer is wrong.

--- a/docs/solutions/documentation-gaps/log-sink-architecture-mismatch-2026-05-06.md
+++ b/docs/solutions/documentation-gaps/log-sink-architecture-mismatch-2026-05-06.md
@@ -1,0 +1,74 @@
+---
+module: observability
+date: "2026-05-06"
+problem_type: documentation_gap
+component: documentation
+severity: medium
+tags: [logging, tracing, mika-server, mika-cli, audit, observability]
+applies_when:
+  - Audit tooling reads per-agent log files for server-mode events
+  - Operators expect mika-server runtime events in ~/.mika/agents/<name>/logs/
+  - Debugging autonomous-loop issues using per-agent CLI log paths
+---
+
+# Log Sink Architecture Mismatch
+
+## Context
+
+An audit (`/mika-audit task ...`) reported that the per-agent runtime log file at `~/.mika/agents/mika-dev/logs/mika.log.2026-05-05` was "sparse" — only 2 entries despite the DB recording 12+ LLM calls and 3+ tool calls in the same window. The initial assumption was a logging regression.
+
+Investigation revealed this is not a regression — it's an architectural mismatch between two log sinks and the audit recipe pointing at the wrong one.
+
+## Guidance
+
+mika has **two distinct log sinks**, each written by a different process:
+
+| Sink | Process | Path | Contains |
+|------|---------|------|----------|
+| Server log | `mika-server` (long-running daemon) | `MIKA_SERVER_LOG_FILE` (default: `/var/log/mika/server.log`) | All runtime events: skill execution, task engine, callbacks, autonomous-loop lifecycle |
+| Per-agent CLI log | `mika` CLI (`mika ask`, `mika chat`) | `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD` | Events from discrete CLI invocations only |
+
+**The key insight:** Both sinks write the same structured JSON with an `agent_id` field. The CLI log is per-agent by path; the server log is per-agent by filter. They are not duplicates — they capture events from different processes.
+
+**Query patterns:**
+- Server-mode events: `jq 'select(.agent_id == "mika-dev")' /var/log/mika/server.log`
+- CLI invocation events: read `~/.mika/agents/mika-dev/logs/mika.log.2026-05-06` directly
+
+**Use `mika logs --agent <name>` to print both resolved paths with sizes and filter commands.**
+
+## Why This Matters
+
+Audit tooling that reads only the per-agent CLI log path will find it nearly empty for server-mode events. This creates false "sparse logging" reports and blocks debugging of autonomous-loop issues. The data exists — it's just in the server log, not where the audit recipe looked.
+
+The single-sink rationale for mika-server (no per-agent file appenders) is intentional:
+1. Per-agent appenders would double disk-write rate per event
+2. Sync gaps risk if a per-agent appender worker can't keep up
+3. Duplicates data already addressable via `agent_id` JSON field
+
+## When to Apply
+
+- Building or modifying audit/grep tooling that reads agent log files
+- Debugging "missing log entries" for server-mode agent activity
+- Writing new observability features that need to find runtime events
+- Any time an operator reports "logs are empty" for an agent
+
+## Examples
+
+**Wrong (reads CLI sink for server events):**
+```bash
+# Will be nearly empty — only CLI invocations write here
+grep "task_engine" ~/.mika/agents/mika-dev/logs/mika.log.2026-05-05
+```
+
+**Right (reads server sink filtered by agent_id):**
+```bash
+# Full runtime events filtered by agent
+jq 'select(.agent_id == "mika-dev" and .timestamp >= "2026-05-05T21:18:00")' \
+  /var/log/mika/server.log
+```
+
+**Discovery command:**
+```bash
+# Shows both paths, sizes, and ready-to-use filter commands
+mika logs --agent mika-dev
+```


### PR DESCRIPTION
## Summary

- Document the two-sink logging architecture (server log vs per-agent CLI log) in `crates/mika-agent/CLAUDE.md` § Observability → Log Sinks
- Add `mika logs [--agent <name>]` CLI subcommand that prints both resolved log paths, file sizes, and ready-to-use `jq` filter commands
- Clarify that per-agent log files are CLI-only sinks — mika-server runtime events live in `MIKA_SERVER_LOG_FILE`

Plan: docs/plans/2026-05-06-003-obs-985-logging-sparseness-plan.md

Companion PR: senara-solutions/mika-platform (TBD — audit recipe correction in `.claude/commands/mika-audit.md`)

Closes #985

## Test plan

- [x] `cargo build -p mika-cli` passes
- [x] `cargo clippy -p mika-cli` clean
- [x] `cargo test -p mika-cli` — 287 tests pass
- [x] lefthook pre-commit hooks pass (fmt, clippy, no-secrets, no-large-files)
- [ ] Manual: `mika logs --agent mika-dev` shows both sink paths with correct sizes
- [ ] Manual: `mika logs --agent mika-dev --format json` emits valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)