### PR TITLE
feat(prompt): silent-mode summary budget cap (mika#1009 Axis 3)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -61,6 +61,32 @@ Use case: agents where the conversational summary is a known context-channel lea
 inject = false
 ```
 
+### `[context.summary].max_tokens` (usize, optional, default: `None`)
+
+Mode-conditional token budget for summary injection (Axis 3 — mika#1021). The field name is mode-agnostic; the gate condition (`SilentTrigger.is_some()`) lives in code. Orthogonal with `inject`: when `inject = false` (Axis 4), Axis 4 wins — `load_gated_summary()` short-circuits before evaluating `max_tokens`.
+
+When set and the in-code gate fires (currently: silent-mode turns — callback, webhook, heartbeat, etc.):
+
+- `Some(0)` → **load-omit sentinel**: summary omitted entirely on silent-mode turns. NOT interpreted as "zero-token cap."
+- `Some(n)` for n > 0 → summary truncated to approximately `n × CHARS_PER_TOKEN_ESTIMATE` (= 4) characters before injection. A truncation marker `[… summary truncated to fit silent-mode budget …]` is appended so the model knows content was elided.
+- `None` → no cap (default; current behavior).
+
+Non-silent turns (conversation mode, CLI) are never affected by `max_tokens` regardless of its value.
+
+Token approximation uses `CHARS_PER_TOKEN_ESTIMATE = 4` (heuristic, conservative for English). Truncation cuts at a word boundary via `truncate_to_token_budget()` in `prompt.rs`.
+
+```toml
+# Cap summary to ~1000 tokens on silent-mode turns, keep full on interactive turns
+[context.summary]
+inject = true
+max_tokens = 1000
+
+# Omit summary entirely on silent-mode turns
+[context.summary]
+inject = true
+max_tokens = 0
+```
+
 ## Tools
 
 Each tool validates inputs. Control fields capped at `MAX_INPUT_LEN = 10_000` chars; payload fields capped at `MAX_PAYLOAD_BYTES = 200 * 1024` bytes (200 KB).

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -397,7 +397,7 @@ defaults to `~/.mika/`.
 
 ## identity.toml
 
-Defines the assistant's display identity and per-agent Knowledge Graph configuration.
+Defines the assistant's display identity, per-agent Knowledge Graph configuration, and context injection controls.
 
 **Default content:**
 
@@ -409,6 +409,10 @@ emoji = "✦"
 # enabled = true                    # default: true — set false to skip KG for this agent
 # docs_root = "/path/to/docs"       # optional; falls back to MIKA_KG_DOCS_ROOT / kg_docs_root / CWD/docs/solutions
 # docs_roots = ["/path/a", "/path/b"]  # optional; multi-corpus (overrides docs_root when set)
+
+# [context.summary]
+# inject = true                     # default: true — set false to disable summary injection entirely (Axis 4)
+# max_tokens = 1000                 # optional — cap summary to ~1000 tokens on silent-mode turns (Axis 3)
 ```
 
 | Field | Description |
@@ -418,8 +422,12 @@ emoji = "✦"
 | `[kg].enabled` | Whether KG ingestion/extraction/resolution runs for this agent. Default: `true`. |
 | `[kg].docs_root` | Absolute path to the docs root this agent's KG reads from. Optional; falls back to the global resolver chain (`MIKA_KG_DOCS_ROOT` env > `kg_docs_root` config > `<CWD>/docs/solutions`). |
 | `[kg].docs_roots` | Array of absolute paths for multi-corpus agents (#798). Overrides `docs_root` (singular) and `MIKA_KG_DOCS_ROOTS` when set. Each path is validated independently; missing paths are warned and skipped. |
+| `[context.summary].inject` | Whether to load and inject the conversational summary into the system prompt. Default: `true`. Set `false` for agents where summary leakage is a known problem (#1019). |
+| `[context.summary].max_tokens` | Optional token cap applied to the summary on silent-mode turns (callback, webhook, heartbeat). `0` = omit summary on silent turns; `n > 0` = truncate to ~n tokens (4 chars/token heuristic). Non-silent turns are never affected. Default: none (#1021). |
 
 **`[kg]` behavior:** When `enabled = false`, no KG subsystem components are constructed for the agent. Existing shared-corpus rows are preserved (cleanup via `mika kg purge`). When `docs_root` is set to an explicit path that doesn't exist, the agent fails to start with a clear error. Agents with matching `docs_root` share extraction via `docs_root_hash` (v27 schema).
+
+**`[context.summary]` behavior:** `inject = false` (Axis 4) is a load-prevention gate — `db.load_conversation_summary()` is never called and the summary is not available to any downstream code path. `max_tokens` (Axis 3) is mode-conditional — it only fires on silent-mode turns (when `SilentTrigger` is present). Axis 4 always wins: when `inject = false`, the `max_tokens` field is never evaluated. See `crates/mika-agent/CLAUDE.md` for implementation details.
 
 To customize, edit `~/.mika/identity.toml`:
 

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -2015,18 +2015,13 @@ async fn run_agent_inner(
     };
     let mut system = prompt::build_system_prompt(&prompt_ctx);
 
-    // Load-prevention gate: when [context.summary].inject is false, skip the
-    // db.load_conversation_summary() call entirely so the summary is never
-    // deserialized into this turn's scope (mika#1009 leak protection).
-    // The nested if is intentional — collapsing would obscure the load-prevention contract.
-    #[allow(clippy::collapsible_if)]
-    if ctx.identity.context.summary.inject {
-        if let Some(summary) = db.load_conversation_summary().await? {
-            system.push_str("\n## Conversation Summary\n");
-            system.push_str("<context type=\"summary\" trust=\"data\">\n");
-            system.push_str(&summary.content);
-            system.push_str("\n</context>\n");
-        }
+    // Axis 4 + Axis 3 summary gate (mika#1019, mika#1021).
+    // Conversation mode: silent_trigger is None — Axis 3 cap does not fire.
+    if let Some(content) = load_gated_summary(db, &ctx.identity.context.summary, None).await? {
+        system.push_str("\n## Conversation Summary\n");
+        system.push_str("<context type=\"summary\" trust=\"data\">\n");
+        system.push_str(&content);
+        system.push_str("\n</context>\n");
     }
 
     // Resolve GitHub token once: prefer GitHub App installation token, fall back to PAT.
@@ -2740,6 +2735,51 @@ async fn execute_tool(
     ToolOutput::error(format!("Unknown tool: {name}"))
 }
 
+// -- Summary Gating (Axis 4 + Axis 3) --
+
+/// Load the conversational summary for injection into the system prompt,
+/// applying Axis 4 (load-prevention) and Axis 3 (mode-conditional cap)
+/// gates in sequence.
+///
+/// Returns `Ok(None)` when the summary should not be injected. Three reasons:
+///   - `inject = false` (Axis 4 short-circuit; no DB call made)
+///   - no summary stored in the DB
+///   - silent mode + `max_tokens = Some(0)` (Axis 3 load-omit sentinel)
+///
+/// Returns `Ok(Some(content))` with the (possibly truncated) summary content
+/// to inject. Caller is responsible for the surrounding `<context>` tag wrap
+/// + section header.
+///
+/// **Invariant: Axis 4 check MUST precede Axis 3 check.** The
+/// `if !summary_config.inject` short-circuit MUST be the first operation in
+/// this function. Reversing the order would call `db.load_conversation_summary()`
+/// before the `inject` gate fires, breaking Axis 4's load-prevention
+/// guarantee (mika#1016 F2). Any future refactor that reorders these checks
+/// must preserve this invariant or it ceases to be a load-prevention helper.
+async fn load_gated_summary(
+    db: &AsyncDatabase,
+    summary_config: &prompt::ContextSummaryConfig,
+    silent_trigger: Option<&SilentTrigger>,
+) -> Result<Option<String>> {
+    // Axis 4: hard load-prevention. MUST be first — see invariant above.
+    if !summary_config.inject {
+        return Ok(None);
+    }
+
+    // Load the summary; absence is not an error.
+    let Some(summary) = db.load_conversation_summary().await? else {
+        return Ok(None);
+    };
+
+    // Axis 3: mode-conditional cap. The mode gate is `silent_trigger.is_some()`;
+    // the field name (`max_tokens`) is mode-agnostic.
+    match (silent_trigger, summary_config.max_tokens) {
+        (Some(_), Some(0)) => Ok(None), // Silent + load-omit sentinel.
+        (Some(_), Some(n)) => Ok(Some(prompt::truncate_to_token_budget(&summary.content, n))),
+        _ => Ok(Some(summary.content)), // Non-silent or no cap → full summary.
+    }
+}
+
 // -- Silent Mode Agent Loop --
 
 /// What triggered a silent-mode agent run.
@@ -3080,18 +3120,15 @@ async fn run_silent_inner(params: &SilentAgentParams<'_>, deadline: Instant) -> 
     };
     let mut system = prompt::build_silent_prompt(&silent_ctx);
 
-    // Load-prevention gate: when [context.summary].inject is false, skip the
-    // db.load_conversation_summary() call entirely so the summary is never
-    // deserialized into this turn's scope (mika#1009 leak protection).
-    // The nested if is intentional — collapsing would obscure the load-prevention contract.
-    #[allow(clippy::collapsible_if)]
-    if ctx.identity.context.summary.inject {
-        if let Some(summary) = db.load_conversation_summary().await? {
-            system.push_str("\n## Conversation Summary\n");
-            system.push_str("<context type=\"summary\" trust=\"data\">\n");
-            system.push_str(&summary.content);
-            system.push_str("\n</context>\n");
-        }
+    // Axis 4 + Axis 3 summary gate (mika#1019, mika#1021).
+    // Silent mode: pass the trigger so Axis 3's mode-conditional cap can fire.
+    if let Some(content) =
+        load_gated_summary(db, &ctx.identity.context.summary, Some(&params.trigger)).await?
+    {
+        system.push_str("\n## Conversation Summary\n");
+        system.push_str("<context type=\"summary\" trust=\"data\">\n");
+        system.push_str(&content);
+        system.push_str("\n</context>\n");
     }
 
     // Match skills based on trigger type:
@@ -8564,5 +8601,150 @@ mod tests {
             "Tool in enabled set with failed call = satisfied (attempt was made, \
              real failure surfaced — not a fabrication)"
         );
+    }
+
+    // -- load_gated_summary tests (Axis 3 — mika#1021) --
+
+    /// Seed a summary into the async DB by saving enough messages and compacting.
+    async fn seed_summary(db: &AsyncDatabase, content: &str) {
+        // Save enough messages so replace_with_summary has something to compact.
+        for i in 0..5 {
+            db.save_message("test-session", "user", &format!("msg {i}"), None)
+                .await
+                .unwrap();
+        }
+        let old = db.load_messages_before_window(3).await.unwrap();
+        let highest_id = old.last().unwrap().id;
+        db.replace_with_summary(content, highest_id).await.unwrap();
+    }
+
+    fn make_callback_trigger() -> SilentTrigger {
+        SilentTrigger::Callback {
+            task_id: "test-task".to_string(),
+            label: "test".to_string(),
+            result: "done".to_string(),
+            failed: false,
+            parent_task_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn gated_summary_no_cap_silent_returns_full() {
+        // max_tokens = None, silent turn, summary present → returns full summary (regression).
+        let db = test_async_db();
+        seed_summary(&db, "Full summary content here").await;
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: None,
+        };
+        let trigger = make_callback_trigger();
+        let result = load_gated_summary(&db, &config, Some(&trigger))
+            .await
+            .unwrap();
+        assert_eq!(result, Some("Full summary content here".to_string()));
+    }
+
+    #[tokio::test]
+    async fn gated_summary_zero_sentinel_silent_returns_none() {
+        // max_tokens = Some(0), silent turn → returns None (load-omit sentinel).
+        let db = test_async_db();
+        seed_summary(&db, "Should be omitted").await;
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: Some(0),
+        };
+        let trigger = make_callback_trigger();
+        let result = load_gated_summary(&db, &config, Some(&trigger))
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn gated_summary_zero_sentinel_non_silent_returns_full() {
+        // max_tokens = Some(0), non-silent turn → returns full (cap gated by mode).
+        let db = test_async_db();
+        seed_summary(&db, "Full content non-silent").await;
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: Some(0),
+        };
+        let result = load_gated_summary(&db, &config, None).await.unwrap();
+        assert_eq!(result, Some("Full content non-silent".to_string()));
+    }
+
+    #[tokio::test]
+    async fn gated_summary_cap_truncates_in_silent() {
+        // max_tokens = Some(n), silent turn, summary > n tokens → truncated.
+        let db = test_async_db();
+        let long_summary = "word ".repeat(500); // 2500 chars, way over budget
+        seed_summary(&db, &long_summary).await;
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: Some(100), // 400 char budget
+        };
+        let trigger = make_callback_trigger();
+        let result = load_gated_summary(&db, &config, Some(&trigger))
+            .await
+            .unwrap();
+        let content = result.unwrap();
+        assert!(content.contains("[… summary truncated to fit silent-mode budget …]"));
+        // Total truncated content (before marker) should be ≤ 400 chars
+        let before_marker = content
+            .strip_suffix("\n[… summary truncated to fit silent-mode budget …]")
+            .unwrap();
+        assert!(before_marker.len() <= 400);
+    }
+
+    #[tokio::test]
+    async fn gated_summary_cap_under_budget_returns_full() {
+        // max_tokens = Some(n), silent turn, summary < n tokens → full summary.
+        let db = test_async_db();
+        seed_summary(&db, "Short summary").await;
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: Some(1000), // 4000 char budget, summary is tiny
+        };
+        let trigger = make_callback_trigger();
+        let result = load_gated_summary(&db, &config, Some(&trigger))
+            .await
+            .unwrap();
+        assert_eq!(result, Some("Short summary".to_string()));
+    }
+
+    #[tokio::test]
+    async fn gated_summary_axis4_wins_over_axis3() {
+        // Axis 4 inject = false + any max_tokens → returns None without DB call.
+        let db = test_async_db();
+        // Don't even seed a summary — Axis 4 should short-circuit before DB call.
+
+        let config = prompt::ContextSummaryConfig {
+            inject: false,
+            max_tokens: Some(500),
+        };
+        let trigger = make_callback_trigger();
+        let result = load_gated_summary(&db, &config, Some(&trigger))
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn gated_summary_no_summary_stored() {
+        // inject = true, max_tokens = None, no summary in DB → returns None.
+        let db = test_async_db();
+        // No summary seeded.
+
+        let config = prompt::ContextSummaryConfig {
+            inject: true,
+            max_tokens: None,
+        };
+        let result = load_gated_summary(&db, &config, None).await.unwrap();
+        assert_eq!(result, None);
     }
 }

--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -7,6 +7,15 @@ use serde::Deserialize;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
+/// Heuristic conversion ratio for character-count to token-count approximation.
+///
+/// Used by [`truncate_to_token_budget()`] (and any other code path that needs to
+/// cap summary content by approximate token count without invoking a real
+/// tokenizer). The 4:1 ratio is acceptable for English and is conservative
+/// enough for cap-enforcement; exact tokenization is not required because the
+/// cap is a soft policy, not a hard limit, and tokenizers vary by provider.
+const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
+
 /// Configuration for periodic memory reflection.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ReflectionConfig {
@@ -152,8 +161,30 @@ pub struct ContextSummaryConfig {
     /// Whether to load and inject the conversational summary into the system prompt.
     /// Default: `true` (preserves current behavior for all existing agents).
     /// Set to `false` for agents where summary leakage is a known problem.
+    /// (Axis 4 — mika#1019)
     #[serde(default = "default_inject_summary")]
     pub inject: bool,
+
+    /// Optional token cap applied to the summary by the gated injection path.
+    ///
+    /// The cap is mode-agnostic at the schema level. Today the only caller
+    /// applying it gates on silent-mode detection — see [`load_gated_summary()`]
+    /// in `agent.rs`. Tomorrow another gate could reuse the same field
+    /// without a rename.
+    ///
+    /// When set:
+    ///   - `Some(0)` → load-omit sentinel: summary is not injected. Same code
+    ///     path as Axis 4's `inject = false` short-circuit, but conditional on
+    ///     the in-code gate firing (e.g., silent-mode only). NOT interpreted as
+    ///     "zero-token cap"; treated as a structural omit signal.
+    ///   - `Some(n)` for n > 0 → summary truncated to approximately
+    ///     `n * CHARS_PER_TOKEN_ESTIMATE` characters before injection.
+    ///   - `None` → no cap (default; current behavior).
+    ///
+    /// Token approximation is heuristic via [`CHARS_PER_TOKEN_ESTIMATE`] (= 4).
+    /// (Axis 3 — mika#1021)
+    #[serde(default)]
+    pub max_tokens: Option<usize>,
 }
 
 fn default_inject_summary() -> bool {
@@ -164,8 +195,45 @@ impl Default for ContextSummaryConfig {
     fn default() -> Self {
         Self {
             inject: default_inject_summary(),
+            max_tokens: None,
         }
     }
+}
+
+/// Truncate a summary string to approximately `max_tokens`, using
+/// [`CHARS_PER_TOKEN_ESTIMATE`] for the conversion. Cuts at a word boundary
+/// near the budget to avoid mid-word truncation in the LLM's view. Appends
+/// a truncation marker so the model knows content was elided.
+///
+/// Heuristic: not exact tokenization. Acceptable because the cap is a soft
+/// policy, not a hard limit, and tokenizers vary by provider.
+pub fn truncate_to_token_budget(summary: &str, max_tokens: usize) -> String {
+    let max_chars = max_tokens.saturating_mul(CHARS_PER_TOKEN_ESTIMATE);
+    if summary.len() <= max_chars {
+        return summary.to_string();
+    }
+    // Cut at the last word boundary at or before `max_chars`.
+    // floor_char_boundary ensures we don't slice mid-codepoint.
+    let safe_boundary = floor_char_boundary(summary, max_chars);
+    let cut = summary[..safe_boundary]
+        .rfind(char::is_whitespace)
+        .unwrap_or(safe_boundary);
+    let mut truncated = summary[..cut].to_string();
+    truncated.push_str("\n[… summary truncated to fit silent-mode budget …]");
+    truncated
+}
+
+/// Returns the largest byte index ≤ `index` that is a valid char boundary.
+/// Equivalent to `str::floor_char_boundary` (nightly-only as of Rust 1.86).
+fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        return s.len();
+    }
+    let mut i = index;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }
 
 /// Agent identity loaded from ~/.mika/identity.toml.
@@ -302,7 +370,10 @@ fn fail_closed_identity() -> Identity {
         // Fail-closed must enforce inject=false so a malformed identity.toml
         // cannot re-enable summary injection (mika#1009 leak protection).
         context: ContextIdentityConfig {
-            summary: ContextSummaryConfig { inject: false },
+            summary: ContextSummaryConfig {
+                inject: false,
+                max_tokens: None,
+            },
         },
     }
 }
@@ -2411,5 +2482,129 @@ inject = true
         )
         .unwrap();
         assert!(identity.context.summary.inject);
