### PR TITLE
docs(solutions): enrich mika#1058 compound doc with operator-perspective + bug family + cross-references

### DIFF
--- a/docs/solutions/logic-errors/callback-deferred-dispatch-gate-rejection-2026-05-10.md
+++ b/docs/solutions/logic-errors/callback-deferred-dispatch-gate-rejection-2026-05-10.md
@@ -1,6 +1,7 @@
 ---
 module: skills-executor
 date: 2026-05-10
+last_updated: 2026-05-10
 problem_type: logic_error
 component: tooling
 severity: high
@@ -9,6 +10,7 @@ symptoms:
   - "executor.rs gate rejects run_claude_pilot from callback turns with 'long-running tool invoked without long_running_ctx'"
   - "DeferredDispatch silent turns fail at INTENT_GUARD because run_claude_pilot is blocked by the same gate"
   - "Pipeline retry path on PIPELINE FAILURE callbacks cannot invoke run_claude_pilot"
+  - "PIPELINE FAILURE marker fires in 3 of 4 dispatch-lib invocations (zero-commit class); 1 silent slip when staged plan was committed before exit"
 root_cause: logic_error
 resolution_type: code_fix
 tags:
@@ -18,9 +20,26 @@ tags:
   - executor-gate
   - cycle-detection
   - pipeline-retry
+  - bug-family-claude-pilot-exits-success
+  - lineage-walk
+  - callback-task-id-bridge
 ---
 
 # Callback and DeferredDispatch Turns Cannot Call Long-Running Tools
+
+## How this surfaced to the operator
+
+Empirically observed across 5 dev-groom sessions over 24 hours (2026-05-09 → 2026-05-10), ~$4.61 of architect work discarded:
+
+| Session | claude-pilot ID | Marker fired? | Cost / turns |
+|---|---|---|---|
+| mika#1051 pass-2 | n/a (manual orchestrator spawn — outside dispatch-lib) | n/a | $1.56 / 32t |
+| mika-platform#96 groom | `582cc389` | **NO** (silent-slip class — HEAD changed because staged plan was committed before exit) | $0.89 / 21t |
+| mika#1052 groom | `a9435e3d` | YES (zero commits) | $1.01 / 15t |
+| mika-skills#159 groom | `239b6320` | YES (zero commits) | $1.15 / 29t |
+| mika-skills#163 groom | `00e01562` | YES (zero commits) | $1.69 / 24t |
+
+**Key empirical insight (drove the fix shape):** 3 of 4 dispatch-lib invocations hit the existing post-flight HEAD-diff PIPELINE FAILURE marker; **1 silently passed** because claude-pilot's first pass had committed the staged plan before the verdict-discard exit, leaving HEAD changed. Recovery first (this fix), detection-extension second (filed as follow-up after #1058 — value goes UP because the silent-slip class becomes a marker-fired class once recovery works).
 
 ## Problem
 
@@ -32,8 +51,10 @@ Two failure modes prevented pipeline retry and deferred dispatch from working:
 
 ## What Didn't Work
 
