### PR TITLE
ops(labels): add regression and kg labels to labels.yml (#1104)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,6 +36,10 @@
   color: "008672"
   description: Extra attention is needed
 
+- name: regression
+  color: "8b0000"
+  description: Functionality that previously worked has broken — distinct from new bugs
+
 # ── Priority ──────────────────────────────────────────────────────────────────
 - name: p0-critical
   color: "b60205"
@@ -81,6 +85,10 @@
 - name: dashboard
   color: "7057ff"
   description: Observability dashboard (React SPA)
+
+- name: kg
+  color: "5C6BC0"
+  description: Knowledge Graph subsystem (extraction, resolution, corpora, schema)
 
 # ── State ─────────────────────────────────────────────────────────────────────
 - name: ready

--- a/docs/plans/2026-05-14-003-ops-add-regression-kg-labels-plan.md
+++ b/docs/plans/2026-05-14-003-ops-add-regression-kg-labels-plan.md
@@ -1,0 +1,55 @@
+---
+type: ops
+ticket: mika issue#1104
+title: "Add regression and kg labels to labels.yml"
+date: 2026-05-14
+branch: ops/1104/labels-add-regression-and-kg-labels-to
+---
+
+# Plan: Add `regression` and `kg` labels to labels.yml
+
+## Context
+
+Two label gaps identified during 2026-05-13 orchestrator audit:
+
+1. **No `regression` label** — multiple regression-class tickets (mika#1089, #1090, #1097, #1102) are indistinguishable from `bug` in filtered views. Regressions are functionality that previously worked and broke — distinct from new defects.
+
+2. **No `kg` component label** — KG subsystem tickets (mika#1076, #1077, #1091, paused #960, #918) have no unifying filter. Needed for `gh issue list --label kg` when operating on the self-awareness research track.
+
+## Change
+
+Edit `mika/.github/labels.yml`. Add two entries in the appropriate sections:
+
+### Under `# ── Type ──` section (after `wontfix` or `help wanted`):
+
+```yaml
+- name: regression
+  color: "8b0000"
+  description: Functionality that previously worked has broken — distinct from new bugs
+```
+
+### Under `# ── Component ──` section (after `dashboard`):
+
+```yaml
+- name: kg
+  color: "5C6BC0"
+  description: Knowledge Graph subsystem (extraction, resolution, corpora, schema)
+```
+
+## Color rationale
+
+- `regression` (#8b0000, dark red) — differentiates from `bug` (#d73a4a, red) and `p0-critical` (#b60205, deep red). Semantically "red family" but visually distinct.
+- `kg` (#5C6BC0, indigo) — differentiates from `agent-core` (#1d76db, blue), `tui` (#5319e7, purple), `team-engine` (#0e8a16, green). Blue-purple range for component labels.
+
+## Verification
+
+Label-sync action (`EndBug/label-sync` in `.github/workflows/labels.yml`) applies on merge. Post-merge verify:
+
+```bash
+gh label list --repo senara-solutions/mika | grep -E '(regression|kg)'
+```
+
+## Out of scope
+
+- Retroactive label application to existing tickets (operator-side, no code change)
+- Additional labels (`architect`, `workflow`, `release` rename) — deferred per ticket


### PR DESCRIPTION
## Summary

Adds two labels to `.github/labels.yml`:

- **`regression`** (Type section, dark red) — for functionality-that-previously-worked-broke tickets, distinguishing them from new-bug tickets (e.g., #1089, #1090, #1097, #1102).
- **`kg`** (Component section, indigo) — for Knowledge Graph subsystem tickets (e.g., #1076, #1077, #1091, paused #960, #918).

## Provenance

Implementation done by orchestrator via Mode 2 fallback recovery. The autonomous-loop dev-pilot was dispatched twice for mika#1104 and produced no commits both times — host task marked `failed` with `callback_delivered_without_pr_url` per mika#1097-style symptom (cost: $0.29 across 2 attempts). Orchestrator applied the trivial 2-section YAML edit per the architect-approved plan-doc on the branch.

Plan: `docs/plans/2026-05-14-003-ops-add-regression-kg-labels-plan.md` (`8d59087f`, architect READY first-pass).

## Test plan

- [ ] mika-qa review for AC verification
- [ ] CI green
- [ ] Post-merge: `gh label list --repo senara-solutions/mika | grep -E '(regression|kg)'` shows both labels active (label-sync action applies on merge)

Closes #1104
