### PR TITLE
infra(skills): raise bundled-skill prompt ceiling from 64KB to 80KB

### DIFF
--- a/crates/mika-agent/docs/skills.md
+++ b/crates/mika-agent/docs/skills.md
@@ -57,7 +57,7 @@ The manifest is a TOML file with two sections: `[skill]` (required) and `[trigge
 | `always_on`    | bool   | No       | `false` | If true, this skill is active on every turn regardless of keywords. For built-in skills, user overrides are stored in the `skill_overrides` DB table (not in `skill.toml`). |
 | `timeout_secs` | u64    | No       | `30`    | Per-tool execution timeout in seconds. |
 | `dependencies` | Array\<String\> | No | `[]` | Other skill names that should be loaded when this skill is active. One level only — no transitive resolution. |
-| `max_prompt_size` | u64 | No | `None` | Override the default 16KB size limit for `system_prompt.md`. Clamped to a 64KB ceiling to prevent abuse. |
+| `max_prompt_size` | u64 | No | `None` | Override the default 16KB size limit for `system_prompt.md`. Clamped to an 80KB ceiling to prevent abuse. |
 
 ### `[triggers]` section
 
@@ -377,7 +377,7 @@ description = "Skill with a large system prompt"
 max_prompt_size = 32768  # 32KB
 ```
 
-The `max_prompt_size` value is clamped to a hard ceiling of **64KB** regardless of what is specified. Use `mika skills validate` to check whether a skill's prompt exceeds its effective limit.
+The `max_prompt_size` value is clamped to a hard ceiling of **80KB** regardless of what is specified. Use `mika skills validate` to check whether a skill's prompt exceeds its effective limit.
 
 ### Per-Provider and Per-Model Variant Directories
 

--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -17,9 +17,9 @@ const MAX_SKILL_TOML_SIZE: u64 = 64 * 1024;
 /// Default maximum size for system_prompt.md snippets (16 KB).
 pub(super) const MAX_PROMPT_SNIPPET_SIZE: u64 = 16 * 1024;
 
-/// Hard ceiling for per-skill `max_prompt_size` override (64 KB).
+/// Hard ceiling for per-skill `max_prompt_size` override (80 KB).
 /// Prevents marketplace skills from loading arbitrarily large prompts.
-pub(super) const MAX_PROMPT_SIZE_CEILING: u64 = 64 * 1024;
+pub(super) const MAX_PROMPT_SIZE_CEILING: u64 = 80 * 1024;
 
 /// Maximum size for tools.json files (256 KB).
 const MAX_TOOLS_JSON_SIZE: u64 = 256 * 1024;