+    }
+
+    // -- truncate_to_token_budget tests (Axis 3 — mika#1021) --
+
+    #[test]
+    fn truncate_empty_string() {
+        let result = truncate_to_token_budget("", 100);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn truncate_short_string_under_budget() {
+        let summary = "This is a short summary.";
+        let result = truncate_to_token_budget(summary, 100);
+        assert_eq!(result, summary);
+    }
+
+    #[test]
+    fn truncate_exactly_at_budget() {
+        // 6 tokens * 4 chars = 24 chars budget
+        let summary = "This is exactly 24 char!"; // 24 chars
+        assert_eq!(summary.len(), 24);
+        let result = truncate_to_token_budget(summary, 6);
+        assert_eq!(result, summary);
+    }
+
+    #[test]
+    fn truncate_over_budget_cuts_at_word_boundary() {
+        // 2 tokens * 4 chars = 8 chars budget
+        let summary = "The quick brown fox jumps over the lazy dog";
+        let result = truncate_to_token_budget(summary, 2);
+        // Should cut at ~8 chars, finding last whitespace before position 8
+        assert!(result.contains("[… summary truncated to fit silent-mode budget …]"));
+        // "The" + space is at position 3, "quick" at position 4-8
+        // Last whitespace at or before 8 is position 3 (after "The")
+        assert!(result.starts_with("The"));
+        // Must be shorter than original
+        assert!(result.len() < summary.len() + 60); // +60 for marker
+    }
+
+    #[test]
+    fn truncate_over_budget_no_whitespace() {
+        // 2 tokens * 4 chars = 8 chars budget; no whitespace → cuts at max_chars
+        let summary = "abcdefghijklmnop";
+        let result = truncate_to_token_budget(summary, 2);
+        assert!(result.starts_with("abcdefgh"));
+        assert!(result.contains("[… summary truncated to fit silent-mode budget …]"));
+    }
+
+    #[test]
+    fn truncate_long_summary_preserves_marker() {
+        let summary = "word ".repeat(500); // 2500 chars
+        let result = truncate_to_token_budget(&summary, 100); // 400 char budget
+        assert!(result.ends_with("[… summary truncated to fit silent-mode budget …]"));
+        // Truncated content (before marker) should be ≤ budget chars
+        let content_before_marker = result
+            .strip_suffix("\n[… summary truncated to fit silent-mode budget …]")
+            .unwrap();
+        assert!(content_before_marker.len() <= 400);
+    }
+
+    #[test]
+    fn truncate_multibyte_unicode_safe() {
+        // Ensure we don't panic on multi-byte UTF-8 characters near the cut point
+        let summary = "日本語のテスト文字列です。これは長いテスト文字列です。";
+        // Each CJK char is 3 bytes; with budget of 5 tokens (20 chars / ~6-7 CJK chars)
+        let result = truncate_to_token_budget(summary, 5);
+        assert!(result.contains("[… summary truncated to fit silent-mode budget …]"));
+        // Should not panic — that's the main assertion
+    }
+
+    // -- ContextSummaryConfig deserialization tests (Axis 3 — mika#1021) --
+
+    #[test]
+    fn summary_config_default_max_tokens_is_none() {
+        let config = ContextSummaryConfig::default();
+        assert!(config.inject);
+        assert!(config.max_tokens.is_none());
+    }
+
+    #[test]
+    fn summary_config_deserializes_max_tokens() {
+        let identity: Identity = toml::from_str(
+            r#"
+name = "Test"
+
+[context.summary]
+inject = true
+max_tokens = 500
+"#,
+        )
+        .unwrap();
+        assert!(identity.context.summary.inject);
+        assert_eq!(identity.context.summary.max_tokens, Some(500));
+    }
+
+    #[test]
+    fn summary_config_deserializes_max_tokens_zero_sentinel() {
+        let identity: Identity = toml::from_str(
+            r#"
+name = "Test"
+
+[context.summary]
+inject = true
+max_tokens = 0
+"#,
+        )
+        .unwrap();
+        assert_eq!(identity.context.summary.max_tokens, Some(0));
+    }
+
+    #[test]
+    fn summary_config_without_max_tokens_defaults_to_none() {
+        let identity: Identity = toml::from_str(
+            r#"
+name = "Test"
+
+[context.summary]
+inject = false
+"#,
+        )
+        .unwrap();
+        assert!(!identity.context.summary.inject);
+        assert!(identity.context.summary.max_tokens.is_none());
     }
 }

