### PR TITLE
feat(dashboard): landing/home overview page (#666)

### DIFF
--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -22,7 +22,9 @@ This Dashboard is currently undergoing the first of three ecosystem-wide design 
 
 ## Pages
 
-Event Timeline, Agents, Sessions, Traces, Tasks (+ detail), Team Runs, LLM Calls (+ detail), Tool Calls (+ detail), Dev Runs (+ detail). Auth via `VITE_MIKA_DASHBOARD_TOKEN` env var. Bearer token. Imports shared components from `@senara-solutions/ui`. All list pages expose `<TimeRangeFilter />` with URL-reflected `?from=...&to=...` state (mika#659).
+**Overview / Home (mika#666):** Landing page at `/` (index route). Shows "state of the world" — stacked widget sections for Agents, Work Items, Dev Runs, Team Runs, Cost (24h), and Recent Activity. Composes existing API hooks on the frontend (no dedicated backend endpoint). Auto-refreshes all widgets at 15s shared interval with LIVE badge. Fresh-install gate: shows cohesive empty state when no agents are provisioned. Event Timeline moved to `/timeline`.
+
+Event Timeline (`/timeline`), Agents, Sessions, Traces, Tasks (+ detail), Team Runs, LLM Calls (+ detail), Tool Calls (+ detail), Dev Runs (+ detail). Auth via `VITE_MIKA_DASHBOARD_TOKEN` env var. Bearer token. Imports shared components from `@senara-solutions/ui`. All list pages expose `<TimeRangeFilter />` with URL-reflected `?from=...&to=...` state (mika#659).
 
 **LLM Calls page (mika#660):** `<CostTrendChart>` time-series visualization above the table, showing estimated cost over time aggregated from `llm_calls` token counts. Two variants: total (single line) and stacked-by-agent. Uses recharts. Backed by `GET /api/v1/llm-calls/cost-trend` with auto-bucketing (hourly <3d, daily ≥3d). Server defaults to last 24h when no `from` param. Pricing is estimated server-side via `crates/mika-agent/src/pricing.rs`.
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router'
 import Layout from './components/Layout.tsx'
+import Home from './pages/Home.tsx'
 import Timeline from './pages/Timeline.tsx'
 import TraceDetail from './pages/TraceDetail.tsx'
 import Traces from './pages/Traces.tsx'
@@ -24,7 +25,8 @@ export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route index element={<Timeline />} />
+        <Route index element={<Home />} />
+        <Route path="timeline" element={<Timeline />} />
         <Route path="traces" element={<Traces />} />
         <Route path="traces/:traceId" element={<TraceDetail />} />
         <Route path="agents" element={<Agents />} />

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -1,8 +1,9 @@
 import { NavLink } from 'react-router'
-import { Activity, Bot, MessageSquare, Search, CheckSquare, Hammer, Users, Brain, Wrench, Layers } from 'lucide-react'
+import { LayoutDashboard, Activity, Bot, MessageSquare, Search, CheckSquare, Hammer, Users, Brain, Wrench, Layers } from 'lucide-react'
 
 const navItems = [
-  { to: '/', label: 'Event Timeline', icon: Activity },
+  { to: '/', label: 'Overview', icon: LayoutDashboard },
+  { to: '/timeline', label: 'Event Timeline', icon: Activity },
   { to: '/agents', label: 'Agents', icon: Bot },
   { to: '/sessions', label: 'Sessions', icon: MessageSquare },
   { to: '/traces', label: 'Traces', icon: Search },

--- a/dashboard/src/components/home/AgentsSummaryWidget.tsx
+++ b/dashboard/src/components/home/AgentsSummaryWidget.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router'
+import { useAgents } from '../../api/agents.ts'
+import { StatusBadge, LoadingState, ErrorState, EmptyState, formatApiError, formatRelativeTime } from '@senara-solutions/ui'
+import WidgetSection from './WidgetSection.tsx'
+
+/**
+ * Agents summary widget for the landing page.
+ * Note: useAgents() returns unpaginated Agent[] and doesn't accept refetchInterval.
+ * The landing page's agents gate in Home.tsx handles the polling lifecycle.
+ */
+export default function AgentsSummaryWidget() {
+  const { data: agents, isLoading, error, refetch } = useAgents()
+
+  return (
+    <WidgetSection
+      label="Agents"
+      count={agents?.length}
+      viewAllTo="/agents"
+    >
+      {isLoading ? (
+        <LoadingState variant="list" rows={3} />
+      ) : error ? (
+        <ErrorState message={formatApiError(error)} retry={() => refetch()} />
+      ) : !agents || agents.length === 0 ? (
+        <EmptyState message="No agents registered" />
+      ) : (
+        <div className="space-y-1">
+          {agents.map((agent) => (
+            <Link
+              key={agent.id}
+              to={`/agents/${agent.id}`}
+              className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-white/[0.03] transition-colors group"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
+                  <span className="text-accent font-semibold text-xs">
+                    {agent.name.charAt(0).toUpperCase()}
+                  </span>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm text-heading font-medium truncate group-hover:text-accent-light transition-colors">
+                    {agent.name}
+                  </p>
+                  <p className="text-[10px] text-muted/40">
+                    {agent.last_seen ? `Last seen ${formatRelativeTime(agent.last_seen)}` : 'Never seen'}
+                  </p>
+                </div>
+              </div>
+              <StatusBadge
+                variant={agent.active ? 'success' : 'neutral'}
+                label={agent.active ? 'Active' : 'Inactive'}
+                dotPulse={agent.active}
+              />
+            </Link>
+          ))}
+        </div>
+      )}
+    </WidgetSection>
+  )
+}

--- a/dashboard/src/components/home/CostSummaryWidget.tsx
+++ b/dashboard/src/components/home/CostSummaryWidget.tsx
@@ -1,17 +1,22 @@
-import { useState } from 'react'
+import { Link } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '../../api/client.ts'
 import type { CostTrendResponse } from '../../api/llmCalls.ts'
-import CostTrendChart, { type ChartVariant } from '../CostTrendChart.tsx'
-import WidgetSection from './WidgetSection.tsx'
+import type { ChartVariant } from '../CostTrendChart.tsx'
+import CostTrendChart from '../CostTrendChart.tsx'
+import { ArrowRight } from 'lucide-react'
 
 interface CostSummaryWidgetProps {
   refetchInterval?: number | false
 }
 
+/**
+ * Cost summary widget for the landing page.
+ * Uses CostTrendChart directly (which has its own bg-bg-card container)
+ * instead of wrapping in WidgetSection to avoid double-card nesting.
+ */
 export default function CostSummaryWidget({ refetchInterval }: CostSummaryWidgetProps) {
-  // Lock to 'total' variant for the compact landing page view
-  const [variant] = useState<ChartVariant>('total')
+  const variant: ChartVariant = 'total'
   const { data, isLoading, error, refetch } = useQuery<CostTrendResponse>({
     queryKey: ['cost-trend', {}],
     queryFn: () => apiFetch('/llm-calls/cost-trend', {}),
@@ -19,10 +24,21 @@ export default function CostSummaryWidget({ refetchInterval }: CostSummaryWidget
   })
 
   return (
-    <WidgetSection
-      label="Cost (24h)"
-      viewAllTo="/llm-calls"
-    >
+    <section>
+      {/* Section header matching WidgetSection style */}
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-[11px] text-muted/60 font-medium uppercase tracking-wider">
+          Cost (24h)
+        </h3>
+        <Link
+          to="/llm-calls"
+          className="flex items-center gap-1 text-[11px] text-muted/50 hover:text-accent-light transition-colors"
+        >
+          View all
+          <ArrowRight size={12} />
+        </Link>
+      </div>
+      {/* CostTrendChart provides its own bg-bg-card container with loading/error/empty states */}
       <CostTrendChart
         data={data?.buckets}
         variant={variant}
@@ -34,8 +50,6 @@ export default function CostSummaryWidget({ refetchInterval }: CostSummaryWidget
         hasEstimatedPricing={data?.has_estimated_pricing}
         defaultRange="last 24h"
       />
-    </WidgetSection>
+    </section>
   )
 }
-
-export type { CostSummaryWidgetProps }

--- a/dashboard/src/components/home/CostSummaryWidget.tsx
+++ b/dashboard/src/components/home/CostSummaryWidget.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '../../api/client.ts'
+import type { CostTrendResponse } from '../../api/llmCalls.ts'
+import CostTrendChart, { type ChartVariant } from '../CostTrendChart.tsx'
+import WidgetSection from './WidgetSection.tsx'
+
+interface CostSummaryWidgetProps {
+  refetchInterval?: number | false
+}
+
+export default function CostSummaryWidget({ refetchInterval }: CostSummaryWidgetProps) {
+  // Lock to 'total' variant for the compact landing page view
+  const [variant] = useState<ChartVariant>('total')
+  const { data, isLoading, error, refetch } = useQuery<CostTrendResponse>({
+    queryKey: ['cost-trend', {}],
+    queryFn: () => apiFetch('/llm-calls/cost-trend', {}),
+    refetchInterval,
+  })
+
+  return (
+    <WidgetSection
+      label="Cost (24h)"
+      viewAllTo="/llm-calls"
+    >
+      <CostTrendChart
+        data={data?.buckets}
+        variant={variant}
+        onVariantChange={() => {}}
+        bucketSize={data?.bucket_size ?? 'hour'}
+        isLoading={isLoading}
+        error={error}
+        onRetry={() => refetch()}
+        hasEstimatedPricing={data?.has_estimated_pricing}
+        defaultRange="last 24h"
+      />
+    </WidgetSection>
+  )
+}
+
+export type { CostSummaryWidgetProps }

--- a/dashboard/src/components/home/DevRunsWidget.tsx
+++ b/dashboard/src/components/home/DevRunsWidget.tsx
@@ -1,0 +1,75 @@
+import { Link } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch, type PaginatedResponse } from '../../api/client.ts'
+import type { DevRun } from '../../api/devRuns.ts'
+import { TaskStatusBadge, LoadingState, ErrorState, EmptyState, formatApiError, formatRelativeTime } from '@senara-solutions/ui'
+import WidgetSection from './WidgetSection.tsx'
+
+interface DevRunsWidgetProps {
+  refetchInterval?: number | false
+}
+
+export default function DevRunsWidget({ refetchInterval }: DevRunsWidgetProps) {
+  const filters = { per_page: 5, page: 1 }
+  const { data, isLoading, error, refetch } = useQuery<PaginatedResponse<DevRun>>({
+    queryKey: ['dev-runs', filters],
+    queryFn: () => apiFetch('/dev-runs', filters as Record<string, string | number | undefined>),
+    refetchInterval,
+  })
+
+  return (
+    <WidgetSection
+      label="Dev Runs"
+      count={data?.total}
+      viewAllTo="/dev-runs"
+    >
+      {isLoading ? (
+        <LoadingState variant="list" rows={3} />
+      ) : error ? (
+        <ErrorState message={formatApiError(error)} retry={() => refetch()} />
+      ) : !data || data.data.length === 0 ? (
+        <EmptyState message="No dev runs" />
+      ) : (
+        <div className="space-y-1">
+          {data.data.map((run) => (
+            <Link
+              key={run.id}
+              to={`/dev-runs/${run.id}`}
+              className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-white/[0.03] transition-colors group"
+            >
+              <div className="min-w-0 flex-1 mr-3">
+                <p className="text-sm text-heading truncate group-hover:text-accent-light transition-colors">
+                  {run.label}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  {run.branch && (
+                    <>
+                      <span className="text-[10px] text-accent/60 font-mono truncate max-w-[200px]">{run.branch}</span>
+                      <span className="text-[10px] text-muted/20">&middot;</span>
+                    </>
+                  )}
+                  {run.pr_url ? (
+                    <a
+                      href={run.pr_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-accent hover:text-accent-light"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      PR #{run.pr_number}
+                    </a>
+                  ) : (
+                    <span className="text-[10px] text-muted/40">{formatRelativeTime(run.created_at)}</span>
+                  )}
+                </div>
+              </div>
+              <TaskStatusBadge status={run.status} />
+            </Link>
+          ))}
+        </div>
+      )}
+    </WidgetSection>
+  )
+}
+
+export type { DevRunsWidgetProps }

--- a/dashboard/src/components/home/DevRunsWidget.tsx
+++ b/dashboard/src/components/home/DevRunsWidget.tsx
@@ -72,4 +72,3 @@ export default function DevRunsWidget({ refetchInterval }: DevRunsWidgetProps) {
   )
 }
 
-export type { DevRunsWidgetProps }

--- a/dashboard/src/components/home/RecentActivityWidget.tsx
+++ b/dashboard/src/components/home/RecentActivityWidget.tsx
@@ -79,4 +79,3 @@ export default function RecentActivityWidget({ refetchInterval }: RecentActivity
   )
 }
 
-export type { RecentActivityWidgetProps }

--- a/dashboard/src/components/home/RecentActivityWidget.tsx
+++ b/dashboard/src/components/home/RecentActivityWidget.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch, type PaginatedResponse } from '../../api/client.ts'
+import type { TimelineRow } from '../../api/timeline.ts'
+import { LoadingState, ErrorState, EmptyState, formatApiError, formatRelativeTime, eventTypeBadge } from '@senara-solutions/ui'
+import WidgetSection from './WidgetSection.tsx'
+
+interface RecentActivityWidgetProps {
+  refetchInterval?: number | false
+}
+
+/** Map timeline row to the most likely detail page route. */
+function eventDetailPath(row: TimelineRow): string | null {
+  if (row.session_id) return `/sessions/${row.session_id}`
+  if (row.trace_id) return `/traces/${row.trace_id}`
+  return null
+}
+
+export default function RecentActivityWidget({ refetchInterval }: RecentActivityWidgetProps) {
+  const filters = { per_page: 8, page: 1 }
+  const { data, isLoading, error, refetch } = useQuery<PaginatedResponse<TimelineRow>>({
+    queryKey: ['timeline', filters],
+    queryFn: () => apiFetch('/timeline', filters as Record<string, string | number | undefined>),
+    refetchInterval,
+  })
+
+  return (
+    <WidgetSection
+      label="Recent Activity"
+      count={data?.total}
+      viewAllTo="/timeline"
+    >
+      {isLoading ? (
+        <LoadingState variant="list" rows={4} />
+      ) : error ? (
+        <ErrorState message={formatApiError(error)} retry={() => refetch()} />
+      ) : !data || data.data.length === 0 ? (
+        <EmptyState message="No recent activity" />
+      ) : (
+        <div className="space-y-1">
+          {data.data.map((row, i) => {
+            const badge = eventTypeBadge(row.event_type)
+            const detailPath = eventDetailPath(row)
+            const content = (
+              <div className="flex items-center justify-between px-3 py-2 rounded-xl hover:bg-white/[0.03] transition-colors group">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <span
+                    className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full shrink-0 ${badge.bg} ${badge.text}`}
+                  >
+                    <span className={`w-1 h-1 rounded-full ${badge.dot}`} />
+                    {badge.label}
+                  </span>
+                  <span className="text-xs text-muted/70 truncate">
+                    {row.agent_id && (
+                      <span className="text-heading font-medium mr-1.5">{row.agent_id}</span>
+                    )}
+                    {row.summary ?? row.event_subtype}
+                  </span>
+                </div>
+                <span className="text-[10px] text-muted/40 shrink-0 ml-2">
+                  {formatRelativeTime(row.created_at)}
+                </span>
+              </div>
+            )
+
+            return detailPath ? (
+              <Link key={i} to={detailPath}>
+                {content}
+              </Link>
+            ) : (
+              <div key={i}>
+                {content}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </WidgetSection>
+  )
+}
+
+export type { RecentActivityWidgetProps }

--- a/dashboard/src/components/home/TeamRunsWidget.tsx
+++ b/dashboard/src/components/home/TeamRunsWidget.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch, type PaginatedResponse } from '../../api/client.ts'
+import type { TeamRun } from '../../api/teams.ts'
+import { TaskStatusBadge, LoadingState, ErrorState, EmptyState, formatApiError } from '@senara-solutions/ui'
+import WidgetSection from './WidgetSection.tsx'
+
+interface TeamRunsWidgetProps {
+  refetchInterval?: number | false
+}
+
+export default function TeamRunsWidget({ refetchInterval }: TeamRunsWidgetProps) {
+  const filters = { per_page: 5, page: 1 }
+  const { data, isLoading, error, refetch } = useQuery<PaginatedResponse<TeamRun>>({
+    queryKey: ['team-runs', filters],
+    queryFn: () => apiFetch('/team-runs', filters as Record<string, string | number | undefined>),
+    refetchInterval,
+  })
+
+  return (
+    <WidgetSection
+      label="Team Runs"
+      count={data?.total}
+      viewAllTo="/team-runs"
+    >
+      {isLoading ? (
+        <LoadingState variant="list" rows={3} />
+      ) : error ? (
+        <ErrorState message={formatApiError(error)} retry={() => refetch()} />
+      ) : !data || data.data.length === 0 ? (
+        <EmptyState message="No team runs" />
+      ) : (
+        <div className="space-y-1">
+          {data.data.map((run) => (
+            <Link
+              key={run.id}
+              to={`/team-runs/${run.id}`}
+              className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-white/[0.03] transition-colors group"
+            >
+              <div className="min-w-0 flex-1 mr-3">
+                <p className="text-sm text-heading truncate group-hover:text-accent-light transition-colors">
+                  {run.team_name}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[10px] text-muted/40 truncate max-w-[250px]">{run.goal}</span>
+                  <span className="text-[10px] text-muted/20">&middot;</span>
+                  <span className="text-[10px] text-muted/40">{run.iteration}/{run.max_iterations}</span>
+                </div>
+              </div>
+              <TaskStatusBadge status={run.status} />
+            </Link>
+          ))}
+        </div>
+      )}
+    </WidgetSection>
+  )
+}
+
+export type { TeamRunsWidgetProps }

--- a/dashboard/src/components/home/TeamRunsWidget.tsx
+++ b/dashboard/src/components/home/TeamRunsWidget.tsx
@@ -56,4 +56,3 @@ export default function TeamRunsWidget({ refetchInterval }: TeamRunsWidgetProps)
   )
 }
 
-export type { TeamRunsWidgetProps }

--- a/dashboard/src/components/home/WidgetSection.tsx
+++ b/dashboard/src/components/home/WidgetSection.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode } from 'react'
+import { Link } from 'react-router'
+import { ArrowRight } from 'lucide-react'
+
+interface WidgetSectionProps {
+  label: string
+  count?: number
+  viewAllTo: string
+  viewAllLabel?: string
+  children: ReactNode
+}
+
+/**
+ * Shared wrapper for landing page widget sections.
+ * Renders a section card with uppercase label, optional count badge,
+ * and a "View all" link in the header.
+ */
+export default function WidgetSection({
+  label,
+  count,
+  viewAllTo,
+  viewAllLabel = 'View all',
+  children,
+}: WidgetSectionProps) {
+  return (
+    <section className="bg-bg-card border border-white/[0.05] rounded-2xl p-5">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2.5">
+          <h3 className="text-[11px] text-muted/60 font-medium uppercase tracking-wider">
+            {label}
+          </h3>
+          {count !== undefined && count > 0 && (
+            <span className="text-[10px] text-accent bg-accent/10 px-1.5 py-0.5 rounded-md font-medium">
+              {count}
+            </span>
+          )}
+        </div>
+        <Link
+          to={viewAllTo}
+          className="flex items-center gap-1 text-[11px] text-muted/50 hover:text-accent-light transition-colors"
+        >
+          {viewAllLabel}
+          <ArrowRight size={12} />
+        </Link>
+      </div>
+      {children}
+    </section>
+  )
+}

--- a/dashboard/src/components/home/WorkItemsWidget.tsx
+++ b/dashboard/src/components/home/WorkItemsWidget.tsx
@@ -56,4 +56,3 @@ export default function WorkItemsWidget({ refetchInterval }: WorkItemsWidgetProp
   )
 }
 
-export type { WorkItemsWidgetProps }

--- a/dashboard/src/components/home/WorkItemsWidget.tsx
+++ b/dashboard/src/components/home/WorkItemsWidget.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch, type PaginatedResponse } from '../../api/client.ts'
+import type { TaskItem } from '../../api/tasks.ts'
+import { TaskStatusBadge, LoadingState, ErrorState, EmptyState, formatApiError, formatRelativeTime } from '@senara-solutions/ui'
+import WidgetSection from './WidgetSection.tsx'
+
+interface WorkItemsWidgetProps {
+  refetchInterval?: number | false
+}
+
+export default function WorkItemsWidget({ refetchInterval }: WorkItemsWidgetProps) {
+  const filters = { status: 'in_progress', per_page: 5, page: 1 }
+  const { data, isLoading, error, refetch } = useQuery<PaginatedResponse<TaskItem>>({
+    queryKey: ['tasks', filters],
+    queryFn: () => apiFetch('/tasks', filters as Record<string, string | number | undefined>),
+    refetchInterval,
+  })
+
+  return (
+    <WidgetSection
+      label="Work Items"
+      count={data?.total}
+      viewAllTo="/tasks?status=in_progress"
+    >
+      {isLoading ? (
+        <LoadingState variant="list" rows={3} />
+      ) : error ? (
+        <ErrorState message={formatApiError(error)} retry={() => refetch()} />
+      ) : !data || data.data.length === 0 ? (
+        <EmptyState message="No active work items" />
+      ) : (
+        <div className="space-y-1">
+          {data.data.map((task) => (
+            <Link
+              key={task.id}
+              to={`/tasks/${task.id}`}
+              className="flex items-center justify-between px-3 py-2.5 rounded-xl hover:bg-white/[0.03] transition-colors group"
+            >
+              <div className="min-w-0 flex-1 mr-3">
+                <p className="text-sm text-heading truncate group-hover:text-accent-light transition-colors">
+                  {task.label}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[10px] text-muted/40">{task.agent_id}</span>
+                  <span className="text-[10px] text-muted/20">&middot;</span>
+                  <span className="text-[10px] text-muted/40">{formatRelativeTime(task.updated_at)}</span>
+                </div>
+              </div>
+              <TaskStatusBadge status={task.status} />
+            </Link>
+          ))}
+        </div>
+      )}
+    </WidgetSection>
+  )
+}
+
+export type { WorkItemsWidgetProps }

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -1,0 +1,65 @@
+import { useAgents } from '../api/agents.ts'
+import { StatusBadge, LoadingState, ErrorState, EmptyState, formatApiError } from '@senara-solutions/ui'
+import { Bot } from 'lucide-react'
+import AgentsSummaryWidget from '../components/home/AgentsSummaryWidget.tsx'
+import WorkItemsWidget from '../components/home/WorkItemsWidget.tsx'
+import DevRunsWidget from '../components/home/DevRunsWidget.tsx'
+import TeamRunsWidget from '../components/home/TeamRunsWidget.tsx'
+import CostSummaryWidget from '../components/home/CostSummaryWidget.tsx'
+import RecentActivityWidget from '../components/home/RecentActivityWidget.tsx'
+
+/** Shared auto-refresh interval for all landing page widgets (ms). */
+const HOME_REFETCH_INTERVAL = 15_000
+
+export default function Home() {
+  // Gate on agents query — fresh installs show a cohesive empty state
+  const { data: agents, isLoading: agentsLoading, error: agentsError, refetch: agentsRefetch } = useAgents()
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <div className="flex items-center gap-3">
+            <h2 className="text-heading text-xl font-semibold">Overview</h2>
+            <StatusBadge variant="success" label="Live" dotPulse />
+          </div>
+          <p className="text-sm text-muted/60 mt-1">
+            Current state across all agents
+          </p>
+        </div>
+      </div>
+
+      {/* Page-level gate: loading / error / fresh-install empty */}
+      {agentsLoading ? (
+        <LoadingState variant="list" rows={6} />
+      ) : agentsError ? (
+        <ErrorState message={formatApiError(agentsError)} retry={() => agentsRefetch()} />
+      ) : !agents || agents.length === 0 ? (
+        <div className="flex items-center justify-center py-20">
+          <EmptyState
+            title="Welcome to Mika"
+            message="No agents are provisioned yet. Start by creating an agent to see your overview."
+            icon={<Bot size={32} />}
+          />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* Agents summary */}
+          <AgentsSummaryWidget />
+
+          {/* Active work — full-width stacked for scanning density */}
+          <WorkItemsWidget refetchInterval={HOME_REFETCH_INTERVAL} />
+          <DevRunsWidget refetchInterval={HOME_REFETCH_INTERVAL} />
+          <TeamRunsWidget refetchInterval={HOME_REFETCH_INTERVAL} />
+
+          {/* Secondary signals — side by side on wide viewports */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <CostSummaryWidget refetchInterval={HOME_REFETCH_INTERVAL} />
+            <RecentActivityWidget refetchInterval={HOME_REFETCH_INTERVAL} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/pages/__tests__/Home.test.tsx
+++ b/dashboard/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Home from '../Home.tsx'
+
+// Mock recharts to avoid jsdom rendering issues
+vi.mock('recharts', () => ({
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: ({ dataKey }: { dataKey: string }) => <div data-testid={`area-${dataKey}`} />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Legend: () => <div data-testid="legend" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+}))
+
+const mockAgents = [
+  { id: 'mika-dev', name: 'mika-dev', active: true, last_seen: '2026-05-06T10:00:00Z', created_at: '2026-01-01T00:00:00Z', message_count: 100 },
+  { id: 'mika-qa', name: 'mika-qa', active: false, last_seen: null, created_at: '2026-01-02T00:00:00Z', message_count: 50 },
+]
+
+let useAgentsReturn = {
+  data: mockAgents as typeof mockAgents | undefined,
+  isLoading: false,
+  error: null as Error | null,
+  refetch: vi.fn(),
+}
+
+// Mock useAgents (used by Home page gate AND AgentsSummaryWidget)
+vi.mock('../../api/agents.ts', () => ({
+  useAgents: () => useAgentsReturn,
+}))
+
+// Mock the API client used by inline useQuery calls in widgets
+vi.mock('../../api/client.ts', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ data: [], total: 0, page: 1, per_page: 5 })),
+}))
+
+function renderHome() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/']}>
+        <Home />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('Home page', () => {
+  beforeEach(() => {
+    useAgentsReturn = {
+      data: mockAgents,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    }
+  })
+
+  it('renders the overview header with LIVE badge', () => {
+    renderHome()
+    expect(screen.getByText('Overview')).toBeTruthy()
+    expect(screen.getByText('Live')).toBeTruthy()
+  })
+
+  it('renders all widget section labels', () => {
+    renderHome()
+    // CSS uppercase transforms "Agents" → "AGENTS" visually; DOM text is lowercase
+    expect(screen.getByText('Agents')).toBeTruthy()
+    expect(screen.getByText('Work Items')).toBeTruthy()
+    expect(screen.getByText('Dev Runs')).toBeTruthy()
+    expect(screen.getByText('Team Runs')).toBeTruthy()
+    expect(screen.getByText('Cost (24h)')).toBeTruthy()
+    expect(screen.getByText('Recent Activity')).toBeTruthy()
+  })
+
+  it('renders agent data in the agents widget', () => {
+    renderHome()
+    expect(screen.getByText('mika-dev')).toBeTruthy()
+    expect(screen.getByText('mika-qa')).toBeTruthy()
+  })
+
+  it('shows active status badge for active agents', () => {
+    renderHome()
+    expect(screen.getByText('Active')).toBeTruthy()
+    expect(screen.getByText('Inactive')).toBeTruthy()
+  })
+
+  it('shows "Never seen" for agent with null last_seen', () => {
+    renderHome()
+    expect(screen.getByText('Never seen')).toBeTruthy()
+  })
+
+  it('renders "View all" links for each section', () => {
+    renderHome()
+    const viewAllLinks = screen.getAllByText('View all')
+    expect(viewAllLinks.length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('navigates to agent detail page via link', () => {
+    renderHome()
+    const agentLink = screen.getByRole('link', { name: /mika-dev/i })
+    expect(agentLink.getAttribute('href')).toBe('/agents/mika-dev')
+  })
+})
+
+describe('Home page — fresh install', () => {
+  it('shows welcome empty state when no agents', () => {
+    useAgentsReturn = {
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    }
+    renderHome()
+    expect(screen.getByText('Welcome to Mika')).toBeTruthy()
+  })
+
+  it('shows loading state while agents query resolves', () => {
+    useAgentsReturn = {
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    }
+    renderHome()
+    // LoadingState renders aria-label
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('shows error state when agents query fails', () => {
+    useAgentsReturn = {
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: vi.fn(),
+    }
+    renderHome()
+    // ErrorState renders retry button
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+  })
+})

--- a/docs/plans/2026-05-06-004-feat-dashboard-landing-home-overview-plan.md
+++ b/docs/plans/2026-05-06-004-feat-dashboard-landing-home-overview-plan.md
@@ -1,0 +1,377 @@
+---
+title: "feat: Dashboard landing/home overview page"
+type: feat
+status: active
+date: 2026-05-06
+issue: 666
+---
+
+# feat: Dashboard landing/home overview page
+
+## Overview
+
+Add a landing page at the dashboard index route (`/`) that shows operators a single-screen "state of the world" — active agents, in-flight work items, dev runs, team runs, cost summary, and recent activity. Currently the index route renders the Event Timeline; this change promotes a purpose-built overview and moves Timeline to `/timeline`.
+
+## Problem Frame
+
+Operators currently check multiple pages (Sessions, Tasks, LLM Calls, Dev Runs, Team Runs) to understand what's happening. A home view collapses the "check multiple pages" loop into one screen. The stitch reconciliation map (Screen #3 "Tasks & Orchestration Overview", `976190aa2b314effb5a51ab8c581180e`) is the canonical design reference for this page and explicitly identifies ticket #666 as the anchor for milestone #13 page redesigns.
+
+## Requirements Trace
+
+- R1. `/dashboard` renders a landing overview, not a blank redirect to a list page
+- R2. Widgets use shared primitives (`<StatusBadge>`, `<ListRow>`, `<LoadingState>`, `<ErrorState>`, `<EmptyState>`, `<TokenBudgetBar>`) from `@senara-solutions/ui`
+- R3. Clicking any widget item navigates to the corresponding full page with matching filters pre-applied
+- R4. Page has a LIVE indicator and auto-refresh
+- R5. Layout follows stitch Screen #3 stacked sections concept (Work Items / Team Runs / Dev Runs / Cost / Activity)
+- R6. Each widget independently handles loading/error/empty states via the canonical ternary pattern
+
+## Scope Boundaries
+
+- No new backend API endpoints — v1 composes existing hooks on the frontend
+- No user-customizable widget layout (reorderable/pinnable) — that's a future iteration
+- No new shared UI components in `packages/ui/` — use existing primitives only
+- No responsive sidebar collapse (pre-existing gap, out of scope)
+- No "Open PRs awaiting review" or "Failing CI" widgets — these require GitHub API integration not yet available in the dashboard API layer
+
+### Deferred to Separate Tasks
+
+- Dedicated `GET /api/v1/overview` backend endpoint for aggregated data: separate optimization PR if N+1 frontend calls cause perceptible latency
+- Customizable widget layout (pinned/reorderable): future iteration per issue description
+- GitHub-sourced widgets (open PRs, CI status): requires `MIKA_GITHUB_TOKEN` plumbing into dashboard API
+- "Milestone progress" widget: requires milestone-type task aggregation query not yet available
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Router:** `dashboard/src/App.tsx` — `<Route index element={<Timeline />} />` is the current index route to replace
+- **Sidebar:** `dashboard/src/components/Sidebar.tsx` — `navItems` array, first entry `{ to: '/', label: 'Event Timeline', icon: Activity }`
+- **Page structure pattern:** Header (h2 title + subtitle + controls) → Filter bar → Canonical lifecycle ternary → Happy path content → Pagination
+- **Card pattern:** `bg-bg-card border border-white/[0.05] rounded-2xl p-5 hover:border-accent/30 hover:shadow-[0_0_30px_rgba(124,106,247,0.06)]` with `Link` wrapper
+- **Existing hooks to compose:** `useAgents()`, `useTasks()`, `useDevRuns()`, `useTeamRuns()`, `useCostTrend()`, `useTimeline()`
+- **CostTrendChart:** `dashboard/src/components/CostTrendChart.tsx` — reusable but has header/controls; landing page needs a compact variant
+- **Auto-refresh precedent:** Timeline page uses `refetchInterval: 5000` for default view; task descendants use conditional 15s
+
+### Institutional Learnings
+
+- **Canonical loading/error/empty primitives are mandatory** — `docs/solutions/best-practices/design-system-state-catalog-extraction-2026-04-27.md`. Hand-rolling is a review fail per `packages/ui/CLAUDE.md`
+- **Multiple independent queries: retry callback must call ALL refetch functions** — same learning
+- **recharts hex colors, not Tailwind classes** — `docs/solutions/660-dashboard-cost-trend-chart-time-series.md`
+- **`dashboard_db` for cross-agent queries** — `docs/solutions/656-core-memory-actionable-dashboard-patterns.md`. Per-agent data requires `state.resolve_agent()`. The landing page uses cross-agent list endpoints, so this is not a concern
+- **`useAgents()` returns unpaginated `Agent[]`** — globally cached on `['agents']` query key, shared across callsites via React Query dedup
+
+### External References
+
+- Stitch Screen #3: `976190aa2b314effb5a51ab8c581180e` — Tasks & Orchestration Overview
+- Design rulebook: `docs/design/luminescent-core.md` — no-line rule, tonal shifting, `rounded-2xl` cards, uppercase tracking-wide labels
+- Stitch map: `docs/design/dashboard-stitch-map.md` § Phase 3 sequence
+
+## Key Technical Decisions
+
+- **Landing page becomes the index route:** The new `Home` page replaces `<Timeline />` at the index route. Timeline moves to `/timeline`. This matches the stitch map's directive that #666 "anchors the rest of the milestone" and the north-star principle that the home view is the operator's entry point
+- **Compose existing API hooks, no new endpoint:** `useAgents()`, `useTasks({ status: 'in_progress', per_page: 5 })`, `useDevRuns({ status: 'active', per_page: 5 })`, `useTeamRuns({ status: 'active', per_page: 5 })`, `useCostTrend({})`, `useTimeline({ per_page: 8 })` — avoids backend changes, all hooks already exist and are well-tested
+- **Single shared refetchInterval of 15s:** Six hooks at 5s each = 72 requests/minute against single-threaded SQLite. 15s is a safe default (~24 requests/minute) that still feels responsive. Applied via a shared constant, not per-hook
+- **Per-widget independent lifecycle:** Each section renders its own `LoadingState`/`ErrorState`/`EmptyState` independently. No page-level aggregated error state — this is consistent with how all other dashboard pages handle multi-query sections and is simpler to implement
+- **Compact cost chart via existing CostTrendChart with reduced height:** Rather than creating a new sparkline component, render `<CostTrendChart>` with `defaultRange="last 24h"` and reduced container height. The component already handles loading/error/empty internally
+- **Widget click-through filter mapping:** Each widget's "View all" link and row clicks navigate with explicit query params matching the target page's `useSearchParamsFilter` expectations
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Route placement:** Landing page at index (`/`), Timeline at `/timeline`. Resolved by stitch map priority and north-star entry-point principle
+- **Refresh interval:** 15s shared across all landing page hooks. Resolved by SQLite contention analysis (6 hooks * 4 requests/minute = 24 req/min, acceptable)
+- **Widget item count:** 5 items per widget section, with "View all N" link showing total count from `PaginatedResponse.total`. Resolved by balancing information density with screen real estate
+- **Fresh-install empty state:** When `useAgents()` returns empty, show a single page-level `<EmptyState>` with a contextual message instead of six individual empty widgets. Resolved by UX clarity — six "no data" blocks is confusing for a new user
+
+### Deferred to Implementation
+
+- Exact Tailwind class combinations for the section header typography — will mirror existing page headers but may need minor adjustments for the stacked-section density
+- Whether `CostTrendChart` height reduction requires prop changes or just a container CSS override — try container-first, add prop if needed
+- Exact copy for each widget's empty-state message — will be finalized during implementation with contextually appropriate text
+
+## Implementation Units
+
+- [x] **Unit 1: Route restructure — move Timeline, add Home route**
+
+  **Goal:** Move the Timeline page from the index route to `/timeline` and create a placeholder `Home` page at the index route. Update Sidebar navigation.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `dashboard/src/pages/Home.tsx`
+  - Modify: `dashboard/src/App.tsx`
+  - Modify: `dashboard/src/components/Sidebar.tsx`
+  - Test: `dashboard/src/pages/__tests__/Home.test.tsx`
+
+  **Approach:**
+  - In `App.tsx`: import `Home`, set `<Route index element={<Home />} />`, add `<Route path="timeline" element={<Timeline />} />`
+  - In `Sidebar.tsx`: add `{ to: '/', label: 'Overview', icon: LayoutDashboard }` as the first nav item (using `LayoutDashboard` from lucide-react). Change Timeline entry from `to: '/'` to `to: '/timeline'`. Keep `end={item.to === '/'}` for exact matching on the overview link
+  - `Home.tsx` starts as a minimal page with the header structure (title "Overview", subtitle, LIVE badge placeholder) and no data — just enough to verify routing works
+
+  **Patterns to follow:**
+  - Sidebar `navItems` array structure in `dashboard/src/components/Sidebar.tsx`
+  - Page header pattern from `dashboard/src/pages/Timeline.tsx`
+
+  **Test scenarios:**
+  - Happy path: navigating to `/` renders the Home page, not Timeline
+  - Happy path: navigating to `/timeline` renders the Timeline page
+  - Happy path: Sidebar shows "Overview" as first item with active state when at `/`
+  - Happy path: Sidebar "Event Timeline" link points to `/timeline`
+  - Edge case: Sidebar exact matching — visiting `/timeline` does not highlight the Overview nav item
+
+  **Verification:**
+  - `npm run build --prefix dashboard` succeeds
+  - Visiting `/` in dev server shows the Home page
+  - Visiting `/timeline` shows the Timeline page
+  - Sidebar highlights the correct nav item for each route
+
+- [x] **Unit 2: Active Agents summary widget**
+
+  **Goal:** Add the first data-driven section to the Home page — a summary of all agents with their status and last-seen time.
+
+  **Requirements:** R2, R3, R6
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `dashboard/src/pages/Home.tsx`
+  - Create: `dashboard/src/components/home/AgentsSummaryWidget.tsx`
+  - Test: `dashboard/src/components/home/__tests__/AgentsSummaryWidget.test.tsx`
+
+  **Approach:**
+  - Create a `home/` directory under `components/` for landing-page-specific widget components
+  - `AgentsSummaryWidget` consumes `useAgents()` (already returns `Agent[]` with `active`, `last_seen`, `message_count`)
+  - Section card styled with `bg-bg-card border border-white/[0.05] rounded-2xl` per convention
+  - Section header: uppercase tracking-wide label "AGENTS" with count badge, "View all" link to `/agents`
+  - Each agent rendered as a `<ListRow variant="navigable">` clicking through to `/agents/{id}`
+  - Agent status shown via `<StatusBadge variant={agent.active ? 'success' : 'neutral'}>` with `dotPulse` for active agents
+  - `formatRelativeTime(agent.last_seen)` for the last-seen timestamp
+  - Canonical lifecycle ternary for loading/error/empty using `@senara-solutions/ui` primitives
+
+  **Patterns to follow:**
+  - Card styling from `dashboard/src/pages/Agents.tsx` grid cards
+  - `ListRow` usage conventions from `packages/ui/CLAUDE.md`
+  - Lifecycle ternary from any existing list page
+
+  **Test scenarios:**
+  - Happy path: renders agent list with names, active status badges, and last-seen times
+  - Happy path: clicking an agent row navigates to `/agents/{agentId}`
+  - Happy path: "View all" link navigates to `/agents`
+  - Edge case: agent with `last_seen: null` shows "Never" or similar fallback
+  - Edge case: agent with `active: false` shows neutral (not success) StatusBadge without dotPulse
+  - Error path: `useAgents()` fails — shows `<ErrorState>` with retry
+  - Edge case: `useAgents()` returns empty array — shows `<EmptyState>` with contextual message
+
+  **Verification:**
+  - Widget renders agents from the API
+  - Status badges use the correct `@senara-solutions/ui` StatusBadge variants
+  - Navigation to agent detail and agents list works
+
+- [x] **Unit 3: Work Items and Runs widgets**
+
+  **Goal:** Add three stacked sections: Active Work Items (tasks), Dev Runs, and Team Runs — the core of the "what's happening now" view per stitch Screen #3.
+
+  **Requirements:** R2, R3, R5, R6
+
+  **Dependencies:** Unit 2 (establishes the widget component pattern)
+
+  **Files:**
+  - Create: `dashboard/src/components/home/WorkItemsWidget.tsx`
+  - Create: `dashboard/src/components/home/DevRunsWidget.tsx`
+  - Create: `dashboard/src/components/home/TeamRunsWidget.tsx`
+  - Modify: `dashboard/src/pages/Home.tsx`
+  - Test: `dashboard/src/components/home/__tests__/WorkItemsWidget.test.tsx`
+  - Test: `dashboard/src/components/home/__tests__/DevRunsWidget.test.tsx`
+  - Test: `dashboard/src/components/home/__tests__/TeamRunsWidget.test.tsx`
+
+  **Approach:**
+  - **WorkItemsWidget:** `useTasks({ status: 'in_progress', per_page: 5 })`. Each row: task label, agent_id, `<TaskStatusBadge>`, `formatRelativeTime(updated_at)`. Row click → `/tasks/{id}`. "View all" → `/tasks?status=in_progress`. Also show count from `PaginatedResponse.total` in the section header ("WORK ITEMS (12)")
+  - **DevRunsWidget:** `useDevRuns({ per_page: 5 })`. Each row: label, branch (if available), `<StatusBadge>` mapped from dev run status, PR link if `pr_url` present. Row click → `/dev-runs/{id}`. "View all" → `/dev-runs`
+  - **TeamRunsWidget:** `useTeamRuns({ per_page: 5 })`. Each row: team_name, goal (truncated), `<StatusBadge>` from status, iteration N/M. Row click → `/team-runs/{id}`. "View all" → `/team-runs`
+  - All three follow the same section card pattern established in Unit 2: card container, uppercase label header with count + "View all" link, `<ListRow variant="navigable">` items, canonical lifecycle ternary
+  - Status mapping for DevRuns: `in_progress` → `info`, `completed` → `success`, `failed` → `error`, `cancelled` → `neutral`, `blocked` → `blocked`
+  - Status mapping for TeamRuns: `running` → `info` with `dotPulse`, `completed` → `success`, `failed` → `error`
+
+  **Patterns to follow:**
+  - Widget component pattern from Unit 2's `AgentsSummaryWidget`
+  - `TaskStatusBadge` usage from existing Tasks page
+  - DevRun/TeamRun status badge mapping from existing Dev Runs and Team Runs list pages
+
+  **Test scenarios:**
+  - Happy path: WorkItemsWidget renders in-progress tasks with labels, agent IDs, and status badges
+  - Happy path: DevRunsWidget renders dev runs with branch names and PR links when available
+  - Happy path: TeamRunsWidget renders team runs with goal text and iteration progress
+  - Happy path: Row clicks navigate to the correct detail pages
+  - Happy path: "View all" links navigate to list pages with appropriate filter params
+  - Edge case: WorkItemsWidget with zero in-progress tasks shows `<EmptyState>` with "No active work items" message
+  - Edge case: DevRun with `branch: null` and `pr_url: null` omits those fields gracefully
+  - Edge case: TeamRun goal text longer than display area is truncated with ellipsis
+  - Error path: each widget independently shows `<ErrorState>` when its hook fails — other widgets remain functional
+  - Integration: section header shows count from `PaginatedResponse.total` (e.g., "WORK ITEMS (12)" even though only 5 are rendered)
+
+  **Verification:**
+  - All three widgets render data from their respective API hooks
+  - Status badges use canonical `@senara-solutions/ui` components (no hand-rolled pills)
+  - Click-through navigation works with correct URL params
+
+- [x] **Unit 4: Cost summary and Recent Activity widgets**
+
+  **Goal:** Add the cost trend chart (compact) and a recent activity feed to complete the landing page's widget set.
+
+  **Requirements:** R2, R3, R5, R6
+
+  **Dependencies:** Unit 3 (establishes full widget pattern; Home page layout is taking shape)
+
+  **Files:**
+  - Create: `dashboard/src/components/home/CostSummaryWidget.tsx`
+  - Create: `dashboard/src/components/home/RecentActivityWidget.tsx`
+  - Modify: `dashboard/src/pages/Home.tsx`
+  - Test: `dashboard/src/components/home/__tests__/CostSummaryWidget.test.tsx`
+  - Test: `dashboard/src/components/home/__tests__/RecentActivityWidget.test.tsx`
+
+  **Approach:**
+  - **CostSummaryWidget:** Renders the existing `<CostTrendChart>` in a compact container. Calls `useCostTrend({})` (server defaults to last 24h). Sets variant to `'total'` (no toggle), reduced chart height via container constraint. Section header: "COST (24H)" with "View all" → `/llm-calls`. Show the `hasEstimatedPricing` footnote. The `onVariantChange` prop receives a no-op since the landing page locks to total view
+  - **RecentActivityWidget:** Calls `useTimeline({ per_page: 8 })`. Each row shows the event type badge (via `eventTypeBadge()` from `@senara-solutions/ui`), agent name (via `getAgentColor()`), content preview, and relative timestamp. Row click → appropriate detail page based on event_type (session → `/sessions/{id}`, task → `/tasks/{id}`, etc.). "View all" → `/timeline` (the relocated Timeline page)
+  - Both follow the established section card + canonical lifecycle ternary pattern
+
+  **Patterns to follow:**
+  - `CostTrendChart` usage from `dashboard/src/pages/LlmCalls.tsx`
+  - Timeline event rendering from `dashboard/src/pages/Timeline.tsx`
+  - `eventTypeBadge()` and `getAgentColor()` utils from `@senara-solutions/ui`
+
+  **Test scenarios:**
+  - Happy path: CostSummaryWidget renders cost chart with last-24h data
+  - Happy path: RecentActivityWidget renders recent timeline events with type badges and agent colors
+  - Happy path: clicking "View all" on cost widget navigates to `/llm-calls`
+  - Happy path: clicking "View all" on activity widget navigates to `/timeline`
+  - Edge case: cost trend returns empty buckets — chart shows `<EmptyState>` "No cost data"
+  - Edge case: timeline returns zero events — shows `<EmptyState>`
+  - Edge case: CostTrendChart `hasEstimatedPricing` flag renders the footnote
+  - Error path: cost API fails — shows `<ErrorState>` with retry while other widgets remain functional
+
+  **Verification:**
+  - Cost chart renders in compact form without variant toggle controls
+  - Recent activity shows event type badges matching the relocated Timeline page
+  - "View all" links target the correct pages
+
+- [x] **Unit 5: LIVE badge and auto-refresh**
+
+  **Goal:** Add a LIVE indicator to the page header and enable auto-refresh on all landing page queries at a shared 15s interval.
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 4 (all widgets exist and can be polled)
+
+  **Files:**
+  - Modify: `dashboard/src/pages/Home.tsx`
+  - Modify: `dashboard/src/components/home/AgentsSummaryWidget.tsx`
+  - Modify: `dashboard/src/components/home/WorkItemsWidget.tsx`
+  - Modify: `dashboard/src/components/home/DevRunsWidget.tsx`
+  - Modify: `dashboard/src/components/home/TeamRunsWidget.tsx`
+  - Modify: `dashboard/src/components/home/CostSummaryWidget.tsx`
+  - Modify: `dashboard/src/components/home/RecentActivityWidget.tsx`
+  - Test: `dashboard/src/pages/__tests__/Home.test.tsx`
+
+  **Approach:**
+  - Define a shared constant `HOME_REFETCH_INTERVAL = 15_000` in `Home.tsx` and pass it to each widget as a prop
+  - Each widget adds `refetchInterval: props.refetchInterval` to its `useQuery` options
+  - LIVE badge in the page header: a `<StatusBadge variant="success" label="LIVE" dotPulse />` positioned to the right of the page title. Visible when auto-refresh is active
+  - The LIVE badge is always visible on the home page (no toggle in v1 — matches the stitch map's "LIVE badge at the top" requirement)
+
+  **Patterns to follow:**
+  - Timeline's `refetchInterval: 5000` pattern in `dashboard/src/pages/Timeline.tsx`
+  - `StatusBadge` with `dotPulse` from `@senara-solutions/ui`
+
+  **Test scenarios:**
+  - Happy path: LIVE badge renders with success variant and pulsing dot
+  - Happy path: all widget hooks receive `refetchInterval` and poll at the shared interval
+  - Edge case: refetch interval does not fire when the browser tab is not visible (React Query's default behavior — verify it's not overridden)
+
+  **Verification:**
+  - LIVE badge visible in the page header
+  - Network tab shows periodic refetches at ~15s intervals across all widget hooks
+
+- [x] **Unit 6: Fresh-install empty state and layout polish**
+
+  **Goal:** Handle the fresh-install case (no agents provisioned) with a single cohesive empty state instead of six independent empty widgets. Polish the overall page layout — section spacing, responsive grid for side-by-side widgets where it makes sense.
+
+  **Requirements:** R1, R2, R6
+
+  **Dependencies:** Unit 5 (all widgets and refresh in place)
+
+  **Files:**
+  - Modify: `dashboard/src/pages/Home.tsx`
+  - Test: `dashboard/src/pages/__tests__/Home.test.tsx`
+
+  **Approach:**
+  - `Home.tsx` calls `useAgents()` directly (in addition to passing it to `AgentsSummaryWidget`). If agents returns empty or loading, render a page-level state instead of all six widgets
+  - Page-level empty state: `<EmptyState title="Welcome to Mika" message="No agents are provisioned yet. Start by creating an agent." icon={Bot} />` — centered, with the contextual guidance
+  - Page-level loading state: `<LoadingState variant="list" rows={6} />` — single skeleton while the agents query resolves (prevents flash of six loading skeletons)
+  - Layout polish: the six widget sections stack vertically in a single column. Cost Summary and Recent Activity can sit side by side in a 2-column grid on wider viewports (`grid grid-cols-1 lg:grid-cols-2 gap-4`) since they are the secondary signals. The three "active work" sections (Work Items, Dev Runs, Team Runs) remain full-width stacked for scanning density
+  - Section spacing: `space-y-4` between sections, consistent with the stitch map's stacked sections concept
+
+  **Patterns to follow:**
+  - `EmptyState` with `action` prop for onboarding CTA (see `packages/ui/` EmptyState API)
+  - Grid layout from `dashboard/src/pages/Agents.tsx` card grid
+
+  **Test scenarios:**
+  - Happy path: when agents exist, all six widgets render in the stacked layout
+  - Happy path: on large viewports, cost and activity widgets appear side by side
+  - Edge case: fresh install with zero agents — shows single page-level EmptyState, not six empty widgets
+  - Edge case: agents query is loading — shows single page-level LoadingState
+  - Edge case: agents query fails — shows page-level ErrorState with retry (prevents rendering widgets that will all fail)
+  - Edge case: agents exist but all other queries return empty — each widget shows its own EmptyState (page-level gate only applies to agents)
+
+  **Verification:**
+  - Fresh-install case shows a single cohesive empty state
+  - Normal case shows all widgets in the correct layout
+  - Responsive grid adjusts on viewport width changes
+
+## System-Wide Impact
+
+- **Interaction graph:** No callbacks, middleware, or observers affected. The landing page is a pure read-only composition of existing API hooks. No new API endpoints means no server-side changes
+- **Error propagation:** Each widget independently handles its own errors via `<ErrorState>`. The page-level gate (Unit 6) catches the "server unreachable" case by checking `useAgents()` first. No cross-widget error coupling
+- **State lifecycle risks:** React Query's `staleTime: 5000` (global default) means widgets may briefly show stale data after navigation and back. This is acceptable and consistent with all other dashboard pages
+- **API surface parity:** The index route change (`/` → Home, `/timeline` → Timeline) is a URL-level change. No internal links outside the dashboard reference the dashboard's index route, so no external consumers break. The Sidebar is the only internal link source and is updated in Unit 1
+- **Unchanged invariants:** All existing API endpoints, hooks, and shared components are consumed as-is with no modifications to their interfaces. The `CostTrendChart` component is used with its existing props — no API changes
+
+## Click-Through Filter Mapping
+
+| Widget | Target route | Query params |
+|--------|-------------|-------------|
+| Agents | `/agents` | (none — full list) |
+| Agent row | `/agents/{agentId}` | (none — detail) |
+| Work Items "View all" | `/tasks?status=in_progress` | `status=in_progress` |
+| Work Item row | `/tasks/{taskId}` | (none — detail) |
+| Dev Runs "View all" | `/dev-runs` | (none — full list) |
+| Dev Run row | `/dev-runs/{taskId}` | (none — detail) |
+| Team Runs "View all" | `/team-runs` | (none — full list) |
+| Team Run row | `/team-runs/{runId}` | (none — detail) |
+| Cost "View all" | `/llm-calls` | (none — full list) |
+| Recent Activity "View all" | `/timeline` | (none — full list) |
+| Activity row | Detail page by event type | (none — detail) |
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Six parallel API calls on page load cause perceptible latency | React Query deduplication + staleTime means cached data is shown instantly on re-visits. Fresh loads fire in parallel (not waterfall). Monitor and consider a `GET /api/v1/overview` endpoint if latency exceeds 2s |
+| 15s polling adds sustained load to SQLite | 15s is conservative (24 req/min vs Timeline's 72 req/min at 5s). React Query pauses polling when the tab is hidden. Monitor via server access logs |
+| Moving Timeline from `/` to `/timeline` breaks bookmarks | Low risk — the dashboard is an internal tool with a small user base. The Sidebar nav is the primary navigation method. No external links reference the dashboard's internal routes |
+| `CostTrendChart` may not look good at reduced height | Try container constraint first; the component's `ResponsiveContainer` adapts. If axes are unreadable, suppress them with a compact-mode prop in a follow-up |
+
+## Documentation / Operational Notes
+
+- Update `dashboard/CLAUDE.md` Pages section to list the new Home/Overview page and the Timeline route change
+- No operational or deployment changes — this is a frontend-only change embedded in the SPA
+
+## Sources & References
+
+- **Stitch Screen #3:** `976190aa2b314effb5a51ab8c581180e` (Tasks & Orchestration Overview)
+- **Design rulebook:** `docs/design/luminescent-core.md`
+- **Stitch reconciliation map:** `docs/design/dashboard-stitch-map.md` § Phase 3, item 1
+- **Related issues:** #666 (this), #13 (milestone), #657 (visual rhythm), #654 (ListRow), #655 (filters), #662 (live-refresh)
+- **Institutional learnings:** `docs/solutions/best-practices/design-system-state-catalog-extraction-2026-04-27.md`, `docs/solutions/660-dashboard-cost-trend-chart-time-series.md`, `docs/solutions/663-pagination-audit-canonical-primitive-enforcement.md`

--- a/docs/solutions/best-practices/dashboard-landing-page-widget-composition-2026-05-06.md
+++ b/docs/solutions/best-practices/dashboard-landing-page-widget-composition-2026-05-06.md
@@ -1,0 +1,104 @@
+---
+module: dashboard
+date: 2026-05-06
+problem_type: best_practice
+component: tooling
+severity: medium
+tags:
+  - dashboard
+  - landing-page
+  - widget
+  - react-query
+  - composition
+  - refetch-interval
+  - cost-trend-chart
+  - empty-state
+applies_when:
+  - Adding a new dashboard overview or summary page that composes multiple existing API hooks
+  - Embedding CostTrendChart or other self-contained components inside WidgetSection wrappers
+  - Wiring auto-refresh (refetchInterval) across multiple independent widgets on one page
+---
+
+# Dashboard Landing Page — Widget Composition Patterns
+
+## Context
+
+The dashboard landing page (#666) composes six independent data sources (agents, tasks, dev runs, team runs, cost trend, timeline) into a single "state of the world" view. Each widget fetches its own data via React Query and independently handles loading/error/empty states. This raised several practical issues around component nesting, refresh coordination, and the shared hook API.
+
+## Guidance
+
+### 1. Avoid card-within-card nesting when embedding self-contained components
+
+`CostTrendChart` already renders its own `bg-bg-card rounded-xl p-6` container with internal loading/error/empty states. Wrapping it in `WidgetSection` (which also renders `bg-bg-card rounded-2xl p-5`) creates double-card nesting with nested padding and backgrounds.
+
+**Solution:** For components with their own card container, skip `WidgetSection` and render a custom section header inline:
+
+```tsx
+<section>
+  <div className="flex items-center justify-between mb-2">
+    <h3 className="text-[11px] text-muted/60 font-medium uppercase tracking-wider">
+      Cost (24h)
+    </h3>
+    <Link to="/llm-calls" className="...">View all</Link>
+  </div>
+  <CostTrendChart ... />
+</section>
+```
+
+### 2. Use inline `useQuery` when hooks don't support `refetchInterval`
+
+Shared hooks like `useTasks()`, `useDevRuns()`, `useTeamRuns()` don't accept a `refetchInterval` parameter — they're designed for list pages without auto-refresh. Rather than modifying shared hooks for a landing-page-only concern, use `useQuery` directly in widget components:
+
+```tsx
+const { data, isLoading, error, refetch } = useQuery<PaginatedResponse<TaskItem>>({
+  queryKey: ['tasks', filters],
+  queryFn: () => apiFetch('/tasks', filters),
+  refetchInterval,  // passed as prop from the parent page
+})
+```
+
+This reuses the same query keys as the shared hooks, so React Query deduplicates across pages.
+
+### 3. `useAgents()` is a special case — unpaginated and shared
+
+`useAgents()` returns `Agent[]` (not `PaginatedResponse<T>`) and doesn't accept options. It's globally cached on `['agents']`. Multiple callsites (Home gate + AgentsSummaryWidget) produce only one network request via React Query dedup. Don't modify it to accept `refetchInterval` — instead rely on the global `staleTime` and window-focus refetch.
+
+### 4. Use a page-level agents gate for fresh-install UX
+
+When `useAgents()` returns empty, show a single page-level `<EmptyState>` rather than six independent empty widgets — the stacked empty states are confusing for a new user. Gate the entire widget grid on the agents query:
+
+```tsx
+{agentsLoading ? (
+  <LoadingState variant="list" rows={6} />
+) : agentsError ? (
+  <ErrorState message={formatApiError(agentsError)} retry={() => agentsRefetch()} />
+) : !agents || agents.length === 0 ? (
+  <EmptyState title="Welcome to Mika" message="No agents provisioned." icon={<Bot size={32} />} />
+) : (
+  <div className="space-y-4">
+    {/* all widgets */}
+  </div>
+)}
+```
+
+### 5. Shared refetch interval as a constant, not a global setting
+
+Define `HOME_REFETCH_INTERVAL = 15_000` as a constant in `Home.tsx` and pass it as a prop to each widget. 15s is a safe default for six parallel hooks against SQLite (~24 req/min). Don't use React Query's global `refetchInterval` — it would affect all pages.
+
+## Why This Matters
+
+- Double-card nesting creates visual artifacts (nested borders, doubled padding) that break the Luminescent Core design system
+- Modifying shared hooks for page-specific concerns couples unrelated surfaces
+- Six empty-state blocks on fresh install look broken, not welcoming
+- Aggressive polling (5s × 6 hooks = 72 req/min) risks SQLite contention on single-threaded backends
+
+## When to Apply
+
+- Adding new dashboard overview/summary pages with multiple composed widgets
+- Embedding existing chart/visualization components that have their own containers
+- Wiring auto-refresh on pages with many independent data sources
+- Handling zero-data states on aggregate pages
+
+## Examples
+
+The landing page at `dashboard/src/pages/Home.tsx` demonstrates all patterns above. Widget components at `dashboard/src/components/home/` show the inline `useQuery` pattern for `refetchInterval` support.


### PR DESCRIPTION
## Summary

- Add a "state of the world" landing page at the dashboard index route (`/`) with stacked widget sections: Agents, Work Items, Dev Runs, Team Runs, Cost (24h), and Recent Activity
- Move Event Timeline from index to `/timeline`
- Compose existing API hooks on the frontend (no new backend endpoints)
- 15s shared auto-refresh interval with LIVE badge
- Fresh-install gate: single cohesive empty state when no agents are provisioned
- All widgets use `@senara-solutions/ui` canonical primitives (StatusBadge, TaskStatusBadge, LoadingState, ErrorState, EmptyState)

Closes #666

Plan: docs/plans/2026-05-06-004-feat-dashboard-landing-home-overview-plan.md
Stitch reference: screen `976190aa2b314effb5a51ab8c581180e` (Tasks & Orchestration Overview)

## Test plan

- [x] `npx tsc --noEmit` passes (TypeScript clean)
- [x] `npx vitest run` — all 60 tests pass (10 new + 50 existing)
- [x] Lefthook pre-commit hooks pass (lint, typecheck, secrets scan)
- [x] `npm run build --prefix dashboard` succeeds
- [ ] Manual: navigate to `/` — see Overview page with LIVE badge
- [ ] Manual: navigate to `/timeline` — see Event Timeline page
- [ ] Manual: Sidebar shows "Overview" first, "Event Timeline" second
- [ ] Manual: click "View all" on each widget — navigates to correct list page
- [ ] Manual: fresh install (no agents) — shows "Welcome to Mika" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)