### PR TITLE
fix(mika-agent): diagnostic instrumentation for run_gh 600s timeout (#900)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "uuid",

--- a/crates/mika-agent/Cargo.toml
+++ b/crates/mika-agent/Cargo.toml
@@ -64,3 +64,4 @@ tower.workspace = true
 http-body-util.workspace = true
 mika-common = { workspace = true, features = ["test-utils"] }
 serial_test.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -2765,6 +2765,14 @@ async fn execute_tool(
 ) -> ToolOutput {
     debug!(tool = %name, "tool_execution");
 
+    // Pre-compute input excerpt for timeout diagnostics (#900). Must happen
+    // before `input` is moved into the execute call.
+    let input_excerpt: String = serde_json::to_string(&input)
+        .unwrap_or_default()
+        .chars()
+        .take(200)
+        .collect();
+
     // 1. Try builtin tool
     if let Some(tool) = dispatch.tools.get(name) {
         let timeout = tool.timeout_secs().unwrap_or(TOOL_TIMEOUT_SECS);
@@ -2780,7 +2788,7 @@ async fn execute_tool(
                 ToolOutput::error(format!("Tool error: {e}"))
             }
             Err(_) => {
-                warn!(tool = %name, timeout_secs = timeout, "tool execution timed out");
+                warn!(tool = %name, timeout_secs = timeout, input_excerpt = %input_excerpt, "tool execution timed out");
                 ToolOutput::error(format!("Tool '{name}' timed out after {timeout}s"))
             }
         };
@@ -2799,7 +2807,7 @@ async fn execute_tool(
             {
                 Ok(output) => output,
                 Err(_) => {
-                    warn!(tool = %name, timeout_secs = timeout, "builtin handler timed out");
+                    warn!(tool = %name, timeout_secs = timeout, input_excerpt = %input_excerpt, "builtin handler timed out");
                     ToolOutput::error(format!("Builtin tool '{name}' timed out after {timeout}s"))
                 }
             };

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -36,6 +36,8 @@ const MAX_CALLBACK_TOOL_STEPS: usize = 20;
 const MAX_TEAM_TOOL_STEPS: usize = 20;
 const TOOL_TIMEOUT_SECS: u64 = 30;
 const AGENT_TOTAL_TIMEOUT_SECS: u64 = 300;
+/// Max chars of serialized tool input to include in timeout log lines (#900).
+const TOOL_TIMEOUT_INPUT_EXCERPT_LEN: usize = 200;
 /// Maximum bytes for callback results injected into the system prompt via
 /// `format_callback_framing()`. Results exceeding this are truncated to prevent
 /// oversized prompts from consuming the agent timeout during serialization.
@@ -2770,7 +2772,7 @@ async fn execute_tool(
     let input_excerpt: String = serde_json::to_string(&input)
         .unwrap_or_default()
         .chars()
-        .take(200)
+        .take(TOOL_TIMEOUT_INPUT_EXCERPT_LEN)
         .collect();
 
     // 1. Try builtin tool

--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -5,9 +5,10 @@
 //! to `ToolContext` (for home_dir, etc.) and return `ToolOutput`.
 
 use std::fmt::Write;
-use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, LazyLock};
 
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::bundled_skills::{is_trust_critical_skill, trust_critical_skill_names};
 use crate::skills::index::{resolve_canonical_provider_model, sanitize_model_dir_name};
@@ -338,11 +339,44 @@ fn parse_command_array(input: &serde_json::Value) -> Result<Vec<String>, ToolOut
     Ok(args)
 }
 
+/// Progress ticker interval for `spawn_and_collect` diagnostic logging (#900).
+/// 30 seconds in production; overridden in tests via `PROGRESS_TICKER_INTERVAL`.
+#[cfg(not(test))]
+const PROGRESS_TICKER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(test)]
+const PROGRESS_TICKER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Read from an async reader into a buffer up to `max_bytes`, incrementing
+/// `counter` after each chunk. Enables external progress observation (#900).
+async fn read_with_counter<R: AsyncRead + Unpin>(
+    reader: R,
+    max_bytes: usize,
+    counter: Arc<AtomicUsize>,
+) -> Vec<u8> {
+    let mut take = reader.take(max_bytes as u64);
+    let mut buf = Vec::with_capacity(max_bytes.min(8192));
+    let mut chunk = [0u8; 256];
+    loop {
+        match take.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                counter.fetch_add(n, Ordering::Relaxed);
+            }
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
 /// Spawn a CLI subprocess, capture bounded stdout/stderr, and return ToolOutput.
 ///
 /// Shared logic for all CLI builtin handlers (gh, gws, etc.). The caller builds
 /// the `Command` with args, env vars, and security scrubbing; this function handles
 /// the spawn-read-wait-format cycle.
+///
+/// Includes diagnostic instrumentation (#900): per-invocation progress ticker at
+/// 30-second intervals logging stdout/stderr byte counts, plus a completion summary.
 async fn spawn_and_collect(
     mut cmd: tokio::process::Command,
     tool_name: &str,
@@ -360,22 +394,64 @@ async fn spawn_and_collect(
         }
     };
 
-    // Read stdout and stderr with bounded size to prevent memory exhaustion
+    let started_at = tokio::time::Instant::now();
+    let stdout_count = Arc::new(AtomicUsize::new(0));
+    let stderr_count = Arc::new(AtomicUsize::new(0));
+
+    // Read stdout and stderr with bounded size, tracking byte counts for diagnostics
     let stdout_handle = child.stdout.take().expect("stdout piped");
     let stderr_handle = child.stderr.take().expect("stderr piped");
-    let mut stdout_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
-    let mut stderr_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
 
-    let mut stdout_take = stdout_handle.take(MAX_OUTPUT_LEN as u64);
-    let mut stderr_take = stderr_handle.take(MAX_OUTPUT_LEN as u64);
-    let (stdout_res, stderr_res) = tokio::join!(
-        stdout_take.read_to_end(&mut stdout_buf),
-        stderr_take.read_to_end(&mut stderr_buf),
+    let stdout_reader = tokio::spawn(read_with_counter(
+        stdout_handle,
+        MAX_OUTPUT_LEN,
+        Arc::clone(&stdout_count),
+    ));
+    let stderr_reader = tokio::spawn(read_with_counter(
+        stderr_handle,
+        MAX_OUTPUT_LEN,
+        Arc::clone(&stderr_count),
+    ));
+
+    // Progress ticker: every PROGRESS_TICKER_INTERVAL, log byte count snapshots (#900)
+    let progress_task = {
+        let stdout_c = Arc::clone(&stdout_count);
+        let stderr_c = Arc::clone(&stderr_count);
+        let name = tool_name.to_string();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(PROGRESS_TICKER_INTERVAL);
+            interval.tick().await; // discard immediate first tick
+            loop {
+                interval.tick().await;
+                tracing::info!(
+                    tool = %name,
+                    stdout_bytes = stdout_c.load(Ordering::Relaxed),
+                    stderr_bytes = stderr_c.load(Ordering::Relaxed),
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    "spawn_and_collect progress"
+                );
+            }
+        })
+    };
+
+    // Wait for both reads + process exit
+    let (stdout_res, stderr_res, wait_res) =
+        tokio::join!(stdout_reader, stderr_reader, child.wait());
+    progress_task.abort();
+
+    let stdout_buf = stdout_res.unwrap_or_default();
+    let stderr_buf = stderr_res.unwrap_or_default();
+
+    // Post-completion summary (#900)
+    tracing::info!(
+        tool = %tool_name,
+        stdout_bytes = stdout_count.load(Ordering::Relaxed),
+        stderr_bytes = stderr_count.load(Ordering::Relaxed),
+        elapsed_ms = started_at.elapsed().as_millis() as u64,
+        "spawn_and_collect complete"
     );
-    stdout_res.ok();
-    stderr_res.ok();
 
-    let status = match child.wait().await {
+    let status = match wait_res {
         Ok(s) => s,
         Err(e) => {
             return ToolOutput::error(format!("Failed to execute {tool_name}: {e}"));
@@ -1649,6 +1725,21 @@ async fn run_gh(input: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolOutput 
     if let Some(token) = ctx.github_token {
         cmd.env("GH_TOKEN", token);
     }
+
+    // Diagnostic instrumentation (#900): log the exact gh subcommand, env key set
+    // (keys only, never values), and token presence for timeout forensics.
+    let env_keys_set: &[&str] = match ctx.github_token {
+        Some(_) => &["GH_PROMPT_DISABLED", "GH_TOKEN"],
+        None => &["GH_PROMPT_DISABLED"],
+    };
+    tracing::info!(
+        tool = "run_gh",
+        argv = ?&gh_args.args,
+        repo = ?&gh_args.repo,
+        env_keys_set = ?env_keys_set,
+        has_github_token = ctx.github_token.is_some(),
+        "run_gh invocation"
+    );
 
     let output = spawn_and_collect(cmd, "gh", "Is the GitHub CLI installed?").await;
 
@@ -5252,5 +5343,224 @@ mod tests {
         assert!(!is_pr_review_command(&args) || args.len() < 2);
         // Just verify it doesn't reach the pr review code path.
         assert!(!is_pr_review_command(&args));
+    }
+
+    // -- Diagnostic instrumentation tests (#900) --
+
+    /// Captured tracing event for test assertions.
+    #[derive(Debug, Clone)]
+    struct CapturedEvent {
+        message: String,
+        fields: std::collections::HashMap<String, String>,
+    }
+
+    /// A tracing layer that captures events into a shared Vec for test assertions.
+    struct CapturingLayer {
+        events: Arc<std::sync::Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut fields = std::collections::HashMap::new();
+            let mut visitor = FieldVisitor(&mut fields);
+            event.record(&mut visitor);
+            let message = fields.remove("message").unwrap_or_default();
+            if let Ok(mut events) = self.events.lock() {
+                events.push(CapturedEvent { message, fields });
+            }
+        }
+    }
+
+    struct FieldVisitor<'a>(&'a mut std::collections::HashMap<String, String>);
+
+    impl tracing::field::Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    /// Set up a tracing subscriber that captures events into a shared Vec.
+    fn capture_tracing_events() -> (
+        tracing::subscriber::DefaultGuard,
+        Arc<std::sync::Mutex<Vec<CapturedEvent>>>,
+    ) {
+        use tracing_subscriber::layer::SubscriberExt;
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let layer = CapturingLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let guard = tracing::subscriber::set_default(subscriber);
+        (guard, events)
+    }
+
+    #[tokio::test]
+    async fn test_spawn_and_collect_emits_complete_log() {
+        let (_guard, events) = capture_tracing_events();
+
+        let mut cmd = tokio::process::Command::new("echo");
+        cmd.arg("hello");
+        let output = spawn_and_collect(cmd, "test_echo", "").await;
+
+        assert!(!output.is_error);
+        assert_eq!(output.content.trim(), "hello");
+
+        let captured = events.lock().unwrap();
+        let complete_events: Vec<_> = captured
+            .iter()
+            .filter(|e| e.message == "spawn_and_collect complete")
+            .collect();
+        assert_eq!(
+            complete_events.len(),
+            1,
+            "expected exactly one 'spawn_and_collect complete' event"
+        );
+        let evt = &complete_events[0];
+        assert_eq!(
+            evt.fields.get("tool").map(|s| s.as_str()),
+            Some("test_echo")
+        );
+        // "hello\n" = 6 bytes
+        assert_eq!(
+            evt.fields.get("stdout_bytes").map(|s| s.as_str()),
+            Some("6")
+        );
+        assert_eq!(
+            evt.fields.get("stderr_bytes").map(|s| s.as_str()),
+            Some("0")
+        );
+        // elapsed_ms should be present and > 0
+        let elapsed: u64 = evt
+            .fields
+            .get("elapsed_ms")
+            .unwrap()
+            .parse()
+            .expect("elapsed_ms should be a number");
+        assert!(elapsed < 10_000, "echo should complete quickly");
+    }
+
+    #[tokio::test]
+    async fn test_run_gh_invocation_log_redacts_token() {
+        let (_guard, events) = capture_tracing_events();
+
+        let harness = TestHarness::new();
+        let mut ctx = harness.ctx();
+        let fake_token = "FAKE_TOKEN_DO_NOT_LOG_ME";
+        ctx.github_token = Some(fake_token);
+
+        // Use an allowed subcommand so we pass validation and reach the invocation log.
+        // `pr list` will fail (no repo context) but the log fires before spawn_and_collect.
+        let input = serde_json::json!({"command": ["pr", "list"]});
+        let _output = run_gh(&input, &ctx).await;
+
+        let captured = events.lock().unwrap();
+        let invocation_events: Vec<_> = captured
+            .iter()
+            .filter(|e| e.message == "run_gh invocation")
+            .collect();
+        assert_eq!(
+            invocation_events.len(),
+            1,
+            "expected exactly one 'run_gh invocation' event"
+        );
+        let evt = &invocation_events[0];
+
+        // env_keys_set should contain GH_TOKEN as a key name
+        let env_keys = evt.fields.get("env_keys_set").expect("env_keys_set field");
+        assert!(
+            env_keys.contains("GH_TOKEN"),
+            "env_keys_set should contain the key name GH_TOKEN"
+        );
+        assert_eq!(
+            evt.fields.get("has_github_token").map(|s| s.as_str()),
+            Some("true")
+        );
+
+        // No field should contain the actual token value
+        for (key, value) in &evt.fields {
+            assert!(
+                !value.contains(fake_token),
+                "field '{key}' leaked the token value: {value}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_spawn_and_collect_handles_large_output() {
+        // Verify that spawn_and_collect returns within a reasonable time
+        // even when the subprocess produces output exceeding MAX_OUTPUT_LEN.
+        // This documents the pipe-deadlock risk for the follow-up ticket.
+        let (_guard, _events) = capture_tracing_events();
+
+        let start = std::time::Instant::now();
+        let mut cmd = tokio::process::Command::new("sh");
+        // Generate 20KB of output (2x MAX_OUTPUT_LEN)
+        cmd.args(["-c", "yes 'AAAAAAAAAA' | head -c 20000"]);
+        let output = spawn_and_collect(cmd, "test_large", "").await;
+        let elapsed = start.elapsed();
+
+        // Should complete within 10 seconds (not hang at 600s)
+        assert!(
+            elapsed.as_secs() < 10,
+            "spawn_and_collect took {elapsed:?} — possible pipe deadlock"
+        );
+        // Output should be capped at MAX_OUTPUT_LEN
+        assert!(
+            output.content.len() <= MAX_OUTPUT_LEN,
+            "output {} exceeds MAX_OUTPUT_LEN {}",
+            output.content.len(),
+            MAX_OUTPUT_LEN
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_and_collect_progress_ticker_fires() {
+        // With PROGRESS_TICKER_INTERVAL = 100ms in test mode, a 500ms sleep
+        // should produce at least 3 progress tick events.
+        let (_guard, events) = capture_tracing_events();
+
+        let mut cmd = tokio::process::Command::new("sleep");
+        cmd.arg("0.5");
+        let _output = spawn_and_collect(cmd, "test_sleep", "").await;
+
+        let captured = events.lock().unwrap();
+        let progress_events: Vec<_> = captured
+            .iter()
+            .filter(|e| e.message == "spawn_and_collect progress")
+            .collect();
+        assert!(
+            progress_events.len() >= 3,
+            "expected at least 3 progress ticks, got {}",
+            progress_events.len()
+        );
+
+        // Verify elapsed_ms is monotonically non-decreasing
+        let elapsed_values: Vec<u64> = progress_events
+            .iter()
+            .map(|e| e.fields.get("elapsed_ms").unwrap().parse::<u64>().unwrap())
+            .collect();
+        for window in elapsed_values.windows(2) {
+            assert!(
+                window[1] >= window[0],
+                "elapsed_ms should be non-decreasing: {elapsed_values:?}"
+            );
+        }
     }
 }

--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -363,7 +363,14 @@ async fn read_with_counter<R: AsyncRead + Unpin>(
                 buf.extend_from_slice(&chunk[..n]);
                 counter.fetch_add(n, Ordering::Relaxed);
             }
-            Err(_) => break,
+            Err(e) => {
+                tracing::warn!(
+                    bytes_read = counter.load(Ordering::Relaxed),
+                    error = %e,
+                    "read_with_counter I/O error, returning partial buffer"
+                );
+                break;
+            }
         }
     }
     buf
@@ -439,8 +446,20 @@ async fn spawn_and_collect(
         tokio::join!(stdout_reader, stderr_reader, child.wait());
     progress_task.abort();
 
-    let stdout_buf = stdout_res.unwrap_or_default();
-    let stderr_buf = stderr_res.unwrap_or_default();
+    let stdout_buf = match stdout_res {
+        Ok(buf) => buf,
+        Err(e) => {
+            tracing::warn!(tool = %tool_name, error = %e, "stdout reader task failed");
+            Vec::new()
+        }
+    };
+    let stderr_buf = match stderr_res {
+        Ok(buf) => buf,
+        Err(e) => {
+            tracing::warn!(tool = %tool_name, error = %e, "stderr reader task failed");
+            Vec::new()
+        }
+    };
 
     // Post-completion summary (#900)
     tracing::info!(

--- a/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
+++ b/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
@@ -54,16 +54,30 @@ If the `gh` subprocess itself hangs (auth retry loop, rate-limit backoff, networ
 Before `spawn_and_collect()` call (line 1653), add:
 
 ```rust
+// Ticket acceptance: "environment variable set (with token redaction)" — emit
+// the set of env var keys this handler is about to set on the subprocess
+// (KEYS only, never values). Threaded through a literal const because the
+// callsite knows exactly which keys are conditionally set; no scan of cmd.env.
+let env_keys_set: &[&str] = match ctx.github_token {
+    Some(_) => &["GH_PROMPT_DISABLED", "GH_TOKEN"],
+    None => &["GH_PROMPT_DISABLED"],
+};
 info!(
     tool = "run_gh",
     argv = ?&gh_args.args,
     repo = ?&gh_args.repo,
+    env_keys_set = ?env_keys_set,
     has_github_token = ctx.github_token.is_some(),
     "run_gh invocation"
 );
 ```
 
-This logs the exact `gh` subcommand at invocation time — the missing diagnostic that makes the current timeout log useless for triage. On the next reproduction, this field tells us exactly which `gh` subcommand triggered the hang and whether a token was available.
+This logs the exact `gh` subcommand at invocation time — the missing diagnostic that makes the current timeout log useless for triage. On the next reproduction this gives us:
+- **argv** — the precise `gh` subcommand and flag set
+- **env_keys_set** — the literal env var keys the handler injected (`["GH_PROMPT_DISABLED", "GH_TOKEN"]` or `["GH_PROMPT_DISABLED"]`), satisfying the ticket's "environment variable set (with token redaction)" wording — names only, never values
+- **has_github_token** — boolean discriminator: token re-injected (mika#515 path) vs PAT fallback
+
+Token redaction is structural: the literal `env_keys_set` slice contains only `&'static str` keys we control. The actual token value is never read by the log statement and never reaches the tracing layer. Defense-in-depth: the existing `Settings::Debug` impl + `SecretString` already redacts elsewhere; this codepath simply never touches the value.
 
 ### Step 2: Add argv excerpt to timeout log line in `dispatch_tool`
 
@@ -99,44 +113,113 @@ This satisfies the acceptance criterion: "add a per-invocation argv excerpt to t
 **File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
 **Function:** `spawn_and_collect()` (line 346)
 
-Add a post-read, pre-wait diagnostic log. This is simpler than the `select!` + ticker approach and avoids replacing the clean `tokio::join!` pattern:
+The ticket spec is literal: "subprocess stdout/stderr byte counts at 30-second intervals." The plan implements both a post-read transition log AND a 30-second periodic progress log during `child.wait()`. The two surfaces are complementary and the architect-flagged spec deviation (F2) is removed.
+
+**Architecture:**
+
+1. **Reader rewrite:** replace `read_to_end` (atomic read) with a chunked read loop that increments shared `Arc<AtomicUsize>` counters per chunk. This is what lets a separate progress task observe byte counts during the read itself. Chunk size 256 bytes — small enough that counters update before bounded `MAX_OUTPUT_LEN` (10KB) cap fires, large enough to keep syscall overhead negligible.
+
+2. **Progress ticker:** `tokio::time::interval(Duration::from_secs(30))` task that snapshots both counters every 30s. The ticker's first tick is consumed (`interval.tick().await`) before entering the periodic loop so we don't double-fire at t=0. The ticker is `tokio::spawn`ed and `.abort()`ed on completion.
+
+3. **Coordination:** `tokio::select!` on `(both reads complete + child.wait())` vs ticker iteration. The reads and child.wait are joined; the ticker is the loser arm that re-enters the loop. When reads + child.wait win, the ticker is aborted and we proceed to the existing exit-status branch.
 
 ```rust
-// After the existing tokio::join! read completes:
-let (stdout_res, stderr_res) = tokio::join!(
-    stdout_take.read_to_end(&mut stdout_buf),
-    stderr_take.read_to_end(&mut stderr_buf),
-);
-stdout_res.ok();
-stderr_res.ok();
+let stdout_count = Arc::new(AtomicUsize::new(0));
+let stderr_count = Arc::new(AtomicUsize::new(0));
+let started_at = Instant::now();
 
-// NEW: Diagnostic log — fires once after reads complete, before wait().
-// On the next hang reproduction, this tells us:
-// - If reads completed instantly (pipe deadlock hypothesis: reads finish, wait blocks)
-// - stdout/stderr byte counts (tells us if the process produced output at all)
+// Chunked read tasks: increment counters per chunk
+let stdout_reader = tokio::spawn(read_with_counter(
+    stdout_handle, MAX_OUTPUT_LEN, Arc::clone(&stdout_count)
+));
+let stderr_reader = tokio::spawn(read_with_counter(
+    stderr_handle, MAX_OUTPUT_LEN, Arc::clone(&stderr_count)
+));
+
+// Progress ticker: every 30s, log a snapshot
+let progress_task = {
+    let stdout_count = Arc::clone(&stdout_count);
+    let stderr_count = Arc::clone(&stderr_count);
+    let tool_name = tool_name.to_string();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        interval.tick().await; // discard immediate first tick
+        loop {
+            interval.tick().await;
+            info!(
+                tool = %tool_name,
+                stdout_bytes = stdout_count.load(Ordering::Relaxed),
+                stderr_bytes = stderr_count.load(Ordering::Relaxed),
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                "spawn_and_collect progress"
+            );
+        }
+    })
+};
+
+// Wait for both reads + process exit
+let (stdout_buf, stderr_buf, status) = tokio::join!(
+    stdout_reader, stderr_reader, child.wait()
+);
+progress_task.abort(); // ticker stops on normal completion
+
+// Post-completion summary (complements progress ticker — fires once at end)
 info!(
     tool = %tool_name,
-    stdout_bytes = stdout_buf.len(),
-    stderr_bytes = stderr_buf.len(),
-    "spawn_and_collect reads complete, waiting for process exit"
+    stdout_bytes = stdout_count.load(Ordering::Relaxed),
+    stderr_bytes = stderr_count.load(Ordering::Relaxed),
+    elapsed_ms = started_at.elapsed().as_millis() as u64,
+    "spawn_and_collect complete"
 );
-
-let status = match child.wait().await {
 ```
 
-**Why not `select!` + ticker:** The ticket requests "log stdout/stderr byte counts at 30-second intervals." However, the `tokio::join!` reads complete almost instantly (they stop at 10KB or EOF). The hang occurs *after* reads complete, during `child.wait()`. A single log line between reads and wait is sufficient to discriminate between the hypotheses:
-- If this log line appears immediately before a 600s timeout → the process is alive but blocked (supports Hypothesis A: pipe deadlock)
-- If this log line never appears → the reads themselves are blocking (supports Hypothesis B: process not producing output, stalled on auth/network)
+`read_with_counter` is a private helper:
 
-Adding a second ticker-based progress log during `child.wait()` would require wrapping `child.wait()` in a `select!`, which adds more complexity than the diagnostic value justifies for a single reproduction. If the third reproduction shows the post-read log fires and then `wait()` hangs, we'll know it's a pipe deadlock and can apply the corrective fix (see Recommended Follow-Up Tickets).
+```rust
+async fn read_with_counter<R: AsyncRead + Unpin>(
+    reader: R,
+    max_bytes: usize,
+    counter: Arc<AtomicUsize>,
+) -> Vec<u8> {
+    let mut take = reader.take(max_bytes as u64);
+    let mut buf = Vec::with_capacity(max_bytes.min(8192));
+    let mut chunk = [0u8; 256];
+    while let Ok(n) = take.read(&mut chunk).await {
+        if n == 0 { break; }
+        buf.extend_from_slice(&chunk[..n]);
+        counter.fetch_add(n, Ordering::Relaxed);
+    }
+    buf
+}
+```
+
+**Discriminators on next reproduction:**
+- **Hypothesis A (pipe deadlock):** progress ticker fires at 30s, 60s, 90s, ... with `stdout_bytes ≈ 10240` (MAX_OUTPUT_LEN ceiling) — reads completed instantly, ticker is logging the steady-state while `child.wait()` blocks
+- **Hypothesis B (auth/network stall):** progress ticker fires with `stdout_bytes = 0` for the entire duration — subprocess produced no output
+- **Hypothesis C (interactive prompt):** indistinguishable from B at the log level; identified by argv (Step 1) showing a subcommand that *could* prompt
+
+**`tokio::select!` lint guard:** `scripts/check-loop-select.sh` rejects `tokio::select!` only inside `run_loop`'s body (mika#848 — the deadline-check guarantee). `spawn_and_collect` is in `builtin_handlers.rs`, outside `run_loop`. The lint does not fire. This implementation uses `tokio::join!` for reads+wait coordination and `tokio::spawn` + `.abort()` for the ticker — no `select!` is needed, sidestepping the lint surface entirely.
+
+**Why not run_gh-only:** Co-locating the instrumentation in `spawn_and_collect` (shared by `run_gh`, `run_gws`, `gh_read`, git ops) gives every CLI subprocess the same forensic trail. Per F6 the architect confirmed the blast radius is acceptable (max 20 tool steps per turn → ≤20 invocations × `(1 + ⌈elapsed/30⌉)` log lines per turn; steady-state for fast tools is 2 log lines per invocation — start + complete). Narrowing to `run_gh` only would require duplicating the ticker machinery in a `spawn_and_collect_instrumented` variant for the sibling handlers when they hang next; we'd rather pay the cost once.
 
 ### Step 4: Tests
 
 **File:** `crates/mika-agent/src/skills/builtin_handlers.rs` (test module)
 
-1. **Test `spawn_and_collect` diagnostic log presence:** Call `spawn_and_collect` with `echo "hello"` and verify it returns successfully. The log assertions are structural — if the code compiles, the log fields are present.
+Address architect F5: log-capturing assertions, not just compile-time structural checks. Use `tracing_subscriber::fmt().with_test_writer()` or a layer that captures `tracing::Event` records into a shared `Vec<Event>`, then assert structurally.
 
-2. **Test `spawn_and_collect` with large output:** Call `spawn_and_collect` with a command that produces > `MAX_OUTPUT_LEN` bytes (e.g., `yes | head -c 20000`) and verify it completes. This tests the existing behavior (not a fix) and documents the pipe-deadlock risk for the follow-up ticket.
+1. **`test_spawn_and_collect_emits_complete_log`:** Use a tracing-capture layer; call `spawn_and_collect` with `echo "hello"`; assert one `spawn_and_collect complete` event was recorded with `stdout_bytes == 6` (echo appends newline), `stderr_bytes == 0`, `elapsed_ms > 0`.
+
+2. **`test_run_gh_invocation_log_redacts_token`:** Capture tracing events; invoke `run_gh` with a fake token (`ctx.github_token = Some("FAKE_TOKEN_DO_NOT_LOG_ME")`); assert the captured `run_gh invocation` event:
+   - includes `env_keys_set` field containing `"GH_TOKEN"` literally
+   - has `has_github_token = true`
+   - has NO event field whose serialized value contains the literal string `"FAKE_TOKEN_DO_NOT_LOG_ME"`
+
+3. **`test_spawn_and_collect_handles_large_output`:** Call `spawn_and_collect` with `yes | head -c 20000` (> `MAX_OUTPUT_LEN`); assert it returns within a wall-clock budget of 10 seconds (currently this can deadlock — the test documents the pipe-deadlock risk for the follow-up ticket and serves as a regression test once the follow-up lands).
+
+4. **`test_spawn_and_collect_progress_ticker_fires`:** Use a short-interval test override of the ticker (gated via `#[cfg(test)]` const or a builder hook) of 100ms instead of 30s; spawn a `sleep 0.5` subprocess; capture events; assert at least 3 `spawn_and_collect progress` events fired with monotonically non-decreasing `elapsed_ms`. This validates the ticker plumbing without making the test slow.
+
+Test infrastructure: a small `capture_tracing_events()` helper in the test module that returns a `(Subscriber, Arc<Mutex<Vec<CapturedEvent>>>)` pair. Used by tests 1, 2, 4.
 
 ### Step 5: Verify with build
 
@@ -155,15 +238,26 @@ cargo clippy -p mika-agent
 
 ## Blast Radius
 
-**`spawn_and_collect` (Step 3):** The diagnostic log is additive (no behavioral change). `spawn_and_collect` is shared by all CLI builtin handlers. Full list of callers:
+**`spawn_and_collect` (Step 3):** Diagnostic logging is additive at the observability layer; the reader rewrite (chunked-read with counter) is a structural change to subprocess collection but preserves identical output buffering and bounds (`MAX_OUTPUT_LEN`). `spawn_and_collect` is shared by all CLI builtin handlers:
 - `run_gh` — GitHub CLI commands (the affected handler)
 - `run_gws` — Google Workspace CLI
-- `run_git_*` — Git operations (push, pull, clone, etc.)
+- `run_git_*` — Git operations
 - `gh_read` — Read-only GitHub operations (mika-arch)
 
-The `info!` log line fires once per invocation for all of these. This is acceptable — the log volume is proportional to tool invocations (bounded by max 20 steps per agent turn).
+**Log volume per invocation:**
+- 1 × `spawn_and_collect complete` event (always)
+- N × `spawn_and_collect progress` events, where N = ⌊elapsed_secs / 30⌋. For fast tools (< 30s), N = 0. For a hung tool that times out at 600s, N = 19.
 
-**`dispatch_tool` (Step 2):** The `input_excerpt` log field is added to timeout events only. These fire at most once per tool timeout — extremely rare in practice.
+Worst-case turn: 20 tool steps × (1 + 19) = 400 log lines. Realistic steady-state: 20 tool steps × 1 = 20 log lines. Log layer is `info!` (not debug) — fine for the production sink. Acceptable per architect F6.
+
+**Behavioral change risk:** The chunked-read loop replaces a single `read_to_end` call. Failure modes covered:
+- Error returned by `take.read()` mid-stream → loop exits via `Err` arm; partial buffer returned (matches existing behavior on read errors).
+- Counter `Ordering::Relaxed` — atomicity is per-store; we never read+modify, only fetch_add. No memory-ordering hazard.
+- Progress-task abort → `tokio::spawn` futures cancel cleanly; no resource leak.
+
+**`run_gh` (Step 1):** One additional `info!` per invocation (bounded by max 20 steps/turn).
+
+**`dispatch_tool` (Step 2):** `input_excerpt` log field added to timeout events only. Fires at most once per tool timeout — extremely rare in practice.
 
 ## Risk Assessment
 

--- a/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
+++ b/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
@@ -1,0 +1,238 @@
+# Plan: Diagnostic Instrumentation for `run_gh` Builtin Handler Timeout
+
+**Ticket:** mika issue#900
+**Type:** fix
+**Branch:** `fix/900/mika-agent-mika-dev-run-gh-builtin`
+**Date:** 2026-05-13
+
+## Problem Statement
+
+The `run_gh` builtin handler hung for 600 seconds on two consecutive invocations when mika-dev queried CI failure details on PR mika#898. The handler produced zero diagnostic output during the hang — only a generic timeout log line after 600s elapsed. The acceptance criteria for this ticket is diagnostic instrumentation (not the corrective fix).
+
+## Root Cause Analysis (from code investigation)
+
+### Why 600s, not 30s?
+
+`run_gh` is a skill-defined builtin handler dispatched via `builtin_handlers::execute()` at `agent.rs:2691`. Skill-defined tools use `dispatch.skill_timeout`, computed by `max_skill_timeout()` — the **maximum** timeout across all matched skills in the turn. When mika-dev's turn matches `dev-pilot` (which declares `timeout_secs = 600` in `skill.toml`), every skill-defined tool in that turn inherits the 600s timeout, including `run_gh` which should return in seconds.
+
+### Why does the agent deadline (300s) not cap it?
+
+The 5-minute agent deadline is checked at the **top** of each loop iteration (`agent.rs:859`), not around each tool execution. If a tool call starts within the deadline but the outer `tokio::time::timeout` wraps it at 600s, the tool runs past the deadline. The deadline is only checked on the *next* iteration, which never arrives because the tool is still running.
+
+### Why does `spawn_and_collect` hang?
+
+`spawn_and_collect()` (`builtin_handlers.rs:346-417`) has no internal timeout or progress logging. It:
+1. Takes stdout/stderr handles and reads them concurrently via `tokio::join!` with `.take(MAX_OUTPUT_LEN)` (10KB)
+2. Waits for process exit via `child.wait().await`
+
+If the `gh` subprocess itself hangs (auth retry loop, rate-limit backoff, network stall, or blocked on writing to a full pipe after 10KB is consumed by the reader), `spawn_and_collect` blocks silently for the full outer timeout.
+
+### Suspected subprocess behavior
+
+`gh run view --log-failed` against a failed CI run can produce megabytes of test output. After `spawn_and_collect` reads 10KB via `.take()`, the stdout reader completes, but the process may still be writing to its stdout pipe. The pipe buffer fills (typically 64KB on Linux), and `gh` blocks on the write. Meanwhile, `child.wait().await` waits for `gh` to exit, creating a deadlock: the process can't exit because it can't write, and the agent can't proceed because the process hasn't exited.
+
+**This is the most likely cause.** The `.take()` reader stops consuming at 10KB, but the process keeps producing. The OS pipe buffer (64KB) fills, and the process blocks on `write()`. `child.wait()` never returns. The 600s outer timeout is the only escape hatch.
+
+## Implementation Plan
+
+### Step 1: Add per-invocation diagnostic logging to `run_gh`
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
+**Function:** `run_gh()` (line 1586)
+
+Before `spawn_and_collect()` call (line 1653), add:
+
+```rust
+info!(
+    tool = "run_gh",
+    argv = ?&gh_args.args,
+    repo = ?&gh_args.repo,
+    has_github_token = ctx.github_token.is_some(),
+    "run_gh invocation"
+);
+```
+
+This logs the exact `gh` subcommand at invocation time — the missing diagnostic that makes the current timeout log useless for triage.
+
+### Step 2: Add argv excerpt to timeout log line in `dispatch_tool`
+
+**File:** `crates/mika-agent/src/agent.rs`
+**Function:** `dispatch_tool()` (line 2663)
+
+The timeout error at line 2681-2682 currently logs:
+```
+warn!(tool = %name, timeout_secs = timeout, "tool execution timed out");
+```
+
+This is in the builtin-tool path (path 1). The skill-tool path (path 2) at line 2699 has a similar pattern. Both need the input args included.
+
+Add truncated input to both timeout log lines:
+```rust
+let input_excerpt = serde_json::to_string(&input)
+    .unwrap_or_default()
+    .chars()
+    .take(200)
+    .collect::<String>();
+warn!(
+    tool = %name,
+    timeout_secs = timeout,
+    input_excerpt = %input_excerpt,
+    "tool execution timed out"
+);
+```
+
+This satisfies the acceptance criterion: "add a per-invocation argv excerpt to the timeout-fired log line so future hangs are auto-categorized."
+
+### Step 3: Add progress logging to `spawn_and_collect`
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
+**Function:** `spawn_and_collect()` (line 346)
+
+Replace the simple `tokio::join!` read pattern with a progress-aware variant that logs byte counts at 30-second intervals:
+
+```rust
+// Read stdout/stderr with progress logging at 30s intervals
+let tool_name_owned = tool_name.to_string();
+let read_with_progress = async {
+    let mut stdout_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
+    let mut stderr_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
+    let mut stdout_take = stdout_handle.take(MAX_OUTPUT_LEN as u64);
+    let mut stderr_take = stderr_handle.take(MAX_OUTPUT_LEN as u64);
+
+    let progress_interval = tokio::time::Duration::from_secs(30);
+    let mut progress_tick = tokio::time::interval(progress_interval);
+    progress_tick.tick().await; // skip first immediate tick
+
+    // Use select! to interleave progress logging with reads
+    let stdout_fut = stdout_take.read_to_end(&mut stdout_buf);
+    let stderr_fut = stderr_take.read_to_end(&mut stderr_buf);
+
+    tokio::pin!(stdout_fut);
+    tokio::pin!(stderr_fut);
+
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+
+    loop {
+        tokio::select! {
+            res = &mut stdout_fut, if !stdout_done => {
+                res.ok();
+                stdout_done = true;
+                if stdout_done && stderr_done { break; }
+            }
+            res = &mut stderr_fut, if !stderr_done => {
+                res.ok();
+                stderr_done = true;
+                if stdout_done && stderr_done { break; }
+            }
+            _ = progress_tick.tick() => {
+                warn!(
+                    tool = %tool_name_owned,
+                    stdout_bytes = stdout_buf.len(),
+                    stderr_bytes = stderr_buf.len(),
+                    stdout_done,
+                    stderr_done,
+                    "spawn_and_collect still reading subprocess output"
+                );
+            }
+        }
+    }
+    (stdout_buf, stderr_buf)
+};
+```
+
+**Decision:** Use `select!` with progress ticker vs simple `tokio::join!`. The `select!` approach adds complexity but provides the 30-second progress logging the ticket requests. The existing `tokio::join!` is simpler but provides zero visibility during hangs.
+
+### Step 4: Fix the pipe-deadlock root cause in `spawn_and_collect`
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
+**Function:** `spawn_and_collect()` (line 346)
+
+The current pattern has a subtle deadlock: after `.take(MAX_OUTPUT_LEN)` reads stop consuming, `child.wait()` blocks forever if the process keeps writing to stdout. Fix by **dropping** the stdout/stderr handles after reading, which closes the pipe and causes the process to get `EPIPE` / `SIGPIPE`:
+
+After reading completes:
+```rust
+// Drop the take wrappers (and thus the underlying pipe handles) so the
+// subprocess gets SIGPIPE if it's still writing. Without this, wait()
+// deadlocks when the process writes > MAX_OUTPUT_LEN.
+drop(stdout_take);
+drop(stderr_take);
+```
+
+**Note:** This is the actual fix for the hang mechanism, but it's diagnostic-adjacent — the ticket says "once cause is known, file or apply the corrective fix (likely separate ticket)." I'm including it here because:
+1. It's a 2-line fix in the same function
+2. It directly addresses the deadlock that the diagnostics are instrumenting
+3. Filing a separate ticket for 2 lines adds overhead with no safety benefit
+
+If the architect disagrees, this step can be extracted to a separate ticket.
+
+### Step 5: Cap `run_gh` tool timeout independently of skill timeout
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
+
+Add a `RUN_GH_TIMEOUT_SECS` constant (60s) and apply it inside `run_gh()` by wrapping the `spawn_and_collect` call:
+
+```rust
+const RUN_GH_TIMEOUT_SECS: u64 = 60;
+
+// Inside run_gh():
+let output = match tokio::time::timeout(
+    std::time::Duration::from_secs(RUN_GH_TIMEOUT_SECS),
+    spawn_and_collect(cmd, "gh", "Is the GitHub CLI installed?"),
+).await {
+    Ok(output) => output,
+    Err(_) => {
+        warn!(
+            tool = "run_gh",
+            timeout_secs = RUN_GH_TIMEOUT_SECS,
+            argv = ?&gh_args.args,
+            "run_gh internal timeout — gh subprocess did not complete"
+        );
+        ToolOutput::error(format!(
+            "gh command timed out after {RUN_GH_TIMEOUT_SECS}s. \
+             The command may have produced too much output or hit a network issue."
+        ))
+    }
+};
+```
+
+**Decision:** This is defense-in-depth against the inherited 600s skill timeout. `run_gh` should never need more than 60s for any `gh` subcommand. The inner timeout fires before the outer skill timeout, giving a specific `run_gh`-scoped error message instead of a generic "tool timed out."
+
+**Out of scope (per ticket):** This is technically a corrective fix, not just diagnostic instrumentation. Same argument as Step 4 — the fix is small and directly related.
+
+### Step 6: Tests
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs` (test module)
+
+1. **Test `run_gh` invocation logging:** Verify the `run_gh invocation` log line is emitted with correct fields. Use `tracing-test` or assert on the log output.
+2. **Test pipe-deadlock fix:** Create a mock process that writes > `MAX_OUTPUT_LEN` bytes to stdout and verify `spawn_and_collect` returns without deadlocking. Use a timeout assertion.
+3. **Test `run_gh` internal timeout:** Mock a `gh` command that sleeps forever, verify `run_gh` returns an error within `RUN_GH_TIMEOUT_SECS`.
+
+**Practical constraint:** The existing test infrastructure in `builtin_handlers.rs` uses `#[tokio::test]` with real commands. The deadlock test needs a synthetic slow command — `sleep 999` or a custom script. The internal timeout test similarly needs `sleep`.
+
+### Step 7: Verify with build
+
+```bash
+cargo build -p mika-agent
+cargo test -p mika-agent -- builtin_handlers
+cargo clippy -p mika-agent
+```
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/skills/builtin_handlers.rs` | Steps 1, 3, 4, 5, 6: diagnostic logging, progress logging, pipe-deadlock fix, internal timeout, tests |
+| `crates/mika-agent/src/agent.rs` | Step 2: input_excerpt in timeout log lines |
+
+## Risk Assessment
+
+- **Low risk:** Steps 1-3 are purely additive logging. No behavioral change.
+- **Medium risk:** Step 4 (pipe-handle drop) changes `spawn_and_collect` behavior. The fix is correct — closing the pipe is the right thing to do after reading is done — but it affects ALL CLI builtin handlers (gh, gws, etc.). If a handler relies on the process continuing to write after the reader stops, this could change behavior. In practice, no handler cares about output beyond `MAX_OUTPUT_LEN`.
+- **Low risk:** Step 5 adds an inner timeout that is strictly tighter than the existing outer timeout. If `run_gh` currently succeeds within 60s (empirically true for all normal operations), this has no behavioral effect.
+
+## Open Questions
+
+1. Should Step 4 (pipe fix) and Step 5 (timeout cap) be separate tickets? The ticket says "acceptance is diagnostic instrumentation, not corrective fix" but the fixes are 2-line and 10-line changes in the same function.
+2. Should the progress logging interval (30s) be configurable? Decision: no — hardcode. The interval is for operator triage, not user-facing behavior.
+3. Should `RUN_GH_TIMEOUT_SECS` apply to `gh_read` as well? Decision: no — `gh_read` is a different handler with different semantics (allowlisted operations). It already has structural safety (operation allowlist, structured errors).

--- a/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
+++ b/docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md
@@ -5,9 +5,13 @@
 **Branch:** `fix/900/mika-agent-mika-dev-run-gh-builtin`
 **Date:** 2026-05-13
 
+## Acceptance Pin
+
+Per ticket: "Acceptance for THIS ticket is the diagnostic instrumentation, not the corrective fix. Once we have data on the third reproduction, we know the cause." This plan is scoped strictly to instrumentation. Corrective fixes (pipe-deadlock fix, per-tool timeout cap) are documented as recommended follow-up tickets.
+
 ## Problem Statement
 
-The `run_gh` builtin handler hung for 600 seconds on two consecutive invocations when mika-dev queried CI failure details on PR mika#898. The handler produced zero diagnostic output during the hang — only a generic timeout log line after 600s elapsed. The acceptance criteria for this ticket is diagnostic instrumentation (not the corrective fix).
+The `run_gh` builtin handler hung for 600 seconds on two consecutive invocations when mika-dev queried CI failure details on PR mika#898. The handler produced zero diagnostic output during the hang — only a generic timeout log line after 600s elapsed.
 
 ## Root Cause Analysis (from code investigation)
 
@@ -27,11 +31,18 @@ The 5-minute agent deadline is checked at the **top** of each loop iteration (`a
 
 If the `gh` subprocess itself hangs (auth retry loop, rate-limit backoff, network stall, or blocked on writing to a full pipe after 10KB is consumed by the reader), `spawn_and_collect` blocks silently for the full outer timeout.
 
-### Suspected subprocess behavior
+### Hypothesized subprocess behavior (UNVERIFIED — sample size 2)
 
-`gh run view --log-failed` against a failed CI run can produce megabytes of test output. After `spawn_and_collect` reads 10KB via `.take()`, the stdout reader completes, but the process may still be writing to its stdout pipe. The pipe buffer fills (typically 64KB on Linux), and `gh` blocks on the write. Meanwhile, `child.wait().await` waits for `gh` to exit, creating a deadlock: the process can't exit because it can't write, and the agent can't proceed because the process hasn't exited.
+**Hypothesis A (pipe deadlock):** `gh run view --log-failed` against a failed CI run can produce megabytes of test output. After `spawn_and_collect` reads 10KB via `.take()`, the stdout reader completes, but the process may still be writing to its stdout pipe. The pipe buffer fills (typically 64KB on Linux), and `gh` blocks on the write. Meanwhile, `child.wait().await` waits for `gh` to exit, creating a deadlock.
 
-**This is the most likely cause.** The `.take()` reader stops consuming at 10KB, but the process keeps producing. The OS pipe buffer (64KB) fills, and the process blocks on `write()`. `child.wait()` never returns. The 600s outer timeout is the only escape hatch.
+**Hypothesis B (auth/network stall):** The `MIKA_GITHUB_TOKEN→GH_TOKEN` re-injection path interacts with GitHub API rate limiting or token issues, causing `gh` to hang on an auth retry loop or network backoff.
+
+**Hypothesis C (gh interactive prompt):** Despite `GH_PROMPT_DISABLED=1` and `stdin(Stdio::null())`, certain `gh` subcommands may still wait for TTY input in edge cases.
+
+**The instrumentation in this ticket is designed to distinguish between these hypotheses on the next reproduction.** The diagnostic fields (argv, stdout/stderr byte counts at intervals, process exit status) will discriminate:
+- Hypothesis A: stdout_bytes reaches 10KB quickly, then progress logs show no further change while `stdout_done=true, stderr_done=true` but process hasn't exited
+- Hypothesis B: stdout_bytes stays at 0 or low values throughout; the subprocess itself is stalled
+- Hypothesis C: similar to B but with specific `gh` subcommands that trigger prompts
 
 ## Implementation Plan
 
@@ -52,7 +63,7 @@ info!(
 );
 ```
 
-This logs the exact `gh` subcommand at invocation time — the missing diagnostic that makes the current timeout log useless for triage.
+This logs the exact `gh` subcommand at invocation time — the missing diagnostic that makes the current timeout log useless for triage. On the next reproduction, this field tells us exactly which `gh` subcommand triggered the hang and whether a token was available.
 
 ### Step 2: Add argv excerpt to timeout log line in `dispatch_tool`
 
@@ -88,129 +99,46 @@ This satisfies the acceptance criterion: "add a per-invocation argv excerpt to t
 **File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
 **Function:** `spawn_and_collect()` (line 346)
 
-Replace the simple `tokio::join!` read pattern with a progress-aware variant that logs byte counts at 30-second intervals:
+Add a post-read, pre-wait diagnostic log. This is simpler than the `select!` + ticker approach and avoids replacing the clean `tokio::join!` pattern:
 
 ```rust
-// Read stdout/stderr with progress logging at 30s intervals
-let tool_name_owned = tool_name.to_string();
-let read_with_progress = async {
-    let mut stdout_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
-    let mut stderr_buf = Vec::with_capacity(MAX_OUTPUT_LEN);
-    let mut stdout_take = stdout_handle.take(MAX_OUTPUT_LEN as u64);
-    let mut stderr_take = stderr_handle.take(MAX_OUTPUT_LEN as u64);
+// After the existing tokio::join! read completes:
+let (stdout_res, stderr_res) = tokio::join!(
+    stdout_take.read_to_end(&mut stdout_buf),
+    stderr_take.read_to_end(&mut stderr_buf),
+);
+stdout_res.ok();
+stderr_res.ok();
 
-    let progress_interval = tokio::time::Duration::from_secs(30);
-    let mut progress_tick = tokio::time::interval(progress_interval);
-    progress_tick.tick().await; // skip first immediate tick
+// NEW: Diagnostic log — fires once after reads complete, before wait().
+// On the next hang reproduction, this tells us:
+// - If reads completed instantly (pipe deadlock hypothesis: reads finish, wait blocks)
+// - stdout/stderr byte counts (tells us if the process produced output at all)
+info!(
+    tool = %tool_name,
+    stdout_bytes = stdout_buf.len(),
+    stderr_bytes = stderr_buf.len(),
+    "spawn_and_collect reads complete, waiting for process exit"
+);
 
-    // Use select! to interleave progress logging with reads
-    let stdout_fut = stdout_take.read_to_end(&mut stdout_buf);
-    let stderr_fut = stderr_take.read_to_end(&mut stderr_buf);
-
-    tokio::pin!(stdout_fut);
-    tokio::pin!(stderr_fut);
-
-    let mut stdout_done = false;
-    let mut stderr_done = false;
-
-    loop {
-        tokio::select! {
-            res = &mut stdout_fut, if !stdout_done => {
-                res.ok();
-                stdout_done = true;
-                if stdout_done && stderr_done { break; }
-            }
-            res = &mut stderr_fut, if !stderr_done => {
-                res.ok();
-                stderr_done = true;
-                if stdout_done && stderr_done { break; }
-            }
-            _ = progress_tick.tick() => {
-                warn!(
-                    tool = %tool_name_owned,
-                    stdout_bytes = stdout_buf.len(),
-                    stderr_bytes = stderr_buf.len(),
-                    stdout_done,
-                    stderr_done,
-                    "spawn_and_collect still reading subprocess output"
-                );
-            }
-        }
-    }
-    (stdout_buf, stderr_buf)
-};
+let status = match child.wait().await {
 ```
 
-**Decision:** Use `select!` with progress ticker vs simple `tokio::join!`. The `select!` approach adds complexity but provides the 30-second progress logging the ticket requests. The existing `tokio::join!` is simpler but provides zero visibility during hangs.
+**Why not `select!` + ticker:** The ticket requests "log stdout/stderr byte counts at 30-second intervals." However, the `tokio::join!` reads complete almost instantly (they stop at 10KB or EOF). The hang occurs *after* reads complete, during `child.wait()`. A single log line between reads and wait is sufficient to discriminate between the hypotheses:
+- If this log line appears immediately before a 600s timeout → the process is alive but blocked (supports Hypothesis A: pipe deadlock)
+- If this log line never appears → the reads themselves are blocking (supports Hypothesis B: process not producing output, stalled on auth/network)
 
-### Step 4: Fix the pipe-deadlock root cause in `spawn_and_collect`
+Adding a second ticker-based progress log during `child.wait()` would require wrapping `child.wait()` in a `select!`, which adds more complexity than the diagnostic value justifies for a single reproduction. If the third reproduction shows the post-read log fires and then `wait()` hangs, we'll know it's a pipe deadlock and can apply the corrective fix (see Recommended Follow-Up Tickets).
 
-**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
-**Function:** `spawn_and_collect()` (line 346)
-
-The current pattern has a subtle deadlock: after `.take(MAX_OUTPUT_LEN)` reads stop consuming, `child.wait()` blocks forever if the process keeps writing to stdout. Fix by **dropping** the stdout/stderr handles after reading, which closes the pipe and causes the process to get `EPIPE` / `SIGPIPE`:
-
-After reading completes:
-```rust
-// Drop the take wrappers (and thus the underlying pipe handles) so the
-// subprocess gets SIGPIPE if it's still writing. Without this, wait()
-// deadlocks when the process writes > MAX_OUTPUT_LEN.
-drop(stdout_take);
-drop(stderr_take);
-```
-
-**Note:** This is the actual fix for the hang mechanism, but it's diagnostic-adjacent — the ticket says "once cause is known, file or apply the corrective fix (likely separate ticket)." I'm including it here because:
-1. It's a 2-line fix in the same function
-2. It directly addresses the deadlock that the diagnostics are instrumenting
-3. Filing a separate ticket for 2 lines adds overhead with no safety benefit
-
-If the architect disagrees, this step can be extracted to a separate ticket.
-
-### Step 5: Cap `run_gh` tool timeout independently of skill timeout
-
-**File:** `crates/mika-agent/src/skills/builtin_handlers.rs`
-
-Add a `RUN_GH_TIMEOUT_SECS` constant (60s) and apply it inside `run_gh()` by wrapping the `spawn_and_collect` call:
-
-```rust
-const RUN_GH_TIMEOUT_SECS: u64 = 60;
-
-// Inside run_gh():
-let output = match tokio::time::timeout(
-    std::time::Duration::from_secs(RUN_GH_TIMEOUT_SECS),
-    spawn_and_collect(cmd, "gh", "Is the GitHub CLI installed?"),
-).await {
-    Ok(output) => output,
-    Err(_) => {
-        warn!(
-            tool = "run_gh",
-            timeout_secs = RUN_GH_TIMEOUT_SECS,
-            argv = ?&gh_args.args,
-            "run_gh internal timeout — gh subprocess did not complete"
-        );
-        ToolOutput::error(format!(
-            "gh command timed out after {RUN_GH_TIMEOUT_SECS}s. \
-             The command may have produced too much output or hit a network issue."
-        ))
-    }
-};
-```
-
-**Decision:** This is defense-in-depth against the inherited 600s skill timeout. `run_gh` should never need more than 60s for any `gh` subcommand. The inner timeout fires before the outer skill timeout, giving a specific `run_gh`-scoped error message instead of a generic "tool timed out."
-
-**Out of scope (per ticket):** This is technically a corrective fix, not just diagnostic instrumentation. Same argument as Step 4 — the fix is small and directly related.
-
-### Step 6: Tests
+### Step 4: Tests
 
 **File:** `crates/mika-agent/src/skills/builtin_handlers.rs` (test module)
 
-1. **Test `run_gh` invocation logging:** Verify the `run_gh invocation` log line is emitted with correct fields. Use `tracing-test` or assert on the log output.
-2. **Test pipe-deadlock fix:** Create a mock process that writes > `MAX_OUTPUT_LEN` bytes to stdout and verify `spawn_and_collect` returns without deadlocking. Use a timeout assertion.
-3. **Test `run_gh` internal timeout:** Mock a `gh` command that sleeps forever, verify `run_gh` returns an error within `RUN_GH_TIMEOUT_SECS`.
+1. **Test `spawn_and_collect` diagnostic log presence:** Call `spawn_and_collect` with `echo "hello"` and verify it returns successfully. The log assertions are structural — if the code compiles, the log fields are present.
 
-**Practical constraint:** The existing test infrastructure in `builtin_handlers.rs` uses `#[tokio::test]` with real commands. The deadlock test needs a synthetic slow command — `sleep 999` or a custom script. The internal timeout test similarly needs `sleep`.
+2. **Test `spawn_and_collect` with large output:** Call `spawn_and_collect` with a command that produces > `MAX_OUTPUT_LEN` bytes (e.g., `yes | head -c 20000`) and verify it completes. This tests the existing behavior (not a fix) and documents the pipe-deadlock risk for the follow-up ticket.
 
-### Step 7: Verify with build
+### Step 5: Verify with build
 
 ```bash
 cargo build -p mika-agent
@@ -222,17 +150,36 @@ cargo clippy -p mika-agent
 
 | File | Change |
 |------|--------|
-| `crates/mika-agent/src/skills/builtin_handlers.rs` | Steps 1, 3, 4, 5, 6: diagnostic logging, progress logging, pipe-deadlock fix, internal timeout, tests |
-| `crates/mika-agent/src/agent.rs` | Step 2: input_excerpt in timeout log lines |
+| `crates/mika-agent/src/skills/builtin_handlers.rs` | Steps 1, 3, 4: `run_gh` invocation log, post-read diagnostic log in `spawn_and_collect`, tests |
+| `crates/mika-agent/src/agent.rs` | Step 2: `input_excerpt` in both timeout log lines (builtin-tool path and skill-tool path) |
+
+## Blast Radius
+
+**`spawn_and_collect` (Step 3):** The diagnostic log is additive (no behavioral change). `spawn_and_collect` is shared by all CLI builtin handlers. Full list of callers:
+- `run_gh` — GitHub CLI commands (the affected handler)
+- `run_gws` — Google Workspace CLI
+- `run_git_*` — Git operations (push, pull, clone, etc.)
+- `gh_read` — Read-only GitHub operations (mika-arch)
+
+The `info!` log line fires once per invocation for all of these. This is acceptable — the log volume is proportional to tool invocations (bounded by max 20 steps per agent turn).
+
+**`dispatch_tool` (Step 2):** The `input_excerpt` log field is added to timeout events only. These fire at most once per tool timeout — extremely rare in practice.
 
 ## Risk Assessment
 
-- **Low risk:** Steps 1-3 are purely additive logging. No behavioral change.
-- **Medium risk:** Step 4 (pipe-handle drop) changes `spawn_and_collect` behavior. The fix is correct — closing the pipe is the right thing to do after reading is done — but it affects ALL CLI builtin handlers (gh, gws, etc.). If a handler relies on the process continuing to write after the reader stops, this could change behavior. In practice, no handler cares about output beyond `MAX_OUTPUT_LEN`.
-- **Low risk:** Step 5 adds an inner timeout that is strictly tighter than the existing outer timeout. If `run_gh` currently succeeds within 60s (empirically true for all normal operations), this has no behavioral effect.
+- **Low risk:** All changes are purely additive logging. No behavioral changes to `run_gh`, `spawn_and_collect`, or `dispatch_tool`.
 
-## Open Questions
+## Recommended Follow-Up Tickets (out of scope per acceptance pin)
 
-1. Should Step 4 (pipe fix) and Step 5 (timeout cap) be separate tickets? The ticket says "acceptance is diagnostic instrumentation, not corrective fix" but the fixes are 2-line and 10-line changes in the same function.
-2. Should the progress logging interval (30s) be configurable? Decision: no — hardcode. The interval is for operator triage, not user-facing behavior.
-3. Should `RUN_GH_TIMEOUT_SECS` apply to `gh_read` as well? Decision: no — `gh_read` is a different handler with different semantics (allowlisted operations). It already has structural safety (operation allowlist, structured errors).
+### Follow-up 1: Fix pipe-deadlock in `spawn_and_collect`
+
+After `.take(MAX_OUTPUT_LEN)` reads complete, drop the pipe handles before `child.wait()`:
+```rust
+drop(stdout_take);
+drop(stderr_take);
+```
+This closes the pipe and causes the subprocess to get `SIGPIPE` if it's still writing. Without this, `wait()` deadlocks when the process writes > `MAX_OUTPUT_LEN`. **Blast radius:** all CLI builtin handlers (listed above). **Prerequisite:** this ticket's instrumentation confirms the pipe-deadlock hypothesis on the third reproduction.
+
+### Follow-up 2: Cap `run_gh` per-tool timeout
+
+Add a `RUN_GH_TIMEOUT_SECS` constant (60s) as an inner timeout inside `run_gh()`, independent of the inherited skill timeout. `run_gh` should never need more than 60s for any `gh` subcommand. **Blast radius:** `run_gh` only.

--- a/docs/solutions/best-practices/subprocess-diagnostic-instrumentation-pattern-2026-05-14.md
+++ b/docs/solutions/best-practices/subprocess-diagnostic-instrumentation-pattern-2026-05-14.md
@@ -1,0 +1,144 @@
+---
+title: "Subprocess diagnostic instrumentation pattern for CLI builtin handlers"
+module: agent
+date: 2026-05-14
+problem_type: best_practice
+component: tooling
+severity: medium
+tags: [spawn-and-collect, run-gh, timeout, diagnostic, instrumentation, subprocess, progress-ticker, tracing]
+applies_when: "A CLI builtin handler (run_gh, run_gws, gh_read, git ops) hangs or times out without producing actionable diagnostic output"
+---
+
+# Subprocess diagnostic instrumentation pattern for CLI builtin handlers
+
+## Context
+
+The `run_gh` builtin handler hung for the full 600-second timeout on two consecutive invocations (mika#900). The only log output was a generic timeout warning with no information about what `gh` subcommand was running, what environment was set, or whether the subprocess was producing any output. This made it impossible to distinguish between three hypothesized root causes (pipe deadlock, auth stall, or interactive prompt hang) without adding instrumentation and waiting for a third reproduction.
+
+The core issue: `spawn_and_collect()` — the shared subprocess lifecycle function for all CLI builtin handlers — had zero observability between spawn and completion. A subprocess that hung for 600 seconds produced exactly zero log lines until the outer timeout fired.
+
+## Guidance
+
+### 1. Pre-spawn invocation log
+
+Log the exact command argv, environment variable key set (names only, never values), and any conditional context before calling `spawn_and_collect`:
+
+```rust
+let env_keys_set: &[&str] = match ctx.github_token {
+    Some(_) => &["GH_PROMPT_DISABLED", "GH_TOKEN"],
+    None => &["GH_PROMPT_DISABLED"],
+};
+tracing::info!(
+    tool = "run_gh",
+    argv = ?&gh_args.args,
+    repo = ?&gh_args.repo,
+    env_keys_set = ?env_keys_set,
+    has_github_token = ctx.github_token.is_some(),
+    "run_gh invocation"
+);
+```
+
+**Token redaction is structural:** the `env_keys_set` slice contains only `&'static str` key names. The actual token value is never read by the log statement.
+
+### 2. Chunked reader with atomic byte counters
+
+Replace atomic `read_to_end` with a chunked read loop that increments shared `Arc<AtomicUsize>` counters per chunk. This lets a separate progress task observe byte counts during the read itself:
+
+```rust
+async fn read_with_counter<R: AsyncRead + Unpin>(
+    reader: R, max_bytes: usize, counter: Arc<AtomicUsize>,
+) -> Vec<u8> {
+    let mut take = reader.take(max_bytes as u64);
+    let mut buf = Vec::with_capacity(max_bytes.min(8192));
+    let mut chunk = [0u8; 256];
+    loop {
+        match take.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                counter.fetch_add(n, Ordering::Relaxed);
+            }
+            Err(e) => {
+                tracing::warn!(bytes_read = counter.load(Ordering::Relaxed),
+                    error = %e, "read_with_counter I/O error");
+                break;
+            }
+        }
+    }
+    buf
+}
+```
+
+### 3. Progress ticker at 30-second intervals
+
+A `tokio::spawn`ed task that snapshots both counters every 30 seconds. Aborted on normal completion:
+
+```rust
+let progress_task = tokio::spawn(async move {
+    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    interval.tick().await; // discard immediate first tick
+    loop {
+        interval.tick().await;
+        tracing::info!(tool = %name, stdout_bytes = ..., stderr_bytes = ...,
+            elapsed_ms = ..., "spawn_and_collect progress");
+    }
+});
+// ... tokio::join!(stdout_reader, stderr_reader, child.wait())
+progress_task.abort();
+```
+
+### 4. Timeout log enrichment
+
+Pre-compute a truncated input excerpt before `input` is moved into the execute call, then include it in timeout log lines:
+
+```rust
+const TOOL_TIMEOUT_INPUT_EXCERPT_LEN: usize = 200;
+let input_excerpt: String = serde_json::to_string(&input)
+    .unwrap_or_default()
+    .chars()
+    .take(TOOL_TIMEOUT_INPUT_EXCERPT_LEN)
+    .collect();
+// ... later, in the Err(_) timeout arm:
+warn!(tool = %name, timeout_secs = timeout, input_excerpt = %input_excerpt,
+    "tool execution timed out");
+```
+
+## Why This Matters
+
+Without these diagnostics, a hung subprocess produces exactly one log line (the timeout warning) with no information about what command was running or whether it was producing output. On the next reproduction, the four surfaces discriminate between the three hypothesized causes:
+
+- **Pipe deadlock:** progress ticker shows `stdout_bytes ≈ 10240` (MAX_OUTPUT_LEN ceiling) quickly, then no further change while reads are done but process hasn't exited
+- **Auth/network stall:** progress ticker shows `stdout_bytes = 0` for the entire duration
+- **Interactive prompt:** same as auth stall but identified by argv showing a subcommand that could prompt
+
+The instrumentation applies to all CLI builtin handlers (run_gh, run_gws, gh_read, git ops) via the shared `spawn_and_collect` function. Worst-case log volume: 20 tool steps × (1 + ⌊elapsed/30⌋) lines per turn. Steady-state for fast tools: 1 completion log line per invocation.
+
+## When to Apply
+
+- When a CLI subprocess handler times out without actionable log output
+- When adding new CLI builtin handlers that use `spawn_and_collect`
+- When debugging subprocess lifecycle issues (pipe deadlock, zombie processes, auth stalls)
+
+## Examples
+
+**Before (no diagnostics):**
+```
+WARN builtin handler timed out  tool=run_gh  timeout_secs=600
+```
+
+**After (four diagnostic surfaces):**
+```
+INFO  run_gh invocation  tool=run_gh  argv=["run","view","12345","--log-failed"]  repo=Some("senara-solutions/mika")  env_keys_set=["GH_PROMPT_DISABLED","GH_TOKEN"]  has_github_token=true
+INFO  spawn_and_collect progress  tool=gh  stdout_bytes=10240  stderr_bytes=0  elapsed_ms=30012
+INFO  spawn_and_collect progress  tool=gh  stdout_bytes=10240  stderr_bytes=0  elapsed_ms=60025
+...
+WARN  builtin handler timed out  tool=run_gh  timeout_secs=600  input_excerpt={"command":["run","view","12345","--log-failed"],"repo":"senara-solutions/mika"}
+```
+
+The progress ticker pattern (`stdout_bytes=10240` stuck at the MAX_OUTPUT_LEN cap) strongly suggests pipe deadlock — the follow-up fix is to drop pipe handles before `child.wait()`.
+
+## Related
+
+- `docs/solutions/runtime-errors/builtin-handler-timeout-ignores-skill-config.md` — the timeout path itself (why run_gh inherits 600s from dev-pilot's skill_timeout)
+- mika#900 — the diagnostic instrumentation ticket
+- mika#515 — `MIKA_GITHUB_TOKEN→GH_TOKEN` re-injection in builtin handlers


### PR DESCRIPTION
## Summary

- Add diagnostic logging to the `run_gh` builtin handler and `spawn_and_collect` to diagnose the 600s timeout observed on PR #898 (mika#900)
- Four instrumentation surfaces: pre-spawn invocation log (argv, env keys, token presence), timeout input excerpt, 30-second progress ticker with byte-count snapshots, and post-completion summary
- Address review findings: log I/O errors in chunked reader, log JoinError on reader task failure, extract magic number to named constant

## Acceptance

Per ticket: "Acceptance for THIS ticket is the diagnostic instrumentation, not the corrective fix." On the next reproduction, the four log surfaces discriminate between pipe-deadlock (stdout reaches 10KB then stalls), auth/network stall (stdout stays at 0), and interactive prompt hang (identified by argv).

## Files Changed

| File | Change |
|------|--------|
| `crates/mika-agent/src/skills/builtin_handlers.rs` | `run_gh` invocation log, `read_with_counter` chunked reader, progress ticker in `spawn_and_collect`, 4 new tests |
| `crates/mika-agent/src/agent.rs` | `input_excerpt` in both timeout log lines, `TOOL_TIMEOUT_INPUT_EXCERPT_LEN` constant |
| `crates/mika-agent/Cargo.toml` | `tracing-subscriber` dev-dependency for test event capture |

## Test plan

- [x] 4 new tests pass: completion log emission, token redaction, large-output handling, progress ticker firing
- [x] All 199 existing builtin_handlers tests pass
- [x] `cargo clippy` clean
- [x] `cargo build` succeeds
- [x] Lefthook pre-commit hooks pass (fmt, clippy, secrets, large files, toml)

Plan: docs/plans/2026-05-13-001-fix-run-gh-diagnostic-instrumentation-plan.md

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)