--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -214,26 +214,13 @@ pub fn truncate_to_token_budget(summary: &str, max_tokens: usize) -> String {
     }
     // Cut at the last word boundary at or before `max_chars`.
     // floor_char_boundary ensures we don't slice mid-codepoint.
-    let safe_boundary = floor_char_boundary(summary, max_chars);
+    let safe_boundary = summary.floor_char_boundary(max_chars);
     let cut = summary[..safe_boundary]
         .rfind(char::is_whitespace)
         .unwrap_or(safe_boundary);
     let mut truncated = summary[..cut].to_string();
     truncated.push_str("\n[… summary truncated to fit silent-mode budget …]");
     truncated
-}
-
-/// Returns the largest byte index ≤ `index` that is a valid char boundary.
-/// Equivalent to `str::floor_char_boundary` (nightly-only as of Rust 1.86).
-fn floor_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
-    }
-    let mut i = index;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
 }
 
 /// Agent identity loaded from ~/.mika/identity.toml.
@@ -2513,13 +2500,12 @@ inject = true
         // 2 tokens * 4 chars = 8 chars budget
         let summary = "The quick brown fox jumps over the lazy dog";
         let result = truncate_to_token_budget(summary, 2);
-        // Should cut at ~8 chars, finding last whitespace before position 8
-        assert!(result.contains("[… summary truncated to fit silent-mode budget …]"));
-        // "The" + space is at position 3, "quick" at position 4-8
-        // Last whitespace at or before 8 is position 3 (after "The")
-        assert!(result.starts_with("The"));
-        // Must be shorter than original
-        assert!(result.len() < summary.len() + 60); // +60 for marker
+        // Budget is 8 chars. Last whitespace at or before position 8 is position 3
+        // (space after "The"). So the pre-marker content should be exactly "The".
+        assert_eq!(
+            result,
+            "The\n[… summary truncated to fit silent-mode budget …]"
+        );
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -397,7 +397,7 @@ defaults to `~/.mika/`.
 
 ## identity.toml
 
-Defines the assistant's display identity and per-agent Knowledge Graph configuration.
+Defines the assistant's display identity, per-agent Knowledge Graph configuration, and context injection controls.
 
 **Default content:**
 
@@ -409,6 +409,10 @@ emoji = "✦"
 # enabled = true                    # default: true — set false to skip KG for this agent
 # docs_root = "/path/to/docs"       # optional; falls back to MIKA_KG_DOCS_ROOT / kg_docs_root / CWD/docs/solutions
 # docs_roots = ["/path/a", "/path/b"]  # optional; multi-corpus (overrides docs_root when set)
+
+# [context.summary]
+# inject = true                     # default: true — set false to disable summary injection entirely (Axis 4)
+# max_tokens = 1000                 # optional — cap summary to ~1000 tokens on silent-mode turns (Axis 3)
 ```
 
 | Field | Description |
@@ -418,8 +422,12 @@ emoji = "✦"
 | `[kg].enabled` | Whether KG ingestion/extraction/resolution runs for this agent. Default: `true`. |
 | `[kg].docs_root` | Absolute path to the docs root this agent's KG reads from. Optional; falls back to the global resolver chain (`MIKA_KG_DOCS_ROOT` env > `kg_docs_root` config > `<CWD>/docs/solutions`). |
 | `[kg].docs_roots` | Array of absolute paths for multi-corpus agents (#798). Overrides `docs_root` (singular) and `MIKA_KG_DOCS_ROOTS` when set. Each path is validated independently; missing paths are warned and skipped. |
+| `[context.summary].inject` | Whether to load and inject the conversational summary into the system prompt. Default: `true`. Set `false` for agents where summary leakage is a known problem (#1019). |
+| `[context.summary].max_tokens` | Optional token cap applied to the summary on silent-mode turns (callback, webhook, heartbeat). `0` = omit summary on silent turns; `n > 0` = truncate to ~n tokens (4 chars/token heuristic). Non-silent turns are never affected. Default: none (#1021). |
 
 **`[kg]` behavior:** When `enabled = false`, no KG subsystem components are constructed for the agent. Existing shared-corpus rows are preserved (cleanup via `mika kg purge`). When `docs_root` is set to an explicit path that doesn't exist, the agent fails to start with a clear error. Agents with matching `docs_root` share extraction via `docs_root_hash` (v27 schema).
+
+**`[context.summary]` behavior:** `inject = false` (Axis 4) is a load-prevention gate — `db.load_conversation_summary()` is never called and the summary is not available to any downstream code path. `max_tokens` (Axis 3) is mode-conditional — it only fires on silent-mode turns (when `SilentTrigger` is present). Axis 4 always wins: when `inject = false`, the `max_tokens` field is never evaluated. See `crates/mika-agent/CLAUDE.md` for implementation details.
 
 To customize, edit `~/.mika/identity.toml`:
 

--- a/docs/memory-classification.md
+++ b/docs/memory-classification.md
@@ -31,7 +31,7 @@ These run automatically on every agent turn. The engine handles them in `prompt.
 | Skill prompt injection | `agent.rs` `inject_skills_and_resolve_tools()` | Every turn | Matched skills' prompts injected based on keyword triggers; `always_on` skills injected unconditionally |
 | Context resolution | `skills/context.rs` `resolve_contexts()` | Every turn (when skills have `[context.*]`) | Deterministic data pre-fetch (e.g., `gh_pr_diff`) before LLM sees the query |
 | Conversation history loading | `agent.rs` `load_recent_messages()` | Every turn | Full message history for the session loaded into the conversation |
-| Conversation summary injection | `agent.rs` (post `build_system_prompt`) | Every turn (when summary exists) | Compaction summary injected as `<context type="summary" trust="data">` |
+| Conversation summary injection | `agent.rs` `load_gated_summary()` | Every turn (gated by `[context.summary]` config) | Compaction summary injected as `<context type="summary" trust="data">`. Gated by Axis 4 (`inject = false` prevents load) and Axis 3 (`max_tokens` caps or omits on silent-mode turns). |
 | Compaction summarization | `compaction.rs` `maybe_compact()` | Post-turn, when message count > 50 | Older messages summarized via LLM, summary stored, originals deleted |
 | Tool call recording | `agent.rs` via `save_tool_call()` | After each tool execution | Full input/output (50KB cap) persisted to `tool_calls` table |
 | LLM call recording | `agent.rs` via `save_llm_call()` | After each LLM API call | Model, tokens, latency, stop reason persisted to `llm_calls` table |

