### PR TITLE
feat(kg): emit reattempted_no_match field on kg_resolver_tick.complete (#961)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -24,7 +24,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 31;
+pub const CURRENT_SCHEMA_VERSION: i64 = 32;
 
 /// SQL for the unified_timeline VIEW — cross-subsystem event correlation.
 /// Used in both clean-slate schema creation and incremental migration.
@@ -1069,6 +1069,11 @@ impl Database {
             info!(version = 31, "database migrated to v31");
         }
 
+        if (3..=31).contains(&version) {
+            self.migrate_v31_to_v32()?;
+            info!(version = 32, "database migrated to v32");
+        }
+
         Ok(())
     }
 
@@ -1123,7 +1128,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (31);
+            INSERT INTO schema_version (version) VALUES (32);
 
             -- Schema meta table for migration state tracking (v27+).
             CREATE TABLE schema_meta (
@@ -1670,6 +1675,16 @@ impl Database {
                 UNIQUE (agent_id, subject_entity_id)
             );
             CREATE INDEX idx_kg_res_log_pending ON kg_resolutions_log(agent_id, outcome);
+
+            -- KG invalidation markers (#961): ephemeral sidecar for tracking
+            -- entities whose no_match resolution log rows were deleted by
+            -- domain-graph rebuild invalidation (#960).
+            CREATE TABLE kg_invalidated_no_match (
+                subject_entity_id INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                invalidated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                PRIMARY KEY (subject_entity_id, agent_id)
+            );
 
             -- Pre-register the default 'mika' agent
             INSERT INTO agents (id, name, home_dir) VALUES ('mika', 'Mika', '');
@@ -3723,6 +3738,36 @@ impl Database {
         tx.commit()?;
 
         info!("v30→v31: added response_text and reasoning columns to llm_calls (#653)");
+
+        Ok(())
+    }
+
+    /// v31→v32: Add `kg_invalidated_no_match` sidecar table (#961).
+    ///
+    /// Ephemeral marker table for tracking entities whose `no_match` resolution
+    /// log rows were deleted by domain-graph rebuild invalidation (#960).
+    /// The resolver reads and cleans up these markers during resolution.
+    fn migrate_v31_to_v32(&mut self) -> Result<()> {
+        let version = self.schema_version()?;
+        if version >= 32 {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS kg_invalidated_no_match (
+                subject_entity_id INTEGER NOT NULL,
+                agent_id TEXT NOT NULL,
+                invalidated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                PRIMARY KEY (subject_entity_id, agent_id)
+            );",
+        )?;
+        tx.execute("INSERT INTO schema_version (version) VALUES (32)", [])?;
+        tx.commit()?;
+
+        info!("v31→v32: added kg_invalidated_no_match sidecar table (#961)");
 
         Ok(())
     }
@@ -13209,6 +13254,7 @@ mod tests {
         db2.migrate_v28_to_v29().unwrap();
         db2.migrate_v29_to_v30().unwrap();
         db2.migrate_v30_to_v31().unwrap();
+        db2.migrate_v31_to_v32().unwrap();
 
         let final_version: i64 = db2
             .conn

--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -198,6 +198,47 @@ pub fn format_entity_key(kind: &str, name: &str) -> String {
     format!("{kind}:{name}")
 }
 
+// ---------------------------------------------------------------------------
+// Invalidation marker helpers (#961)
+// ---------------------------------------------------------------------------
+
+/// Record subject entity IDs whose `no_match` resolution log rows were
+/// deleted by domain-graph rebuild invalidation (#960). Uses `INSERT OR
+/// IGNORE` so duplicate markers from crash-restart-crash-restart are safe.
+///
+/// Called by `domain_builder::rebuild()` inside its transaction, after
+/// deleting the `kg_resolutions_log` rows.
+pub fn record_invalidated_no_match(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    subject_entity_ids: &[i64],
+) -> rusqlite::Result<usize> {
+    let mut total = 0usize;
+    let mut stmt = conn.prepare_cached(
+        "INSERT OR IGNORE INTO kg_invalidated_no_match (subject_entity_id, agent_id) VALUES (?1, ?2)",
+    )?;
+    for &id in subject_entity_ids {
+        total += stmt.execute(rusqlite::params![id, agent_id])?;
+    }
+    Ok(total)
+}
+
+/// Remove a single invalidation marker after the entity has been re-resolved.
+/// No-op if the marker does not exist (idempotent).
+///
+/// Called by `entity_resolver::write_log()` after writing the new resolution
+/// log row, ensuring cleanup from all code paths (startup, compound-hook, tick).
+pub fn clear_invalidated_no_match(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    subject_entity_id: i64,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM kg_invalidated_no_match WHERE subject_entity_id = ?1 AND agent_id = ?2",
+        rusqlite::params![subject_entity_id, agent_id],
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -278,4 +278,133 @@ mod tests {
     fn kg_chunk_source_type_value() {
         assert_eq!(KG_CHUNK_SOURCE_TYPE, "kg_chunk");
     }
+
+    // --- #961: invalidation marker helpers ---
+
+    /// Helper: open an in-memory DB for marker tests.
+    fn marker_test_db() -> rusqlite::Connection {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        db.register_agent("test-agent", "test-agent", "/tmp/test")
+            .unwrap();
+        db.conn
+    }
+
+    #[test]
+    fn record_invalidated_inserts_markers() {
+        let conn = marker_test_db();
+        let inserted = record_invalidated_no_match(&conn, "test-agent", &[1, 2, 3]).unwrap();
+        assert_eq!(inserted, 3);
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'test-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn record_invalidated_insert_or_ignore_idempotent() {
+        let conn = marker_test_db();
+        let first = record_invalidated_no_match(&conn, "test-agent", &[42]).unwrap();
+        assert_eq!(first, 1);
+
+        // Second call with same (subject_entity_id, agent_id) is a no-op.
+        let second = record_invalidated_no_match(&conn, "test-agent", &[42]).unwrap();
+        assert_eq!(second, 0, "INSERT OR IGNORE should return 0 on duplicate");
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'test-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "still only one row");
+    }
+
+    #[test]
+    fn record_invalidated_empty_slice() {
+        let conn = marker_test_db();
+        let inserted = record_invalidated_no_match(&conn, "test-agent", &[]).unwrap();
+        assert_eq!(inserted, 0);
+    }
+
+    #[test]
+    fn clear_invalidated_removes_marker() {
+        let conn = marker_test_db();
+        record_invalidated_no_match(&conn, "test-agent", &[10]).unwrap();
+
+        let removed = clear_invalidated_no_match(&conn, "test-agent", 10).unwrap();
+        assert_eq!(removed, 1);
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'test-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn clear_invalidated_noop_on_missing() {
+        let conn = marker_test_db();
+        // No marker exists — DELETE is a no-op.
+        let removed = clear_invalidated_no_match(&conn, "test-agent", 999).unwrap();
+        assert_eq!(removed, 0, "should be no-op when marker does not exist");
+    }
+
+    #[test]
+    fn markers_scoped_by_agent() {
+        let conn = marker_test_db();
+        conn.execute(
+            "INSERT OR IGNORE INTO agents (id, name, home_dir) VALUES ('other-agent', 'other', '/tmp/other')",
+            [],
+        )
+        .unwrap();
+
+        record_invalidated_no_match(&conn, "test-agent", &[1, 2]).unwrap();
+        record_invalidated_no_match(&conn, "other-agent", &[1, 3]).unwrap();
+
+        // Each agent sees only their markers.
+        let test_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'test-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let other_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'other-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(test_count, 2);
+        assert_eq!(other_count, 2);
+
+        // Clear for one agent doesn't affect the other.
+        clear_invalidated_no_match(&conn, "test-agent", 1).unwrap();
+        let test_after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'test-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let other_after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = 'other-agent'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(test_after, 1, "test-agent lost one marker");
+        assert_eq!(other_after, 2, "other-agent unchanged");
+    }
 }

--- a/crates/mika-agent/src/kg/entity_resolver.rs
+++ b/crates/mika-agent/src/kg/entity_resolver.rs
@@ -380,8 +380,9 @@ impl SubjectEntityResolver {
             )
             .await;
 
-            // Track reattempted no_match entities (#961). Only count when a
-            // log row was written (all outcomes except SkippedBudget).
+            // Track reattempted no_match entities (#961). SkippedBudget
+            // entities never reach here (the `continue` above skips them);
+            // all remaining outcomes wrote a log row via apply_result.
             if entity.was_invalidated {
                 stats.reattempted_no_match += 1;
             }

--- a/crates/mika-agent/src/kg/entity_resolver.rs
+++ b/crates/mika-agent/src/kg/entity_resolver.rs
@@ -9,6 +9,10 @@
 //! This module is the sole writer of `kg_subject_resolutions` and
 //! `kg_resolutions_log` rows. No other code path writes these tables.
 //!
+//! This module also reads and deletes from `kg_invalidated_no_match` (#961)
+//! to track reattempted entities whose prior `no_match` log rows were
+//! invalidated by domain-graph rebuild (#960).
+//!
 //! ## Resolution Pipeline
 //!
 //! For each subject entity with a well-known type (skill, tool, agent, problem_type, concept):
@@ -75,6 +79,10 @@ struct PendingEntity {
     confidence: f64,
     /// The corpus this entity belongs to (shared-layer key from v27).
     docs_root_hash: String,
+    /// True when this entity has a marker in `kg_invalidated_no_match` (#961),
+    /// meaning its prior `no_match` resolution log row was deleted by
+    /// domain-graph rebuild invalidation (#960).
+    was_invalidated: bool,
 }
 
 /// A domain entity candidate for disambiguation.
@@ -144,6 +152,11 @@ pub struct ResolutionStats {
     pub llm_calls: u32,
     /// Per-corpus entity attempt counts for fairness observability (#927).
     pub per_corpus_attempted: HashMap<String, u32>,
+    /// Count of entities this batch that were re-attempts from prior `no_match`
+    /// outcomes invalidated by domain-graph rebuild (#961). Zero when no
+    /// invalidation occurred; non-zero on the first resolution pass after a
+    /// rebuild that invalidated rows for an extant type.
+    pub reattempted_no_match: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -367,6 +380,12 @@ impl SubjectEntityResolver {
             )
             .await;
 
+            // Track reattempted no_match entities (#961). Only count when a
+            // log row was written (all outcomes except SkippedBudget).
+            if entity.was_invalidated {
+                stats.reattempted_no_match += 1;
+            }
+
             if let ResolutionResult::Error(msg) = &result {
                 warn!(
                     trace_id = %self.trace_id,
@@ -391,6 +410,7 @@ impl SubjectEntityResolver {
             errors = stats.errors,
             llm_calls = stats.llm_calls,
             aborted_budget = stats.aborted_budget,
+            reattempted_no_match = stats.reattempted_no_match,
             event = %completion_event,
         );
 
@@ -859,6 +879,9 @@ impl SubjectEntityResolver {
                             name: row.get(3)?,
                             confidence: row.get(4)?,
                             docs_root_hash: row.get(5)?,
+                            // Compound-hook path resolves freshly extracted
+                            // entities, not invalidation reattempts (#961).
+                            was_invalidated: false,
                         })
                     })?
                     .filter_map(|r| r.ok())
@@ -1024,10 +1047,13 @@ impl SubjectEntityResolver {
         self.db
             .with_db(move |db| {
                 let sql =
-                    "SELECT e.id, e.entity_key, e.type, e.name, e.confidence, e.docs_root_hash
+                    "SELECT e.id, e.entity_key, e.type, e.name, e.confidence, e.docs_root_hash,
+                            (inv.subject_entity_id IS NOT NULL) AS was_invalidated
                      FROM kg_subject_entities e
                      LEFT JOIN kg_resolutions_log r
                          ON r.subject_entity_id = e.id AND r.agent_id = ?1
+                     LEFT JOIN kg_invalidated_no_match inv
+                         ON inv.subject_entity_id = e.id AND inv.agent_id = ?1
                      WHERE e.docs_root_hash = ?2
                        AND e.type IN ('skill', 'tool', 'agent', 'problem_type', 'concept')
                        AND (
@@ -1051,6 +1077,7 @@ impl SubjectEntityResolver {
                             name: row.get(3)?,
                             confidence: row.get(4)?,
                             docs_root_hash: row.get(5)?,
+                            was_invalidated: row.get::<_, i64>(6)? != 0,
                         })
                     })?
                     .filter_map(|r| r.ok())
@@ -1355,6 +1382,13 @@ impl SubjectEntityResolver {
                         model,
                         duration_ms,
                     ],
+                )?;
+                // Clean up invalidation marker if present (#961). Defensive
+                // DELETE from all code paths (startup, compound-hook, tick).
+                crate::db::kg_schema::clear_invalidated_no_match(
+                    &db.conn,
+                    &agent_id,
+                    subject_entity_id,
                 )?;
                 Ok(())
             })
@@ -1741,6 +1775,7 @@ mod tests {
             name: "self_dev".to_string(),
             confidence: 0.85,
             docs_root_hash: "0000000000000000".to_string(),
+            was_invalidated: false,
         };
 
         let candidates = vec![
@@ -2113,6 +2148,185 @@ mod tests {
         assert!(
             resolution.is_none(),
             "no resolution row should be written for DB miss"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #961: reattempted_no_match counter tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: seed invalidation markers into `kg_invalidated_no_match`.
+    async fn seed_invalidation_markers(
+        db: &crate::async_db::AsyncDatabase,
+        subject_entity_ids: &[i64],
+    ) {
+        let ids = subject_entity_ids.to_vec();
+        let agent_id = db.agent_id.clone();
+        db.with_db(move |db| {
+            crate::db::kg_schema::record_invalidated_no_match(&db.conn, &agent_id, &ids)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    /// Helper: count rows in `kg_invalidated_no_match` for this agent.
+    async fn count_invalidation_markers(db: &crate::async_db::AsyncDatabase) -> usize {
+        let agent_id = db.agent_id.clone();
+        db.with_db(move |db| {
+            let count: i64 = db.conn.query_row(
+                "SELECT COUNT(*) FROM kg_invalidated_no_match WHERE agent_id = ?1",
+                rusqlite::params![agent_id],
+                |row| row.get(0),
+            )?;
+            Ok(count as usize)
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Non-zero path: entities with invalidation markers are counted in
+    /// `reattempted_no_match`. Markers are cleaned up after resolution.
+    #[tokio::test]
+    async fn reattempted_no_match_nonzero_with_markers() {
+        let db = f3_test_db();
+
+        // Seed a domain entity for exact match.
+        f3_seed_domain_entity(&db, "concept", "cross-repo:worktree-isolation").await;
+
+        // Seed 3 concept-typed subject entities (no log rows → pending via
+        // r.id IS NULL). Two match the domain entity, one does not.
+        let s1 =
+            f3_seed_subject_entity(&db, "concept", "cross-repo:worktree-isolation", 0.95).await;
+        let s2 = f3_seed_subject_entity(&db, "concept", "unmatched-concept-a", 0.95).await;
+        let s3 = f3_seed_subject_entity(&db, "concept", "unmatched-concept-b", 0.95).await;
+
+        // Mark all 3 as invalidated (simulates #960 rebuild).
+        seed_invalidation_markers(&db, &[s1, s2, s3]).await;
+        assert_eq!(count_invalidation_markers(&db).await, 3);
+
+        // Resolve without LLM (exact-match only). s1 matches, s2/s3 get
+        // skipped_no_llm (no LLM configured).
+        let resolver = SubjectEntityResolver::new(
+            db.clone(),
+            None, // no LLM → exact-match only
+            vec!["0000000000000000".to_string()],
+            Some("test-reattempt-nonzero"),
+        );
+
+        let stats = resolver.resolve_pending(100).await.unwrap();
+
+        // All 3 were invalidated and resolved (wrote log rows).
+        assert_eq!(
+            stats.reattempted_no_match, 3,
+            "all 3 invalidated entities should be counted"
+        );
+        assert_eq!(stats.matched_exact, 1, "s1 should exact-match");
+        assert_eq!(stats.skipped_no_llm, 2, "s2/s3 have no LLM → skipped");
+
+        // Markers should be cleaned up.
+        assert_eq!(
+            count_invalidation_markers(&db).await,
+            0,
+            "all markers should be cleaned up after resolution"
+        );
+    }
+
+    /// Zero path: entities without invalidation markers produce
+    /// `reattempted_no_match=0`.
+    #[tokio::test]
+    async fn reattempted_no_match_zero_without_markers() {
+        let db = f3_test_db();
+
+        // Seed a domain entity and subject entities but NO markers.
+        f3_seed_domain_entity(&db, "concept", "infra:helm-values").await;
+        f3_seed_subject_entity(&db, "concept", "infra:helm-values", 0.95).await;
+        f3_seed_subject_entity(&db, "concept", "some-other-concept", 0.95).await;
+
+        let resolver = SubjectEntityResolver::new(
+            db.clone(),
+            None,
+            vec!["0000000000000000".to_string()],
+            Some("test-reattempt-zero"),
+        );
+
+        let stats = resolver.resolve_pending(100).await.unwrap();
+
+        assert_eq!(
+            stats.reattempted_no_match, 0,
+            "no markers → reattempted_no_match should be 0"
+        );
+        assert!(stats.total > 0, "should have resolved some entities");
+    }
+
+    /// Mixed path: only invalidated entities increment the counter.
+    #[tokio::test]
+    async fn reattempted_no_match_mixed_invalidated_and_fresh() {
+        let db = f3_test_db();
+
+        f3_seed_domain_entity(&db, "concept", "cross-repo:branch-naming").await;
+
+        // s1: invalidated (marker present).
+        let s1 = f3_seed_subject_entity(&db, "concept", "cross-repo:branch-naming", 0.95).await;
+        // s2: fresh (no marker).
+        let _s2 = f3_seed_subject_entity(&db, "concept", "fresh-concept", 0.95).await;
+
+        seed_invalidation_markers(&db, &[s1]).await;
+
+        let resolver = SubjectEntityResolver::new(
+            db.clone(),
+            None,
+            vec!["0000000000000000".to_string()],
+            Some("test-reattempt-mixed"),
+        );
+
+        let stats = resolver.resolve_pending(100).await.unwrap();
+
+        assert_eq!(
+            stats.reattempted_no_match, 1,
+            "only s1 (invalidated) should be counted"
+        );
+        assert_eq!(stats.total, 2, "both entities should be processed");
+    }
+
+    /// Edge case: invalidated entity that resolves as `no_match` again
+    /// (no domain match available) — still counted in `reattempted_no_match`,
+    /// marker cleaned up, new `no_match` log row written.
+    #[tokio::test]
+    async fn reattempted_no_match_resolves_as_no_match_again() {
+        let db = f3_test_db();
+
+        // No domain entity for this type → will resolve as skipped_no_llm
+        // (no LLM configured) which still writes a log row.
+        let s1 = f3_seed_subject_entity(&db, "concept", "orphaned-concept", 0.95).await;
+
+        seed_invalidation_markers(&db, &[s1]).await;
+
+        let resolver = SubjectEntityResolver::new(
+            db.clone(),
+            None,
+            vec!["0000000000000000".to_string()],
+            Some("test-reattempt-no-match-again"),
+        );
+
+        let stats = resolver.resolve_pending(100).await.unwrap();
+
+        assert_eq!(
+            stats.reattempted_no_match, 1,
+            "invalidated entity should be counted even if it resolves as skipped_no_llm"
+        );
+        assert_eq!(
+            count_invalidation_markers(&db).await,
+            0,
+            "marker should be cleaned up"
+        );
+
+        // Verify a log row was written.
+        let outcome = f3_get_outcome(&db, s1).await;
+        assert_eq!(
+            outcome.as_deref(),
+            Some(outcome::SKIPPED_NO_LLM),
+            "should write skipped_no_llm log row"
         );
     }
 }

--- a/crates/mika-agent/src/kg/resolver_tick.rs
+++ b/crates/mika-agent/src/kg/resolver_tick.rs
@@ -140,6 +140,7 @@ async fn tick_body(
                 matched_exact = stats.matched_exact,
                 matched_llm = stats.matched_llm,
                 no_match = stats.no_match,
+                reattempted_no_match = stats.reattempted_no_match,
                 duration_ms = stats.duration_ms,
                 per_corpus_attempted = %per_corpus_attempted,
                 event = "kg_resolver_tick.complete",

--- a/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
@@ -23,7 +23,7 @@ use mika_agent::db::{CURRENT_SCHEMA_VERSION, Database};
 /// Current schema version this fixture module is pinned to.
 /// Bump this when updating fixtures for a new schema version.
 /// Type is i64 to match db.rs::CURRENT_SCHEMA_VERSION source of truth.
-const PINNED_SCHEMA_VERSION: i64 = 31;
+const PINNED_SCHEMA_VERSION: i64 = 32;
 
 const _: () = assert!(
     CURRENT_SCHEMA_VERSION == PINNED_SCHEMA_VERSION,

--- a/crates/mika-agent/tests/schema_v27_convergence.rs
+++ b/crates/mika-agent/tests/schema_v27_convergence.rs
@@ -180,7 +180,7 @@ fn fresh_db_has_schema_meta_with_coalesce_marker() {
 // ===== Schema version =====
 
 #[test]
-fn fresh_db_is_at_v31() {
+fn fresh_db_is_at_v32() {
     let (_dir, conn) = build_fresh_db().unwrap();
 
     let version: i64 = conn
@@ -189,7 +189,7 @@ fn fresh_db_is_at_v31() {
         })
         .unwrap();
 
-    assert_eq!(version, 31, "Fresh DB must be at schema version 31");
+    assert_eq!(version, 32, "Fresh DB must be at schema version 32");
 }
 
 // ===== Index verification =====

--- a/docs/plans/2026-05-07-003-feat-kg-reattempted-no-match-field-plan.md
+++ b/docs/plans/2026-05-07-003-feat-kg-reattempted-no-match-field-plan.md
@@ -1,0 +1,261 @@
+---
+title: "feat(kg): emit reattempted_no_match field on kg_resolver_tick.complete"
+type: feat
+status: active
+date: 2026-05-07
+---
+
+# feat(kg): emit reattempted_no_match field on kg_resolver_tick.complete
+
+## Overview
+
+Add a `reattempted_no_match: u32` field to the `kg_resolver_tick.complete` structured log event (and `resolution_pending_complete`) so operators can answer: "of this tick's resolved entities, how many were re-attempts from prior `no_match` outcomes invalidated by #960's domain-graph rebuild?"
+
+## Problem Frame
+
+Issue #960 invalidates `no_match` resolution log rows when domain graph rebuilds add new entities of a type. After invalidation (DELETE from `kg_resolutions_log`), those entities re-enter the pending pool via the `r.id IS NULL` path. However, they are indistinguishable from never-resolved entities. Operators need per-tick visibility into how many pending entities are reattempts from prior `no_match` outcomes vs genuinely new entities.
+
+## Requirements Trace
+
+- R1. `kg_resolver_tick.complete` log event includes new field `reattempted_no_match: u32`
+- R2. Field is zero on ticks following a rebuild with no invalidation (steady state)
+- R3. Field is non-zero on the first tick after a rebuild that invalidated rows for an extant type
+- R4. Unit test in `entity_resolver.rs::tests` covers both zero and non-zero paths
+- R5. Field is also emitted on `resolution_pending_complete` (startup resolver path) for immediate post-rebuild visibility
+
+## Scope Boundaries
+
+- No changes to the rebuild-side invalidation event (`domain_rebuild_invalidated_resolutions`) — covered by #960
+- No re-resolution of non-`no_match` outcomes (e.g., `matched_llm` when better candidates appear)
+- No surfacing the count on the tick start event (start-time count is misleading)
+
+### Deferred to Separate Tasks
+
+- Integration with #960's domain builder (one-line call to `record_invalidated_no_match`): done when #960 merges. Resolver-side is complete and independently testable.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/kg/entity_resolver.rs` — `ResolutionStats` struct (line 128-147), `resolve_entities` loop (line 299-398), `apply_result` (line 400+)
+- `crates/mika-agent/src/kg/resolver_tick.rs` — `kg_resolver_tick.complete` event (line 131-146)
+- `crates/mika-agent/src/kg/domain_builder.rs` — #960's invalidation step (on branch `fix/960/kg-domain-graph-rebuild-must-invalidate`, commit `6ed6cbbf`)
+- `crates/mika-agent/src/db.rs` — schema migrations, `CURRENT_SCHEMA_VERSION = 31`
+- `crates/mika-agent/src/db/kg_schema.rs` — KG-specific DB helpers
+- Pattern: `per_corpus_attempted` field added in #927 — most recent example of adding a counter to `ResolutionStats` + emitting on tick log
+
+### Institutional Learnings
+
+- `docs/solutions/874-kg-resolver-candidate-list-db-fallback.md` — Resolution outcome taxonomy and `ResolutionStats` counter pattern
+- `docs/solutions/kg/906-resolver-tick-periodic-drain-2026-04-30.md` — Three execution contexts share `resolve_pending(budget)` path; any new field must work across all three
+- `docs/solutions/best-practices/kg-resolver-tick-visibility-audit-2026-05-06.md` — Counter scope must match the 5-type allowlist (`skill`, `tool`, `agent`, `problem_type`, `concept`)
+- `docs/solutions/logic-errors/kg-resolver-per-corpus-starvation-2026-05-02.md` — `per_corpus_attempted` pattern for adding observability fields
+
+## Key Technical Decisions
+
+- **Sidecar table `kg_invalidated_no_match` over in-memory tracker:** A DB table survives crashes between domain rebuild and resolver tick, works across all three execution contexts (startup, compound-hook, periodic tick), and avoids threading `Arc<Mutex<HashSet>>` through the application. The table is ephemeral (rows cleaned up after resolution) and tiny (bounded by the number of previously-`no_match` entities per rebuild).
+
+- **Record + DELETE pattern over soft-delete on `kg_resolutions_log`:** Adding an `invalidated_at` column to `kg_resolutions_log` would require expanding the CHECK constraint (another table rebuild migration) and modifying the pending query. A separate sidecar table is less invasive and keeps #960's clean DELETE semantics.
+
+- **Detection at query time (pending-entity fetch) over per-entity check:** Extend `get_pending_entities_for_corpus` to LEFT JOIN the sidecar table and return `was_invalidated: bool` on `PendingEntity`. This avoids N+1 queries during the resolution loop.
+
+- **Cleanup in `write_log` over cleanup in `apply_result`:** Adding a defensive DELETE to `write_log()` ensures markers are cleaned up from ANY code path that writes a resolution log row (startup, compound-hook, tick), not just the `resolve_pending` path. Prevents orphan markers from compound-hook races (flow analysis gap #3).
+
+- **Helper function `record_invalidated_no_match` in `kg_schema.rs`:** Isolates the sidecar write into a reusable function that the domain builder calls. Preserves the entity resolver's sole-writer contract for `kg_resolutions_log` — the domain builder uses a separate module for the marker table. The `kg_resolutions_log` DELETE stays in `domain_builder.rs` (#960's code).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Module ownership for invalidation markers:** The sidecar table `kg_invalidated_no_match` is written by `domain_builder` (via helper in `kg_schema.rs`) and read/cleaned by `entity_resolver`. Both modules import the shared helper. The entity resolver's sole-writer contract for `kg_resolutions_log` is unchanged — `domain_builder` deletes from `kg_resolutions_log` (per #960), the entity resolver writes to it. The sidecar table has no sole-writer contract (write-once-read-once lifecycle).
+
+- **Table schema PK:** `(subject_entity_id, agent_id)` composite PK, matching `kg_resolutions_log`'s per-agent granularity. A single subject entity shared across agents (via `docs_root_hash`) can have separate `no_match` log rows per agent.
+
+- **Race between startup resolver and periodic tick:** The first tick is skipped by design (`interval.tick().await` on resolver_tick.rs line 69), guaranteeing the startup resolver runs before any tick sees invalidated entities. Counter inflation is impossible under this invariant.
+
+- **`INSERT OR IGNORE` for crash-restart-crash-restart:** If the server restarts twice and the first rebuild already inserted markers for the same entities, `INSERT OR IGNORE` handles the UNIQUE constraint gracefully.
+
+### Deferred to Implementation
+
+- Exact column ordering in the new migration DDL
+
+## Implementation Units
+
+- [ ] **Unit 1: Schema v32 — add `kg_invalidated_no_match` table**
+
+**Goal:** Create the sidecar table that records which subject entities had their `no_match` resolution log rows deleted by #960's domain-graph rebuild invalidation.
+
+**Requirements:** R1, R2, R3 (foundational for all)
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs` (migration v31→v32, bump `CURRENT_SCHEMA_VERSION`, AND add table to `migrate_v1` clean-install DDL)
+- Modify: `crates/mika-agent/src/db/kg_schema.rs` (add `record_invalidated_no_match` and `clear_invalidated_no_match` helpers)
+- Modify: `CLAUDE.md` and `crates/mika-agent/CLAUDE.md` (schema version reference)
+
+**Approach:**
+- Table DDL: `kg_invalidated_no_match(subject_entity_id INTEGER NOT NULL, agent_id TEXT NOT NULL, invalidated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), PRIMARY KEY (subject_entity_id, agent_id))`. No FK constraints (lightweight marker, not relational integrity).
+- Migration: `ALTER TABLE` is not needed — just `CREATE TABLE IF NOT EXISTS` in the v31→v32 migration block. Also add the CREATE TABLE to `migrate_v1`'s clean-install DDL (fresh databases skip incremental migrations).
+- Helper `record_invalidated_no_match(conn, agent_id, subject_entity_ids: &[i64])`: batch `INSERT OR IGNORE INTO kg_invalidated_no_match` for each ID.
+- Helper `clear_invalidated_no_match(conn, agent_id, subject_entity_id)`: single-row DELETE.
+- Both helpers take `&rusqlite::Connection` (called inside `with_db` closures).
+
+**Patterns to follow:**
+- v30→v31 migration pattern in `db.rs` (additive CREATE TABLE)
+- `write_log` helper pattern in `kg_schema.rs` for DB helpers
+
+**Test scenarios:**
+- Happy path: `record_invalidated_no_match` inserts rows, `clear_invalidated_no_match` removes them
+- Edge case: `INSERT OR IGNORE` — calling `record_invalidated_no_match` twice with the same IDs does not error
+- Edge case: `clear_invalidated_no_match` on non-existent row is a no-op (no error)
+
+**Verification:**
+- `cargo test -p mika-agent` passes with the new schema version
+- Fresh DB creation reaches v32
+
+- [ ] **Unit 2: Extend `PendingEntity` with `was_invalidated` flag and detection query**
+
+**Goal:** Modify the pending-entity query to detect which entities were invalidated by a prior domain rebuild, and carry that information through the resolution loop.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` (extend `PendingEntity` struct, modify `get_pending_entities_for_corpus` query, update `get_entities_by_ids`, add `reattempted_no_match: u32` to `ResolutionStats`)
+
+**Approach:**
+- Add `pub was_invalidated: bool` to `PendingEntity` struct.
+- Modify `get_pending_entities_for_corpus` SQL to LEFT JOIN `kg_invalidated_no_match inv ON inv.subject_entity_id = e.id AND inv.agent_id = ?1`. Return `(inv.subject_entity_id IS NOT NULL) AS was_invalidated` as a new SELECT column.
+- Update `get_entities_by_ids` (line ~826, used by compound-hook `resolve_doc_entities`) to hardcode `was_invalidated: false` — compound-hook resolves freshly extracted entities, not invalidation reattempts.
+- Add `pub reattempted_no_match: u32` to `ResolutionStats` (derives `Default` → starts at 0).
+
+**Patterns to follow:**
+- `per_corpus_attempted` field addition in #927 (counter on `ResolutionStats`)
+- Existing `PendingEntity` struct and query mapping pattern
+
+**Test scenarios:**
+- Happy path: pending entity with a marker in `kg_invalidated_no_match` has `was_invalidated = true`
+- Happy path: pending entity without a marker has `was_invalidated = false`
+- Edge case: entity is pending via trace-id mismatch (re-extraction) AND has an invalidation marker — `was_invalidated` should still be true (both conditions can co-occur)
+
+**Verification:**
+- `PendingEntity` struct correctly carries the flag from the query
+- `ResolutionStats` has the new field defaulting to 0
+
+- [ ] **Unit 3: Increment counter in resolution loop and clean up markers**
+
+**Goal:** Wire the `was_invalidated` flag to the `reattempted_no_match` counter and clean up sidecar markers after resolution.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` (`resolve_entities` loop, `write_log` method)
+
+**Approach:**
+- In `resolve_entities`, after `apply_result` for each entity: if `entity.was_invalidated` and the result wrote a log row (any outcome except `SkippedBudget` — i.e., `ExactMatch`, `LlmMatch`, `LlmMatchDbFallback`, `NoMatch`, `SkippedDiscoveredType`, `SkippedNoLlm`, `Error`), increment `stats.reattempted_no_match`. `SkippedBudget` entities stay pending with their marker intact for the next tick.
+- In `write_log` (the shared log-row writer), add a defensive `DELETE FROM kg_invalidated_no_match WHERE subject_entity_id = ?1 AND agent_id = ?2` after the UPSERT. This ensures cleanup from ALL code paths (startup, compound-hook, tick) — not just `resolve_pending`.
+- The cleanup DELETE uses `clear_invalidated_no_match` helper from Unit 1.
+
+**Patterns to follow:**
+- Existing counter increment pattern in `resolve_entities` (e.g., `stats.llm_calls`)
+- `write_log` method's existing UPSERT + audit event pattern
+
+**Test scenarios:**
+- Happy path: 3 pending entities with `was_invalidated=true`, all resolve → `reattempted_no_match=3`
+- Happy path: 3 pending entities with `was_invalidated=false` → `reattempted_no_match=0`
+- Happy path: mix of 2 invalidated + 3 non-invalidated → `reattempted_no_match=2`
+- Edge case: invalidated entity hits `SkippedBudget` → NOT counted in `reattempted_no_match` (entity stays pending, marker stays)
+- Edge case: `write_log` called from compound-hook path cleans up sidecar marker even though no counter was incremented (cleanup is unconditional in `write_log`)
+- Integration: after resolution, `kg_invalidated_no_match` table is empty for processed entities
+
+**Verification:**
+- `reattempted_no_match` counter accurately reflects invalidated entities that were actually re-resolved
+- Sidecar table rows are cleaned up after resolution
+
+- [ ] **Unit 4: Emit field on log events**
+
+**Goal:** Surface `reattempted_no_match` on both `kg_resolver_tick.complete` and `resolution_pending_complete` structured log events.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/resolver_tick.rs` (add field to `kg_resolver_tick.complete` event)
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` (add field to `resolution_pending_complete` event)
+
+**Approach:**
+- In `resolver_tick.rs` line 131-146: add `reattempted_no_match = stats.reattempted_no_match` to the `info!` macro.
+- In `entity_resolver.rs` line 381-395: add `reattempted_no_match = stats.reattempted_no_match` to the `resolution_pending_complete` `info!` macro.
+
+**Patterns to follow:**
+- Existing field emissions in both log events (e.g., `per_corpus_attempted`, `llm_calls`)
+
+**Test scenarios:**
+Test expectation: none — log emission is verified by inspection and covered by the integration tests in Unit 5 that assert `ResolutionStats` field values.
+
+**Verification:**
+- `reattempted_no_match` appears in both log events
+- Field is 0 when no invalidation occurred, non-zero when it did
+
+- [ ] **Unit 5: Unit tests for both paths**
+
+**Goal:** Cover both the zero and non-zero `reattempted_no_match` paths with deterministic tests.
+
+**Requirements:** R4
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` (add tests in `#[cfg(test)] mod tests`)
+
+**Approach:**
+- Test 1 (non-zero path): Seed subject entities with provenance, seed `kg_invalidated_no_match` markers, seed domain entities for exact match. Run `resolve_pending`. Assert `stats.reattempted_no_match > 0` and sidecar table is empty after.
+- Test 2 (zero path): Seed subject entities with provenance but NO sidecar markers. Run `resolve_pending`. Assert `stats.reattempted_no_match == 0`.
+- Both tests use `MockLlmProvider` (no network) — exact-match resolution only.
+- Follow existing test patterns (e.g., `f3_path1_in_list_accept` test setup).
+
+**Patterns to follow:**
+- Existing entity resolver tests at line 1912+ (DB seeding, `MockLlmProvider`, assertion on resolution outcomes)
+- `seed_subjects_with_resolutions` helper from #960's domain_builder tests for seeding subject entities
+
+**Test scenarios:**
+- Happy path: 5 concept-typed subjects with invalidation markers, 1 matching domain entity → `reattempted_no_match=5`, markers cleaned up
+- Happy path: 5 concept-typed subjects without invalidation markers → `reattempted_no_match=0`
+- Edge case: mix of invalidated and non-invalidated pending entities → counter reflects only invalidated ones
+- Edge case: invalidated entity that resolves as `no_match` again (no domain match) — still counted in `reattempted_no_match`, marker cleaned up, new `no_match` log row written
+
+**Verification:**
+- `cargo test -p mika-agent` passes
+- Both zero and non-zero paths have explicit assertions
+
+## System-Wide Impact
+
+- **Interaction graph:** Domain builder (writes markers) → entity resolver (reads markers, increments counter, cleans up) → resolver tick (emits field on log event). Compound-hook path also cleans up markers via `write_log` but does not increment counter.
+- **Error propagation:** Sidecar table operations are non-critical. If `record_invalidated_no_match` fails, the invalidation still works (entities become pending); the counter just reports 0. If `clear_invalidated_no_match` fails, the marker lingers but is harmless (next resolution of the same entity will see it again).
+- **State lifecycle risks:** Markers accumulate if entities are never re-resolved (e.g., perpetually budget-skipped). Bounded by the number of `no_match` entities invalidated per rebuild — typically < 100 per mika-arch corpus. No cleanup sweep needed for v1.
+- **API surface parity:** No dashboard or API changes — this is log-only observability.
+- **Unchanged invariants:** `kg_resolutions_log` schema unchanged. Entity resolver's sole-writer contract for `kg_resolutions_log` and `kg_subject_resolutions` unchanged. Domain builder's sole-writer contract for `kg_entities` and `kg_relationships` unchanged. The new `kg_invalidated_no_match` table has no sole-writer contract (write-once-read-once lifecycle). The entity resolver module docstring should be updated to note it reads/deletes from `kg_invalidated_no_match`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| #960 not merged — domain builder doesn't write markers yet | Resolver-side is complete and testable. Counter is 0 until #960 integration (one-line call). Tests seed the sidecar table directly. |
+| Schema v32 conflicts with another in-flight migration | Current schema is v31. No other v32 migration in progress. |
+| Counter double-counts if startup resolver and tick race | First tick is skipped by design (`interval.tick().await`). Documented as "at least N" semantics. |
+
+## Documentation / Operational Notes
+
+- `CLAUDE.md` Signal F observation instructions should be updated to include the `reattempted_no_match` field once #960 is merged: `grep kg_resolver_tick.complete server.log | jq '.reattempted_no_match'`
+- The field is zero on all ticks until #960 merges and the domain builder calls `record_invalidated_no_match`
+
+## Sources & References
+
+- Related issues: #960 (parent — domain-graph rebuild invalidation), #906 (periodic resolver tick), #927 (per-corpus fairness — most recent `ResolutionStats` addition)
+- Related code: `crates/mika-agent/src/kg/entity_resolver.rs`, `crates/mika-agent/src/kg/resolver_tick.rs`, `crates/mika-agent/src/kg/domain_builder.rs`
+- #960 implementation: branch `fix/960/kg-domain-graph-rebuild-must-invalidate`, commit `6ed6cbbf`

--- a/docs/solutions/best-practices/kg-sidecar-marker-for-cross-module-state-transfer-2026-05-07.md
+++ b/docs/solutions/best-practices/kg-sidecar-marker-for-cross-module-state-transfer-2026-05-07.md
@@ -1,0 +1,80 @@
+---
+module: kg/entity_resolver
+date: 2026-05-07
+problem_type: best_practice
+component: tooling
+severity: low
+tags:
+  - kg
+  - entity-resolver
+  - domain-builder
+  - sidecar-table
+  - observability
+  - cross-module-state
+applies_when:
+  - A module deletes rows that another module needs to detect were previously present
+  - Cross-module state transfer must survive process crashes
+  - An in-memory tracker would require threading Arc<Mutex<T>> through unrelated code paths
+---
+
+# Sidecar Marker Table for Cross-Module State Transfer in KG
+
+## Context
+
+Issue #960 introduced domain-graph rebuild invalidation: when `domain_builder::rebuild()` adds new entities of a type, it DELETEs `kg_resolutions_log` rows with `outcome='no_match'` for subjects of that type. This makes those entities re-enter the pending pool for the next resolver tick.
+
+Issue #961 needed the resolver to distinguish "reattempted after invalidation" entities from "never resolved" entities — both appear identical in the pending query (`r.id IS NULL`). The domain builder and resolver are separate modules with no shared runtime state; the domain builder runs once at startup, the resolver runs per-agent at startup and every 30 minutes.
+
+## Guidance
+
+Use a lightweight sidecar table as a durable marker when one module needs to communicate state to another module that runs later, and the original data was deleted rather than soft-flagged.
+
+The pattern:
+1. **Writer module** INSERTs marker rows in the same transaction that DELETEs the original data
+2. **Reader module** LEFT JOINs the marker table in its existing query to detect the state
+3. **Reader module** DELETEs marker rows after processing, in the same `with_db` closure that writes the new state
+
+Key design decisions for `kg_invalidated_no_match`:
+- **No FK constraints** — the table is ephemeral; entities may be deleted independently
+- **`INSERT OR IGNORE`** — safe for crash-restart-crash-restart (duplicate markers are no-ops)
+- **Cleanup in `write_log()` not `apply_result()`** — ensures cleanup from ALL code paths (startup, compound-hook, periodic tick), not just the `resolve_pending` path
+- **Composite PK `(subject_entity_id, agent_id)`** — matches `kg_resolutions_log`'s per-agent granularity for multi-agent shared-corpus deployments
+
+## Why This Matters
+
+Three alternatives were considered and rejected:
+- **In-memory `HashSet`**: Would require `Arc<Mutex<HashSet<i64>>>` threaded from `domain_builder` through `AgentState` to `SubjectEntityResolver`. Doesn't survive crashes. Adds coupling between modules that currently share no state.
+- **Soft-delete on `kg_resolutions_log`** (add `invalidated_at` column): Requires expanding the CHECK constraint (table rebuild migration) and modifying the pending query's WHERE clause. More invasive than a separate table.
+- **Marker column on `kg_subject_entities`**: Violates the subject extractor's sole-writer contract for that table.
+
+The sidecar table costs one CREATE TABLE (additive migration, no data conversion), two helper functions in `kg_schema.rs`, and a LEFT JOIN on a table that typically has 0-100 rows.
+
+## When to Apply
+
+This pattern is appropriate when:
+- Module A deletes data that Module B needs to detect was previously present
+- The modules run in different execution contexts (different startup phases, different tick intervals)
+- The state transfer must survive process crashes between the write and read
+- The marker data is small and ephemeral (cleaned up after first read)
+
+It is NOT appropriate when:
+- The modules share runtime state already (use a field on the shared struct instead)
+- The original data can be soft-deleted instead (add a status/flag column)
+- The marker would accumulate unboundedly (add a TTL or periodic sweep)
+
+## Examples
+
+Helper functions in `kg_schema.rs` keep the SQL isolated:
+
+```rust
+// Writer side (domain_builder, inside transaction):
+kg_schema::record_invalidated_no_match(&conn, agent_id, &subject_entity_ids)?;
+
+// Reader side (entity_resolver, in pending query):
+// LEFT JOIN kg_invalidated_no_match inv
+//     ON inv.subject_entity_id = e.id AND inv.agent_id = ?1
+// ... (inv.subject_entity_id IS NOT NULL) AS was_invalidated
+
+// Cleanup side (entity_resolver, in write_log after UPSERT):
+kg_schema::clear_invalidated_no_match(&conn, agent_id, subject_entity_id)?;
+```


### PR DESCRIPTION
## Summary

- Add `reattempted_no_match: u32` field to `ResolutionStats` and emit it on both `kg_resolver_tick.complete` and `resolution_pending_complete` structured log events
- Schema v31→v32: new `kg_invalidated_no_match` sidecar table tracks entities whose `no_match` log rows were deleted by domain-graph rebuild invalidation (#960)
- Resolver LEFT JOINs the sidecar table in `get_pending_entities_for_corpus` to detect reattempts; `write_log()` defensively cleans up markers from all code paths (startup, compound-hook, tick)
- 10 new unit tests: 4 for the entity resolver counter (nonzero, zero, mixed, re-no-match), 6 for the `kg_schema` helper functions (insert, idempotency, empty slice, clear, no-op, agent scoping)

**Dependency:** Companion to #960 — the domain builder integration (one-line call to `record_invalidated_no_match`) is deferred until #960 merges. Counter is 0 until then. Tests seed the sidecar table directly.

Closes #961

Plan: `docs/plans/2026-05-07-003-feat-kg-reattempted-no-match-field-plan.md`

## Test plan

- [x] `cargo test -p mika-agent --lib` — all 2524 tests pass (2522 + 2 ignored)
- [x] `cargo clippy -p mika-agent -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] Schema convergence test passes (fresh install DDL matches incremental migration)
- [x] KG eval fixtures pin bumped to v32
- [ ] After #960 merges: verify `record_invalidated_no_match` is called from `domain_builder::rebuild()` and counter is non-zero on first tick after a rebuild that invalidates rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)