### PR TITLE
fix(tui): split running counter into executing + queued (#1057)

### DIFF
--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -8,10 +8,11 @@ use std::thread::JoinHandle;
 use tokio::sync::oneshot;
 
 use crate::db::{
-    AgentRow, AgentWithStats, AuditEvent, Commitment, CoreMemoryEntry, Database, Event, FailedSend,
-    NewTask, Person, Preference, SearchResult, Session, SessionMessage, SessionWithStats,
-    SkillOverride, Task, TaskFilters, TaskHealthSummary, TaskSessionRow, TeamRow, TeamRunFilters,
-    TeamRunRow, TeamRunSummary, TeamWorkspaceEntry, TimelineFilters, TimelineRow,
+    AgentRow, AgentWithStats, AuditEvent, BackgroundTaskCounts, Commitment, CoreMemoryEntry,
+    Database, Event, FailedSend, NewTask, Person, Preference, SearchResult, Session,
+    SessionMessage, SessionWithStats, SkillOverride, Task, TaskFilters, TaskHealthSummary,
+    TaskSessionRow, TeamRow, TeamRunFilters, TeamRunRow, TeamRunSummary, TeamWorkspaceEntry,
+    TimelineFilters, TimelineRow,
 };
 
 type DbClosure = Box<dyn FnOnce(&mut Database) + Send>;
@@ -419,6 +420,12 @@ impl AsyncDatabase {
     pub async fn get_user_visible_tasks(&self) -> Result<Vec<Task>> {
         let id = self.agent_id.clone();
         self.with_db(move |db| db.get_user_visible_tasks(&id)).await
+    }
+
+    pub async fn get_background_task_counts(&self) -> Result<BackgroundTaskCounts> {
+        let id = self.agent_id.clone();
+        self.with_db(move |db| db.get_background_task_counts(&id))
+            .await
     }
 
     pub async fn get_active_background_task_count(&self) -> Result<usize> {

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -168,6 +168,15 @@ pub struct Task {
     pub r#type: String,
 }
 
+/// Split counts of active background callback tasks. `executing` = subprocess alive
+/// (`process_id IS NOT NULL`), `queued` = waiting for dispatch slot (`process_id IS NULL`).
+/// Used by TUI footer badge to distinguish `[1 running, 2 queued]` (#1057).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundTaskCounts {
+    pub executing: usize,
+    pub queued: usize,
+}
+
 /// A parent self_dev task left `in_progress` after its callback subtask
 /// delivered without producing a PR. Used by the task engine reaper (#871).
 #[derive(Debug, Clone)]
@@ -4941,20 +4950,33 @@ impl Database {
         Ok(rows)
     }
 
-    /// Count active background tasks (long-running callback tasks that are pending or in-progress).
-    /// Used by TUI footer badge. Complements `get_user_visible_tasks()` which intentionally
-    /// excludes callback tasks.
-    pub fn get_active_background_task_count(&self, agent_id: &str) -> Result<usize> {
-        let count: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM tasks
+    /// Split counts of active background tasks: executing (subprocess alive) vs queued (waiting).
+    /// Uses `process_id IS NOT NULL` as the discriminator for executing tasks.
+    /// Used by TUI footer badge to show `[1 running, 2 queued]` instead of `[3 running]`.
+    pub fn get_background_task_counts(&self, agent_id: &str) -> Result<BackgroundTaskCounts> {
+        let (executing, queued): (i64, i64) = self.conn.query_row(
+            "SELECT
+               COALESCE(SUM(CASE WHEN process_id IS NOT NULL THEN 1 ELSE 0 END), 0),
+               COALESCE(SUM(CASE WHEN process_id IS NULL THEN 1 ELSE 0 END), 0)
+             FROM tasks
              WHERE agent_id = ?1
                AND trigger_type = 'callback'
                AND action_type = 'resume_agent'
                AND status IN ('pending', 'in_progress')",
             params![agent_id],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
-        Ok(count as usize)
+        Ok(BackgroundTaskCounts {
+            executing: executing as usize,
+            queued: queued as usize,
+        })
+    }
+
+    /// Count active background tasks (long-running callback tasks that are pending or in-progress).
+    /// Convenience wrapper that sums executing + queued counts.
+    pub fn get_active_background_task_count(&self, agent_id: &str) -> Result<usize> {
+        let counts = self.get_background_task_counts(agent_id)?;
+        Ok(counts.executing + counts.queued)
     }
 
     pub fn get_inject_context_tasks(&self, agent_id: &str) -> Result<Vec<Task>> {
@@ -10792,6 +10814,91 @@ mod tests {
 
         // Reminder should NOT count as a background task
         assert_eq!(db.get_active_background_task_count("mika").unwrap(), 0);
+    }
+
+    #[test]
+    fn test_get_background_task_counts_splits_executing_and_queued() {
+        let db = db();
+
+        // No callback tasks → both zero
+        let counts = db.get_background_task_counts("mika").unwrap();
+        assert_eq!(
+            counts,
+            BackgroundTaskCounts {
+                executing: 0,
+                queued: 0
+            }
+        );
+
+        // Create two pending callback tasks (no process_id) → both queued
+        let id1 = db.create_task(&callback_task("mika")).unwrap();
+        let mut task2 = callback_task("mika");
+        task2.label = "build_project".to_string();
+        let _id2 = db.create_task(&task2).unwrap();
+        let counts = db.get_background_task_counts("mika").unwrap();
+        assert_eq!(
+            counts,
+            BackgroundTaskCounts {
+                executing: 0,
+                queued: 2
+            }
+        );
+
+        // Set process_id on task1 → 1 executing, 1 queued
+        db.set_task_process_id(&id1, Some(12345)).unwrap();
+        let counts = db.get_background_task_counts("mika").unwrap();
+        assert_eq!(
+            counts,
+            BackgroundTaskCounts {
+                executing: 1,
+                queued: 1
+            }
+        );
+
+        // Backward compat: total still matches
+        assert_eq!(db.get_active_background_task_count("mika").unwrap(), 2);
+    }
+
+    #[test]
+    fn test_get_background_task_counts_all_executing() {
+        let db = db();
+
+        let id1 = db.create_task(&callback_task("mika")).unwrap();
+        let mut task2 = callback_task("mika");
+        task2.label = "build_project".to_string();
+        let id2 = db.create_task(&task2).unwrap();
+
+        db.set_task_process_id(&id1, Some(100)).unwrap();
+        db.set_task_process_id(&id2, Some(200)).unwrap();
+
+        let counts = db.get_background_task_counts("mika").unwrap();
+        assert_eq!(
+            counts,
+            BackgroundTaskCounts {
+                executing: 2,
+                queued: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_background_task_counts_excludes_terminal_status() {
+        let db = db();
+
+        let id1 = db.create_task(&callback_task("mika")).unwrap();
+        db.set_task_process_id(&id1, Some(100)).unwrap();
+
+        // Complete the task — should not appear in either bucket
+        db.update_task_completed(&id1, "mika", Some("done"))
+            .unwrap();
+        let counts = db.get_background_task_counts("mika").unwrap();
+        assert_eq!(
+            counts,
+            BackgroundTaskCounts {
+                executing: 0,
+                queued: 0
+            }
+        );
     }
 
     #[test]

--- a/crates/mika-cli/src/commands/tasks.rs
+++ b/crates/mika-cli/src/commands/tasks.rs
@@ -91,12 +91,22 @@ fn print_task_summary(t: &Task) {
         .as_ref()
         .map(|s| format_ts(s))
         .unwrap_or_else(|| t.trigger_type.clone());
-    let pid_info = t
-        .process_id
-        .map(|pid| format!(" [PID {pid}]"))
-        .unwrap_or_default();
+    // For callback tasks, annotate executing vs queued (#1057)
+    let status_info = if t.trigger_type == "callback" {
+        if let Some(pid) = t.process_id {
+            format!(" [executing, PID {pid}]")
+        } else if t.status == "pending" || t.status == "in_progress" {
+            " [queued]".to_string()
+        } else {
+            String::new()
+        }
+    } else {
+        t.process_id
+            .map(|pid| format!(" [PID {pid}]"))
+            .unwrap_or_default()
+    };
     println!(
-        "    {}: [{}] [{}] \"{}\" ({}){pid_info}",
+        "    {}: [{}] [{}] \"{}\" ({}){status_info}",
         short_id, t.status, t.action_type, t.label, when
     );
 }

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -578,7 +578,12 @@ pub struct App<'a> {
     pub pending_task_count: usize,
     /// Cached count of active background callback tasks (polled periodically for footer badge).
     /// Agent-scoped (not session-scoped) — NOT reset on /clear.
-    pub active_background_task_count: usize,
+    /// Cached count of actively-executing background tasks (process_id IS NOT NULL).
+    /// Agent-scoped — NOT reset on /clear.
+    pub executing_task_count: usize,
+    /// Cached count of queued background tasks (process_id IS NULL).
+    /// Agent-scoped — NOT reset on /clear.
+    pub queued_task_count: usize,
 
     // Team mode fields (None when in agent mode)
     /// Team worker channel for sending goals.
@@ -678,7 +683,8 @@ impl<'a> App<'a> {
             context_tokens: None,
             last_seen_msg_id: 0,
             pending_task_count: 0,
-            active_background_task_count: 0,
+            executing_task_count: 0,
+            queued_task_count: 0,
             team_tx: None,
             team_rx: None,
             team_name: None,
@@ -764,7 +770,8 @@ impl<'a> App<'a> {
             context_tokens: None,
             last_seen_msg_id: 0,
             pending_task_count: 0,
-            active_background_task_count: 0,
+            executing_task_count: 0,
+            queued_task_count: 0,
             team_tx: Some(team_tx),
             team_rx: Some(team_rx),
             team_name: Some(team_name.to_string()),
@@ -1032,10 +1039,12 @@ impl<'a> App<'a> {
         // Background task count polling: refresh every ~5s for footer badge.
         if !self.is_team_mode()
             && self.tick_count.is_multiple_of(POLL_INTERVAL_TICKS)
-            && let Ok(count) = self.db.get_active_background_task_count().await
-            && count != self.active_background_task_count
+            && let Ok(counts) = self.db.get_background_task_counts().await
+            && (counts.executing != self.executing_task_count
+                || counts.queued != self.queued_task_count)
         {
-            self.active_background_task_count = count;
+            self.executing_task_count = counts.executing;
+            self.queued_task_count = counts.queued;
             self.needs_redraw = true;
         }
 

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -1627,7 +1627,8 @@ mod tests {
         };
         app.pending_command = Some("/model opus".to_string());
         app.pending_task_count = 3;
-        app.active_background_task_count = 2;
+        app.executing_task_count = 1;
+        app.queued_task_count = 2;
         app.status = AgentStatus::Thinking;
 
         handle_clear(&mut app, "").await;
@@ -1648,8 +1649,12 @@ mod tests {
         );
         assert_eq!(app.pending_task_count, 0, "pending_task_count should be 0");
         assert_eq!(
-            app.active_background_task_count, 2,
-            "active_background_task_count should be preserved (agent-scoped, not session-scoped)"
+            app.executing_task_count, 1,
+            "executing_task_count should be preserved (agent-scoped, not session-scoped)"
+        );
+        assert_eq!(
+            app.queued_task_count, 2,
+            "queued_task_count should be preserved (agent-scoped, not session-scoped)"
         );
         assert_eq!(app.status, AgentStatus::Idle, "status should be Idle");
     }

--- a/crates/mika-cli/src/tui/ui.rs
+++ b/crates/mika-cli/src/tui/ui.rs
@@ -1060,13 +1060,15 @@ fn draw_footer(f: &mut Frame<'_>, app: &mut App<'_>, area: Rect, terminal_width:
                 Style::default().fg(Color::DarkGray),
             ));
         }
-        // Active background task badge
-        if app.active_background_task_count > 0 {
+        // Active background task badge — split executing vs queued (#1057)
+        if app.executing_task_count > 0 || app.queued_task_count > 0 {
             s.push(Span::styled(" | ", Style::default().fg(Color::DarkGray)));
-            s.push(Span::styled(
-                format!("[{} running]", app.active_background_task_count),
-                Style::default().fg(Color::Yellow),
-            ));
+            let badge = match (app.executing_task_count, app.queued_task_count) {
+                (e, q) if e > 0 && q > 0 => format!("[{e} running, {q} queued]"),
+                (e, _) if e > 0 => format!("[{e} running]"),
+                (_, q) => format!("[{q} queued]"),
+            };
+            s.push(Span::styled(badge, Style::default().fg(Color::Yellow)));
         }
         s
     };

--- a/docs/plans/2026-05-11-002-fix-tui-running-counter-split-plan.md
+++ b/docs/plans/2026-05-11-002-fix-tui-running-counter-split-plan.md
@@ -1,0 +1,163 @@
+---
+title: "fix: Split TUI running counter into executing + queued"
+type: fix
+status: active
+date: 2026-05-11
+---
+
+# fix: Split TUI running counter into executing + queued
+
+## Overview
+
+The TUI footer badge `[N running]` conflates actively-executing callback tasks (subprocess alive) with queued/deferred ones (waiting for dispatch slot). This caused an operator misread (2026-05-10) where `[3 running]` implied parallel execution when only 1 claude-pilot was running and 2 were deferred behind it. Fix by splitting the counter using the existing `process_id` field as the discriminator.
+
+## Problem Frame
+
+`get_active_background_task_count()` counts all callback+resume_agent tasks with `status IN ('pending', 'in_progress')` regardless of whether a subprocess is actually running. The `process_id` column already tracks live subprocesses (set on spawn, cleared on death), but the TUI counter ignores it. The same conflation exists in `mika tasks list` output, which shows raw status without distinguishing executing from queued.
+
+## Requirements Trace
+
+- R1. Operator can distinguish "actively executing" from "queued for next slot" at a glance from the TUI
+- R2. Counter shape is consistent between TUI status bar and `mika tasks list` output
+- R3. No behavior change to dispatch sequencing — purely display fix
+
+## Scope Boundaries
+
+- No changes to task state machine, dispatch logic, or callback lifecycle
+- No new DB columns or migrations
+- No changes to `--format json` output shapes (only human-readable text)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/db.rs:4947-4958` — `get_active_background_task_count()` current query
+- `crates/mika-agent/src/db.rs:152` — `process_id: Option<i64>` on Task struct
+- `crates/mika-agent/src/db.rs:5086` — `set_task_process_id()` sets PID on spawn
+- `crates/mika-agent/src/db.rs:5118` — `get_active_callback_tasks_with_process_id()` already queries by PID presence
+- `crates/mika-agent/src/async_db.rs:424-426` — async wrapper pattern
+- `crates/mika-cli/src/tui/ui.rs:1064-1070` — footer badge rendering
+- `crates/mika-cli/src/tui/app.rs:579-581` — `active_background_task_count` field + polling at line 1032
+- `crates/mika-cli/src/commands/tasks.rs:87-102` — `print_task_summary()` already shows `[PID N]`
+- `crates/mika-cli/src/tui/commands/handlers.rs:1630-1652` — `/clear` test preserves background count
+
+## Key Technical Decisions
+
+- **Use `process_id IS NOT NULL` as the executing discriminator**: The `process_id` field is already the source of truth for subprocess liveness — set by `spawn_long_running_exec()`, cleared by the callback watchdog on process death. No new heuristic needed.
+- **Return a struct, not a tuple**: A `BackgroundTaskCounts { executing: usize, queued: usize }` struct is clearer than `(usize, usize)` at callsites and self-documents the meaning.
+- **Keep the old method as a convenience**: `get_active_background_task_count()` can delegate to the new method and sum, preserving any callers and keeping tests simpler to migrate incrementally.
+
+## Implementation Units
+
+- [x] **Unit 1: DB + async layer — split counter query**
+
+  **Goal:** Add `get_background_task_counts()` returning `BackgroundTaskCounts { executing, queued }` and update the async wrapper.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `crates/mika-agent/src/db.rs`
+  - Modify: `crates/mika-agent/src/async_db.rs`
+  - Test: `crates/mika-agent/src/db.rs` (inline `#[cfg(test)]` module)
+
+  **Approach:**
+  - Add `BackgroundTaskCounts` struct in `db.rs` near the existing method
+  - New query uses two `SUM(CASE WHEN process_id IS NOT NULL THEN 1 ELSE 0 END)` expressions in a single SELECT to avoid two round-trips
+  - Rewrite `get_active_background_task_count()` to delegate: call `get_background_task_counts()` and return `executing + queued`
+  - Add async wrapper `get_background_task_counts()` in `async_db.rs` following the existing `with_db` pattern
+
+  **Patterns to follow:**
+  - Existing `get_active_background_task_count()` for query structure
+  - Existing async wrappers in `async_db.rs` for the delegation pattern
+
+  **Test scenarios:**
+  - Happy path: Two pending callback tasks, one with `process_id` set, one without → `executing=1, queued=1`
+  - Happy path: No callback tasks → `executing=0, queued=0`
+  - Happy path: All tasks have `process_id` → `executing=N, queued=0`
+  - Happy path: No tasks have `process_id` → `executing=0, queued=N`
+  - Edge case: Task completed (terminal status) with `process_id` still set → not counted in either bucket
+  - Integration: `get_active_background_task_count()` returns sum of both fields (backward compat)
+
+  **Verification:**
+  - `cargo test -p mika-agent -- test_get_active_background_task_count` passes (existing tests + new ones)
+
+- [x] **Unit 2: TUI app state + footer badge**
+
+  **Goal:** Split the `active_background_task_count` field into `executing_task_count` + `queued_task_count` and render `[1 running, 2 queued]` in the footer.
+
+  **Requirements:** R1
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `crates/mika-cli/src/tui/app.rs`
+  - Modify: `crates/mika-cli/src/tui/ui.rs`
+  - Modify: `crates/mika-cli/src/tui/commands/handlers.rs` (test update)
+
+  **Approach:**
+  - Replace `active_background_task_count: usize` with `executing_task_count: usize` and `queued_task_count: usize`
+  - Update polling block (~line 1032) to call `get_background_task_counts()` and set both fields
+  - Update `/clear` handler to preserve both fields (agent-scoped, not session-scoped)
+  - Badge rendering logic in `ui.rs`:
+    - Both > 0: `[1 running, 2 queued]` (Yellow)
+    - Only executing > 0: `[1 running]` (Yellow)
+    - Only queued > 0: `[2 queued]` (Yellow)
+    - Both 0: no badge (existing behavior)
+
+  **Patterns to follow:**
+  - Existing badge rendering for `[N tasks]` and `[N hidden]` in `ui.rs`
+  - Existing `/clear` preservation test in `handlers.rs`
+
+  **Test scenarios:**
+  - Happy path: Update `/clear` test to assert both `executing_task_count` and `queued_task_count` are preserved
+  - Edge case: Both counts zero → no badge rendered (existing behavior)
+
+  **Verification:**
+  - `cargo test -p mika-cli` passes
+  - `cargo clippy -p mika-cli` clean
+
+- [x] **Unit 3: `mika tasks list` — annotate callback task status**
+
+  **Goal:** Add `[executing]` or `[queued]` annotation to callback tasks in `print_task_summary()` for consistency with the TUI badge.
+
+  **Requirements:** R2
+
+  **Dependencies:** None (uses existing `process_id` field on Task struct)
+
+  **Files:**
+  - Modify: `crates/mika-cli/src/commands/tasks.rs`
+
+  **Approach:**
+  - In `print_task_summary()`, for callback tasks (`trigger_type == "callback"`), replace the raw `[PID N]` suffix with `[executing, PID N]` when `process_id.is_some()`, or `[queued]` when `process_id.is_none()` and status is `pending` or `in_progress`
+  - Non-callback tasks unchanged
+
+  **Patterns to follow:**
+  - Existing `pid_info` formatting in `print_task_summary()` at line 94-97
+
+  **Test scenarios:**
+  - Test expectation: none — pure formatting change on a display-only function; verified manually via `mika tasks list`
+
+  **Verification:**
+  - `cargo build -p mika-cli` compiles
+  - Manual: `mika tasks list` shows `[executing, PID N]` for active callbacks and `[queued]` for deferred ones
+
+## System-Wide Impact
+
+- **Interaction graph:** Only TUI polling and CLI task list rendering are affected. No callbacks, middleware, or dispatch logic touched.
+- **API surface parity:** `--format json` output for `mika tasks list` already includes `process_id` as a field; no change needed there.
+- **Unchanged invariants:** Task state machine, dispatch sequencing, callback lifecycle, watchdog behavior all untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `process_id` may briefly be NULL between task creation and subprocess spawn | This is correct behavior — the task genuinely is "queued" during that window. The counter accurately reflects reality. |
+| Subprocess dies but `process_id` not yet cleared by watchdog | Brief ~60s window where a dead task shows as "executing". Acceptable — the watchdog clears it on the next tick. No worse than current behavior. |
+
+## Sources & References
+
+- Related issue: senara-solutions/mika#1057
+- Callback watchdog: mika#959 (process liveness detection via `process_id`)
+- Deferred dispatch: mika#1058, mika#1070 (deferred callback promotion)

--- a/docs/plans/2026-05-12-001-fix-tui-running-counter-split-plan.md
+++ b/docs/plans/2026-05-12-001-fix-tui-running-counter-split-plan.md
@@ -1,0 +1,249 @@
+---
+title: "fix: Split TUI [N running] badge into executing vs queued counts"
+type: fix
+status: active
+date: 2026-05-12
+issue: "#1057"
+---
+
+# fix: Split TUI [N running] badge into executing vs queued counts
+
+## Overview
+
+The TUI footer badge `[N running]` conflates actively-executing callback tasks (claude-pilot subprocess running) with queued/deferred wrappers (acknowledged but waiting for a dispatch slot). This causes operator misreads — `[3 running]` implies parallel execution when only 1 subprocess is active and 2 are waiting. The fix splits the counter into `[1 running, 2 queued]` (Option A from the ticket), preserving queue-depth visibility while making execution state clear at a glance.
+
+## Problem Frame
+
+When mika-dev dispatches multiple sequential grooms, the TUI shows `[3 running]` because `get_active_background_task_count()` counts all callback tasks with `status IN ('pending', 'in_progress')` regardless of whether they have a live subprocess. The operator cannot distinguish executing from queued without running `mika tasks list` and checking PID annotations.
+
+## Requirements Trace
+
+- R1. Operator can distinguish "actively executing" from "queued for next slot" at a glance from the TUI
+- R2. Counter shape is consistent between TUI status bar and `mika tasks list` output
+- R3. No behavior change to dispatch sequencing — purely a display fix
+
+## Scope Boundaries
+
+- No changes to task state machine or dispatch logic
+- No schema migration — `process_id` column already exists
+- No changes to `mika tasks list` row format — it already shows `[PID N]` suffixes which serve R2
+
+### Deferred to Separate Tasks
+
+- `mika tasks list` header could show a summary like `Active Tasks (1 running, 2 queued):` instead of `Active Tasks (3):` — cosmetic enhancement, not blocking
+
+## Pinned Source (Phase 0)
+
+### Current `get_active_background_task_count()` body
+
+```sql
+-- db.rs:5129-5133
+SELECT COUNT(*) FROM tasks
+WHERE agent_id = ?1
+  AND trigger_type = 'callback'
+  AND action_type = 'resume_agent'
+  AND status IN ('pending', 'in_progress')
+```
+
+Returns `Result<usize>`. Async wrapper at `async_db.rs:424-426` delegates via `with_db`.
+
+### Exhaustive caller inventory
+
+| Caller | File | Usage |
+|--------|------|-------|
+| `App::tick()` | `crates/mika-cli/src/tui/app.rs:1035` | Polls every ~5s, stores in `self.active_background_task_count` |
+| `AsyncDatabase::get_active_background_task_count()` | `crates/mika-agent/src/async_db.rs:424` | Async wrapper (sole intermediary) |
+
+No server, engine, dispatch, or skill code calls this function. The async wrapper is the sole consumer, called only from `app.rs` tick. Three existing test functions in `db.rs:10921-10988` exercise the sync method directly.
+
+### `process_id` lifecycle
+
+| Event | Code site | Effect |
+|-------|-----------|--------|
+| **Set** | `skills/executor.rs:1424-1425` — `spawn_long_running_exec()` | `set_task_process_id(&task_id, Some(pid))` immediately after `child.id()` |
+| **Cleared (cancel)** | `task_engine/process_kill.rs:176` — `cancel_task_and_kill()` | `clear_task_process_id()` after `kill_process_gracefully()` |
+| **Cleared (orphan kill)** | `task_engine/engine.rs:305-306` — `kill_orphan_processes()` | `clear_task_process_id()` after `kill_process_immediate()` for expired tasks |
+| **Never explicitly cleared on normal completion** | Callback delivery marks task `completed`/`delivered` but does NOT clear `process_id` | Stale `process_id` on completed tasks is harmless — our query filters `status IN ('pending', 'in_progress')` |
+
+**Stale-PID invariant:** Between subprocess death and watchdog cleanup (~60s detection + 120s grace = ~3 min), `process_id` remains set on a dead-process task. The old counter also counted these as "running." The new discriminator (`process_id IS NOT NULL AND status = 'in_progress'`) is strictly more accurate: it excludes completed/failed tasks with stale `process_id`. The stale-PID window is inherited, not widened.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/db.rs:5127-5138` — `get_active_background_task_count()` current COUNT query
+- `crates/mika-agent/src/async_db.rs:424-426` — async wrapper
+- `crates/mika-cli/src/tui/app.rs:581` — `active_background_task_count: usize` field
+- `crates/mika-cli/src/tui/app.rs:1032-1040` — polling in `tick()`
+- `crates/mika-cli/src/tui/ui.rs:1063-1070` — badge rendering in `draw_footer()`
+- `crates/mika-cli/src/tui/commands/handlers.rs` — `/clear` preserves background task count (agent-scoped)
+- Existing pattern: `pending_task_count` + `active_background_task_count` — same polling/rendering shape
+
+### Institutional Learnings
+
+- `docs/solutions/ux-improvements/tui-background-task-running-indicator.md` — original badge implementation; documents the agent-scoped vs session-scoped semantics and `/clear` preservation
+- `docs/solutions/logic-errors/failed-callback-tasks-silently-dropped.md` — warns that callback status filters across db.rs must be kept consistent; audit all callback query locations when adding new filters
+- `docs/solutions/logic-errors/callback-processing-race-steals-tui-notifications.md` — TUI polling and engine dispatch share callback queries; new filters must not interfere with claim ordering
+
+## Key Technical Decisions
+
+- **Option A (split counter) over Option B (hide queued):** Preserves queue-depth visibility which is valuable for reasoning about dispatch backlog and cost
+- **`process_id IS NOT NULL` as the executing signal:** The `process_id` column is populated by `spawn_long_running_exec()` at subprocess spawn time and used by the callback watchdog (#959) for liveness checks. It is the ground-truth indicator that a subprocess is running — more reliable than `status = 'in_progress'` alone (which is set when mika-dev accepts the dispatch, before spawn)
+- **Return a struct from one query, not two queries:** Single `SELECT` with conditional counting (`SUM(CASE WHEN ... END)`) avoids doubling DB round-trips on the 5s polling cadence
+- **Replace single field with a struct:** `BackgroundTaskCounts { executing: usize, queued: usize }` replaces `active_background_task_count: usize` — clearer than two loosely-coupled fields
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should deferred callbacks (label `LIKE '%:deferred'`) count as queued or executing?** Queued — they have no subprocess and are waiting for a dispatch slot, same as pending wrappers. The `process_id IS NULL` filter naturally classifies them correctly.
+- **Should we change `mika tasks list` row output?** No — it already shows `[PID N]` for executing tasks, which satisfies R2. The header line could be enhanced but that is a cosmetic follow-up.
+
+### Deferred to Implementation
+
+- Exact Rust struct field names — will follow existing naming conventions
+
+## Implementation Units
+
+- [ ] **Unit 1: Split the DB query**
+
+**Goal:** Replace `get_active_background_task_count()` with a method that returns both executing and queued counts from a single query.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/db.rs`
+- Modify: `crates/mika-agent/src/async_db.rs`
+- Test: `crates/mika-agent/src/db.rs` (inline `#[cfg(test)]` module)
+
+**Approach:**
+- Add a `BackgroundTaskCounts` struct with `executing: usize` and `queued: usize` fields
+- Replace `get_active_background_task_count()` with `get_background_task_counts()` returning `BackgroundTaskCounts`
+- Single SQL query using conditional aggregation: executing = `process_id IS NOT NULL AND status = 'in_progress'`; queued = the remainder (`process_id IS NULL` or `status = 'pending'`)
+- Keep the same base filter: `trigger_type = 'callback' AND action_type = 'resume_agent' AND status IN ('pending', 'in_progress')`
+- Update the async wrapper in `async_db.rs` to match
+
+**Patterns to follow:**
+- Existing `get_active_background_task_count()` shape
+- Other struct-returning db methods (e.g., `Task` struct pattern)
+
+**Test scenarios:**
+- Happy path: 1 task with process_id + 2 tasks without process_id -> `BackgroundTaskCounts { executing: 1, queued: 2 }`
+- Happy path: 0 callback tasks -> `BackgroundTaskCounts { executing: 0, queued: 0 }`
+- Edge case: all tasks executing (all have process_id) -> queued = 0
+- Edge case: all tasks queued (none have process_id) -> executing = 0
+- Edge case: pending status tasks always count as queued regardless of process_id presence
+
+**Verification:**
+- `cargo test -p mika-agent` passes with new tests covering the split counts
+
+- [ ] **Unit 2: Update TUI app state and polling**
+
+**Goal:** Replace the single `active_background_task_count` field with executing + queued counts and update the polling logic.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `crates/mika-cli/src/tui/app.rs`
+
+**Approach:**
+- Replace `active_background_task_count: usize` with two fields: `executing_task_count: usize` and `queued_task_count: usize`
+- Update initialization (two locations) to set both to 0
+- Update the tick polling block to call `get_background_task_counts()` and compare both values for change detection
+- Preserve agent-scoped semantics: NOT reset on `/clear` (same as current behavior)
+
+**Patterns to follow:**
+- Existing polling pattern at `app.rs:1032-1040`
+- Existing `/clear` preservation logic in `commands/handlers.rs`
+
+**Test scenarios:**
+- Happy path: verify `/clear` handler does NOT reset `executing_task_count` or `queued_task_count` (agent-scoped semantics preserved — same as existing `active_background_task_count` behavior documented in `docs/solutions/ux-improvements/tui-background-task-running-indicator.md`)
+
+**Verification:**
+- `cargo build` succeeds with no unused-field warnings
+- `/clear` handler code inspection confirms new fields are NOT listed among reset fields
+
+- [ ] **Unit 3: Update TUI footer badge rendering**
+
+**Goal:** Render `[1 running, 2 queued]` instead of `[3 running]` in the TUI footer.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `crates/mika-cli/src/tui/ui.rs`
+
+**Approach:**
+- Update the badge rendering block at `ui.rs:1063-1070`
+- Three display states:
+  - Both > 0: `[N running, M queued]` — "running" in Yellow, "queued" in DarkGray or Cyan
+  - Only executing > 0: `[N running]` — Yellow (same as current for single dispatch)
+  - Only queued > 0: `[M queued]` — DarkGray (no active execution, tasks waiting)
+  - Both = 0: no badge (same as current)
+- Use multiple styled `Span`s within the badge for color differentiation
+
+**Patterns to follow:**
+- Existing multi-span badge patterns in `draw_footer()` (e.g., `[N tasks]` badge)
+- Color conventions: Yellow for active/running, DarkGray for passive/waiting
+
+**Test scenarios:**
+- Test expectation: none — pure rendering logic. Visual correctness verified by running the TUI.
+
+**Verification:**
+- `cargo build` succeeds
+- Running `mika` with active background tasks shows the split counter format
+
+- [ ] **Unit 4: Update any remaining references**
+
+**Goal:** Fix all compilation errors from the renamed field and ensure consistency.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `crates/mika-cli/src/tui/commands/handlers.rs` (if `/clear` handler references the old field name)
+- Grep: any other references to `active_background_task_count` across the codebase
+
+**Approach:**
+- Search for all references to `active_background_task_count` and update them
+- The `/clear` handler intentionally does NOT reset this field — preserve that semantic with the new field names
+- Verify no other crate consumes `get_active_background_task_count()` from the public API
+
+**Patterns to follow:**
+- Existing field reference patterns
+
+**Test scenarios:**
+- Test expectation: none — mechanical rename, no behavioral change
+
+**Verification:**
+- `cargo build` succeeds with zero warnings
+- `cargo clippy` clean
+- `cargo test` passes
+
+## System-Wide Impact
+
+- **Interaction graph:** The DB query is consumed only by TUI polling (app.rs tick). No server, engine, or skill code calls `get_active_background_task_count()`. The async wrapper is the sole consumer from CLI code.
+- **Error propagation:** No change — query errors are absorbed by the `let Ok(...)` guard in the polling block.
+- **State lifecycle risks:** None — the fields are display-only counters refreshed every 5s. No cache invalidation or write-back.
+- **API surface parity:** `mika tasks list` already shows PID info per-row; no format change needed for R2 consistency. The `--format json` output includes `process_id` in the task JSON.
+- **Unchanged invariants:** Dispatch sequencing, callback lifecycle, watchdog behavior, `/clear` agent-scoped semantics — all unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `process_id` may be NULL for a brief window between task creation and subprocess spawn | This is correct behavior — the task IS queued during that window. The display accurately reflects reality. |
+| Stale `process_id` on dead subprocess (~3 min watchdog window) | The stale-PID window is inherited from the existing counter, not widened. The new discriminator is strictly more accurate because it excludes completed/failed tasks with stale `process_id`. No regression. |
+| Other code paths consuming `get_active_background_task_count()` break | Exhaustive caller inventory (see Pinned Source): only the async wrapper calls it, called only from `app.rs` tick. Two callers total. |
+
+## Sources & References
+
+- Related issue: [#1057](https://github.com/senara-solutions/mika/issues/1057)
+- Prior implementation: `docs/solutions/ux-improvements/tui-background-task-running-indicator.md`
+- Callback audit learnings: `docs/solutions/logic-errors/failed-callback-tasks-silently-dropped.md`


### PR DESCRIPTION
## Summary

Splits the mika-dev TUI `[N running]` status counter into `[executing, queued]` so operators can distinguish active claude-pilot subprocesses from deferred wrappers in the queue. Closes mika#1057.

## Plan

See `docs/plans/2026-05-12-001-fix-tui-running-counter-split-plan.md` for groomed design + architect GROOMED verdict.

## Recovery note

This PR is being opened by orchestrator-Claude after the original claude-pilot impl session (81 turns, 2026-05-11) terminated before opening the PR. The 2 commits (`74c0fb60` plan + `1965fd72` impl) are claude-pilot's work; this PR finalizes delivery.