--- a/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
+++ b/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
@@ -133,6 +133,22 @@ Helper signature (lives in `prompt.rs` next to `ContextSummaryConfig`):
 /// to inject. Caller is responsible for the surrounding `<context>` tag wrap
 /// + section header.
 ///
+/// **NF3 — `Ok(None)` conflation (intentional KISS).** Callers cannot
+/// distinguish "load-prevented by `inject = false`" from "no summary in DB"
+/// from "Axis 3 sentinel fired" via the return value alone. This conflation
+/// is acceptable because the caller's response (skip injection) is the same
+/// in all three cases. To audit Axis 4's load-prevention guarantee
+/// specifically, inspect `summary_config.inject` directly — do NOT infer
+/// from the return value. A typed enum return
+/// (`LoadPrevented`/`NoSummary`/`Injected`) is not needed today.
+///
+/// **NF4 — invariant: Axis 4 check MUST precede Axis 3 check.** The
+/// `if !summary_config.inject` short-circuit MUST be the first operation in
+/// this function. Reversing the order would call `db.load_conversation_summary()`
+/// before the `inject` gate fires, breaking Axis 4's load-prevention
+/// guarantee (mika#1016 F2). Any future refactor that reorders these checks
+/// must preserve this invariant or it ceases to be a load-prevention helper.
+///
 /// The "gated" name signals: this is the policy-aware load path. Any direct
 /// `db.load_conversation_summary()` callers (e.g., debugging, migration)
 /// bypass the gates intentionally.