-- **Prompt-only enforcement:** LLMs rationalize crossing prompt budgets; the gate is a structural `Option` check, not behavioral.
-- **Watchdog re-spawn from dispatch-lib:** Parallel retry mechanism in bash, requires verdict-extraction-from-DB coupling, becomes tech debt the moment the engine fix lands.
+- **Prompt-only enforcement on dev-groom** ("STOP — DO NOT EXIT" directive + Phase 5 verification gate of git/gh checks before emitting Verdict line): LLMs rationalize crossing prompt budgets; the gate is a structural `Option` check, not behavioral. Architect pass-1 review (session `d268e776`) returned ITERATE — load-bearing finding: claimed engine guard (mika#864 required-suffix-line) prevents claude-pilot exit, but actually the guard fires on mika-dev's host turn, NOT on claude-pilot's subprocess session. Per `feedback_prompt_enforcement_fragile` (auto memory [claude]): only structural constraints hold.
+- **Watchdog re-spawn from dispatch-lib:** Parallel retry mechanism in bash, requires verdict-extraction-from-DB coupling, becomes tech debt the moment the engine fix lands. Per `feedback_loop_stability_beats_loop_speed` (auto memory [claude]): velocity is not a design driver; engine-level fix beats faster-to-ship bash bridge.
+- **Existing recovery primitives don't apply** (session history): mika#959's process-liveness watchdog (`check_callback_process_liveness()`) detects dead subprocesses via `/proc/<pid>/stat` and respawns — but here the process IS gone cleanly (exit 0), just at the wrong workflow point. mika#991's `SilentTrigger::PostCallbackAdvance` fires after a callback turn completes to check queue advancement — but mika#1058's failure is that the callback child task is never *created* (the outer groom subprocess exits before reaching the dispatch). PostCallbackAdvance has no hook for a groom that self-terminates. Both adjacent fixes target different layers.
+- **Detection-extension first** (extend dispatch-lib post-flight check beyond HEAD-SHA): wrong sequencing. Existing HEAD-marker already covers 75% of cases (3 of 4 above); pairing better detection with broken recovery wastes the leverage. Filed as follow-up — value rises *after* this fix lands. Per `feedback_evidence_before_diagnosis` (auto memory [claude]): the empirical 3-of-4-vs-1-of-4 split changed the fix shape.
 
 ## Solution
 
@@ -91,14 +112,48 @@ Lineage walk on `(repo, issue_number, skill)` tuple using existing `parent_task_
 - ✅ Catches A→B→A class via lineage walk
 - Fail-open on extraction failure; `depth ≤ 3` schema CHECK is structural backstop
 
+**Why lineage walk and not retry-budget-on-the-task** (session history): mika#1011's DeferredDispatch implementation accepted the infinite-chain risk as low-probability without bookkeeping. A retry counter on the dispatched task (alternative considered) doesn't catch A→B→A — neither task's counter increments past 1. Lineage walk catches A→B→A by design **and** is durable across service restarts because `parent_task_id` is in the DB (a budget counter would reset on restart, losing cycle context). Combined with the existing `tasks.depth ≤ 3` CHECK constraint as the structural ceiling, runaway recursion can't exceed 4 levels even if the lineage walk has bugs.
+
 ## Why This Works
 
-The gate at `executor.rs` was intentional defensive code (commit `04ae084c`) to prevent loop-like behavior in callback turns. The fix preserves the gate for non-deferred contexts (heartbeat, reflection, CLI test) while enabling the specific pattern the engine already supports: deferred dispatch through `register_deferred_callback()`.
+The gate at `executor.rs` was intentional defensive code (commit `04ae084c`, "feat(tui): callback delivery polling and loop prevention") to prevent loop-like behavior in callback turns. The fix preserves the gate for non-deferred contexts (heartbeat, reflection, CLI test) while enabling the specific pattern the engine already supports: deferred dispatch through `register_deferred_callback()`.
 
 DeferredDispatch turns are the engine's auto-recovery path for `global_dispatch_active` rejections — their sole purpose is to call `run_claude_pilot`. Blocking them from doing so via the gate was a latent bug from the original silent-mode `None` assignment.
+
+**mika#1011 architectural parent** (session history): the gate at `executor.rs:284` was introduced as a deliberate feature *for* DeferredDispatch — when `global_dispatch_active` is true, reject and register a `SilentTrigger::DeferredDispatch` task that fires when the slot frees. Tested and working for the standard "queue advancement" case. The flaw mika#1058 surfaces is that `run_silent_inner` passed `None` for `long_running_ctx` to **all** silent triggers (including DeferredDispatch), so the very mechanism designed to recover from gate rejection ended up rejected by the same gate. The fix is conceptually small — construct `LongRunningContext` for DeferredDispatch — but only visible once a real consumer (mika-dev's pipeline-retry) exercised the path. The 24-hour bleed is the empirical cost of having a recovery primitive ship without an exercising consumer.
+
+**Engine-level over watchdog (`feedback_loop_stability_beats_loop_speed`, auto memory [claude]):** the bash watchdog would have shipped faster but become tech debt the moment the engine fix landed; engine-level fix is the durable layer.
 
 ## Prevention
 
 - When adding new `SilentTrigger` variants that need to execute long-running tools, construct `LongRunningContext` explicitly rather than inheriting the blanket `None` for silent mode
 - The `callback_task_id` field on `ToolContext` is the signal — if a turn can legitimately defer a long-running dispatch, it must carry the task ID for cycle detection
 - Test new dispatch paths with the executor gate: verify both the `long_running_ctx = Some` path (gate passes) and the `callback_task_id` intercept path (gate catches and defers)
+- **Couple engine capabilities to their first consumer in the same PR.** PR #1061 ships both the executor change and the `self-dev/system_prompt.md` update teaching the LLM to recognize `{"status": "deferred"}`. Engine capabilities that ship without an exercising consumer become latent surface area no one tests — the `DeferredDispatch.long_running_ctx = None` latent bug existed precisely because the silent-trigger path had no consumer until pipeline-retry surfaced it.
+- **When introducing engine guards, frame them as denylist not blanket-refusal.** Commit `04ae084c` refused all `long_running_ctx.is_none()` calls; the surgical version refuses only direct calls and cycle-creating callback calls. If the original commit had asked "what legitimate path needs `None` here?" the DeferredDispatch consumer would have surfaced earlier.
+- **Look for existing-but-unexposed safe paths before inventing new primitives** — `DeferredDispatch` was already in production via queue advancement; it just wasn't exposed to the LLM as a callback-turn retry primitive. The "designed-but-unshipped protocol" pattern recurs in this codebase; before designing a new dispatch surface, grep `silent_trigger`, `callback_task_id`, `action_type` for existing safe paths.
+- **When a defensive guard is hardened (mika#537 made silent fall-through an explicit error), use that moment to re-evaluate whether the underlying refusal is too broad** — hardening surfaces bad UX (cryptic → loud error) without questioning whether the rejection itself is correct. Treat hardening as a forcing function for policy review.
+
+## Bug family — "claude-pilot exits Success without producing work"
+
+mika#1058 is the third documented member of a recurring failure family. The shared symptom: claude-pilot subprocess returns exit code 0 with `[done] Success` log line, but the workflow's expected artifact (commit / PR / Plan callout / writeback) is missing.
+
+| Member | Mechanism | Layer | Status |
+|---|---|---|---|
+| mika#537 | `execute_skill_tool` silently fell through long-running handler to sync exec on callback turns; sync path didn't inject `__mika_task_id`, handler exited 1 with cryptic message | Executor | CLOSED — gate hardened from silent fall-through to explicit error |
+| mika#940 family (mika#1032 / mika#1033) | claude-pilot `/mika` pipeline exits before reaching `git push` + `gh pr create`; work stranded in worktree | claude-pilot session prompt + handler | OPEN — no structural fix yet; orchestrator-recovery recipe exists |
+| **mika#1058 (this doc)** | Subprocess exits Success after `mika ask --agent mika-arch` returns; mika-dev's pipeline-retry from callback context blocked by `executor.rs:284` gate | Executor + dev-groom flow | **CLOSED 2026-05-10 — engine-level fix shipped** |
+
+Pattern: each member is a different exit point in claude-pilot's session lifecycle that produces "Success" without the workflow's contractual artifact. Recovery layer differs per member (orchestrator-direct for #940, engine-level for #1058), but the *detection* layer (post-flight HEAD-diff PIPELINE FAILURE marker in `_shared/dispatch-lib.sh`) is shared and partial — it catches HEAD-unchanged cases but misses HEAD-changed-but-incomplete cases (the silent-slip class). Detection-extension is filed as a follow-up to mika#1058.
+
+## Related
+
+- `architecture-patterns/callback-task-loop-prevention.md` — the original "loop prevention" intent this fix narrows without unwinding. This fix preserves the defensive principle but makes it surgical.
+- `architecture-patterns/webhook-deferral-queue-callback-sequencing.md` — the `DeferredDispatch` primitive being wrapped. Read for context on why DeferredDispatch is the right primitive to lean on (vs inventing new dispatch infrastructure).
+- `logic-errors/long-running-handler-silent-fallthrough.md` — mika#537 (CLOSED). Same gate, different fall-through mode. **Stale-flag candidate** — the gate it celebrates is now structurally limited; reading without context risks reintroducing the same Mode B regression mika#1058 fixed.
+- `logic-errors/dispatch-retry-parent-status-promotion-2026-05-07.md` — mika#958. Adjacent retry-semantics fix; same module.
+- `dev-loop/dev-pilot-handler-silent-exit-0-pattern-2026-04-29.md` — mika#940 sibling family. Different exit point in the same family. No engine-level fix yet.
+- `runtime-errors/silent-callback-max-steps-exhaustion.md` — directly referenced as the DeferredDispatch latent-bug failure mode (Mode A). The exhaustion would happen because the LLM hit the gate, gate fired correction, hit the gate again, until max steps.
+- `best-practices/auto-groom-on-dispatch-2026-05-06.md` — mika#996, the dispatch path that triggers dev-groom for ungroomed `ready` tickets and exposed this bug at scale.
+- `best-practices/required-suffix-line-guard-verdict-ghosting-structural-fix-2026-04-29.md` — mika#864 referent. Important to read alongside this doc: that guard fires on **mika-dev's host turn** (when mika-dev processes the claude-pilot callback), NOT on **claude-pilot's subprocess session**. This layering distinction is what made the prompt-only fix attempt fail (the verification gate would have been on the wrong layer).
+- mika-platform#75 — dispatcher-bootstrapping has no designed escape hatch. Meta-pattern under which the bug-fix ticket itself was groomed via orchestrator-direct recovery.


### PR DESCRIPTION
## Why

`/ce:compound` pass on the just-landed mika#1058 fix (PR #1061). Related Docs Finder identified HIGH 5/5 overlap with the impl-side doc that PR #1061 wrote (`docs/solutions/logic-errors/callback-deferred-dispatch-gate-rejection-2026-05-10.md`), recommended **UPDATE rather than create new**. Session historian (Claude Code session search across last 7 days) surfaced two facts the impl-side doc misses: mika#1011 introduced the `executor.rs:284` gate AS A FEATURE for DeferredDispatch (not inherited from the older `04ae084c` commit), and mika#959/#991's adjacent recovery primitives are inapplicable for distinct layering reasons.

## What

Strictly additive enrichment to the existing compound doc. **No content removed or rewritten.** New sections + targeted expansions:

**Frontmatter:** added `last_updated: 2026-05-10` + 3 tags (`bug-family-claude-pilot-exits-success`, `lineage-walk`, `callback-task-id-bridge`) + 1 symptom (the 3-of-4-marker-fired vs 1-of-4-silent-slip empirical split).

**New section: "How this surfaced to the operator"** — 5-session table with per-session claude-pilot ID, marker-fired-or-not, cost/turns. Total ~$4.61 of architect work discarded over 24h. The empirical 3-of-4-vs-1-of-4 split is the load-bearing observation that drove fix sequencing (recovery first, detection-extension second).

**Expanded "What Didn't Work":**
- Prompt-only enforcement: added the architect pass-1 ITERATE F2 finding (the supposed engine guard mika#864 fires on mika-dev's host turn, NOT on claude-pilot's subprocess session — so the prompt verification gate would have been on the wrong layer).
- mika#959 watchdog (process-liveness via `/proc/<pid>/stat`): inapplicable because the process IS gone cleanly (exit 0), just at the wrong workflow point.
- mika#991 `SilentTrigger::PostCallbackAdvance`: inapplicable because the failure is upstream — the callback child task is never created (outer groom subprocess exits before reaching dispatch).
- Detection-extension first: wrong sequencing — pairing better detection with broken recovery wastes the leverage.

**Expanded cycle-detection design:** added the lineage-walk-vs-retry-budget durability rationale — `parent_task_id` is in the DB so lineage walk is durable across service restarts; a budget counter would reset on restart, losing cycle context.

**Expanded "Why This Works":** added mika#1011 architectural parent context. The gate at `executor.rs:284` was introduced as a deliberate feature *for* DeferredDispatch — when `global_dispatch_active` is true, reject and register a deferred task. The flaw mika#1058 surfaces is that `run_silent_inner` passed `None` for `long_running_ctx` to all silent triggers (including DeferredDispatch), so the very mechanism designed to recover from gate rejection ended up rejected by the same gate. The 24-hour bleed is the empirical cost of having a recovery primitive ship without an exercising consumer.

**Added 4 prevention rules:**
- Couple engine capabilities to their first consumer in the same PR (the `DeferredDispatch.long_running_ctx = None` latent bug existed precisely because the silent-trigger path had no consumer until pipeline-retry surfaced it).
- Frame engine guards as denylist not blanket-refusal.
- Look for existing-but-unexposed safe paths before inventing new primitives ("designed-but-unshipped protocol" pattern).
- Treat guard hardening (mika#537 silent → explicit) as a forcing function for policy review, not just UX cleanup.

**New section: "Bug family — claude-pilot exits Success without producing work"** — frames this as third documented member with mika#537 (CLOSED, executor layer, gate-hardened) and mika#940/family (mika#1032/mika#1033, OPEN, claude-pilot session prompt + handler layer). Pattern: each member is a different exit point in claude-pilot's lifecycle that produces "Success" without the workflow's contractual artifact.

**New section: "Related"** — 9 cross-references the impl doc didn't cite, including:
- `architecture-patterns/callback-task-loop-prevention.md` (the original loop-prevention intent narrowed by this fix)
- `architecture-patterns/webhook-deferral-queue-callback-sequencing.md` (the wrapped primitive)
- `logic-errors/long-running-handler-silent-fallthrough.md` — **flagged as stale candidate** (the gate it celebrates is now structurally limited; reading without context risks reintroducing the same Mode B regression)
- `dev-loop/dev-pilot-handler-silent-exit-0-pattern-2026-04-29.md` (mika#940 sibling — different exit point, no engine-level fix yet)
- `runtime-errors/silent-callback-max-steps-exhaustion.md` (the failure mode for Mode A before the fix)
- `best-practices/required-suffix-line-guard-verdict-ghosting-structural-fix-2026-04-29.md` — important to read alongside; the host-turn vs subprocess-session layering distinction is what made the prompt-only attempt fail
- mika-platform#75 — meta-pattern under which mika#1058 was groomed via orchestrator-direct recovery

## Files

- `docs/solutions/logic-errors/callback-deferred-dispatch-gate-rejection-2026-05-10.md` — additive update only

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] All cross-referenced doc paths resolve (manual verification)
- [ ] No regressions in the original technical content (read original PR #1061 doc + diff to confirm additive)

## Companion to

- mika#1058 (the bug ticket — CLOSED via PR #1061)
- PR #1061 (the engine fix — MERGED 2026-05-10 12:27Z)

This PR enriches the compound doc PR #1061 wrote during impl with the operator-perspective context, cross-references, and bug-family framing that surfaced from a /ce:compound pass after the engine fix shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)