### PR TITLE
feat: attach LLM request/response bodies to Langfuse generation spans (#671)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Optional (callback watchdog):
 Optional (runtime observability):
 - `MIKA_STORE_LLM_CALLS` — Store LLM call metadata (model, tokens, latency) in SQLite (default: true)
 - `MIKA_STORE_TOOL_CALLS` — Store full tool call input/output in SQLite (default: true, 50KB cap per field)
-- `MIKA_LOG_LLM_BODIES` — Log full LLM request/response bodies at debug level to log file (default: false, dev-only)
+- `MIKA_LOG_LLM_BODIES` — Log full LLM request/response bodies at debug level to log file AND, when telemetry is enabled, attach as `gen_ai.prompt`/`gen_ai.completion` span attributes for Langfuse Generation input/output (default: false, dev-only)
 
 Optional (telemetry — requires `--features telemetry` build):
 - `MIKA_TELEMETRY_ENABLED` — Enable OpenTelemetry trace export (default: false)

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -427,7 +427,7 @@ Axum-based with two auth layers: mutation endpoints require `MIKA_INTERNAL_TOKEN
 
 **Span filtering:** Per-layer `filter::Targets` on the OTel layer exports only `target: "mika::otel"` spans (LLM calls, agent turns, server requests).
 
-**LLM observability:** `llm_call` spans with `gen_ai.*` semantic convention attributes, feature-gated behind `#[cfg(feature = "telemetry")]`. Team engine emits `TeamEvent` variants for live dashboard updates.
+**LLM observability:** `llm_call` spans with `gen_ai.*` semantic convention attributes, feature-gated behind `#[cfg(feature = "telemetry")]`. When `log_llm_bodies=true`, request/response bodies are attached as `gen_ai.prompt`/`gen_ai.completion` span attributes for Langfuse Generation input/output (#671). Response bodies use `serialize_response_text()` from `mika-common::llm` (same format as `llm_calls.response_text`). Team engine emits `TeamEvent` variants for live dashboard updates.
 
 **Session lifecycle:** Silent dispatcher variants call `end_session()` after completion. CLI commands call `end_session()` on all exit paths. `startup_recovery()` prunes old sessions via `prune_old_sessions()`.
 

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -916,32 +916,16 @@ async fn run_loop(
             match &llm_result {
                 Ok(resp) => {
                     // Serialize response content: text blocks + tool call summaries
-                    let response_text = {
-                        let mut parts = Vec::new();
-                        for block in &resp.content {
-                            match block {
-                                LlmResponseContent::Text(t) => parts.push(t.clone()),
-                                LlmResponseContent::ToolCall {
-                                    name, arguments, ..
-                                } => {
-                                    let args_str = arguments.to_string();
-                                    let args_truncated = crate::db::truncate_chars(&args_str, 200);
-                                    parts.push(format!("[Tool Call: {name}({args_truncated})]"));
-                                }
-                            }
-                        }
-                        let joined = parts.join("\n");
-                        let stripped = mika_common::llm::strip_internal_tags(&joined);
-                        if stripped.is_empty() {
-                            None
-                        } else {
-                            Some(crate::db::truncate_chars(&stripped, 50_000))
-                        }
-                    };
-                    let reasoning_text = resp
-                        .reasoning
-                        .as_deref()
-                        .map(|r| crate::db::truncate_chars(r, 50_000));
+                    let response_text = mika_common::llm::serialize_response_text(
+                        &resp.content,
+                        mika_common::llm::MAX_RESPONSE_TEXT_CHARS,
+                    );
+                    let reasoning_text = resp.reasoning.as_deref().map(|r| {
+                        mika_common::llm::truncate_chars(
+                            r,
+                            mika_common::llm::MAX_RESPONSE_TEXT_CHARS,
+                        )
+                    });
                     if let Err(e) = db
                         .save_llm_call(
                             &id,

--- a/crates/mika-agent/tests/eval/kg_provider_eval/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_provider_eval/mod.rs
@@ -206,7 +206,7 @@ pub fn create_kg_provider(spec: &KgProviderSpec) -> Option<Arc<dyn LlmProvider>>
     };
 
     // 4096 max tokens is plenty for JSON extraction/resolution output.
-    match create_provider(&model_spec, 4096) {
+    match create_provider(&model_spec, 4096, false) {
         Ok(provider) => Some(provider),
         Err(e) => {
             eprintln!(

--- a/crates/mika-agent/tests/eval/providers.rs
+++ b/crates/mika-agent/tests/eval/providers.rs
@@ -77,7 +77,7 @@ pub fn create_real_provider(kind: ProviderKind) -> Option<Arc<dyn LlmProvider>> 
         api_key,
     };
 
-    match create_provider(&spec, kind.max_output_tokens()) {
+    match create_provider(&spec, kind.max_output_tokens(), false) {
         Ok(provider) => Some(provider),
         Err(e) => {
             eprintln!(

--- a/crates/mika-common/src/claude.rs
+++ b/crates/mika-common/src/claude.rs
@@ -334,10 +334,20 @@ pub struct ClaudeClient {
     auth: AnthropicAuth,
     pub model: String,
     pub max_tokens: u32,
+    /// When true AND the `telemetry` feature is enabled, attach request/response
+    /// bodies as `gen_ai.prompt` / `gen_ai.completion` span attributes on `llm_call`
+    /// spans for Langfuse generation input/output. See #671.
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    pub log_llm_bodies: bool,
 }
 
 impl ClaudeClient {
-    pub fn new(api_key: Option<String>, model: String, max_tokens: u32) -> Result<Self> {
+    pub fn new(
+        api_key: Option<String>,
+        model: String,
+        max_tokens: u32,
+        log_llm_bodies: bool,
+    ) -> Result<Self> {
         let credential = api_key
             .map(|k| k.trim().to_string())
             .filter(|k| !k.is_empty())
@@ -366,6 +376,7 @@ impl ClaudeClient {
             auth,
             model,
             max_tokens,
+            log_llm_bodies,
         })
     }
 
@@ -377,6 +388,7 @@ impl ClaudeClient {
             auth: AnthropicAuth::ApiKey(String::new()),
             model: String::new(),
             max_tokens: 0,
+            log_llm_bodies: false,
         }
     }
 
@@ -410,6 +422,16 @@ impl ClaudeClient {
             span.set_attribute("gen_ai.provider.name", "anthropic");
             span.set_attribute("gen_ai.request.model", request.model.clone());
             span.set_attribute("gen_ai.request.max_tokens", request.max_tokens as i64);
+
+            // Attach request body for Langfuse Generation "Input" (#671)
+            if self.log_llm_bodies
+                && let Ok(body_json) = serde_json::to_string(request)
+            {
+                span.set_attribute(
+                    "gen_ai.prompt",
+                    crate::llm::truncate_chars(&body_json, crate::llm::MAX_RESPONSE_TEXT_CHARS),
+                );
+            }
         }
 
         let response = self
@@ -433,6 +455,34 @@ impl ClaudeClient {
                 "gen_ai.response.finish_reasons",
                 format!("{:?}", response.stop_reason),
             );
+
+            // Attach response body for Langfuse Generation "Output" (#671)
+            if self.log_llm_bodies {
+                let content: Vec<crate::llm::LlmResponseContent> = response
+                    .content
+                    .iter()
+                    .filter_map(|block| match block {
+                        ContentBlock::Text { text } => {
+                            Some(crate::llm::LlmResponseContent::Text(text.clone()))
+                        }
+                        ContentBlock::ToolUse { id, name, input } => {
+                            Some(crate::llm::LlmResponseContent::ToolCall {
+                                id: id.clone(),
+                                name: name.clone(),
+                                arguments: input.clone(),
+                            })
+                        }
+                        ContentBlock::Thinking { .. } | ContentBlock::Image { .. } => None,
+                        ContentBlock::ToolResult { .. } => None,
+                    })
+                    .collect();
+                if let Some(text) = crate::llm::serialize_response_text(
+                    &content,
+                    crate::llm::MAX_RESPONSE_TEXT_CHARS,
+                ) {
+                    span.set_attribute("gen_ai.completion", text);
+                }
+            }
         }
 
         Ok(response)
@@ -749,13 +799,13 @@ mod tests {
     #[test]
     fn test_new_trims_api_key_whitespace() {
         let client =
-            ClaudeClient::new(Some("  sk-ant-test  ".into()), "model".into(), 100).unwrap();
+            ClaudeClient::new(Some("  sk-ant-test  ".into()), "model".into(), 100, false).unwrap();
         assert!(matches!(client.auth, AnthropicAuth::ApiKey(ref k) if k == "sk-ant-test"));
     }
 
     #[test]
     fn test_new_rejects_whitespace_only_key() {
-        let result = ClaudeClient::new(Some("   ".into()), "model".into(), 100);
+        let result = ClaudeClient::new(Some("   ".into()), "model".into(), 100, false);
         let Err(e) = result else {
             panic!("should reject whitespace-only key");
         };
@@ -764,7 +814,7 @@ mod tests {
 
     #[test]
     fn test_new_rejects_none_key() {
-        let result = ClaudeClient::new(None, "model".into(), 100);
+        let result = ClaudeClient::new(None, "model".into(), 100, false);
         let Err(e) = result else {
             panic!("should reject None key");
         };
@@ -782,16 +832,26 @@ mod tests {
 
     #[test]
     fn test_new_with_oauth_token() {
-        let client =
-            ClaudeClient::new(Some("sk-ant-oat01-test-token".into()), "model".into(), 100).unwrap();
+        let client = ClaudeClient::new(
+            Some("sk-ant-oat01-test-token".into()),
+            "model".into(),
+            100,
+            false,
+        )
+        .unwrap();
         assert!(client.auth.is_oauth());
         assert!(matches!(client.auth, AnthropicAuth::OAuthManaged(_)));
     }
 
     #[test]
     fn test_new_with_api_key() {
-        let client =
-            ClaudeClient::new(Some("sk-ant-api03-test-key".into()), "model".into(), 100).unwrap();
+        let client = ClaudeClient::new(
+            Some("sk-ant-api03-test-key".into()),
+            "model".into(),
+            100,
+            false,
+        )
+        .unwrap();
         assert!(!client.auth.is_oauth());
         assert!(matches!(client.auth, AnthropicAuth::ApiKey(_)));
     }

--- a/crates/mika-common/src/config.rs
+++ b/crates/mika-common/src/config.rs
@@ -1104,7 +1104,7 @@ impl Settings {
             base_url: config.base_url,
             api_key: config.api_key,
         };
-        crate::llm::create_provider(&spec, self.llm_max_tokens)
+        crate::llm::create_provider(&spec, self.llm_max_tokens, self.log_llm_bodies)
     }
 
     /// Create an LLM provider for a specific provider kind with an optional model override.
@@ -1131,7 +1131,7 @@ impl Settings {
             base_url: base_url.map(String::from),
             api_key: api_key.map(String::from),
         };
-        crate::llm::create_provider(&spec, self.llm_max_tokens)
+        crate::llm::create_provider(&spec, self.llm_max_tokens, self.log_llm_bodies)
     }
 
     /// Create an LLM provider for KG extraction (NER + fact triples).

--- a/crates/mika-common/src/llm/anthropic.rs
+++ b/crates/mika-common/src/llm/anthropic.rs
@@ -20,8 +20,13 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
-    pub fn new(api_key: Option<String>, model: String, max_tokens: u32) -> Result<Self> {
-        let client = ClaudeClient::new(api_key, model, max_tokens)?;
+    pub fn new(
+        api_key: Option<String>,
+        model: String,
+        max_tokens: u32,
+        log_llm_bodies: bool,
+    ) -> Result<Self> {
+        let client = ClaudeClient::new(api_key, model, max_tokens, log_llm_bodies)?;
         Ok(Self { client })
     }
 

--- a/crates/mika-common/src/llm/mod.rs
+++ b/crates/mika-common/src/llm/mod.rs
@@ -85,6 +85,57 @@ pub fn strip_internal_tags(text: &str) -> String {
     collapsed.trim().to_string()
 }
 
+/// Maximum characters for serialized response text in both the `llm_calls` table
+/// and telemetry span attributes. Shared constant to keep both stores consistent.
+pub const MAX_RESPONSE_TEXT_CHARS: usize = 50_000;
+
+/// Maximum characters for truncated tool call arguments in response text summaries.
+const MAX_TOOL_ARGS_CHARS: usize = 200;
+
+/// Serialize LLM response content blocks into a human-readable text representation.
+///
+/// Joins text blocks with newlines, formats tool calls as `[Tool Call: name(args)]`
+/// with truncated arguments, strips internal tags, and truncates to `max_chars`.
+/// Returns `None` if the result is empty after stripping.
+///
+/// This is the canonical serialization used by both:
+/// - `llm_calls.response_text` column (schema v31, #653)
+/// - `gen_ai.completion` OTLP span attribute (#671)
+pub fn serialize_response_text(content: &[LlmResponseContent], max_chars: usize) -> Option<String> {
+    let mut parts = Vec::new();
+    for block in content {
+        match block {
+            LlmResponseContent::Text(t) => parts.push(t.clone()),
+            LlmResponseContent::ToolCall {
+                name, arguments, ..
+            } => {
+                let args_str = arguments.to_string();
+                let args_truncated = truncate_chars(&args_str, MAX_TOOL_ARGS_CHARS);
+                parts.push(format!("[Tool Call: {name}({args_truncated})]"));
+            }
+        }
+    }
+    let joined = parts.join("\n");
+    let stripped = strip_internal_tags(&joined);
+    if stripped.is_empty() {
+        None
+    } else {
+        Some(truncate_chars(&stripped, max_chars))
+    }
+}
+
+/// Truncate a string to `max_chars` characters, appending "..." if truncated.
+///
+/// UTF-8 safe — counts characters, not bytes.
+pub fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars).collect();
+        format!("{truncated}...")
+    }
+}
+
 /// Provider-agnostic trait for LLM chat completions.
 ///
 /// Each provider (Anthropic, OpenAI-compatible, etc.) implements this trait
@@ -326,13 +377,18 @@ impl FromStr for ProviderKind {
 ///
 /// For Anthropic, uses the native Anthropic API client.
 /// For all others, uses the OpenAI-compatible provider.
-pub fn create_provider(spec: &ModelSpec, max_tokens: u32) -> Result<Arc<dyn LlmProvider>> {
+pub fn create_provider(
+    spec: &ModelSpec,
+    max_tokens: u32,
+    log_llm_bodies: bool,
+) -> Result<Arc<dyn LlmProvider>> {
     match spec.provider {
         ProviderKind::Anthropic => {
             let provider = anthropic::AnthropicProvider::new(
                 spec.api_key.clone(),
                 spec.model.clone(),
                 max_tokens,
+                log_llm_bodies,
             )
             .context("failed to create Anthropic provider")?;
             Ok(Arc::new(provider))
@@ -351,6 +407,7 @@ pub fn create_provider(spec: &ModelSpec, max_tokens: u32) -> Result<Arc<dyn LlmP
                 spec.model.clone(),
                 max_tokens,
                 spec.provider,
+                log_llm_bodies,
             );
             Ok(Arc::new(provider))
         }
@@ -637,6 +694,94 @@ Bye."#;
         let input =
             r#"Hi <context type="x">data</context> and <context type="y">more data context > end"#;
         assert_eq!(strip_internal_tags(input), "Hi  and  end");
+    }
+
+    // -- truncate_chars tests --
+
+    #[test]
+    fn test_truncate_chars_short_string() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_chars_exact_length() {
+        assert_eq!(truncate_chars("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_chars_long_string() {
+        assert_eq!(truncate_chars("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn test_truncate_chars_multibyte_utf8() {
+        // Ensure it counts chars, not bytes — "é" is 2 bytes but 1 char
+        let input = "café latte";
+        assert_eq!(truncate_chars(input, 4), "café...");
+    }
+
+    // -- serialize_response_text tests --
+
+    #[test]
+    fn test_serialize_response_text_text_only() {
+        let content = vec![LlmResponseContent::Text("Hello world".into())];
+        let result = serialize_response_text(&content, 50_000);
+        assert_eq!(result, Some("Hello world".into()));
+    }
+
+    #[test]
+    fn test_serialize_response_text_mixed_content() {
+        let content = vec![
+            LlmResponseContent::Text("Let me search.".into()),
+            LlmResponseContent::ToolCall {
+                id: "tc_1".into(),
+                name: "search_memory".into(),
+                arguments: serde_json::json!({"query": "test"}),
+            },
+        ];
+        let result = serialize_response_text(&content, 50_000).unwrap();
+        assert!(result.contains("Let me search."));
+        assert!(result.contains("[Tool Call: search_memory("));
+        assert!(result.contains("\"query\":\"test\""));
+    }
+
+    #[test]
+    fn test_serialize_response_text_empty() {
+        let content: Vec<LlmResponseContent> = vec![];
+        assert_eq!(serialize_response_text(&content, 50_000), None);
+    }
+
+    #[test]
+    fn test_serialize_response_text_truncates() {
+        let content = vec![LlmResponseContent::Text("a".repeat(60_000))];
+        let result = serialize_response_text(&content, 50_000).unwrap();
+        // 50000 chars + "..."
+        assert!(result.len() <= 50_003 + 10); // char count, not byte count
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_serialize_response_text_tool_args_truncated() {
+        let long_args = serde_json::json!({"key": "x".repeat(300)});
+        let content = vec![LlmResponseContent::ToolCall {
+            id: "tc_1".into(),
+            name: "my_tool".into(),
+            arguments: long_args,
+        }];
+        let result = serialize_response_text(&content, 50_000).unwrap();
+        assert!(result.contains("[Tool Call: my_tool("));
+        // The args should be truncated to 200 chars with "..."
+        assert!(result.contains("..."));
+    }
+
+    #[test]
+    fn test_serialize_response_text_strips_internal_tags() {
+        let content = vec![LlmResponseContent::Text(
+            "Hello <context type=\"tool_history\" trust=\"metadata\">hidden</context> world".into(),
+        )];
+        let result = serialize_response_text(&content, 50_000).unwrap();
+        assert_eq!(result, "Hello  world");
+        assert!(!result.contains("hidden"));
     }
 
     // -- send_message_with_deadline default implementation tests --

--- a/crates/mika-common/src/llm/openai.rs
+++ b/crates/mika-common/src/llm/openai.rs
@@ -141,6 +141,10 @@ pub struct OpenAiCompatibleProvider {
     model: String,
     max_tokens: u32,
     provider_kind: ProviderKind,
+    /// When true AND the `telemetry` feature is enabled, attach request/response
+    /// bodies as `gen_ai.prompt` / `gen_ai.completion` span attributes. See #671.
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    log_llm_bodies: bool,
 }
 
 impl OpenAiCompatibleProvider {
@@ -150,6 +154,7 @@ impl OpenAiCompatibleProvider {
         model: String,
         max_tokens: u32,
         provider_kind: ProviderKind,
+        log_llm_bodies: bool,
     ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
@@ -166,6 +171,7 @@ impl OpenAiCompatibleProvider {
             model,
             max_tokens,
             provider_kind,
+            log_llm_bodies,
         }
     }
 
@@ -347,6 +353,17 @@ impl LlmProvider for OpenAiCompatibleProvider {
             span.set_attribute("gen_ai.provider.name", self.provider_kind.to_string());
             span.set_attribute("gen_ai.request.model", request.model.clone());
             span.set_attribute("gen_ai.request.max_tokens", request.max_tokens as i64);
+
+            // Attach request body for Langfuse Generation "Input" (#671)
+            if self.log_llm_bodies {
+                let openai_req = to_openai_request(request);
+                if let Ok(body_json) = serde_json::to_string(&openai_req) {
+                    span.set_attribute(
+                        "gen_ai.prompt",
+                        super::truncate_chars(&body_json, super::MAX_RESPONSE_TEXT_CHARS),
+                    );
+                }
+            }
         }
 
         let response = self
@@ -370,6 +387,16 @@ impl LlmProvider for OpenAiCompatibleProvider {
                 "gen_ai.response.finish_reasons",
                 format!("{:?}", response.stop_reason),
             );
+
+            // Attach response body for Langfuse Generation "Output" (#671)
+            if self.log_llm_bodies
+                && let Some(text) = super::serialize_response_text(
+                    &response.content,
+                    super::MAX_RESPONSE_TEXT_CHARS,
+                )
+            {
+                span.set_attribute("gen_ai.completion", text);
+            }
         }
 
         Ok(response)

--- a/docs/plans/2026-05-06-007-feat-671-llm-bodies-to-langfuse-plan.md
+++ b/docs/plans/2026-05-06-007-feat-671-llm-bodies-to-langfuse-plan.md
@@ -1,0 +1,290 @@
+---
+title: "feat: Attach LLM request/response bodies to Langfuse generation spans via OTLP"
+type: feat
+status: active
+date: 2026-05-06
+issue: 671
+---
+
+# feat: Attach LLM request/response bodies to Langfuse generation spans via OTLP
+
+## Overview
+
+When `MIKA_LOG_LLM_BODIES` is enabled alongside telemetry, attach serialized LLM request and response bodies as `gen_ai.prompt` / `gen_ai.completion` span attributes on existing `llm_call` spans. This sends bodies to Langfuse's Generation input/output fields via the existing OTLP pipeline. Local log file output remains unchanged as the offline fallback.
+
+## Problem Frame
+
+`MIKA_LOG_LLM_BODIES` currently writes full LLM request/response JSON to local log files via the `mika::llm_debug` tracing target. This is useful for local debugging but bodies are disconnected from their traces in Langfuse. Langfuse is purpose-built for this — bodies belong with their generation spans, correlated with token counts, latency, and trace context.
+
+The prior architecture (documented in `docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md`) explicitly excluded body content from spans: "No prompt/response content in spans — only metadata." Issue #671 reverses that decision, gated behind the existing `log_llm_bodies` toggle so the operator retains control.
+
+## Requirements Trace
+
+- R1. When `log_llm_bodies=true` AND telemetry is enabled, LLM request bodies appear in Langfuse Generation "Input" field
+- R2. When `log_llm_bodies=true` AND telemetry is enabled, LLM response bodies appear in Langfuse Generation "Output" field
+- R3. Local log file output (`mika::llm_debug` target) continues to work unchanged when telemetry is disabled
+- R4. When `log_llm_bodies=false` (default), no body content is attached to spans — preserving the current behavior
+- R5. Body content is truncated defensively to prevent runaway payloads (50K char cap, matching `llm_calls.response_text`)
+- R6. Both Anthropic and OpenAI-compatible providers attach bodies symmetrically
+- R7. Response body serialization reuses the `response_text` format from #653 (text blocks joined, tool call summaries, internal tags stripped) rather than raw API response JSON
+
+## Scope Boundaries
+
+- No new config option — reuses existing `MIKA_LOG_LLM_BODIES` toggle
+- No Langfuse native API integration — bodies flow through existing OTLP pipeline
+- No changes to the OTLP transport, TracerProvider, or layer filtering
+- No changes to `llm_calls` table schema or SQLite storage
+- Request body serialization uses provider-specific wire format JSON (already computed for `mika::llm_debug` logging)
+
+### Deferred to Separate Tasks
+
+- Separate `MIKA_TELEMETRY_LLM_BODIES` toggle independent of file logging: future iteration if operators want bodies in Langfuse without local file logging
+- Request body size optimization (e.g., omitting system prompt, summarizing tool definitions): future iteration based on Langfuse usage patterns
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Span creation + attribute setting:** `claude.rs:398-436` (Anthropic) and `openai.rs:334-373` (OpenAI-compatible) — `info_span!(target: "mika::otel", "llm_call", ...)` with `#[cfg(feature = "telemetry")]` blocks using `OpenTelemetrySpanExt::set_attribute()`
+- **Body logging sites:** `claude.rs:640-680` (Anthropic `send_once`) and `openai.rs:190-232` (OpenAI `send_once`) — gated by `tracing::enabled!(target: "mika::llm_debug", ...)`
+- **Response text serialization:** `agent.rs:919-940` — joins text blocks, formats tool calls as `[Tool Call: name(args)]`, strips internal tags, truncates to 50K chars
+- **Provider construction:** `llm/mod.rs:329-358` — `create_provider()` takes `ModelSpec` + `max_tokens`, no `Settings` reference
+- **Telemetry layer filter:** `telemetry.rs:91` — `filter::Targets::new().with_target("mika::otel", tracing::Level::INFO)` — only `mika::otel` spans reach OTLP
+- **Text truncation:** `db::truncate_chars()` (char-count, appends "...") and `text::safe_truncate()` (byte-count, `&str`)
+
+### Institutional Learnings
+
+- `langfuse-non-llm-span-filtering.md`: Prior explicit decision "No prompt/response content in spans — only metadata." This feature reverses that, gated behind `log_llm_bodies`
+- `runtime-observability-llm-tool-call-recording.md`: `log_llm_bodies` deliberately uses `mika::llm_debug` (not `mika::otel`) "to avoid sending sensitive content to Langfuse" — the 50KB truncation uses `is_char_boundary()` for safe UTF-8
+- `653-llm-call-detail-response-content-linked-tool-calls.md`: Schema v31 `response_text` serialization format is the canonical response body representation — reuse it
+- `otlp-endpoint-path-requirement.md`: OTLP exporter silently swallows failures — test with real Langfuse to verify large attributes arrive
+
+### External References
+
+- **OTLP attribute size limits:** OTel spec default is unlimited (no `AttributeValueLengthLimit`). Rust SDK does not auto-truncate. OTLP HTTP has no per-attribute protocol limit; practical limit is transport message size (~4MB for gRPC, server-dependent for HTTP)
+- **Langfuse OTLP mapping:** `gen_ai.prompt` → Generation "Input" field; `gen_ai.completion` → Generation "Output" field. Langfuse does NOT support the newer events-based GenAI semconv format (span events `gen_ai.client.inference.operation.details`) — attribute-based format is required
+- **Langfuse size limits:** 5MB per API request (Cloud), ~1MB per trace rendering. A 50K-char body (~50KB) is well within all limits
+- **Langfuse issue #12657:** Events-based GenAI conventions not yet supported — must use span attributes
+
+## Key Technical Decisions
+
+- **Reuse `log_llm_bodies` toggle (not a new config):** The operator already uses this to opt into body visibility. Adding a separate `MIKA_TELEMETRY_LLM_BODIES` creates unnecessary config surface for the v1 implementation. If orthogonal control is needed later, it's additive.
+- **Thread `log_llm_bodies` into providers via struct field:** The `ClaudeClient` and `OpenAiCompatibleProvider` structs need to know whether to attach body attributes. Adding a `log_llm_bodies: bool` field and plumbing it through constructors is the minimal change. The alternative (checking a global/static) fights the existing constructor-injection pattern.
+- **Use `gen_ai.prompt` / `gen_ai.completion` attribute names:** These are the GenAI semantic convention attributes Langfuse maps to its Generation UI. Using `langfuse.observation.input` / `langfuse.observation.output` would couple to Langfuse specifically.
+- **Serialize request body as JSON string:** The request body is already serialized to JSON for `mika::llm_debug` logging. Reuse that serialization path for the span attribute, applying the 50K char truncation.
+- **Serialize response body in `response_text` format:** Rather than raw API JSON (which includes wire-format noise), use the same human-readable format as `llm_calls.response_text` — text blocks joined with newlines, tool calls as `[Tool Call: name(args)]`, internal tags stripped. This requires computing the serialized form in the provider layer, not just in `agent.rs`.
+- **Attach at `send_message_with_deadline` level (not `send_once`):** Body attributes should be set alongside existing `gen_ai.*` attributes in the same `#[cfg(feature = "telemetry")]` blocks. The request body is available before the inner call; the response body after. This keeps the body attribute logic co-located with the other generation metadata rather than scattered in `send_once`.
+- **50K char truncation cap:** Matches `llm_calls.response_text` column cap. Well within Langfuse's 5MB request limit. Prevents runaway payloads from poisoning the OTLP pipeline.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **OTLP attribute size limits?** No hard limit in OTel spec or OTLP protocol. Rust SDK does not auto-truncate. 50K chars (~50KB) is well within Langfuse's 5MB request limit and ~1MB trace rendering limit. Resolved: OTLP works fine for our payload sizes.
+- **`gen_ai.content.prompt` vs `gen_ai.prompt`?** Langfuse maps `gen_ai.prompt` (NOT `gen_ai.content.prompt`) to its Generation Input field. Resolved: use `gen_ai.prompt` and `gen_ai.completion`.
+- **Separate toggle vs reuse `log_llm_bodies`?** Reuse existing toggle for v1. A separate `MIKA_TELEMETRY_LLM_BODIES` is additive if needed later.
+
+### Deferred to Implementation
+
+- **Exact `LlmResponse` → response text serialization in provider layer:** The `response_text` construction currently lives in `agent.rs`. Need to determine whether to extract it to a shared function in `mika-common` or duplicate a simplified version in the providers. Implementation will reveal the cleanest factoring.
+
+## Implementation Units
+
+- [x] **Unit 1: Thread `log_llm_bodies` into provider constructors**
+
+**Goal:** Pass the `log_llm_bodies` setting from `Settings` through `create_provider()` into `ClaudeClient` and `OpenAiCompatibleProvider` as a struct field.
+
+**Requirements:** R4 (gating), R6 (both providers)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-common/src/claude.rs` (add `log_llm_bodies: bool` field to `ClaudeClient`, update `new()` signature)
+- Modify: `crates/mika-common/src/llm/openai.rs` (add `log_llm_bodies: bool` field to `OpenAiCompatibleProvider`, update `new()` signature)
+- Modify: `crates/mika-common/src/llm/anthropic.rs` (update `AnthropicProvider::new()` to accept and forward the flag)
+- Modify: `crates/mika-common/src/llm/mod.rs` (update `create_provider()` to accept `log_llm_bodies: bool` and pass it through)
+- Modify: `crates/mika-common/src/llm/mock.rs` (update `MockLlmProvider` if needed for `create_provider` signature compatibility)
+- Modify: `crates/mika-agent/src/agent.rs` (pass `settings.log_llm_bodies` to `create_provider()`)
+- Modify: `crates/mika-cli/src/main.rs` (pass `log_llm_bodies` to `create_provider()` at CLI call sites)
+- Test: `crates/mika-common/src/claude.rs` (existing `ClaudeClient::new` tests — update signatures)
+
+**Approach:**
+- Add `log_llm_bodies: bool` to `ClaudeClient`, `OpenAiCompatibleProvider`, and `AnthropicProvider` structs
+- Thread through `create_provider(spec, max_tokens, log_llm_bodies)` → provider constructors
+- Default to `false` in test helpers and dummy providers
+- All existing call sites pass the setting from their `Settings` instance
+
+**Patterns to follow:**
+- `provider_kind: ProviderKind` field on `OpenAiCompatibleProvider` — same constructor threading pattern
+
+**Test scenarios:**
+- Happy path: `ClaudeClient::new()` with `log_llm_bodies=true` stores the flag; with `false` stores false
+- Happy path: `create_provider()` accepts the new parameter and constructs providers successfully
+- Edge case: existing tests that construct providers directly compile with the updated signature (compilation is the test)
+
+**Verification:**
+- `cargo build` succeeds with no signature mismatches
+- `cargo test -p mika-common` passes
+- `cargo test -p mika-agent` passes (agent.rs call sites updated)
+
+- [x] **Unit 2: Extract response text serialization to shared function**
+
+**Goal:** Move the `response_text` construction logic from `agent.rs` into a shared function in `mika-common` so both the agent loop and the provider telemetry code can use it.
+
+**Requirements:** R7 (reuse response_text format)
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `crates/mika-common/src/llm/mod.rs` (add `pub fn serialize_response_text(content: &[LlmResponseContent]) -> Option<String>`)
+- Modify: `crates/mika-agent/src/agent.rs` (replace inline `response_text` construction with call to the shared function)
+- Test: `crates/mika-common/src/llm/mod.rs` (unit tests for the shared function)
+
+**Approach:**
+- Extract the logic from `agent.rs:919-940` into `mika_common::llm::serialize_response_text(content: &[LlmResponseContent], max_chars: usize) -> Option<String>`
+- Uses `strip_internal_tags()` (already in `mika-common::llm`) and `truncate_chars()` — need to either re-export `truncate_chars` from `mika-common` or use `safe_truncate` with a char-count variant
+- The function takes a `max_chars` parameter so callers can use 50K for DB and telemetry
+- `agent.rs` becomes a one-liner call to the shared function
+
+**Patterns to follow:**
+- `strip_internal_tags()` in `mika-common::llm` — same module, shared utility function pattern
+
+**Test scenarios:**
+- Happy path: text-only response → joined text with internal tags stripped, truncated to cap
+- Happy path: mixed text + tool call response → text and `[Tool Call: name(args)]` summaries joined
+- Edge case: empty content → returns `None`
+- Edge case: content exceeding 50K chars → truncated with "..." suffix
+- Edge case: tool call args exceeding 200 chars → args truncated in summary
+
+**Verification:**
+- `agent.rs` `response_text` construction is a single function call
+- `cargo test -p mika-common` passes with new unit tests
+- `cargo test -p mika-agent` passes (behavior unchanged)
+
+- [x] **Unit 3: Attach request body as `gen_ai.prompt` span attribute**
+
+**Goal:** When `log_llm_bodies` is true and telemetry feature is enabled, serialize the LLM request body and attach it as a `gen_ai.prompt` attribute on the `llm_call` span.
+
+**Requirements:** R1 (request bodies in Langfuse Input), R4 (gating), R5 (truncation), R6 (both providers)
+
+**Dependencies:** Unit 1 (log_llm_bodies field available on providers)
+
+**Files:**
+- Modify: `crates/mika-common/src/claude.rs` (add `gen_ai.prompt` attribute in the pre-call `#[cfg(feature = "telemetry")]` block in `send_message_with_deadline`)
+- Modify: `crates/mika-common/src/llm/openai.rs` (same pattern in `send_message_with_deadline`)
+- Test: `crates/mika-common/src/claude.rs` (unit test verifying request serialization + truncation)
+
+**Approach:**
+- In each provider's `send_message_with_deadline`, after the existing `gen_ai.request.*` attributes, add a guarded block:
+  ```
+  if self.log_llm_bodies {
+      // Serialize the provider-specific request to JSON, truncate to 50K chars, set as gen_ai.prompt
+  }
+  ```
+- For Anthropic: serialize `MessagesRequest` to JSON (same serialization as `send_once` body logging)
+- For OpenAI: serialize `OpenAiRequest` to JSON (same as `send_once`)
+- Apply `truncate_chars()` / equivalent with 50K cap before setting the attribute
+- The serialization cost is only paid when `log_llm_bodies=true` (same gating as existing file logging)
+
+**Patterns to follow:**
+- Existing `span.set_attribute("gen_ai.request.model", ...)` calls in the same `#[cfg(feature = "telemetry")]` blocks
+
+**Test scenarios:**
+- Happy path: with `log_llm_bodies=true` and telemetry feature, request JSON is serialized and set as attribute (verify serialization produces valid JSON)
+- Happy path: with `log_llm_bodies=false`, no serialization occurs (verify via absence of attribute — or test that no JSON serialization is called)
+- Edge case: request body exceeding 50K chars → truncated with "..." suffix
+- Edge case: request serialization failure → no attribute set, no panic (fire-and-forget)
+
+**Verification:**
+- `cargo test --features telemetry -p mika-common` passes
+- `cargo test -p mika-common` passes (non-telemetry build)
+- Body logging to files still works independently
+
+- [x] **Unit 4: Attach response body as `gen_ai.completion` span attribute**
+
+**Goal:** When `log_llm_bodies` is true and telemetry feature is enabled, serialize the LLM response in `response_text` format and attach it as a `gen_ai.completion` attribute on the `llm_call` span.
+
+**Requirements:** R2 (response bodies in Langfuse Output), R4 (gating), R5 (truncation), R6 (both providers), R7 (response_text format)
+
+**Dependencies:** Unit 1 (log_llm_bodies field), Unit 2 (shared serialization function)
+
+**Files:**
+- Modify: `crates/mika-common/src/claude.rs` (add `gen_ai.completion` attribute in the post-call `#[cfg(feature = "telemetry")]` block in `send_message_with_deadline`)
+- Modify: `crates/mika-common/src/llm/openai.rs` (same pattern in `send_message_with_deadline`)
+- Test: `crates/mika-common/src/claude.rs` (unit test verifying response serialization matches `response_text` format)
+
+**Approach:**
+- In each provider's `send_message_with_deadline`, after the existing `gen_ai.usage.*` / `gen_ai.response.*` attributes, add:
+  ```
+  if self.log_llm_bodies {
+      // Convert provider-specific response to LlmResponse content, call serialize_response_text(), set as gen_ai.completion
+  }
+  ```
+- For Anthropic: convert `MessagesResponse.content` blocks to `LlmResponseContent` variants, then call `serialize_response_text()`
+- For OpenAI: the response is already converted to `LlmResponse` by `send_message_with_deadline` — use `response.content` directly with `serialize_response_text()`
+- Note: In `claude.rs`, the response is `MessagesResponse` (Anthropic-specific), not `LlmResponse`. The conversion to `LlmResponse` happens in `anthropic.rs`. The simplest approach is to serialize the Anthropic response to a similar format: iterate `ContentBlock` variants (Text → text, ToolUse → `[Tool Call: ...]`), strip tags, truncate. Alternatively, move the attribute setting into `anthropic.rs` after the conversion.
+
+**Patterns to follow:**
+- `serialize_response_text()` from Unit 2
+- Existing `gen_ai.response.finish_reasons` attribute setting in the same blocks
+
+**Test scenarios:**
+- Happy path: text-only response → stripped, truncated text set as `gen_ai.completion` attribute
+- Happy path: mixed text + tool call response → text with `[Tool Call: ...]` summaries
+- Happy path: with `log_llm_bodies=false`, no response serialization occurs
+- Edge case: empty response content → no attribute set (matches `response_text = None` behavior)
+- Edge case: response exceeding 50K chars → truncated
+- Integration: Anthropic response → `gen_ai.completion` attribute matches the `response_text` that would be stored in `llm_calls` table for the same response
+
+**Verification:**
+- `cargo test --features telemetry -p mika-common` passes
+- `cargo test -p mika-common` passes (non-telemetry build)
+- Response format in Langfuse matches what the dashboard shows from `llm_calls.response_text`
+
+- [x] **Unit 5: Update documentation and solution doc**
+
+**Goal:** Document the reversed architectural decision and update relevant docs.
+
+**Requirements:** R3 (local logging unchanged), R4 (gating documented)
+
+**Dependencies:** Units 3, 4
+
+**Files:**
+- Modify: `docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md` (update the "No prompt/response content in spans" decision with a note that #671 reversed this, gated behind `log_llm_bodies`)
+- Modify: `docs/solutions/architecture-patterns/runtime-observability-llm-tool-call-recording.md` (note that `log_llm_bodies` now also drives OTLP body attributes when telemetry is enabled)
+
+**Approach:**
+- Add a note to each doc referencing #671 and the gating behavior
+- Keep the existing content as historical context
+
+**Test expectation: none — documentation only**
+
+**Verification:**
+- Docs accurately describe the new dual behavior of `log_llm_bodies`
+
+## System-Wide Impact
+
+- **Interaction graph:** The change is confined to the `llm_call` span attribute setting in two provider implementations (`claude.rs`, `openai.rs`). No callbacks, middleware, or observers are affected. The OTLP export pipeline (`telemetry.rs`) is unchanged — it exports whatever attributes are on `mika::otel` spans.
+- **Error propagation:** Body serialization or attribute setting failures must not crash the agent loop. Use the existing fire-and-forget pattern — if JSON serialization fails (`serde_json::to_string` returns `Err`), skip the attribute silently. `set_attribute()` itself does not return errors.
+- **State lifecycle risks:** None. Span attributes are ephemeral (exported via OTLP, then discarded). No persistent state changes.
+- **API surface parity:** Both Anthropic and OpenAI-compatible providers must implement the same body attachment behavior. The `LlmProvider` trait is unchanged — body attachment is an internal provider concern, not a trait contract.
+- **Unchanged invariants:** The `mika::llm_debug` tracing target and local file logging behavior is completely unchanged. The `llm_calls` table storage is unchanged. The OTLP `filter::Targets` filter is unchanged. The `telemetry` feature gate is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Large body attributes increase OTLP payload size, potentially causing export failures | 50K char truncation cap. Langfuse accepts up to 5MB per request; 50K chars (~50KB) is 1% of that. OTLP exporter silently drops failed batches — no agent impact. |
+| Sensitive data (API keys in system prompt, user PII) reaches Langfuse | This is an operator opt-in (`log_llm_bodies=true`). The same data already flows to local log files when enabled. Operators who enable it accept the data exposure. |
+| Serialization cost on hot path | Gated behind `if self.log_llm_bodies` — zero cost when disabled (default). When enabled, JSON serialization is ~1ms for a 50K request, negligible compared to the LLM API call latency. |
+| `ClaudeClient` response is `MessagesResponse` (Anthropic-specific), not `LlmResponse` | May need a lightweight conversion or dedicated serialization for Anthropic `ContentBlock` types. Implementation will determine the cleanest factoring. |
+
+## Sources & References
+
+- Related issue: #671
+- Related issue: #653 (LLM call detail — response_text column)
+- Predecessor doc: `docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md`
+- Pattern doc: `docs/solutions/architecture-patterns/runtime-observability-llm-tool-call-recording.md`
+- Langfuse OTLP docs: https://langfuse.com/integrations/native/opentelemetry
+- Langfuse GenAI events issue: https://github.com/langfuse/langfuse/issues/12657
+- OTel attribute limits spec: https://opentelemetry.io/docs/specs/otel/common/

--- a/docs/solutions/architecture-patterns/runtime-observability-llm-tool-call-recording.md
+++ b/docs/solutions/architecture-patterns/runtime-observability-llm-tool-call-recording.md
@@ -37,7 +37,7 @@ Both tables added as UNION ALL legs in `unified_timeline` VIEW — automatically
 
 - `store_llm_calls` (default: true) — gate SQLite writes
 - `store_tool_calls` (default: true) — gate SQLite writes
-- `log_llm_bodies` (default: false) — dev-only full request/response dump via `mika::llm_debug` tracing target
+- `log_llm_bodies` (default: false) — dual-purpose: (1) dev-only full request/response dump via `mika::llm_debug` tracing target to log files, (2) when telemetry is also enabled, attaches `gen_ai.prompt` / `gen_ai.completion` span attributes to `llm_call` spans for Langfuse Generation input/output (#671)
 
 ### Agent loop integration
 
@@ -58,7 +58,7 @@ Both tables added as UNION ALL legs in `unified_timeline` VIEW — automatically
 - **50KB output cap**: Covers 99% of tool outputs while preventing storage blowup. UTF-8 safe truncation via `is_char_boundary()`.
 - **Fire-and-forget writes with `warn!`**: Observability should never break the agent loop. Errors are logged, not propagated.
 - **Config on by default**: The whole point is visibility. Users who don't want the overhead can opt out.
-- **`log_llm_bodies` via separate tracing target**: Uses `mika::llm_debug` (not `mika::otel`) to avoid sending sensitive content to Langfuse. The config option auto-adds the filter directive so users don't fiddle with `RUST_LOG`.
+- **`log_llm_bodies` via separate tracing target**: Uses `mika::llm_debug` (not `mika::otel`) for local log file output. The config option auto-adds the filter directive so users don't fiddle with `RUST_LOG`. Since #671, `log_llm_bodies` also gates OTLP body attributes when the `telemetry` feature is enabled — request bodies as `gen_ai.prompt` and response bodies as `gen_ai.completion` on `llm_call` spans. Both paths (log file and OTLP) are independently useful: log files work offline, OTLP correlates bodies with Langfuse traces.
 
 ## Bugs Found and Fixed
 

--- a/docs/solutions/best-practices/llm-body-telemetry-via-otlp-span-attributes-2026-05-06.md
+++ b/docs/solutions/best-practices/llm-body-telemetry-via-otlp-span-attributes-2026-05-06.md
@@ -1,0 +1,114 @@
+---
+title: "LLM body telemetry via OTLP span attributes for Langfuse"
+date: 2026-05-06
+category: best-practices
+module: mika-common/llm
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Adding LLM request/response body content to telemetry spans
+  - Extending the gen_ai.* semantic convention attributes on llm_call spans
+  - Choosing between OTLP span attributes vs Langfuse native API for large payloads
+tags:
+  - telemetry
+  - langfuse
+  - otlp
+  - opentelemetry
+  - gen-ai
+  - span-attributes
+  - llm-bodies
+  - observability
+---
+
+# LLM Body Telemetry via OTLP Span Attributes for Langfuse
+
+## Context
+
+`MIKA_LOG_LLM_BODIES` originally wrote full LLM request/response JSON to local log files via the `mika::llm_debug` tracing target. Bodies were disconnected from their Langfuse traces. Issue #671 evaluated whether to send bodies via the existing generic OTLP pipeline or via Langfuse's native API.
+
+The prior architecture (documented in `langfuse-non-llm-span-filtering.md`) explicitly excluded body content from spans: "No prompt/response content in spans -- only metadata." This decision was reversed in #671, gated behind the existing `log_llm_bodies` toggle.
+
+## Guidance
+
+### Use `gen_ai.prompt` and `gen_ai.completion` span attributes
+
+Langfuse maps these specific attribute names to its Generation "Input" and "Output" fields:
+
+- `gen_ai.prompt` -- request body (JSON-serialized wire format)
+- `gen_ai.completion` -- response body (human-readable `serialize_response_text` format)
+
+Do NOT use `gen_ai.content.prompt` / `gen_ai.content.completion` (Langfuse doesn't map these). Do NOT use the newer events-based GenAI semconv format (`gen_ai.client.inference.operation.details`) -- Langfuse does not support it (langfuse/langfuse#12657).
+
+### Thread config through provider constructors, not globals
+
+The `log_llm_bodies: bool` field is added to `ClaudeClient` and `OpenAiCompatibleProvider` structs, threaded through `create_provider()`. This follows the existing constructor-injection pattern (like `provider_kind`). Avoid static/global config checks in the provider layer.
+
+### Reuse `serialize_response_text()` for response bodies
+
+`mika_common::llm::serialize_response_text()` is the canonical serialization for LLM response content. It produces the same format used by `llm_calls.response_text` (schema v31): text blocks joined with newlines, tool calls as `[Tool Call: name(args)]`, internal tags stripped, truncated to `MAX_RESPONSE_TEXT_CHARS` (50K).
+
+### Apply defensive truncation (50K chars)
+
+OTLP has no hard per-attribute size limit. Langfuse accepts up to 5MB per request. But apply `truncate_chars()` at 50K chars to prevent runaway payloads from poisoning the pipeline. This matches the `llm_calls.response_text` column cap.
+
+### Feature-gate telemetry code behind `#[cfg(feature = "telemetry")]`
+
+Body attribute attachment lives inside existing `#[cfg(feature = "telemetry")]` blocks alongside `gen_ai.request.model` etc. Use `#[cfg_attr(not(feature = "telemetry"), allow(dead_code))]` on the `log_llm_bodies` struct field to suppress dead-code warnings in the default (non-telemetry) build.
+
+## Why This Matters
+
+Bodies in Langfuse, correlated with token counts, latency, and trace context, are far more useful than bodies scattered in local log files. The OTLP approach keeps the architecture clean (no Langfuse-specific SDK coupling) while the 50K char cap and `log_llm_bodies` gating ensure the feature is safe for production.
+
+## When to Apply
+
+- When adding new telemetry data to LLM call spans
+- When considering Langfuse native API vs generic OTLP for new attributes
+- When adding new providers that need body telemetry parity
+
+## Examples
+
+Request body attachment (Anthropic provider, `claude.rs`):
+
+```rust
+#[cfg(feature = "telemetry")]
+{
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    // ... existing gen_ai.request.* attributes ...
+
+    if self.log_llm_bodies
+        && let Ok(body_json) = serde_json::to_string(request)
+    {
+        span.set_attribute(
+            "gen_ai.prompt",
+            crate::llm::truncate_chars(&body_json, crate::llm::MAX_RESPONSE_TEXT_CHARS),
+        );
+    }
+}
+```
+
+Response body attachment (OpenAI-compatible provider, `openai.rs`):
+
+```rust
+#[cfg(feature = "telemetry")]
+{
+    // ... existing gen_ai.usage.* attributes ...
+
+    if self.log_llm_bodies
+        && let Some(text) = super::serialize_response_text(
+            &response.content,
+            super::MAX_RESPONSE_TEXT_CHARS,
+        )
+    {
+        span.set_attribute("gen_ai.completion", text);
+    }
+}
+```
+
+## Related
+
+- Issue: #671
+- Predecessor: `docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md`
+- Pattern: `docs/solutions/architecture-patterns/runtime-observability-llm-tool-call-recording.md`
+- Schema v31: `docs/solutions/653-llm-call-detail-response-content-linked-tool-calls.md`
+- Langfuse OTLP docs: https://langfuse.com/integrations/native/opentelemetry

--- a/docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md
+++ b/docs/solutions/integration-issues/langfuse-non-llm-span-filtering.md
@@ -67,7 +67,7 @@ The `send_message` method was split into `send_message` (span + telemetry wrappe
 
 - **Filter applied inside `build_otel_layer()`**, not in `logging.rs` match arms — avoids type-level explosion (see `docs/solutions/architecture-patterns/log-format-selection-tracing-subscriber.md`).
 - **`set_attribute()` over tracing field names** — gen_ai attribute keys have dots (`gen_ai.operation.name`) which work as tracing field names but `set_attribute()` is cleaner and naturally feature-gated.
-- **No prompt/response content in spans** — only metadata (model, tokens, stop reason). Sensitive data stays out of Langfuse.
+- **~~No prompt/response content in spans~~ — Reversed by #671.** When `MIKA_LOG_LLM_BODIES=true` AND telemetry is enabled, request bodies are attached as `gen_ai.prompt` and response bodies as `gen_ai.completion` span attributes. This populates Langfuse's Generation "Input"/"Output" fields. Gated behind the existing `log_llm_bodies` toggle — the operator explicitly opts in. When `log_llm_bodies=false` (default), only metadata (model, tokens, stop reason) is sent, preserving the original behavior.
 - **`use<>` precise capturing** — required in Rust 2024 edition for `impl Trait` return types that take `&Settings` but don't capture the lifetime.
 
 ## Prevention


### PR DESCRIPTION
## Summary

- When `MIKA_LOG_LLM_BODIES=true` and telemetry is enabled, attach serialized LLM request/response bodies as `gen_ai.prompt` / `gen_ai.completion` span attributes on `llm_call` spans — Langfuse maps these to Generation Input/Output fields via OTLP
- Extract `serialize_response_text()` and `truncate_chars()` to `mika-common::llm` as shared utilities used by both the agent loop (`llm_calls` table) and telemetry (span attributes)
- Thread `log_llm_bodies: bool` through `create_provider()` → provider constructors (symmetric across Anthropic and OpenAI-compatible providers)
- Feature-gated behind `#[cfg(feature = "telemetry")]` with zero cost when `log_llm_bodies=false` (default)
- Updated solution docs to document the reversed architectural decision from `langfuse-non-llm-span-filtering.md`

Plan: docs/plans/2026-05-06-007-feat-671-llm-bodies-to-langfuse-plan.md

Closes #671

## Test plan

- [x] `cargo test` — all 3,662 tests pass (10 new tests for `serialize_response_text` and `truncate_chars`)
- [x] `cargo build` — clean (no warnings)
- [x] `cargo build --features telemetry -p mika-common` — clean (no warnings)
- [x] Lefthook hooks pass (rust-fmt, rust-clippy, no-secrets, no-large-files)
- [ ] Manual: enable `MIKA_LOG_LLM_BODIES=true` + telemetry, verify bodies appear in Langfuse Generation Input/Output fields
- [ ] Manual: verify local log file output still works when telemetry is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)