### PR TITLE
fix(qa-review): add docs/brainstorms/ to source-changes exclude list

### DIFF
--- a/docs/plans/2026-05-11-002-fix-qa-pipeline-brainstorms-exclude-plan.md
+++ b/docs/plans/2026-05-11-002-fix-qa-pipeline-brainstorms-exclude-plan.md
@@ -1,0 +1,86 @@
+---
+type: fix
+ticket: mika issue#975
+branch: fix/975/qa-pipeline-add-docs-brainstorms-to
+date: 2026-05-11
+---
+
+# Fix QA Pipeline: Add docs/brainstorms/ to Source-Changes Exclude List
+
+## Problem
+
+The QA review skill's "Source changes exist" check (Step 2, line 102 of `skills/bundled/qa-review/system_prompt.md`) has an incomplete exclude list. It only filters out `docs/plans/`, `docs/solutions/`, and `.claude/` — but misses `docs/brainstorms/`, `docs/adr/`, `.github/`, and other non-source paths.
+
+This creates a false-positive `block[pipeline]` when a PR contains only brainstorm documents, because they're incorrectly classified as "source changes" requiring a plan callout.
+
+The CI-side `scripts/verify-pipeline.sh` already handles this correctly by excluding all `docs/` subdirectories (via `grep -v -E '^docs/'`), `.github/`, and `.claude/worktrees/`. The QA skill prompt needs to align.
+
+## Root Cause Analysis
+
+Two parallel implementations of the "is this a source change?" heuristic have drifted:
+
+| Implementation | Excludes | Correct? |
+|---|---|---|
+| `scripts/verify-pipeline.sh` (lines 60-64) | All `docs/`, `.github/`, `.claude/worktrees/` | ✅ |
+| `qa-review/system_prompt.md` check 2 (line 102) | `docs/plans/`, `docs/solutions/`, `.claude/` only | ❌ |
+| `qa-review/system_prompt.md` pipeline-exempt check (line 87) | `docs/plans/`, `docs/solutions/`, `.claude/`, `.github/` | Partially ✅ (still missing `docs/brainstorms/` etc.) |
+
+## Fix
+
+Align both QA prompt checks with the `verify-pipeline.sh` logic. Replace individual `docs/plans/` and `docs/solutions/` exclusions with a single `docs/` exclusion, and add `.github/` where missing.
+
+### Change 1: Step 2 "Source changes exist" (line 100-103)
+
+**Before:**
+```
+run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/plans/' | grep -v '^docs/solutions/' | grep -v '^\\.claude/' | head -1")
+```
+
+**After:**
+```
+run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/' | grep -v '^\\.github/' | grep -v '^\\.claude/' | head -1")
+```
+
+This aligns with `verify-pipeline.sh`'s `SOURCE_BUCKET` logic: source = everything NOT under `docs/`, `.github/`, or `.claude/`.
+
+### Change 2: Pipeline-exempt docs-only confirmation (line 87)
+
+**Before:**
+```
+run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/plans/' | grep -v '^docs/solutions/' | grep -v '^\\.claude/' | grep -v '^\\.github/' | head -1")
+```
+
+**After:**
+```
+run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/' | grep -v '^\\.github/' | grep -v '^\\.claude/' | head -1")
+```
+
+Same broadening — if the only changes are under `docs/` (any subdirectory), `.github/`, or `.claude/`, that's docs-only.
+
+### Change 3: Update Step 2 description text (line 100)
+
+**Before:**
+```
+2. **Source changes exist** — Check that the PR has changes beyond `docs/plans/`, `docs/solutions/`, and `.claude/`:
+```
+
+**After:**
+```
+2. **Source changes exist** — Check that the PR has changes beyond `docs/`, `.github/`, and `.claude/`:
+```
+
+## Files Modified
+
+1. `skills/bundled/qa-review/system_prompt.md` — Three changes (lines 87, 100, 102)
+
+## Acceptance Criteria
+
+- [ ] `docs/brainstorms/` is excluded from the source-changes check in the QA pipeline
+- [ ] A PR containing only `docs/brainstorms/` files passes QA without a `block[pipeline]` on missing plan callout
+- [ ] Existing excludes (`docs/plans/`, `docs/solutions/`, `.claude/`) are preserved (subsumed by broader `docs/` exclude)
+- [ ] The pipeline-exempt docs-only check is also aligned
+- [ ] `scripts/verify-pipeline.sh` logic and `qa-review` prompt logic agree on what constitutes "source changes"
+
+## Risk Assessment
+
+**Low risk.** The change broadens the exclude list, which can only reduce false-positive blocks (never introduce false-negative passes). The broader `docs/` pattern is already proven correct in `verify-pipeline.sh`. No Rust code changes — prompt-only fix, takes effect on next skill bundle rebuild.

