### PR TITLE
fix(skill): dispatch-lib.sh passes /ce:work for groomed plans

### DIFF
--- a/docs/plans/2026-05-11-003-fix-dispatch-lib-plan-on-branch-entry-command-plan.md
+++ b/docs/plans/2026-05-11-003-fix-dispatch-lib-plan-on-branch-entry-command-plan.md
@@ -1,0 +1,152 @@
+---
+title: "fix: dispatch-lib.sh should pass /ce:work for groomed plans"
+type: fix
+status: active
+date: 2026-05-11
+issue: 1074
+---
+
+# fix: dispatch-lib.sh should pass /ce:work for groomed plans
+
+## Overview
+
+When `dispatch_claude_pilot` dispatches a session for a ticket with a groomed plan-on-branch, it currently always passes `--command "/mika"` for the `dev-pilot` skill. The model must then "decide" to invoke `/ce:work` — but it sometimes narrates instead of acting, causing the narrate-then-exit failure class. This fix detects the plan callout in the issue body and passes `--command "/ce:work <PLAN_PATH>"` directly, eliminating the model's opportunity to narrate instead of act.
+
+## Problem Frame
+
+The grooming pipeline writes a callout into the issue body:
+```
+> - **Plan:** `docs/plans/<filename>.md` (committed on branch @ `<sha>`)
+```
+
+The `/mika` slash command (Claude Code side) already detects this and skips `/ce:plan`, jumping to `/ce:work`. But this detection happens *inside* the Claude Code session — the model must parse the issue, detect the plan, and invoke `/ce:work`. This is where the narrate-then-exit failure occurs: the model recognizes it should call `/ce:work` but instead narrates "Proceeding to /ce:work" and calls `end_turn`.
+
+The structural fix is to move plan-on-branch detection *upstream* to `dispatch-lib.sh` (the shell script that launches `claude-pilot`), so the entry command is already `/ce:work <PLAN_PATH>` and the model has no decision to make.
+
+## Requirements Trace
+
+- R1. `dispatch_claude_pilot` in `_shared/dispatch-lib.sh` parses the issue body for plan callout before choosing the entry command
+- R2. When plan callout is found AND the file exists in the worktree, `ENTRY_COMMAND` is set to `/ce:work <PLAN_PATH>` instead of `/mika`
+- R3. When no plan callout is found OR the file doesn't exist, behavior is unchanged (`ENTRY_COMMAND="/mika"`)
+- R4. The plan path is validated (`test -f`) before overriding the entry command
+
+## Scope Boundaries
+
+- Only the `dev-pilot` skill arm is affected; `dev-groom` is unchanged
+- The plan callout detection uses the same pattern as `/mika` command and self-dev prompt: `> - **Plan:**` followed by a backtick-wrapped path containing `docs/plans/`
+- No changes to `claude-pilot` itself, only to the entry command passed to it
+- The existing `/mika` command's plan-on-branch detection (prompt-level) remains as defense-in-depth — this change makes it rarely exercised but does not remove it
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/bundled/_shared/dispatch-lib.sh` — the skill-to-entry-command mapping is at lines 457-462, a case switch. The `_set_up_worktree()` function (line 162-293) already parses the issue body into `$ISSUE_BODY` and sets up `$WORKTREE_DIR`
+- `skills/bundled/self-dev/system_prompt.md` line 253 — the bypass predicate is `Plan: docs/plans/` (substring match including the path prefix to avoid false positives on "Plan:" in prose)
+- `.claude/commands/mika.md` line 17 — the exact callout shape: `> - **Plan:** \`docs/plans/<filename>.md\` (committed on branch @ <sha>)`
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/auto-groom-on-dispatch-2026-05-06.md` — documents the grooming-as-dispatch-phase pattern and the plan callout bypass predicate
+- 10+ prior prompt-enforcement failures document the unreliability of prompt-only enforcement for this failure class (referenced in #1074)
+
+## Key Technical Decisions
+
+- **Detection placement:** After `_set_up_worktree()` and before `_run_claude_pilot()` — because `_set_up_worktree()` populates `$ISSUE_BODY` and `$WORKTREE_DIR` which are both needed for detection and validation
+- **Override scope:** Only for `SKILL=dev-pilot` — the `dev-groom` arm has its own entry command (`/mika-groom-ticket`) which should never be overridden
+- **Validation with `test -f`:** The plan path must exist in the worktree before overriding — if the branch was rebased and the plan file was lost, fall back to `/mika` gracefully
+- **Regex pattern:** Use `grep -oP` to extract the path from the callout, matching the exact shape `> - **Plan:** \`(docs/plans/[^\`]+)\`` — this is consistent with the self-dev prompt's bypass predicate requiring `docs/plans/` prefix
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to put the override logic?** After `_set_up_worktree()` in `dispatch_claude_pilot()`. The case switch sets the default, then the plan-on-branch detection overrides it conditionally. This keeps the case switch clean and the override logic localized.
+- **Should this be a new function or inline?** New helper function `_detect_plan_on_branch()` — consistent with the `_`-prefixed internal helper pattern in the file, and keeps `dispatch_claude_pilot()` readable.
+
+### Deferred to Implementation
+
+- Exact `grep` flags for portable regex extraction (GNU vs BSD grep compatibility — the handler runs on Linux so `grep -oP` with PCRE is available)
+
+## Implementation Units
+
+- [ ] **Unit 1: Add plan-on-branch detection helper**
+
+**Goal:** Add `_detect_plan_on_branch()` that parses `$ISSUE_BODY` for the plan callout, extracts the path, validates it exists in `$WORKTREE_DIR`, and sets `ENTRY_COMMAND` to `/ce:work <path>` when found.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/bundled/_shared/dispatch-lib.sh`
+
+**Approach:**
+- Add a new `_detect_plan_on_branch()` helper function following the existing `_`-prefixed convention
+- The function checks: (1) `SKILL` is `dev-pilot`, (2) `ISSUE_BODY` is non-empty, (3) the callout pattern matches, (4) extracted path passes `test -f` in `WORKTREE_DIR`
+- When all checks pass, override `ENTRY_COMMAND` to `/ce:work <path>` and emit an informational stderr message
+- When any check fails, return silently (no-op, preserving default behavior)
+- Call this function in `dispatch_claude_pilot()` after `_set_up_worktree()` and before `_handle_dry_run()`
+
+**Patterns to follow:**
+- `_set_up_worktree()` for variable naming and stderr logging conventions
+- The self-dev prompt's bypass predicate pattern: substring match on `Plan: docs/plans/`
+
+**Test scenarios:**
+- Happy path: issue body contains `> - **Plan:** \`docs/plans/feat-plan.md\``, file exists in worktree -> ENTRY_COMMAND overridden to `/ce:work docs/plans/feat-plan.md`
+- Edge case: issue body contains the Plan callout but the file does NOT exist in worktree -> ENTRY_COMMAND remains `/mika`
+- Edge case: issue body contains "Plan:" in prose but NOT as the structured callout (no `docs/plans/` prefix) -> ENTRY_COMMAND remains `/mika`
+- Edge case: `SKILL` is `dev-groom` (not `dev-pilot`) -> function is a no-op regardless of issue body
+- Edge case: `ISSUE_BODY` is empty (free-text mode, no issue fetched) -> function is a no-op
+- Edge case: plan path contains spaces or special characters -> correctly extracted and validated
+
+**Verification:**
+- `bash skills/bundled/_shared/test-dispatch-lib.sh` passes with new test cases
+- The case switch (lines 457-462) is unchanged — the override is applied after it
+
+- [ ] **Unit 2: Add test cases for plan-on-branch detection**
+
+**Goal:** Extend `test-dispatch-lib.sh` with structural tests verifying the plan-on-branch detection logic.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `skills/bundled/_shared/test-dispatch-lib.sh`
+
+**Approach:**
+- Add a new test section (Test 6) following the existing pattern of structural verification via `sed`/`grep` on the source file
+- Verify the helper function exists, checks for `dev-pilot` skill, uses the correct callout pattern, validates file existence, and overrides `ENTRY_COMMAND`
+- Verify the function is called at the right point in `dispatch_claude_pilot()` (after `_set_up_worktree`, before `_handle_dry_run`)
+
+**Patterns to follow:**
+- Existing test structure in `test-dispatch-lib.sh` — `assert_contains`/`assert_not_contains`/`assert_eq` helpers, section-based organization, structural verification via source inspection
+
+**Test scenarios:**
+- Happy path: test script runs successfully with all new assertions passing
+- Integration: verify the function call ordering in `dispatch_claude_pilot()` matches the expected sequence
+
+**Verification:**
+- `bash skills/bundled/_shared/test-dispatch-lib.sh` exits 0 with all tests passing
+
+## System-Wide Impact
+
+- **Interaction graph:** `dispatch-lib.sh` -> `claude-pilot` -> Claude Code session. The entry command change is the only interaction affected. Downstream, `/ce:work` receives the plan path and executes it — this path is already exercised when `/mika` detects plan-on-branch prompt-side
+- **Error propagation:** If plan detection fails (file missing, pattern doesn't match), the fallback is the current behavior (`/mika`). No new failure modes introduced
+- **State lifecycle risks:** None — the detection is stateless, reading `$ISSUE_BODY` which is already populated
+- **Unchanged invariants:** The case switch contract (mika#932) is unchanged. The `dev-groom` arm is unaffected. The `_set_up_worktree()` function is unmodified
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| False positive plan detection on prose containing "Plan:" | Pattern requires `docs/plans/` prefix and backtick-wrapped path, consistent with self-dev bypass predicate |
+| Plan file exists but is stale/wrong branch | `test -f` validates presence; staleness is a pre-existing concern not introduced by this change |
+| `grep -oP` not available | Handler runs on Linux (Gentoo) where GNU grep with PCRE is standard; add fallback comment |
+
+## Sources & References
+
+- Related issues: #1074, #1072 (prompt-level mitigation)
+- Related code: `skills/bundled/_shared/dispatch-lib.sh`, `skills/bundled/self-dev/system_prompt.md`
+- Related learnings: `docs/solutions/best-practices/auto-groom-on-dispatch-2026-05-06.md`

--- a/docs/solutions/best-practices/dispatch-lib-plan-on-branch-entry-command-override-2026-05-11.md
+++ b/docs/solutions/best-practices/dispatch-lib-plan-on-branch-entry-command-override-2026-05-11.md
@@ -1,0 +1,84 @@
+---
+title: dispatch-lib plan-on-branch entry command override
+date: 2026-05-11
+category: best-practices
+module: skills
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - dispatch-lib.sh dispatches a claude-pilot session for a groomed ticket with a plan callout in the issue body
+  - Debugging narrate-then-exit failures where the model recognizes it should call /ce:work but narrates instead
+  - Extending the plan-on-branch detection pattern to new dispatch skills
+tags:
+  - dispatch-lib
+  - claude-pilot
+  - plan-on-branch
+  - entry-command
+  - narrate-then-exit
+  - dev-pilot
+  - groomed-plans
+---
+
+# dispatch-lib plan-on-branch entry command override
+
+## Context
+
+When the grooming pipeline writes a plan callout into an issue body (`> - **Plan:** \`docs/plans/<file>.md\``), the autonomous dispatch flow previously always passed `--command "/mika"` to claude-pilot. Inside the Claude Code session, the `/mika` slash command detected the plan callout and skipped to `/ce:work`. However, this detection happened *inside* the model session — the model had to parse the issue, recognize the plan, and invoke `/ce:work`. This is where the narrate-then-exit failure class occurred: the model would narrate "Proceeding to /ce:work" and call `end_turn` instead of actually invoking the slash command.
+
+10+ prior prompt-enforcement attempts failed to eliminate this behavior reliably. The structural insight: if the model doesn't need to make the decision, it can't narrate instead of acting.
+
+## Guidance
+
+Move plan-on-branch detection upstream to `dispatch-lib.sh` (the shell script that launches claude-pilot). When the issue body contains the plan callout, pass `--command "/ce:work <PLAN_PATH>"` directly instead of `--command "/mika"`.
+
+The detection is implemented as `_detect_plan_on_branch()` — an internal helper called after `_set_up_worktree()` (which populates `$ISSUE_BODY` and `$WORKTREE_DIR`) and before `_handle_dry_run()`. It:
+
+1. Guards on `SKILL=dev-pilot` only (dev-groom has its own entry command)
+2. Extracts the plan path using `grep -oP` with a PCRE pattern requiring the `docs/plans/` prefix
+3. Validates the file exists in the worktree with `[ -f ]`
+4. Overrides `ENTRY_COMMAND` only when all checks pass; falls back silently otherwise
+
+The case switch (mika#932 contract) remains unchanged — it sets the default, and the plan detection conditionally overrides it.
+
+## Why This Matters
+
+Prompt-level enforcement is unreliable for preventing model narration failures. When a model can "decide" to take an action, it can also decide to narrate about taking the action instead. The only structural fix is to eliminate the decision point by passing the correct entry command upstream. This pattern applies to any dispatch flow where the model's first action is deterministic based on available metadata.
+
+## When to Apply
+
+- When adding new dispatch skills that have deterministic entry commands based on issue metadata
+- When debugging narrate-then-exit failures in any claude-pilot dispatch path
+- When extending plan-on-branch detection to other callout patterns (e.g., branch callouts, label-based routing)
+
+## Examples
+
+Before (narrate-then-exit prone):
+```bash
+# dispatch-lib.sh always passes /mika
+case "$SKILL" in
+  dev-pilot)  ENTRY_COMMAND="/mika" ;;
+esac
+# Model inside /mika must decide to invoke /ce:work
+```
+
+After (structural fix):
+```bash
+# Case switch sets default
+case "$SKILL" in
+  dev-pilot)  ENTRY_COMMAND="/mika" ;;
+esac
+
+# After worktree setup, detect plan callout and override
+_detect_plan_on_branch  # Sets ENTRY_COMMAND="/ce:work <path>" if plan found
+
+# claude-pilot receives the correct entry command directly
+claude-pilot --command "$ENTRY_COMMAND" ...
+```
+
+## Related
+
+- [Shared dispatch library for claude-pilot skills](shared-dispatch-library-for-claude-pilot-skills-2026-04-29.md) — the dispatch-lib architecture this builds on
+- [Auto-groom on dispatch](auto-groom-on-dispatch-2026-05-06.md) — the grooming pipeline that produces plan callouts
+- mika#1074 — structural fix issue
+- mika#1072 — prompt-level mitigation (interim fix)

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -297,7 +297,8 @@ _handle_dry_run() {
         if [ -n "$REPO" ] && [ -n "$ISSUE_NUM" ]; then
             jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUM" --arg branch "$BRANCH" \
                 --arg worktree "$WORKTREE_DIR" --arg prompt "$PROMPT" \
-                '{dry_run:true, repo:$repo, issue:$issue, branch:$branch, worktree_dir:$worktree, prompt:$prompt}'
+                --arg entry_command "$ENTRY_COMMAND" \
+                '{dry_run:true, repo:$repo, issue:$issue, branch:$branch, worktree_dir:$worktree, prompt:$prompt, entry_command:$entry_command}'
             git -C "$SUB_REPO_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
             PARENT_DIR=$("$PLATFORM_DIR/scripts/derive-worktree-path" --branch "$BRANCH" --no-repo)
             rmdir "$PARENT_DIR" 2>/dev/null || true
@@ -408,6 +409,42 @@ _deliver_callback() {
     fi
 }
 
+_detect_plan_on_branch() {
+    # Plan-on-branch detection (mika#1074): When the issue body contains a groomed
+    # plan callout, override ENTRY_COMMAND from "/mika" to "/ce:work <path>".
+    # This eliminates the narrate-then-exit failure class — the model no longer
+    # needs to "decide" to invoke /ce:work because the entry command does it directly.
+    #
+    # Only applies to dev-pilot skill. dev-groom has its own entry command.
+    # Falls back silently (no-op) when any precondition fails.
+
+    # Guard: only override for dev-pilot
+    [ "$SKILL" = "dev-pilot" ] || return 0
+
+    # Guard: need an issue body to parse
+    [ -n "$ISSUE_BODY" ] || return 0
+
+    # Guard: need a worktree directory for file validation
+    [ -n "$WORKTREE_DIR" ] || return 0
+
+    # Extract plan path from the callout pattern:
+    #   > - **Plan:** `docs/plans/<filename>.md` (committed on branch @ <sha>)
+    # The pattern requires `docs/plans/` prefix to avoid false positives on
+    # prose containing "Plan:" (consistent with self-dev bypass predicate).
+    local PLAN_PATH
+    PLAN_PATH=$(printf '%s\n' "$ISSUE_BODY" | grep -oP '> - \*\*Plan:\*\* `\Kdocs/plans/[^`]+' | head -1)
+
+    [ -n "$PLAN_PATH" ] || return 0
+
+    # Validate the plan file exists in the worktree
+    if [ -f "$WORKTREE_DIR/$PLAN_PATH" ]; then
+        ENTRY_COMMAND="/ce:work $PLAN_PATH"
+        echo "Plan-on-branch detected: overriding entry command to '/ce:work $PLAN_PATH'" >&2
+    else
+        echo "Plan-on-branch callout found but file not in worktree: $WORKTREE_DIR/$PLAN_PATH — falling back to /mika" >&2
+    fi
+}
+
 # --- Public API ---
 
 # Single entrypoint. No args — entry command is derived from the $SKILL field
@@ -463,6 +500,7 @@ dispatch_claude_pilot() {
     _setup_gh_auth
     _scrub_env
     _set_up_worktree
+    _detect_plan_on_branch
     _handle_dry_run
     _run_claude_pilot "$ENTRY_COMMAND"
     _deliver_callback

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -179,6 +179,86 @@ else
     echo "  ✗ self-dev/system_prompt.md not found at expected path"
 fi
 
+# --- Test 6: Plan-on-branch detection (mika#1074) ---
+
+echo ""
+echo "Test 6: Plan-on-branch detection (_detect_plan_on_branch)"
+echo "----------------------------------------------------------"
+
+# Verify the helper function exists
+PLAN_FUNC=$(sed -n '/_detect_plan_on_branch()/,/^}/p' "$DISPATCH_LIB")
+assert_contains "Function _detect_plan_on_branch exists" "_detect_plan_on_branch()" "$PLAN_FUNC"
+
+# Verify it guards on dev-pilot skill
+assert_contains "Guards on dev-pilot skill" 'dev-pilot' "$PLAN_FUNC"
+
+# Verify it checks ISSUE_BODY is non-empty
+assert_contains "Checks ISSUE_BODY is non-empty" 'ISSUE_BODY' "$PLAN_FUNC"
+
+# Verify it checks WORKTREE_DIR is non-empty
+assert_contains "Checks WORKTREE_DIR is non-empty" 'WORKTREE_DIR' "$PLAN_FUNC"
+
+# Verify it uses the correct plan callout pattern with docs/plans/ prefix
+assert_contains "Uses docs/plans/ prefix in pattern" 'docs/plans/' "$PLAN_FUNC"
+
+# Verify it validates file existence ([ -f or test -f)
+assert_contains "Validates plan file exists before overriding" '[ -f' "$PLAN_FUNC"
+
+# Verify it overrides ENTRY_COMMAND to /ce:work
+assert_contains "Overrides ENTRY_COMMAND to /ce:work" '/ce:work' "$PLAN_FUNC"
+
+# Verify the function is called in dispatch_claude_pilot after _set_up_worktree
+# and before _handle_dry_run
+DISPATCH_BODY=$(sed -n '/^dispatch_claude_pilot()/,/^}/p' "$DISPATCH_LIB")
+# Extract the call sequence: _set_up_worktree, _detect_plan_on_branch, _handle_dry_run
+CALL_SEQUENCE=$(printf '%s\n' "$DISPATCH_BODY" | grep -E '^\s+_(set_up_worktree|detect_plan_on_branch|handle_dry_run)' | tr -s ' ' | sed 's/^ //')
+EXPECTED_SEQUENCE=$(printf '%s\n' "_set_up_worktree" "_detect_plan_on_branch" "_handle_dry_run")
+assert_eq "Call ordering: _set_up_worktree -> _detect_plan_on_branch -> _handle_dry_run" "$EXPECTED_SEQUENCE" "$CALL_SEQUENCE"
+
+# Verify the case switch is unchanged (dev-pilot still maps to /mika as default)
+CASE_BLOCK=$(sed -n '/case "\$SKILL" in/,/esac/p' "$DISPATCH_LIB")
+assert_contains "Case switch still maps dev-pilot to /mika" 'dev-pilot)  ENTRY_COMMAND="/mika"' "$CASE_BLOCK"
+assert_contains "Case switch still maps dev-groom to /mika-groom-ticket" 'dev-groom)  ENTRY_COMMAND="/mika-groom-ticket"' "$CASE_BLOCK"
+
+# Verify fallback behavior: function returns 0 (no-op) on guard failures
+# 4 guards: skill, issue_body, worktree_dir, plan_path empty
+NON_COMMENT_RETURNS=$(printf '%s\n' "$PLAN_FUNC" | grep -v '^\s*#' | grep -c 'return 0' || true)
+assert_eq "Has 4 guard return statements (skill, body, worktree, plan_path)" "4" "$NON_COMMENT_RETURNS"
+
+# --- Test 7: Plan callout regex extraction (mika#1074) ---
+
+echo ""
+echo "Test 7: Plan callout regex extraction (live)"
+echo "----------------------------------------------"
+
+# Exercise the grep -oP regex against a canonical callout string
+CALLOUT_REGEX='> - \*\*Plan:\*\* `\Kdocs/plans/[^`]+'
+
+# Happy path: canonical callout with trailing context
+TEST_BODY='> - **Plan:** `docs/plans/2026-05-11-001-feat-foo-plan.md` (committed on branch @ abc1234)'
+EXTRACTED=$(printf '%s\n' "$TEST_BODY" | grep -oP "$CALLOUT_REGEX" | head -1)
+assert_eq "Extracts plan path from canonical callout" "docs/plans/2026-05-11-001-feat-foo-plan.md" "$EXTRACTED"
+
+# Edge case: callout with no trailing context (just backtick-close)
+TEST_BODY2='> - **Plan:** `docs/plans/short.md`'
+EXTRACTED2=$(printf '%s\n' "$TEST_BODY2" | grep -oP "$CALLOUT_REGEX" | head -1)
+assert_eq "Extracts plan path from minimal callout" "docs/plans/short.md" "$EXTRACTED2"
+
+# Edge case: prose containing "Plan:" without docs/plans/ prefix — should NOT match
+TEST_BODY3='The Plan: is to refactor the module'
+EXTRACTED3=$(printf '%s\n' "$TEST_BODY3" | grep -oP "$CALLOUT_REGEX" | head -1 || true)
+assert_eq "Prose Plan: without docs/plans/ prefix does not match" "" "$EXTRACTED3"
+
+# Edge case: multiple callouts — first one wins
+TEST_BODY4='> - **Plan:** `docs/plans/first.md` (committed on branch @ aaa)
+> - **Plan:** `docs/plans/second.md` (committed on branch @ bbb)'
+EXTRACTED4=$(printf '%s\n' "$TEST_BODY4" | grep -oP "$CALLOUT_REGEX" | head -1)
+assert_eq "Multiple callouts: first one wins" "docs/plans/first.md" "$EXTRACTED4"
+
+# Verify dry_run output includes entry_command field
+DRY_RUN_JQ=$(sed -n '/_handle_dry_run()/,/^}/p' "$DISPATCH_LIB")
+assert_contains "Dry run output includes entry_command" 'entry_command' "$DRY_RUN_JQ"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

When `dispatch_claude_pilot` dispatches a session for a ticket with a groomed plan-on-branch, it now passes `--command "/ce:work <path>"` instead of `--command "/mika"` to `claude-pilot`. This eliminates the narrate-then-exit failure class — the model no longer needs to "decide" to invoke `/ce:work` because the entry command does it directly.

- Adds `_detect_plan_on_branch()` helper that parses the issue body for the plan callout pattern, validates the file exists in the worktree, and overrides `ENTRY_COMMAND` when found
- Guards on `dev-pilot` skill only — `dev-groom` entry command is unchanged
- Falls back silently to `/mika` when any precondition fails (no issue body, no worktree, file missing, pattern doesn't match)
- Adds `entry_command` to dry_run JSON output for operator observability
- Adds 16 test assertions: structural verification (Test 6) + live regex extraction against canonical callout strings (Test 7)

Closes #1074

Plan: docs/plans/2026-05-11-003-fix-dispatch-lib-plan-on-branch-entry-command-plan.md

## Test plan

- [x] `bash skills/bundled/_shared/test-dispatch-lib.sh` — all new assertions pass (34 passed, 2 pre-existing failures in Test 5 unrelated to this change)
- [x] Live regex extraction tests verify correct path extraction from canonical callout, minimal callout, prose false positive rejection, and multiple-callout first-wins behavior
- [x] Structural tests verify call ordering (`_set_up_worktree` → `_detect_plan_on_branch` → `_handle_dry_run`), guard count, case switch preservation, and `entry_command` in dry_run output
- [ ] End-to-end: dispatch a groomed ticket via `run_claude_pilot` and verify claude-pilot receives `/ce:work <path>` as the entry command

🤖 Generated with [Claude Code](https://claude.com/claude-code)