### PR TITLE
fix(task_engine): reaper checks child's dispatch_class, not parent's (#1118 v2)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -5255,13 +5255,16 @@ impl Database {
     ///
     /// A parent is "orphaned" when:
     /// - `status = 'in_progress'`, `source = 'self_dev'`, `trigger_type = 'manual'`
-    /// - `dispatch_class = 'implement'` (or NULL — pre-v34 rows via COALESCE)
     /// - Its latest callback subtask is `status = 'delivered'`
+    /// - **The callback's** `dispatch_class = 'implement'` (or NULL — pre-v34 via COALESCE).
+    ///   The class is keyed off the child (per-dispatch) rather than the parent
+    ///   because reused parents (mika#920 pattern) carry stale class data from
+    ///   their original dispatch.
     /// - The callback's `updated_at` is older than `grace_seconds` ago
     /// - Parent metadata does NOT contain `$.claude_pilot.pr_url`
     /// - No other active callback child exists (defers to #870's retry loop)
     ///
-    /// Groom-class parents (mika#1001) are NOT reaped here — their expected
+    /// Groom-class callbacks (mika#1001) are NOT reaped here — their expected
     /// artifact is a plan commit pushed to the branch, not a PR url. Groom-class
     /// leak detection is a separate follow-up (mika#1118 Option B).
     pub fn find_orphaned_parent_tasks(
@@ -5279,7 +5282,7 @@ impl Database {
                AND parent.status = 'in_progress'
                AND parent.source = 'self_dev'
                AND parent.trigger_type = 'manual'
-               AND COALESCE(parent.dispatch_class, 'implement') = 'implement'
+               AND COALESCE(child.dispatch_class, 'implement') = 'implement'
                AND child.trigger_type = 'callback'
                AND child.action_type = 'resume_agent'
                AND child.status = 'delivered'
@@ -11614,19 +11617,19 @@ mod tests {
         assert_eq!(orphans.len(), 1);
     }
 
-    /// mika#1118 — groom-class parents must NOT be reaped by the implement-class
-    /// reaper. Their expected artifact is a plan commit pushed to a branch, not a
-    /// PR url. The reaper's pr_url check is implement-shaped only.
+    /// mika#1118 v2 — groom-class CALLBACKS must NOT trigger reaping of their
+    /// parent. The class is keyed off the child (per-dispatch) because reused
+    /// parents (mika#920) carry stale class data.
     #[test]
     fn test_find_orphaned_parent_tasks_groom_class_not_reaped() {
         let db = db();
-        let (parent_id, child_id) = create_orphaned_parent_setup(&db);
+        let (_parent_id, child_id) = create_orphaned_parent_setup(&db);
 
-        // Set parent dispatch_class to 'groom' (v34+ schema)
+        // Set CHILD callback dispatch_class to 'groom' (the per-dispatch class)
         db.conn
             .execute(
                 "UPDATE tasks SET dispatch_class = 'groom' WHERE id = ?1",
-                params![parent_id],
+                params![child_id],
             )
             .unwrap();
 
@@ -11641,23 +11644,23 @@ mod tests {
         let orphans = db.find_orphaned_parent_tasks("mika", 600).unwrap();
         assert!(
             orphans.is_empty(),
-            "groom-class parent should not be reaped — produces plan commits, not PRs"
+            "parent with groom-class callback should not be reaped — grooming produces plan commits, not PRs"
         );
     }
 
-    /// mika#1118 — implement-class parents are still reaped when callback delivers
-    /// without producing a PR. Confirms the dispatch_class='implement' filter does
-    /// not regress the original #871 behavior.
+    /// mika#1118 v2 — implement-class callbacks still trigger reaping when the
+    /// dispatch completes without producing a PR. Confirms the per-child filter
+    /// does not regress the original #871 behavior.
     #[test]
     fn test_find_orphaned_parent_tasks_implement_class_still_reaped() {
         let db = db();
         let (parent_id, child_id) = create_orphaned_parent_setup(&db);
 
-        // Set parent dispatch_class explicitly to 'implement'
+        // Set CHILD callback dispatch_class explicitly to 'implement'
         db.conn
             .execute(
                 "UPDATE tasks SET dispatch_class = 'implement' WHERE id = ?1",
-                params![parent_id],
+                params![child_id],
             )
             .unwrap();
 
@@ -11675,27 +11678,27 @@ mod tests {
         assert_eq!(orphans[0].callback_task_id, child_id);
     }
 
-    /// mika#1118 — NULL dispatch_class (pre-v34 rows) is treated as 'implement'
-    /// via COALESCE. Preserves backward compatibility with rows created before
-    /// the v33→v34 migration added the column.
+    /// mika#1118 v2 — NULL dispatch_class on the CHILD callback (pre-v34 rows)
+    /// is treated as 'implement' via COALESCE. Preserves backward compatibility
+    /// with rows created before the v33→v34 migration added the column.
     #[test]
     fn test_find_orphaned_parent_tasks_null_dispatch_class_treated_as_implement() {
         let db = db();
         let (parent_id, child_id) = create_orphaned_parent_setup(&db);
 
-        // Helper does NOT set dispatch_class — defaults to NULL.
-        // Verify the column is actually NULL on this row.
+        // Helper does NOT set dispatch_class — defaults to NULL on both parent
+        // and child. Verify the CHILD's column is actually NULL.
         let class: Option<String> = db
             .conn
             .query_row(
                 "SELECT dispatch_class FROM tasks WHERE id = ?1",
-                params![parent_id],
+                params![child_id],
                 |row| row.get(0),
             )
             .unwrap();
         assert!(
             class.is_none(),
-            "test setup invariant: dispatch_class should be NULL pre-v34-style"
+            "test setup invariant: child dispatch_class should be NULL pre-v34-style"
         );
 
         // Backdate child past grace
@@ -11710,9 +11713,42 @@ mod tests {
         assert_eq!(
             orphans.len(),
             1,
-            "NULL dispatch_class must still be reaped (COALESCE -> 'implement')"
+            "NULL child dispatch_class must still be reaped (COALESCE -> 'implement')"
         );
         assert_eq!(orphans[0].id, parent_id);
+    }
+
+    /// mika#1118 v2 — the key regression case: reused parent (mika#920) with
+    /// NULL `parent.dispatch_class` but groom-class `child.dispatch_class`.
+    /// v1 would have reaped because it checked the parent's class. v2 must NOT
+    /// reap because the child's class is the per-dispatch authority.
+    #[test]
+    fn test_find_orphaned_parent_tasks_stale_parent_class_doesnt_drive_reaping() {
+        let db = db();
+        let (_parent_id, child_id) = create_orphaned_parent_setup(&db);
+
+        // Parent stays NULL (simulates reused parent from pre-v34 or mika#920).
+        // Child is the fresh groom-class dispatch.
+        db.conn
+            .execute(
+                "UPDATE tasks SET dispatch_class = 'groom' WHERE id = ?1",
+                params![child_id],
+            )
+            .unwrap();
+
+        // Backdate child past grace
+        db.conn
+            .execute(
+                "UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-700 seconds') WHERE id = ?1",
+                params![child_id],
+            )
+            .unwrap();
+
+        let orphans = db.find_orphaned_parent_tasks("mika", 600).unwrap();
+        assert!(
+            orphans.is_empty(),
+            "stale parent class must not override the fresh child class — v1 regression"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

v2 fix for the reaper-bug regression that bit production today (#1118).

PR #1119 (the v1 fix, merged earlier) keyed the filter off \`parent.dispatch_class\`. Empirical test on mika#923 confirmed that's the wrong column: parent.dispatch_class carries stale data from the parent's original dispatch when the parent is reused (mika#920 task-reuse pattern).

**Today on mika#923:**
- Fresh groom dispatch ran the full pipeline (plan + first-pass review pushed to branch)
- \`parent.dispatch_class = NULL\` (stale, from earlier failed dispatch)
- \`child.dispatch_class = 'groom'\` (correct, per-dispatch)
- Reaper still killed parent with \`callback_delivered_without_pr_url\` — because v1 looked at the parent's column

Change the filter to read from the child callback's dispatch_class. That's the per-dispatch class, always accurate.

## Diff

\`\`\`diff
-               AND COALESCE(parent.dispatch_class, 'implement') = 'implement'
+               AND COALESCE(child.dispatch_class, 'implement') = 'implement'
\`\`\`

Plus doc-comment update calling out the reused-parent rationale.

## Test changes

- 3 existing v1 tests updated to set child's dispatch_class (not parent's)
- 1 new test \`test_find_orphaned_parent_tasks_stale_parent_class_doesnt_drive_reaping\` directly covers the v1 regression scenario: NULL parent + groom child → must not reap. This is the test that would have caught v1 before deploy.
- All 9 tests pass: 5 pre-existing + 3 updated + 1 new

## Test plan

- [x] \`cargo test -p mika-agent --lib find_orphaned_parent_tasks\` → 9 passed, 0 failed
- [x] \`rust-fmt\` + \`rust-clippy\` clean via pre-commit lefthook
- [ ] Post-merge: redeploy + dispatch test groom on a fresh ticket to verify parent stays in_progress past 600s

## Recovery follow-up

5 stuck tickets (mika#794, #861, #903, #923, #815) are unblocked from the reaper side once this ships. Their plans + reviews are on the remote branches; fresh dispatches will complete cleanly.

Closes the v1 regression of #1118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)