--- a/docs/solutions/975-qa-pipeline-brainstorms-exclude-list.md
+++ b/docs/solutions/975-qa-pipeline-brainstorms-exclude-list.md
@@ -1,0 +1,33 @@
+---
+module: qa-review
+tags: [qa-pipeline, source-changes, exclude-list, false-positive]
+problem_type: heuristic-drift
+category: workflow-issues
+date: 2026-05-11
+issue: 975
+---
+
+# QA Pipeline: docs/brainstorms/ Missing from Source-Changes Exclude List
+
+## Problem
+
+The QA review skill's "source changes exist" check had an incomplete exclude list. It filtered out `docs/plans/`, `docs/solutions/`, and `.claude/` — but not `docs/brainstorms/`, `docs/adr/`, or `.github/`. This caused false-positive `block[pipeline]` on brainstorm-only PRs, creating a circular dependency (a brainstorm doc would need a plan doc describing the addition of a brainstorm doc).
+
+## Root Cause
+
+Two parallel implementations of the "is this a source change?" heuristic drifted apart:
+
+- `scripts/verify-pipeline.sh` correctly excluded all `docs/` subdirectories via `grep -v -E '^docs/'`
+- `skills/bundled/qa-review/system_prompt.md` only excluded specific subdirectories (`docs/plans/`, `docs/solutions/`)
+
+The QA skill check was added before `docs/brainstorms/` existed as a convention and was never updated when that directory came into use.
+
+## Fix
+
+Replaced the individual `docs/plans/` and `docs/solutions/` exclusions in the QA review prompt with a single `^docs/` exclusion, aligning with `verify-pipeline.sh`'s existing `SOURCE_BUCKET` logic. Also added `\.github/` to the Step 2 check where it was missing (already present in the pipeline-exempt check).
+
+**File:** `skills/bundled/qa-review/system_prompt.md` — three edits (pipeline-exempt check, Step 2 description, Step 2 command).
+
+## Lesson
+
+When two components implement the same heuristic (CI script + skill prompt), keep them in sync. The broader pattern (`^docs/`) is more future-proof than enumerating subdirectories — new `docs/` subdirectories are automatically excluded without requiring a prompt update.

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -84,7 +84,7 @@ Run these checks using `run_gh`. Combine into as few calls as possible. If ANY c
 If the labels include `pipeline-exempt`:
 1. Confirm the PR is docs-only by running the same source-change check as check 2:
    ```
-   run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/plans/' | grep -v '^docs/solutions/' | grep -v '^\\.claude/' | grep -v '^\\.github/' | head -1")
+   run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/' | grep -v '^\\.github/' | grep -v '^\\.claude/' | head -1")
    ```
 2. If the result is empty (no source files): skip checks 1–3 and Step 2.5 entirely. Note: "Pipeline-exempt: docs-only PR, skipping pipeline checks and plan-AC verification." Jump to Step 3.
 3. If the result is non-empty (source files present): note "pipeline-exempt label present but PR contains source changes — ignoring label." Continue with checks 1–3 normally.
@@ -97,9 +97,9 @@ If the labels do NOT include `pipeline-exempt`: continue with checks 1–3 norma
    ```
    If no match: `block[pipeline]` — "Missing plan document in docs/plans/"
 
-2. **Source changes exist** — Check that the PR has changes beyond `docs/plans/`, `docs/solutions/`, and `.claude/`:
+2. **Source changes exist** — Check that the PR has changes beyond `docs/`, `.github/`, and `.claude/`:
    ```
-   run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/plans/' | grep -v '^docs/solutions/' | grep -v '^\\.claude/' | head -1")
+   run_gh("pr diff <PR_URL> --name-only | grep -v '^docs/' | grep -v '^\\.github/' | grep -v '^\\.claude/' | head -1")
    ```
    If empty: `block[pipeline]` — "No source changes beyond documentation"
 


### PR DESCRIPTION
## Summary

- Aligns the QA review skill's source-change heuristic with `verify-pipeline.sh` by replacing individual `docs/plans/` and `docs/solutions/` exclusions with a single `docs/` exclusion
- Prevents false-positive `block[pipeline]` on brainstorm-only PRs (and any future `docs/` subdirectories)
- Adds `.github/` exclusion to Step 2 check where it was missing

Closes #975

Plan: docs/plans/2026-05-11-002-fix-qa-pipeline-brainstorms-exclude-plan.md

## Test plan

- [ ] Verify a PR containing only `docs/brainstorms/` files no longer triggers `block[pipeline]`
- [ ] Verify existing excludes (`docs/plans/`, `docs/solutions/`, `.claude/`) still work (subsumed by `docs/`)
- [ ] Verify PRs with actual source changes still require plan docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)