@@ -516,7 +516,7 @@ pub fn scan_skills_dir(skills_dir: &Path) -> ScanResult {
                     size,
                     limit,
                     "prompt exceeds size limit — skill NOT loaded. \
-                     Increase max_prompt_size in skill.toml (ceiling: 64KB) or reduce the prompt."
+                     Increase max_prompt_size in skill.toml (ceiling: 80KB) or reduce the prompt."
                 );
                 skipped.push(SkippedSkill {
                     name: manifest.skill.name.clone(),
@@ -2169,7 +2169,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        // 100KB prompt — over 64KB ceiling
+        // 100KB prompt — over 80KB ceiling
         let content = "x".repeat(100 * 1024);
         fs::write(skill_dir.join("system_prompt.md"), &content).unwrap();
 
@@ -2270,7 +2270,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        // 29KB prompt — over 16KB default but under 64KB ceiling
+        // 29KB prompt — over 16KB default but under 80KB ceiling
         let content = "x".repeat(29 * 1024);
         fs::write(skill_dir.join("system_prompt.md"), &content).unwrap();
 

--- a/crates/mika-agent/tests/bundled_skills_load.rs
+++ b/crates/mika-agent/tests/bundled_skills_load.rs
@@ -55,7 +55,7 @@ fn bundled_skills_load_without_oversized_prompts() {
              Each skipped skill below is invisible at runtime — the agent \
              will boot in a silently-degraded state until the cause is fixed.\n\n\
              Per-skill remediation:\n  - 'oversized prompt': raise `max_prompt_size` \
-             in the skill's `skill.toml` (ceiling 64KB), or trim the prompt.\n  - other \
+             in the skill's `skill.toml` (ceiling 80KB), or trim the prompt.\n  - other \
              reasons: see the skill's manifest, prompt file, and `scan_skills_dir` \
              error variants.\n\nDropped skills:\n",
         );

--- a/docs/plans/2026-05-14-001-infra-raise-prompt-ceiling-plan.md
+++ b/docs/plans/2026-05-14-001-infra-raise-prompt-ceiling-plan.md
@@ -1,0 +1,77 @@
+# Plan: Raise bundled-skill prompt ceiling from 64KB to 80KB
+
+**Ticket:** mika issue#1105
+**Type:** infra
+**Date:** 2026-05-14
+
+## Context
+
+The hard ceiling for bundled-skill `system_prompt.md` files is 64KB (65,536 bytes), enforced by `MAX_PROMPT_SIZE_CEILING` in `crates/mika-agent/src/skills/index.rs`. The `self-dev` prompt is at 65,248B — 288B of headroom. Two open PRs (#1101, #1103) each push past the limit and are blocked.
+
+This is a tactical unblock: raise the ceiling to 80KB (81,920 bytes) to restore ~22% headroom while a structural decomposition of self-dev is planned separately.
+
+## Scope
+
+**In scope:**
+1. Raise `MAX_PROMPT_SIZE_CEILING` constant from `64 * 1024` to `80 * 1024`
+2. Update all user-facing strings that reference "64KB" in the context of the prompt ceiling
+3. Update documentation that references the 64KB ceiling
+
+**Out of scope:**
+- `MAX_SKILL_TOML_SIZE` stays at `64 * 1024` (separate concern — manifest file size, not prompt size)
+- `INVESTIGATE_BODY_LIMIT` in `server/investigate.rs` (unrelated 64KB constant)
+- Test data values that construct oversized files for testing (these test the mechanism, not the specific number)
+
+## Changes
+
+### 1. `crates/mika-agent/src/skills/index.rs` — Constants and messages
+
+| Location | Current | New |
+|----------|---------|-----|
+| Line 22: `MAX_PROMPT_SIZE_CEILING` constant | `64 * 1024` | `80 * 1024` |
+| Line 20: Doc comment | "Hard ceiling … (64 KB)" | "Hard ceiling … (80 KB)" |
+| Line 438: warn message | `"skill.toml exceeds 64KB, skipping"` | No change — this references `MAX_SKILL_TOML_SIZE`, not the prompt ceiling |
+| Line 442: reason format | `"skill.toml exceeds 64KB ({}B)"` | No change — same, `MAX_SKILL_TOML_SIZE` |
+| Line 519: error message | `"ceiling: 64KB"` | `"ceiling: 80KB"` |
+| Line 662: diagnostic | `"skill.toml exceeds 64KB"` | No change — `MAX_SKILL_TOML_SIZE` |
+
+### 2. `crates/mika-agent/tests/bundled_skills_load.rs` — Regression test
+
+| Location | Current | New |
+|----------|---------|-----|
+| Line 57-58: remediation hint | `"ceiling 64KB"` | `"ceiling 80KB"` |
+
+### 3. `crates/mika-agent/src/skills/index.rs` — Test comments
+
+| Location | Current | New |
+|----------|---------|-----|
+| Line 2172: test comment | `"100KB prompt — over 64KB ceiling"` | `"100KB prompt — over 80KB ceiling"` |
+| Line 2273: test comment | `"29KB prompt — over 16KB default but under 64KB ceiling"` | `"29KB prompt — over 16KB default but under 80KB ceiling"` |
+
+### 4. Documentation updates
+
+| File | Current | New |
+|------|---------|-----|
+| `crates/mika-agent/docs/skills.md` line 60 | `"Clamped to a 64KB ceiling"` | `"Clamped to an 80KB ceiling"` |
+| `crates/mika-agent/docs/skills.md` line 380 | `"hard ceiling of **64KB**"` | `"hard ceiling of **80KB**"` |
+| `crates/mika-agent/docs/architecture.md` line 277 | `"max 64KB"` — this refers to skill.toml, not prompt | No change |
+
+### 5. No test logic changes needed
+
+The existing tests construct oversized files relative to `MAX_PROMPT_SIZE_CEILING` implicitly:
+- `test_scan_skips_oversized_manifest` — tests `MAX_SKILL_TOML_SIZE` (65KB file vs 64KB limit), unchanged
+- `test_scan_skips_prompt_over_ceiling` — tests 100KB prompt, still over 80KB ceiling, test still passes
+- `test_scan_loads_custom_max_prompt_size` — tests 29KB prompt under ceiling with `max_prompt_size = 65536`, still under 80KB, test still passes
+
+The test at line 2269 uses `max_prompt_size = 65536` which is a per-skill override (clamped to ceiling). With ceiling at 80KB, 65536 is still under ceiling so the clamp is a no-op and the behavior is identical. No change needed.
+
+## Verification
+
+```bash
+cargo test -p mika-agent --test bundled_skills_load
+cargo test -p mika-agent -- test_scan_skips_oversized_manifest test_scan_skips_prompt_over_ceiling test_scan_loads_custom_max_prompt_size
+```
+
+## Risk
+
+Low. Pure constant change with documentation alignment. No behavioral change for any prompt currently under 64KB. The only behavioral change is that prompts between 64KB and 80KB that were previously rejected will now load.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -57,7 +57,7 @@ The manifest is a TOML file with two sections: `[skill]` (required) and `[trigge
 | `always_on`    | bool   | No       | `false` | If true, this skill is active on every turn regardless of keywords. For built-in skills, user overrides are stored in the `skill_overrides` DB table (not in `skill.toml`). |
 | `timeout_secs` | u64    | No       | `30`    | Per-tool execution timeout in seconds. |
 | `dependencies` | Array\<String\> | No | `[]` | Other skill names that should be loaded when this skill is active. One level only — no transitive resolution. |
-| `max_prompt_size` | u64 | No | `None` | Override the default 16KB size limit for `system_prompt.md`. Clamped to a 64KB ceiling to prevent abuse. |
+| `max_prompt_size` | u64 | No | `None` | Override the default 16KB size limit for `system_prompt.md`. Clamped to an 80KB ceiling to prevent abuse. |
 
 ### `[triggers]` section
 
@@ -377,7 +377,7 @@ description = "Skill with a large system prompt"
 max_prompt_size = 32768  # 32KB
 ```
 
-The `max_prompt_size` value is clamped to a hard ceiling of **64KB** regardless of what is specified. Use `mika skills validate` to check whether a skill's prompt exceeds its effective limit.
+The `max_prompt_size` value is clamped to a hard ceiling of **80KB** regardless of what is specified. Use `mika skills validate` to check whether a skill's prompt exceeds its effective limit.
 
 ### Per-Provider and Per-Model Variant Directories
 

--- a/docs/solutions/infrastructure/1105-prompt-ceiling-raise-64kb-to-80kb-2026-05-14.md
+++ b/docs/solutions/infrastructure/1105-prompt-ceiling-raise-64kb-to-80kb-2026-05-14.md
@@ -1,0 +1,41 @@
+---
+module: mika-agent/skills
+tags: [skills, prompt-size, ceiling, bundled-skills, infrastructure]
+problem_type: infrastructure
+category: infrastructure
+---
+
+# Raise bundled-skill prompt ceiling from 64KB to 80KB
+
+## Problem
+
+The hard ceiling for bundled-skill `system_prompt.md` files (`MAX_PROMPT_SIZE_CEILING`) was 64KB (65,536 bytes). The `self-dev` prompt had grown to 65,248B — only 288B of headroom. Two PRs (#1101, #1103) that each added legitimate content to self-dev were blocked because they pushed past the ceiling.
+
+The ceiling exists as a structural guard: without it, an oversized prompt causes the skill to be silently skipped at startup, leaving the agent in a degraded state. The guard converts silent degradation into a build-time / CI failure.
+
+## Solution
+
+Raised `MAX_PROMPT_SIZE_CEILING` from `64 * 1024` to `80 * 1024` (81,920 bytes). This is a tactical unblock that restores ~22% headroom.
+
+### Files changed
+
+- `crates/mika-agent/src/skills/index.rs` — constant, doc comment, warning message, test comments
+- `crates/mika-agent/tests/bundled_skills_load.rs` — remediation hint in failure message
+- `docs/skills.md` and `crates/mika-agent/docs/skills.md` — documentation references
+
+### What was NOT changed (and why)
+
+- `MAX_SKILL_TOML_SIZE` stays at 64KB — that's the manifest file size limit, a separate concern
+- `INVESTIGATE_BODY_LIMIT` in `server/investigate.rs` — unrelated 64KB constant
+- Test data values that construct oversized files — they test the mechanism (100KB vs ceiling), not the specific number
+
+## Follow-up
+
+This is not the permanent target. A structural decomposition of self-dev along the trigger-event axis will bring the prompt back under a tighter ceiling. Once that lands, the ceiling should be re-tightened.
+
+## Verification
+
+```bash
+cargo test -p mika-agent --test bundled_skills_load
+cargo test -p mika-agent -- test_scan_clamps_override_to_ceiling test_scan_skips_always_on_skill_with_oversized_prompt
+```


### PR DESCRIPTION
## Summary

Tactical unblock for #1101 and #1103 — raises `MAX_PROMPT_SIZE_CEILING` from 64KB to 80KB (81,920 bytes), restoring ~22% headroom for the self-dev prompt which is at 65,248B on main.

- Update `MAX_PROMPT_SIZE_CEILING` constant from `64 * 1024` to `80 * 1024`
- Update all user-facing messages and documentation referencing the ceiling
- `MAX_SKILL_TOML_SIZE` (64KB) unchanged — separate concern (manifest file size)

This is a tactical unblock, not the permanent target. A structural decomposition of self-dev along the trigger-event axis will bring the prompt back under a tighter ceiling.

Closes #1105

Plan: docs/plans/2026-05-14-001-infra-raise-prompt-ceiling-plan.md
Plan: docs/plans/2026-05-13-003-bug-dev-groom-claude-pilot-exits-success-without-architect-plan.md
Plan: docs/plans/2026-05-14-002-fix-dispatch-gate-broaden-then-investigate-plan.md

## Test plan

- [x] `cargo test -p mika-agent --test bundled_skills_load` passes
- [x] All ceiling-related unit tests pass (`test_scan_clamps_override_to_ceiling`, `test_scan_skips_always_on_skill_with_oversized_prompt`, etc.)
- [x] `docs/skills.md` and `crates/mika-agent/docs/skills.md` in sync
- [x] No stale "64KB" references in prompt-ceiling context (remaining 64KB references are `MAX_SKILL_TOML_SIZE` — separate concern)
- [ ] After rebase, #1101 and #1103 should pass `bundled_skills_load` without prompt size changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)