@@ -141,7 +157,7 @@ async fn load_gated_summary(
     summary_config: &ContextSummaryConfig,
     silent_trigger: Option<&SilentTrigger>,
 ) -> Result<Option<String>> {
-    // Axis 4: hard load-prevention.
+    // Axis 4: hard load-prevention. MUST be first — see NF4 invariant above.
     if !summary_config.inject {
         return Ok(None);
     }

--- a/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
+++ b/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
@@ -1,0 +1,217 @@
+---
+ticket: mika#1021
+type: feat
+module: mika-agent
+tags: [prompt-assembly, identity, context-channel-leakage, silent-mode]
+parent: mika#1009
+sibling: mika#1019
+---
+
+# Plan: Silent-Mode Summary Budget Cap (mika#1009 Axis 3)
+
+## Problem
+
+mika#1009's finding doc identified a 300:1 system-prompt-to-messages token ratio in silent-mode (callback / webhook event) turns: the messages array is a single trigger event (often a few hundred tokens) while the system prompt — including the conversational summary — can run thousands of tokens. At this ratio the LLM treats the summary as if it were prior conversation history and produces degenerate responses referencing "prior turns" the model never participated in.
+
+Axis 4 (mika#1019, shipped 2026-05-07) added per-agent **load-prevention** of the summary block via `[context.summary].inject = false`. Axis 4 is the right shape for agents whose typical operation pattern is silent-mode-dominant (mika-arch). It is not the right shape for agents that benefit from summary continuity in interactive turns but get burned by it in silent turns — those agents need a **mode-conditional** gate, not a global opt-out.
+
+This plan adds Axis 3: a silent-mode-only budget cap that short-circuits the same load-prevention path Axis 4 introduced, but conditional on the call site being a silent trigger. Agents keep the summary on streaming/CLI turns and lose it on callback/webhook turns where the ratio is dangerous.
+
+## Design
+
+Add `silent_mode_max_tokens: Option<usize>` to the existing `[context.summary]` section in `identity.toml` (which Axis 4 introduced). The field is `Option` so unset means "no cap" (preserves current behavior). When set:
+
+- `None` → behavior unchanged from current (or from Axis 4's `inject = false` if also set; Axis 4 wins by short-circuit).
+- `Some(0)` → silent-mode summary is omitted entirely (load-prevention; same code path as Axis 4 but conditional).
+- `Some(n)` → silent-mode summary is loaded but truncated to ~n tokens before injection. Non-silent turns load the full summary unchanged.
+
+### Why this shape
+
+**Why `Option` not `usize` with sentinel default.** A sentinel like `0 = unlimited` would conflict with `0 = omit`, and a u32::MAX sentinel is uglier than absent. `Option<usize>` reads as "optional cap" which is the actual semantic.
+
+**Why nested under `[context.summary]` (already exists from Axis 4).** Axis 4's design explicitly anticipated this field as a sibling: see Axis 4 plan §"Why nested `[context.summary]`" — `budget_tokens` was the named example. Filing it under the same section is the no-rename, no-migration path Axis 4 specifically designed for.
+
+**Why "silent-mode" not "callback-mode" or "webhook-mode".** The existing `SilentTrigger` enum at `crates/mika-agent/src/agent.rs` (and its variant `SilentTrigger::DeferredDispatch` introduced in mika#1011) is the canonical structural marker for "this turn has no human in the loop and no streaming UI." Both callback and webhook events flow through `SilentTrigger`. Naming the field `silent_mode_max_tokens` aligns with the existing engine vocabulary. A future maintainer searching for "silent" finds both the enum and the config.
+
+**Why token-cap semantics, not character-cap.** The leak is measured in tokens (the LLM's frame of reference). Approximating tokens via character count (4 chars ≈ 1 token in English) is acceptable for cap-enforcement; precise tokenization is not required because (a) the cap is heuristic, not a hard limit, and (b) tokenizers vary by provider and bringing one in just for cap-enforcement is overkill. Document the approximation in the field's doc comment.
+
+### Rejected alternatives
+
+- **Field on `Identity` top level (e.g., `summary_silent_mode_budget`).** Loses the `[context.summary]` grouping that Axis 4 introduced and which is the right home for any summary-control field.
+- **Hardcoded budget in `agent.rs` with no config.** Removes operator control. Different agents (mika-arch is callback-dominant; mika-prime is interactive-dominant) want different policies.
+- **Detect silent mode via messages-array-length heuristic** (`if messages.len() <= 2`). Heuristic shape; couples to message-shape that may change. The `SilentTrigger` enum is the structural marker designed for exactly this case.
+- **Apply in summarizer (Axis 2 territory).** Axis 2 changes summary content/format. Axis 3 changes summary delivery conditional on call site. Different layers; both legitimate.
+
+## Implementation Steps
+
+### Step 1: Extend `ContextSummaryConfig` with `silent_mode_max_tokens`
+
+**File:** `crates/mika-agent/src/prompt.rs`
+
+Extend the struct introduced in mika#1019:
+
+```rust
+#[derive(Debug, Deserialize, Clone)]
+pub struct ContextSummaryConfig {
+    /// Whether to load and inject the conversational summary into the system prompt.
+    /// Default: `true` (preserves current behavior for all existing agents).
+    /// Set to `false` for agents where summary leakage is a known problem on every turn.
+    /// (Axis 4 — mika#1019)
+    #[serde(default = "default_inject_summary")]
+    pub inject: bool,
+
+    /// Optional token budget applied to the summary on silent-mode turns
+    /// (callback/webhook events with no streaming UI). When set:
+    ///   - `Some(0)` → summary omitted entirely on silent turns.
+    ///   - `Some(n)` → summary truncated to ~n tokens (≈ 4n characters) before injection.
+    ///   - `None`    → no cap (default; current behavior).
+    /// Non-silent turns ignore this field and inject the full summary.
+    /// Token approximation is heuristic (4 chars ≈ 1 token); exact tokenization
+    /// is not required for cap-enforcement.
+    /// (Axis 3 — mika#1021)
+    #[serde(default)]
+    pub silent_mode_max_tokens: Option<usize>,
+}
+
+impl Default for ContextSummaryConfig {
+    fn default() -> Self {
+        Self {
+            inject: default_inject_summary(),
+            silent_mode_max_tokens: None,
+        }
+    }
+}
+```
+
+**Rationale:** Additive change. Existing `identity.toml` files without the new field deserialize correctly with `silent_mode_max_tokens = None`. No migration needed.
+
+### Step 2: Plumb silent-mode signal into prompt assembly
+
+**File:** `crates/mika-agent/src/agent.rs`
+
+Locate the two summary-injection sites (per mika#1009 finding):
+
+1. **Conversation mode** at `agent.rs:2018-2024`
+2. **Team/silent mode** at `agent.rs:3044-3049`
+
+For both sites, plumb the in-scope `silent_trigger: Option<&SilentTrigger>` (or equivalent silent-mode signal) into the gating logic. The conversation-mode path is non-silent by definition — `silent_trigger` is `None` and the cap is bypassed. The team/silent path has `Some(SilentTrigger::*)` — apply the cap.
+
+Gating logic (after Axis 4's `inject` check passes):
+
+```rust
+// Axis 3 — silent-mode summary budget cap (mika#1021)
+let summary_to_inject = match (silent_trigger, identity.context.summary.silent_mode_max_tokens) {
+    (Some(_), Some(0)) => None,                                   // Silent + budget=0 → omit
+    (Some(_), Some(n)) => Some(truncate_to_token_budget(&summary, n)),  // Silent + cap → truncate
+    _ => Some(summary),                                            // Non-silent or no cap → unchanged
+};
+
+if let Some(content) = summary_to_inject {
+    system.push_str("\n## Conversation Summary\n");
+    system.push_str("<context type=\"summary\" trust=\"data\">\n");
+    system.push_str(&content);
+    system.push_str("\n</context>\n");
+}
+```
+
+**Why gate after the `inject` check, not before.** Axis 4's `inject = false` is strictly stronger (load-prevention skips the `db.load_conversation_summary()` call entirely; Axis 3's cap operates on already-loaded content). When `inject = false`, control never reaches Axis 3's gate — Axis 4 wins by short-circuit, satisfying the orthogonality requirement (AC#4).
+
+### Step 3: Token-budget truncation helper
+
+**File:** `crates/mika-agent/src/prompt.rs` (or a new `crates/mika-agent/src/prompt/budget.rs` if `prompt.rs` is already large)
+
+```rust
+/// Truncate a summary string to approximately `max_tokens`, using the
+/// 4-chars-per-token heuristic. Cuts at a word boundary near the budget
+/// to avoid mid-word truncation in the LLM's view. Appends a truncation
+/// marker so the model knows content was elided.
+///
+/// Heuristic: not exact tokenization. Acceptable because the cap is a
+/// soft policy, not a hard limit, and tokenizers vary by provider.
+pub fn truncate_to_token_budget(summary: &str, max_tokens: usize) -> String {
+    let max_chars = max_tokens.saturating_mul(4);
+    if summary.len() <= max_chars {
+        return summary.to_string();
+    }
+    // Cut at the last word boundary at or before `max_chars`.
+    let cut = summary[..max_chars]
+        .rfind(char::is_whitespace)
+        .unwrap_or(max_chars);
+    let mut truncated = summary[..cut].to_string();
+    truncated.push_str("\n[… summary truncated to fit silent-mode budget …]");
+    truncated
+}
+```
+
+**Rationale:** Heuristic truncation at word boundary. Truncation marker is honest signal to the model and to a debugging operator reading the prompt log.
+
+### Step 4: Identity TOML update for at-risk agents (operator-deferred)
+
+This step files no code change. After this PR ships, the operator can opt-in per agent:
+
+```toml
+# ~/.mika/agents/<agent>/identity.toml
+[context.summary]
+inject = true                       # Axis 4 — keep summary on interactive turns
+silent_mode_max_tokens = 1000       # Axis 3 — cap to ~1000 tokens on silent turns
+```
+
+Or a stricter policy:
+
+```toml
+[context.summary]
+inject = true
+silent_mode_max_tokens = 0          # Axis 3 — omit summary entirely on silent turns
+```
+
+The plan does NOT seed `well_known_agents.rs` with new defaults for any agent. Operator decides per-agent based on observed behavior. Document the field in `crates/mika-agent/CLAUDE.md` per AC#5; that's the only documentation touchpoint this PR makes.
+
+## Test Strategy
+
+### Unit tests
+
+1. **`silent_mode_max_tokens = None`, silent turn** → summary unchanged (regression).
+2. **`silent_mode_max_tokens = Some(0)`, silent turn** → summary absent in prompt.
+3. **`silent_mode_max_tokens = Some(0)`, non-silent turn** → summary present (cap is silent-only).
+4. **`silent_mode_max_tokens = Some(n)`, silent turn, summary > n tokens** → truncation marker present in prompt.
+5. **`silent_mode_max_tokens = Some(n)`, silent turn, summary < n tokens** → summary unchanged.
+6. **Axis 4 wins:** `inject = false` + `silent_mode_max_tokens = Some(100)` → summary entirely absent (load-prevention shortcut).
+7. **`truncate_to_token_budget` boundary tests:** empty string, exactly max_chars, max_chars + 1, very long with whitespace, very long without whitespace.
+
+### Integration / eval tests
+
+`crates/mika-agent/tests/eval/` already exercises the prompt-assembly seam. Add a scenario:
+- Agent with `silent_mode_max_tokens = Some(500)` + a 5000-char summary fixture
+- Trigger via `EvalHarness` callback path (silent)
+- Assert `LlmRequest.system` contains truncation marker + `system.len()` is bounded
+
+No real-LLM eval needed — the assertion is on prompt content, not LLM behavior.
+
+## Acceptance Criteria
+
+Mirroring the ticket body for traceability:
+
+- **AC#1**: Silent-mode is structurally detected via the existing `SilentTrigger` signal in `build_system_prompt()`. The predicate flows through to the gating logic in both conversation-mode (`agent.rs:2018-2024`) and team-mode (`agent.rs:3044-3049`) paths.
+- **AC#2**: Silent-mode + summary tokens > budget → summary is omitted (when `Some(0)`) or truncated to budget (when `Some(n)`). Verifiable via unit tests #2 and #4 above.
+- **AC#3**: Non-silent mode → behavior unchanged from current. Regression tests #1 and #3 above + existing eval scenarios pass.
+- **AC#4**: When Axis 4's `inject = false`, Axis 3's budget logic is short-circuited. Verifiable via test #6. Orthogonality flag per `feedback_orthogonality_flag_semantics`.
+- **AC#5**: `crates/mika-agent/CLAUDE.md` documents the new field + the heuristic truncation contract under § Conventions or § Three-Layer Memory Model.
+
+## Risks & Open Questions
+
+- **R1 (low):** The `SilentTrigger` enum may not be in scope at exactly the line of the summary-injection sites. If plumbing requires a function-signature change, additional callers may need updating. Mitigation: scoped grep for callers during Step 2; widen the change if needed.
+- **R2 (low):** Heuristic 4-char-per-token approximation is conservative for English (English tends toward ~4 chars/token in practice). For other languages the approximation skews. Acceptable because (a) the budget is a soft policy and (b) the only callers writing summaries today are the existing summarizer which produces English. If multi-language summaries become common, revisit with a tokenizer-based cap (separate ticket).
+- **R3 (low):** A future Axis 2 (summarizer content reform) may make summary content less leak-prone, reducing the need for Axis 3. Axis 3 still has independent value (defense-in-depth + per-agent policy control). No architectural conflict.
+- **OQ1 (groom):** Is the right default `silent_mode_max_tokens = None` (no cap unless opted-in, current shape) or a small built-in cap (e.g., `Some(2000)`) shipping as-default for all agents? The plan assumes `None` (additive, opt-in). Architect: confirm or override.
+- **OQ2 (groom):** Should the truncation marker text be configurable, or is a fixed `[… summary truncated to fit silent-mode budget …]` good enough? Plan assumes fixed.
+
+## Sources
+
+- mika#1009 finding doc: `mika/docs/solutions/best-practices/mika-arch-init-context-leakage-2026-05-06.md`
+- mika#1019 (Axis 4 sibling) — closed via PR #1019 on 2026-05-07T17:39Z
+- mika#1019 plan: `mika/docs/plans/2026-05-07-005-feat-prompt-inject-summary-opt-out-plan.md`
+- `crates/mika-agent/src/agent.rs:2018-2024` (conversation-mode summary injection)
+- `crates/mika-agent/src/agent.rs:3044-3049` (team/silent-mode summary injection)
+- `crates/mika-agent/src/prompt.rs:353-387` (existing `ContextSummaryConfig` from Axis 4)
+- `SilentTrigger` enum (existing structural silent-mode marker)
+- 2026-05-07 orchestrator handoff carry-forward (mika#1009 axes 3/2/1 sequencing)

--- a/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
+++ b/docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md
@@ -19,21 +19,25 @@ This plan adds Axis 3: a silent-mode-only budget cap that short-circuits the sam
 
 ## Design
 
-Add `silent_mode_max_tokens: Option<usize>` to the existing `[context.summary]` section in `identity.toml` (which Axis 4 introduced). The field is `Option` so unset means "no cap" (preserves current behavior). When set:
+Add `max_tokens: Option<usize>` to the existing `[context.summary]` section in `identity.toml` (which Axis 4 introduced). The field is `Option` so unset means "no cap" (preserves current behavior). The field is **mode-agnostic on its name** — the silent-mode gating lives in code (`if silent_trigger.is_some()`), not in the field's identifier. This per architect first-pass F1 (Orthogonality/KISS): the field is "max_tokens applied when the in-code gate fires"; mixing the gate condition into the name would over-couple config schema to current call-site policy.
+
+When set:
 
 - `None` → behavior unchanged from current (or from Axis 4's `inject = false` if also set; Axis 4 wins by short-circuit).
-- `Some(0)` → silent-mode summary is omitted entirely (load-prevention; same code path as Axis 4 but conditional).
-- `Some(n)` → silent-mode summary is loaded but truncated to ~n tokens before injection. Non-silent turns load the full summary unchanged.
+- `Some(0)` → on silent-mode turns, summary is omitted entirely. **`Some(0)` is a load-omit sentinel, not a "zero-token cap" interpreted literally** — the code path for `Some(0)` is the same as Axis 4's `inject = false` short-circuit but conditional on silent mode. Calling out the sentinel meaning explicitly per architect first-pass NF1.
+- `Some(n)` for n > 0 → on silent-mode turns, summary is loaded and truncated to approximately n tokens before injection. Non-silent turns load the full summary unchanged.
 
 ### Why this shape
 
 **Why `Option` not `usize` with sentinel default.** A sentinel like `0 = unlimited` would conflict with `0 = omit`, and a u32::MAX sentinel is uglier than absent. `Option<usize>` reads as "optional cap" which is the actual semantic.
 
-**Why nested under `[context.summary]` (already exists from Axis 4).** Axis 4's design explicitly anticipated this field as a sibling: see Axis 4 plan §"Why nested `[context.summary]`" — `budget_tokens` was the named example. Filing it under the same section is the no-rename, no-migration path Axis 4 specifically designed for.
+**Why `max_tokens` not `silent_mode_max_tokens`** (architect F1). The mode-gating belongs in code, not in the field identifier. Today the only call site applying the cap is the silent-mode injection path; tomorrow another call site (e.g., compaction-triggered re-summarization) might want the same cap with different gate logic. Naming the field for its current gate freezes that coupling. `max_tokens` says what it is (a token cap on summary content); the gate `if silent_trigger.is_some()` says when. Two orthogonal concerns, two separate names — per `feedback_orthogonality_flag_semantics`.
 
-**Why "silent-mode" not "callback-mode" or "webhook-mode".** The existing `SilentTrigger` enum at `crates/mika-agent/src/agent.rs` (and its variant `SilentTrigger::DeferredDispatch` introduced in mika#1011) is the canonical structural marker for "this turn has no human in the loop and no streaming UI." Both callback and webhook events flow through `SilentTrigger`. Naming the field `silent_mode_max_tokens` aligns with the existing engine vocabulary. A future maintainer searching for "silent" finds both the enum and the config.
+**Why nested under `[context.summary]` (already exists from Axis 4).** Axis 4's design explicitly anticipated a cap field as a sibling: see Axis 4 plan §"Why nested `[context.summary]`" — `budget_tokens` was the named example. Filing it under the same section is the no-rename, no-migration path Axis 4 specifically designed for.
 
-**Why token-cap semantics, not character-cap.** The leak is measured in tokens (the LLM's frame of reference). Approximating tokens via character count (4 chars ≈ 1 token in English) is acceptable for cap-enforcement; precise tokenization is not required because (a) the cap is heuristic, not a hard limit, and (b) tokenizers vary by provider and bringing one in just for cap-enforcement is overkill. Document the approximation in the field's doc comment.
+**Why detect via `SilentTrigger` (not callback-mode or webhook-mode).** The existing `SilentTrigger` enum at `crates/mika-agent/src/agent.rs` (and its variant `SilentTrigger::DeferredDispatch` introduced in mika#1011) is the canonical structural marker for "this turn has no human in the loop and no streaming UI." Both callback and webhook events flow through `SilentTrigger`. The detection lives in code; the field stays mode-agnostic.
+
+**Why token-cap semantics, not character-cap.** The leak is measured in tokens (the LLM's frame of reference). Approximating tokens via character count (4 chars ≈ 1 token in English) is acceptable for cap-enforcement; precise tokenization is not required because (a) the cap is heuristic, not a hard limit, and (b) tokenizers vary by provider and bringing one in just for cap-enforcement is overkill. The 4-char ratio is captured as a named constant `CHARS_PER_TOKEN_ESTIMATE = 4` (architect NF2) rather than a magic number, so a future maintainer encountering `max_chars = max_tokens * 4` doesn't have to re-derive the rationale.
 
 ### Rejected alternatives
 
@@ -44,9 +48,22 @@ Add `silent_mode_max_tokens: Option<usize>` to the existing `[context.summary]` 
 
 ## Implementation Steps
 
-### Step 1: Extend `ContextSummaryConfig` with `silent_mode_max_tokens`
+### Step 1: Extend `ContextSummaryConfig` with `max_tokens` field + `CHARS_PER_TOKEN_ESTIMATE` constant
 
 **File:** `crates/mika-agent/src/prompt.rs`
+
+Add the named constant near the top of the module:
+
+```rust
+/// Heuristic conversion ratio for character-count to token-count approximation.
+///
+/// Used by `truncate_to_token_budget()` (and any other code path that needs to
+/// cap summary content by approximate token count without invoking a real
+/// tokenizer). The 4:1 ratio is acceptable for English and is conservative
+/// enough for cap-enforcement; exact tokenization is not required because the
+/// cap is a soft policy, not a hard limit, and tokenizers vary by provider.
+const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
+```
 
 Extend the struct introduced in mika#1019:
 
@@ -60,53 +77,94 @@ pub struct ContextSummaryConfig {
     #[serde(default = "default_inject_summary")]
     pub inject: bool,
 
-    /// Optional token budget applied to the summary on silent-mode turns
-    /// (callback/webhook events with no streaming UI). When set:
-    ///   - `Some(0)` → summary omitted entirely on silent turns.
-    ///   - `Some(n)` → summary truncated to ~n tokens (≈ 4n characters) before injection.
-    ///   - `None`    → no cap (default; current behavior).
-    /// Non-silent turns ignore this field and inject the full summary.
-    /// Token approximation is heuristic (4 chars ≈ 1 token); exact tokenization
-    /// is not required for cap-enforcement.
+    /// Optional token cap applied to the summary by the gated injection path.
+    ///
+    /// The cap is mode-agnostic at the schema level. Today the only caller
+    /// applying it gates on `SilentTrigger::is_some()` — see
+    /// `load_gated_summary()`. Tomorrow another gate could reuse the same field
+    /// without a rename.
+    ///
+    /// When set:
+    ///   - `Some(0)` → load-omit sentinel: summary is not injected. Same code
+    ///     path as Axis 4's `inject = false` short-circuit, but conditional on
+    ///     the in-code gate firing (e.g., silent-mode only). NOT interpreted as
+    ///     "zero-token cap"; treated as a structural omit signal.
+    ///   - `Some(n)` for n > 0 → summary truncated to approximately
+    ///     `n * CHARS_PER_TOKEN_ESTIMATE` characters before injection.
+    ///   - `None` → no cap (default; current behavior).
+    ///
+    /// Token approximation is heuristic via `CHARS_PER_TOKEN_ESTIMATE` (= 4).
     /// (Axis 3 — mika#1021)
     #[serde(default)]
-    pub silent_mode_max_tokens: Option<usize>,
+    pub max_tokens: Option<usize>,
 }
 
 impl Default for ContextSummaryConfig {
     fn default() -> Self {
         Self {
             inject: default_inject_summary(),
-            silent_mode_max_tokens: None,
+            max_tokens: None,
         }
     }
 }
 ```
 
-**Rationale:** Additive change. Existing `identity.toml` files without the new field deserialize correctly with `silent_mode_max_tokens = None`. No migration needed.
+**Rationale:** Additive change. Existing `identity.toml` files without the new field deserialize correctly with `max_tokens = None`. No migration needed. Field name is mode-agnostic per architect F1; gate condition lives in `load_gated_summary()` (Step 2).
 
-### Step 2: Plumb silent-mode signal into prompt assembly
+### Step 2: Extract `load_gated_summary()` shared helper + plumb into both sites
 
-**File:** `crates/mika-agent/src/agent.rs`
+**Files:** `crates/mika-agent/src/prompt.rs` (helper definition) and `crates/mika-agent/src/agent.rs` (two call-site updates).
 
-Locate the two summary-injection sites (per mika#1009 finding):
+Per architect first-pass F2 (DRY): extract the Axis-4-then-Axis-3 gate sequence into one helper called from both injection sites. Without this, both call sites would duplicate (a) the `inject = false` short-circuit, (b) the `db.load_conversation_summary()` call, (c) the `silent_trigger`-conditional cap application, and (d) the `<context>` tag wrapping. With the helper, both sites call one function and get one consistent semantics.
 
-1. **Conversation mode** at `agent.rs:2018-2024`
-2. **Team/silent mode** at `agent.rs:3044-3049`
-
-For both sites, plumb the in-scope `silent_trigger: Option<&SilentTrigger>` (or equivalent silent-mode signal) into the gating logic. The conversation-mode path is non-silent by definition — `silent_trigger` is `None` and the cap is bypassed. The team/silent path has `Some(SilentTrigger::*)` — apply the cap.
-
-Gating logic (after Axis 4's `inject` check passes):
+Helper signature (lives in `prompt.rs` next to `ContextSummaryConfig`):
 
 ```rust
-// Axis 3 — silent-mode summary budget cap (mika#1021)
-let summary_to_inject = match (silent_trigger, identity.context.summary.silent_mode_max_tokens) {
-    (Some(_), Some(0)) => None,                                   // Silent + budget=0 → omit
-    (Some(_), Some(n)) => Some(truncate_to_token_budget(&summary, n)),  // Silent + cap → truncate
-    _ => Some(summary),                                            // Non-silent or no cap → unchanged
-};
+/// Load the conversational summary for injection into the system prompt,
+/// applying Axis 4 (load-prevention) and Axis 3 (mode-conditional cap)
+/// gates in sequence.
+///
+/// Returns `Ok(None)` when the summary should not be injected. Three reasons:
+///   - `inject = false` (Axis 4 short-circuit; no DB call made)
+///   - no summary stored in the DB
+///   - silent mode + `max_tokens = Some(0)` (Axis 3 load-omit sentinel)
+///
+/// Returns `Ok(Some(content))` with the (possibly truncated) summary content
+/// to inject. Caller is responsible for the surrounding `<context>` tag wrap
+/// + section header.
+///
+/// The "gated" name signals: this is the policy-aware load path. Any direct
+/// `db.load_conversation_summary()` callers (e.g., debugging, migration)
+/// bypass the gates intentionally.
+async fn load_gated_summary(
+    db: &Database,
+    summary_config: &ContextSummaryConfig,
+    silent_trigger: Option<&SilentTrigger>,
+) -> Result<Option<String>> {
+    // Axis 4: hard load-prevention.
+    if !summary_config.inject {
+        return Ok(None);
+    }
 
-if let Some(content) = summary_to_inject {
+    // Load the summary; absence is not an error.
+    let Some(summary) = db.load_conversation_summary().await? else {
+        return Ok(None);
+    };
+
+    // Axis 3: mode-conditional cap. The mode gate is `silent_trigger.is_some()`;
+    // the field name (`max_tokens`) is mode-agnostic.
+    match (silent_trigger, summary_config.max_tokens) {
+        (Some(_), Some(0)) => Ok(None),  // Silent + load-omit sentinel.
+        (Some(_), Some(n)) => Ok(Some(truncate_to_token_budget(&summary.content, n))),
+        _ => Ok(Some(summary.content)),  // Non-silent or no cap → full summary.
+    }
+}
+```
+
+Both summary-injection sites collapse to:
+
+```rust
+if let Some(content) = load_gated_summary(&db, &identity.context.summary, silent_trigger.as_ref()).await? {
     system.push_str("\n## Conversation Summary\n");
     system.push_str("<context type=\"summary\" trust=\"data\">\n");
     system.push_str(&content);
@@ -114,22 +172,29 @@ if let Some(content) = summary_to_inject {
 }
 ```
 
-**Why gate after the `inject` check, not before.** Axis 4's `inject = false` is strictly stronger (load-prevention skips the `db.load_conversation_summary()` call entirely; Axis 3's cap operates on already-loaded content). When `inject = false`, control never reaches Axis 3's gate — Axis 4 wins by short-circuit, satisfying the orthogonality requirement (AC#4).
+The `silent_trigger.as_ref()` argument is `None` at the conversation-mode call site (no in-scope `silent_trigger`), and `Some(_)` at the team/silent-mode call site. The helper handles both uniformly; the call sites stay parallel.
+
+**Why one helper, not two.** A two-helper split (e.g., `load_summary_for_conversation()` + `load_summary_for_silent()`) would still duplicate the Axis 4 short-circuit and the load call. One helper that takes the silent-trigger as an `Option` parameter is the minimal surface that closes both DRY axes (the load call AND the gate sequence). Per architect Q3: this also bounds the `SilentTrigger` plumbing scope to one parameter, no cascade.
+
+**Why the helper returns `Ok(None)` instead of an empty string for the omit case.** `Ok(None)` lets the caller skip the surrounding `<context>` tags and section header entirely — emitting `## Conversation Summary\n<context>...empty...</context>` would inject the framing without the content, which is its own form of leakage signal to the model.
+
+**Orthogonality with Axis 4.** Axis 4's `inject = false` is strictly stronger (returns `Ok(None)` before any DB call). Axis 3's cap fires only when `inject = true` AND `max_tokens` is set AND silent mode is detected. The two gates are orthogonal: `inject` controls "load at all"; `max_tokens` controls "how much, when in mode." Satisfies AC#4 and `feedback_orthogonality_flag_semantics`.
 
 ### Step 3: Token-budget truncation helper
 
-**File:** `crates/mika-agent/src/prompt.rs` (or a new `crates/mika-agent/src/prompt/budget.rs` if `prompt.rs` is already large)
+**File:** `crates/mika-agent/src/prompt.rs` (alongside `CHARS_PER_TOKEN_ESTIMATE` constant from Step 1).
 
 ```rust
-/// Truncate a summary string to approximately `max_tokens`, using the
-/// 4-chars-per-token heuristic. Cuts at a word boundary near the budget
-/// to avoid mid-word truncation in the LLM's view. Appends a truncation
-/// marker so the model knows content was elided.
+/// Truncate a summary string to approximately `max_tokens`, using
+/// `CHARS_PER_TOKEN_ESTIMATE` for the conversion. Cuts at a word boundary
+/// near the budget to avoid mid-word truncation in the LLM's view. Appends
+/// a truncation marker so the model knows content was elided.
 ///
-/// Heuristic: not exact tokenization. Acceptable because the cap is a
-/// soft policy, not a hard limit, and tokenizers vary by provider.
+/// Heuristic: not exact tokenization. Acceptable because the cap is a soft
+/// policy, not a hard limit, and tokenizers vary by provider. The constant
+/// `CHARS_PER_TOKEN_ESTIMATE` documents the conversion ratio in one place.
 pub fn truncate_to_token_budget(summary: &str, max_tokens: usize) -> String {
-    let max_chars = max_tokens.saturating_mul(4);
+    let max_chars = max_tokens.saturating_mul(CHARS_PER_TOKEN_ESTIMATE);
     if summary.len() <= max_chars {
         return summary.to_string();
     }
@@ -143,7 +208,9 @@ pub fn truncate_to_token_budget(summary: &str, max_tokens: usize) -> String {
 }
 ```
 
-**Rationale:** Heuristic truncation at word boundary. Truncation marker is honest signal to the model and to a debugging operator reading the prompt log.
+**Rationale (per architect NF2):** the `CHARS_PER_TOKEN_ESTIMATE` constant defined in Step 1 replaces the magic `4` literal here. Future maintainers see the named constant and find its definition + rationale at the module top, not buried inside this helper.
+
+Heuristic truncation at word boundary. Truncation marker is honest signal to the model and to a debugging operator reading the prompt log. Marker text is fixed (architect Q2: YAGNI — no observed need for variation).
 
 ### Step 4: Identity TOML update for at-risk agents (operator-deferred)
 
@@ -152,8 +219,8 @@ This step files no code change. After this PR ships, the operator can opt-in per
 ```toml
 # ~/.mika/agents/<agent>/identity.toml
 [context.summary]
-inject = true                       # Axis 4 — keep summary on interactive turns
-silent_mode_max_tokens = 1000       # Axis 3 — cap to ~1000 tokens on silent turns
+inject = true            # Axis 4 — keep summary on interactive turns
+max_tokens = 1000        # Axis 3 — cap to ~1000 tokens when the silent-mode gate fires
 ```
 
 Or a stricter policy:
@@ -161,29 +228,34 @@ Or a stricter policy:
 ```toml
 [context.summary]
 inject = true
-silent_mode_max_tokens = 0          # Axis 3 — omit summary entirely on silent turns
+max_tokens = 0           # Axis 3 — omit summary entirely when the silent-mode gate fires
 ```
 
 The plan does NOT seed `well_known_agents.rs` with new defaults for any agent. Operator decides per-agent based on observed behavior. Document the field in `crates/mika-agent/CLAUDE.md` per AC#5; that's the only documentation touchpoint this PR makes.
 
 ## Test Strategy
 
-### Unit tests
+### Unit tests for `load_gated_summary()`
 
-1. **`silent_mode_max_tokens = None`, silent turn** → summary unchanged (regression).
-2. **`silent_mode_max_tokens = Some(0)`, silent turn** → summary absent in prompt.
-3. **`silent_mode_max_tokens = Some(0)`, non-silent turn** → summary present (cap is silent-only).
-4. **`silent_mode_max_tokens = Some(n)`, silent turn, summary > n tokens** → truncation marker present in prompt.
-5. **`silent_mode_max_tokens = Some(n)`, silent turn, summary < n tokens** → summary unchanged.
-6. **Axis 4 wins:** `inject = false` + `silent_mode_max_tokens = Some(100)` → summary entirely absent (load-prevention shortcut).
-7. **`truncate_to_token_budget` boundary tests:** empty string, exactly max_chars, max_chars + 1, very long with whitespace, very long without whitespace.
+1. **`max_tokens = None`, silent turn, summary present** → returns `Ok(Some(full))` (regression).
+2. **`max_tokens = Some(0)`, silent turn** → returns `Ok(None)` (load-omit sentinel; Axis 3 fires).
+3. **`max_tokens = Some(0)`, non-silent turn** → returns `Ok(Some(full))` (cap is gated by mode).
+4. **`max_tokens = Some(n)`, silent turn, summary > n tokens** → returns `Ok(Some(truncated))` with truncation marker.
+5. **`max_tokens = Some(n)`, silent turn, summary < n tokens** → returns `Ok(Some(full))`.
+6. **Axis 4 wins (`inject = false` + any `max_tokens`)** → returns `Ok(None)` without DB call (verify via mock DB asserting `load_conversation_summary` was NOT called).
+7. **No summary stored** (`inject = true`, `max_tokens = None`) → returns `Ok(None)`.
+
+### Unit tests for `truncate_to_token_budget()` helper
+
+8. **Boundary tests:** empty string, exactly `max_tokens * CHARS_PER_TOKEN_ESTIMATE` chars, `+1` over, very long with whitespace, very long without whitespace (no boundary → cuts at `max_chars`).
 
 ### Integration / eval tests
 
 `crates/mika-agent/tests/eval/` already exercises the prompt-assembly seam. Add a scenario:
-- Agent with `silent_mode_max_tokens = Some(500)` + a 5000-char summary fixture
+- Agent with `max_tokens = Some(500)` + a 5000-char summary fixture
 - Trigger via `EvalHarness` callback path (silent)
-- Assert `LlmRequest.system` contains truncation marker + `system.len()` is bounded
+- Assert `LlmRequest.system` contains the truncation marker + `system.len()` is bounded
+- Negative-control variant: same agent, `max_tokens = None`, callback path → assert summary present in full
 
 No real-LLM eval needed — the assertion is on prompt content, not LLM behavior.
 
@@ -191,19 +263,22 @@ No real-LLM eval needed — the assertion is on prompt content, not LLM behavior
 
 Mirroring the ticket body for traceability:
 
-- **AC#1**: Silent-mode is structurally detected via the existing `SilentTrigger` signal in `build_system_prompt()`. The predicate flows through to the gating logic in both conversation-mode (`agent.rs:2018-2024`) and team-mode (`agent.rs:3044-3049`) paths.
-- **AC#2**: Silent-mode + summary tokens > budget → summary is omitted (when `Some(0)`) or truncated to budget (when `Some(n)`). Verifiable via unit tests #2 and #4 above.
-- **AC#3**: Non-silent mode → behavior unchanged from current. Regression tests #1 and #3 above + existing eval scenarios pass.
-- **AC#4**: When Axis 4's `inject = false`, Axis 3's budget logic is short-circuited. Verifiable via test #6. Orthogonality flag per `feedback_orthogonality_flag_semantics`.
-- **AC#5**: `crates/mika-agent/CLAUDE.md` documents the new field + the heuristic truncation contract under § Conventions or § Three-Layer Memory Model.
+- **AC#1**: Silent-mode detection lives in `load_gated_summary()` via `Option<&SilentTrigger>` parameter. Both call sites (`agent.rs:2018-2024` conversation-mode and `agent.rs:3044-3049` team-mode) pass the in-scope `silent_trigger.as_ref()`. The mode-gating predicate is `silent_trigger.is_some()`, structurally tied to the canonical `SilentTrigger` enum.
+- **AC#2**: Silent-mode + `max_tokens = Some(0)` → summary omitted (load-omit sentinel). Silent-mode + `max_tokens = Some(n)` for n > 0 → summary truncated to ~n tokens with marker. Verifiable via unit tests #2 and #4.
+- **AC#3**: Non-silent mode + any `max_tokens` value → summary unchanged. Verifiable via unit tests #3 and #5 + existing eval scenarios pass.
+- **AC#4**: Axis 4's `inject = false` short-circuits before any DB call OR cap evaluation. Verifiable via unit test #6 (mock DB asserting `load_conversation_summary` not called when `inject = false`). Orthogonality flag per `feedback_orthogonality_flag_semantics`.
+- **AC#5**: `crates/mika-agent/CLAUDE.md` documents the `[context.summary].max_tokens` field, the load-omit sentinel semantics for `Some(0)`, the `CHARS_PER_TOKEN_ESTIMATE` heuristic, and the orthogonality with `[context.summary].inject`. Update lives under § Conventions or § Three-Layer Memory Model.
 
 ## Risks & Open Questions
 
-- **R1 (low):** The `SilentTrigger` enum may not be in scope at exactly the line of the summary-injection sites. If plumbing requires a function-signature change, additional callers may need updating. Mitigation: scoped grep for callers during Step 2; widen the change if needed.
-- **R2 (low):** Heuristic 4-char-per-token approximation is conservative for English (English tends toward ~4 chars/token in practice). For other languages the approximation skews. Acceptable because (a) the budget is a soft policy and (b) the only callers writing summaries today are the existing summarizer which produces English. If multi-language summaries become common, revisit with a tokenizer-based cap (separate ticket).
+- **R1 (low):** `SilentTrigger` plumbing into `load_gated_summary()` is bounded to one parameter (per architect Q3 answered). The two call sites in `agent.rs` already have `silent_trigger` in scope (the conversation-mode path has `None`; the team-mode path has `Some(_)`); no signature cascade beyond those two sites. Mitigation: scoped grep during implementation; if a third call site is found, decide between (a) routing it through the helper or (b) leaving it ungated with a comment.
+- **R2 (low):** Heuristic 4-char-per-token approximation is conservative for English. For non-English languages the approximation skews. Acceptable because (a) the budget is a soft policy, (b) the only callers writing summaries today are the existing summarizer which produces English, and (c) the conversion ratio is captured as the named `CHARS_PER_TOKEN_ESTIMATE` constant so a future maintainer can swap the implementation in one place. If multi-language summaries become common, revisit with a tokenizer-based cap (separate ticket).
 - **R3 (low):** A future Axis 2 (summarizer content reform) may make summary content less leak-prone, reducing the need for Axis 3. Axis 3 still has independent value (defense-in-depth + per-agent policy control). No architectural conflict.
-- **OQ1 (groom):** Is the right default `silent_mode_max_tokens = None` (no cap unless opted-in, current shape) or a small built-in cap (e.g., `Some(2000)`) shipping as-default for all agents? The plan assumes `None` (additive, opt-in). Architect: confirm or override.
-- **OQ2 (groom):** Should the truncation marker text be configurable, or is a fixed `[… summary truncated to fit silent-mode budget …]` good enough? Plan assumes fixed.
+
+**Resolved by architect first-pass:**
+- Q1 (default policy): `None` is correct — additive, opt-in, no built-in default cap.
+- Q2 (truncation marker text): fixed text is correct — YAGNI; no observed need for variation.
+- Q3 (`SilentTrigger` plumbing scope): bounded to one parameter via `load_gated_summary()` — see R1.
 
 ## Sources
 

--- a/docs/solutions/best-practices/silent-mode-summary-budget-cap-2026-05-08.md
+++ b/docs/solutions/best-practices/silent-mode-summary-budget-cap-2026-05-08.md
@@ -1,0 +1,111 @@
+---
+title: "Silent-mode summary budget cap prevents context-channel leakage"
+date: 2026-05-08
+category: best-practices
+module: mika-agent
+problem_type: best_practice
+component: assistant
+severity: medium
+applies_when:
+  - "Agent receives callback/webhook/heartbeat triggers with a short messages array"
+  - "Conversational summary dominates the system prompt relative to the actual trigger message"
+  - "Agent references 'prior turns' that don't exist in the current silent-mode session"
+tags:
+  - prompt-assembly
+  - silent-mode
+  - context-channel-leakage
+  - identity-toml
+  - summary-injection
+  - mika-1009
+  - axis-3
+---
+
+# Silent-mode summary budget cap prevents context-channel leakage
+
+## Context
+
+mika#1009 identified a 300:1 system-prompt-to-messages token ratio in silent-mode turns: the messages array contains a single trigger event (a few hundred tokens) while the system prompt — including the conversational summary from compaction — runs thousands of tokens. At this ratio the LLM misinterprets summary content as prior conversation turns and produces degenerate responses referencing "prior turns" the model never participated in.
+
+Axis 4 (mika#1019) addressed this for summary-dominant agents (mika-arch) with `[context.summary].inject = false` — a global load-prevention gate. But agents that benefit from summary continuity on interactive turns but get burned by it on silent turns need a **mode-conditional** gate, not a global opt-out. Axis 3 fills this gap.
+
+## Guidance
+
+Add `max_tokens` to the `[context.summary]` section in `identity.toml`. The field is mode-agnostic at the schema level — the silent-mode gating lives in code (`load_gated_summary()` in `agent.rs`), not in the field name.
+
+```toml
+# Cap summary to ~1000 tokens on silent-mode turns, keep full on interactive turns
+[context.summary]
+inject = true
+max_tokens = 1000
+```
+
+Or for stricter control — omit summary entirely on silent turns:
+
+```toml
+[context.summary]
+inject = true
+max_tokens = 0    # load-omit sentinel: summary skipped on silent-mode turns
+```
+
+### Implementation details
+
+- **`load_gated_summary()`** (`agent.rs`) consolidates the Axis 4 + Axis 3 gate sequence. Both summary injection sites (conversation-mode and silent-mode) call this single helper.
+- **Invariant:** Axis 4 (`inject = false`) MUST short-circuit before Axis 3 evaluation — the `inject` check is the first operation, preventing any DB call when load-prevention is active.
+- **`truncate_to_token_budget()`** (`prompt.rs`) performs the actual truncation at a word boundary using `str::floor_char_boundary()` for UTF-8 safety. Uses `CHARS_PER_TOKEN_ESTIMATE = 4` (heuristic, conservative for English).
+- **`Some(0)` sentinel:** Treated as a structural omit signal (summary not injected), NOT as a "zero-token cap." Same code path as Axis 4's `inject = false` short-circuit but conditional on silent mode.
+- **Non-silent turns are never affected** regardless of `max_tokens` value.
+
+### Gate sequence
+
+```
+Axis 4: inject = false?  →  Yes: skip (no DB call)  →  Ok(None)
+                          →  No: load summary from DB
+Axis 3: silent mode + max_tokens set?
+  →  Some(0): skip (load-omit sentinel)  →  Ok(None)
+  →  Some(n): truncate to ~n tokens       →  Ok(Some(truncated))
+  →  None or non-silent: full summary     →  Ok(Some(full))
+```
+
+## Why This Matters
+
+Silent-mode turns (callback, webhook, heartbeat, reminder, deferred dispatch) have no human in the loop and no streaming UI. The short messages array creates a token ratio that causes the LLM to hallucinate conversation context from the summary. Axis 3 provides per-agent, mode-conditional control so operators can balance summary continuity on interactive turns against leakage risk on silent turns.
+
+This is defense-in-depth alongside Axis 4 (global opt-out) and the eventual Axis 2 (summarizer content reform). Each axis operates at a different layer: Axis 4 controls *whether* to load; Axis 3 controls *how much* to inject when loaded; Axis 2 will control *what* goes into the summary in the first place.
+
+## When to Apply
+
+- When an agent exhibits "prior turns" hallucination on callback or webhook turns but needs full summary on interactive turns
+- When provisioning a new agent that handles both interactive and silent triggers
+- When debugging context-channel leakage symptoms (degenerate responses, false completion claims on silent turns)
+
+## Examples
+
+**Before (Axis 4 only — binary choice):**
+
+```toml
+# Option A: Keep summary everywhere (leaks on silent turns)
+[context.summary]
+inject = true
+
+# Option B: Remove summary everywhere (loses continuity on interactive turns)
+[context.summary]
+inject = false
+```
+
+**After (Axis 3 — mode-conditional):**
+
+```toml
+# Summary on interactive turns, capped on silent turns
+[context.summary]
+inject = true
+max_tokens = 500
+```
+
+## Related
+
+- mika#1009 — Parent finding doc identifying 4-axis fix plan
+- mika#1019 — Axis 4 sibling (`[context.summary].inject` opt-out)
+- `docs/solutions/best-practices/mika-arch-init-context-leakage-2026-05-06.md` — Parent finding
+- `docs/solutions/best-practices/per-agent-context-injection-opt-out-2026-05-07.md` — Axis 4 compound doc
+- `crates/mika-agent/CLAUDE.md` § Context Injection Configuration — field documentation
+- `docs/configuration.md` § identity.toml — operator-facing documentation


### PR DESCRIPTION
## Summary

- Add `[context.summary].max_tokens` field to `identity.toml` for mode-conditional summary truncation on silent-mode turns (callback/webhook/heartbeat)
- Extract `load_gated_summary()` helper consolidating Axis 4 (load-prevention) + Axis 3 (mode-conditional cap) gates with documented ordering invariant
- Add `truncate_to_token_budget()` with UTF-8-safe word boundary truncation via `str::floor_char_boundary()`

Prevents the 300:1 system-prompt-to-messages ratio that causes degenerate LLM behavior on silent-mode turns. Non-silent turns (conversation mode, CLI) are never affected.

Plan: docs/plans/2026-05-07-006-feat-prompt-silent-mode-summary-budget-cap-plan.md

Closes #1021

## Test plan

- [x] 7 unit tests for `load_gated_summary()` covering all gate combinations (silent/non-silent × None/Some(0)/Some(n))
- [x] 7 unit tests for `truncate_to_token_budget()` covering empty, under-budget, exact, over-budget, no-whitespace, long summary, multi-byte UTF-8
- [x] 4 deserialization tests for `ContextSummaryConfig` with/without `max_tokens`
- [x] Full test suite passes (2551 tests, 0 failures)
- [x] Clippy clean, fmt clean, pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)