### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v0.10.0](https://github.com/senara-solutions/mika/releases/tag/v0.10.0) — 2026-05-08
+
+### Added
+
+- *(self-dev)* auto-groom ungroomed tickets before dispatch (#996) (#1004)
 ## [v0.9.1](https://github.com/senara-solutions/mika/releases/tag/v0.9.1) — 2026-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mika-a2a"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "mika-agent"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "mika-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "mika-common"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "mika-gateway"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 license = "MIT"
 description = "AI executive assistant with persistent memory"


### PR DESCRIPTION
## Release v0.10.0
## [v0.10.0](https://github.com/senara-solutions/mika/releases/tag/v0.10.0) — 2026-05-08

### Added

- *(self-dev)* auto-groom ungroomed tickets before dispatch (#996) (#1004)

---
Merging this PR will trigger tag creation and GitHub release.