### PR TITLE
fix(task-engine): re-add anti-cascade guard for deferred-dispatch chain promotion (#1124)

### DIFF
--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -467,12 +467,39 @@ impl TaskDispatcher {
             // engine's next periodic scan (~60s) dispatches it as a
             // DeferredDispatch silent turn. Must run AFTER mark_task_delivered.
             //
-            // mika#1070 — Removed anti-cascade guard. The previous guard prevented
-            // chain promotion when a DeferredDispatch turn itself completed (the
-            // label matched DEFERRED_DISPATCH_LABEL). Each promotion is a DB write
-            // (LIMIT 1) that returns immediately; the promoted task dispatches on
-            // the next engine tick — no call-stack cascade.
-            self.dispatch_next_deferred_callback().await;
+            // mika#1070 — Removed anti-cascade guard. Rationale at the time was
+            // "promotion is just a DB write, no call-stack cascade."
+            //
+            // mika#1124 — Re-added the anti-cascade guard with refined rationale.
+            // Empirically (today, 2026-05-15 drain of 4-ticket queue), when a
+            // DeferredDispatch turn's silent run completes WITHOUT actually calling
+            // `run_claude_pilot` (e.g., LLM emits no tool calls, hits the stall
+            // detector, or has any other no-op shape), chain-promoting the next
+            // deferred callback creates an inline loop: N deferred wrappers each
+            // get promoted → silent turn fires → no pilot dispatched → marked
+            // delivered → chain-promotes the next → repeat, until the queue is
+            // empty. Reaper then kills the parent (no PR url, grace expired).
+            //
+            // Observed: parent `19c8bbbe` (mika#861 today) accumulated 10 deferred
+            // callbacks all delivered with result "deferred dispatch slot freed",
+            // none ran the impl pilot. Same shape on `14f9f32d` (mika#1124's own
+            // groom dispatch — 6 deferred wrappers, none ran).
+            //
+            // Fix: skip inline chain-promotion when the just-completed task is
+            // itself a deferred wrapper. Deferred wrappers don't represent real
+            // dispatch completion — their completion shouldn't trigger queue
+            // progression. Real callbacks (impl-class run_claude_pilot completions)
+            // still chain immediately. The periodic backstop
+            // (`promote_pending_deferred_if_idle`, ~60s cadence, slot-checked)
+            // handles re-promotion when the dispatch slot becomes truly idle.
+            if task.label != crate::agent::DEFERRED_DISPATCH_LABEL {
+                self.dispatch_next_deferred_callback().await;
+            } else {
+                debug!(
+                    task_id = %task.id,
+                    "deferred wrapper completed — skipping inline chain-promotion (mika#1124); periodic backstop will handle re-promotion if slot is idle"
+                );
+            }
         }
 
         if let Err(e) = self.db.end_session(&session_id).await {
@@ -2307,6 +2334,110 @@ mod tests {
         // Parent should still be in_progress (not auto-blocked)
         let parent = db.get_task_unscoped(&parent_id).await.unwrap().unwrap();
         assert_eq!(parent.status, "in_progress");
+    }
+
+    /// mika#1124: drift guard — the DEFERRED_DISPATCH_LABEL constant is the
+    /// load-bearing string the anti-cascade guard at the chain-promotion
+    /// callsite matches against. If either side drifts, the wedge returns
+    /// silently.
+    #[test]
+    fn test_deferred_dispatch_label_string_drift_guard() {
+        assert_eq!(
+            crate::agent::DEFERRED_DISPATCH_LABEL,
+            "long_running:run_claude_pilot:deferred",
+            "DEFERRED_DISPATCH_LABEL changed — verify the anti-cascade guard \
+             in dispatch_resume_agent (mika#1124) still matches the wrapper task label."
+        );
+    }
+
+    /// mika#1124: the legitimate FIFO promotion path still works. Verifies that
+    /// `dispatch_next_deferred_callback` promotes the oldest pending deferred
+    /// callback when invoked. The anti-cascade guard short-circuits this call
+    /// only when the just-completed task is itself a deferred wrapper —
+    /// non-wrapper callbacks and the periodic backstop still drive the queue.
+    #[tokio::test]
+    async fn test_dispatch_next_deferred_callback_promotes_pending() {
+        let db = test_db();
+        let dispatcher = test_dispatcher(db.clone());
+
+        let parent_id = db
+            .create_task(NewTask {
+                agent_id: "mika".to_string(),
+                team_run_id: None,
+                parent_task_id: None,
+                depth: 0,
+                label: "manual self_dev parent".to_string(),
+                trigger_type: "manual".to_string(),
+                cron_expr: None,
+                event_source: None,
+                event_offset_secs: None,
+                condition_expr: None,
+                next_fire_at: None,
+                timeout_at: None,
+                action_type: "none".to_string(),
+                action_config: "{}".to_string(),
+                input_context: None,
+                created_by_session: None,
+                created_trace_id: None,
+                reference_url: None,
+                source: Some("self_dev".to_string()),
+                metadata: None,
+                r#type: None,
+                dispatch_class: None,
+            })
+            .await
+            .unwrap();
+
+        let deferred_id = db
+            .create_task(NewTask {
+                agent_id: "mika".to_string(),
+                team_run_id: None,
+                parent_task_id: Some(parent_id),
+                depth: 1,
+                label: crate::agent::DEFERRED_DISPATCH_LABEL.to_string(),
+                trigger_type: "callback".to_string(),
+                cron_expr: None,
+                event_source: None,
+                event_offset_secs: None,
+                condition_expr: None,
+                next_fire_at: Some(crate::timestamp::now()),
+                timeout_at: None,
+                action_type: "resume_agent".to_string(),
+                action_config: r#"{"text": "deferred"}"#.to_string(),
+                input_context: None,
+                created_by_session: None,
+                created_trace_id: None,
+                reference_url: None,
+                source: None,
+                metadata: None,
+                r#type: None,
+                dispatch_class: Some("implement".to_string()),
+            })
+            .await
+            .unwrap();
+
+        // Pre-condition: deferred wrapper is `pending`.
+        let before = db.get_task_unscoped(&deferred_id).await.unwrap().unwrap();
+        assert_eq!(before.status, "pending");
+
+        // Drive the legitimate promotion path directly.
+        dispatcher.dispatch_next_deferred_callback().await;
+
+        // Post-condition: the wrapper is `completed` with the synthetic result
+        // the engine recognizes for DeferredDispatch silent-turn dispatch.
+        let after = db.get_task_unscoped(&deferred_id).await.unwrap().unwrap();
+        assert_eq!(
+            after.status, "completed",
+            "deferred wrapper should be promoted"
+        );
+        assert!(
+            after
+                .result
+                .as_deref()
+                .unwrap_or("")
+                .contains("deferred dispatch slot freed"),
+            "promoted wrapper carries the engine's synthetic result string"
+        );
     }
 
     /// #991: maybe_fire_post_callback_advance fires and auto-blocks when no


### PR DESCRIPTION
## Summary

Re-adds the anti-cascade guard removed in mika#1070. Inline chain-promotion of deferred-dispatch callbacks now only fires when the just-completed task is NOT itself a deferred wrapper.

Closes mika#1124.

## The wedge

The chain-promotion call at `dispatcher.rs:475` fires unconditionally after every callback delivery. When a `DeferredDispatch` silent turn completes WITHOUT producing a `run_claude_pilot` call (LLM emits no tool calls, stall detector trips, intent-guard mis-fires), the wrapper still hits `mark_task_delivered`, which still chain-promotes the next deferred wrapper, which fires another silent turn that doesn't dispatch — looping until queue empty. The dispatch slot stays empty the whole time; the reaper eventually kills the parent.

## Empirical evidence (2026-05-15 drain)

- Parent `19c8bbbe` (mika#861) accumulated **10 deferred callbacks** all delivered with `result = "deferred dispatch slot freed"`. None ran the impl pilot. Reaper marked parent `failed`.
- Parent `14f9f32d` (mika#1124's own groom dispatch) — 6 deferred wrappers, same shape.
- 4-way drain success rate: 1/4.

## Fix

Wrap the chain-promotion call with `if task.label != DEFERRED_DISPATCH_LABEL`. Real callbacks (impl-class `run_claude_pilot` completions) chain immediately. Deferred wrappers do not — the periodic backstop (`promote_pending_deferred_if_idle`, 60s cadence, slot-checked) handles re-promotion when the dispatch slot becomes truly idle.

## Why mika#1070's rationale missed this

mika#1070 removed the guard with the rationale "promotion is just a DB write, no call-stack cascade — each promotion dispatches on the next engine tick." That's correct in the happy path: a deferred wrapper's silent turn calls `run_claude_pilot`, producing a real callback whose completion legitimately advances the queue.

The failure mode it didn't anticipate: silent-turn completion WITHOUT a real dispatch is also possible (zero-tool-call exits, stall detection, etc.), and chain-promoting in that state drains the queue uselessly.

## Tests

- `test_deferred_dispatch_label_string_drift_guard` — drift guard for the load-bearing const-string match.
- `test_dispatch_next_deferred_callback_promotes_pending` — legitimate FIFO promotion path still works (backstop + non-wrapper-callback flow).

Targeted dispatcher tests: 28 passed (was 26 + 2 new).

## Test plan

- [x] `cargo test -p mika-agent --lib task_engine::dispatcher::tests` — all 28 pass
- [x] Release build (`cargo build --release --features telemetry --bin mika-server --bin mika --bin mika-gateway`) succeeds
- [ ] Post-deploy: drain 2+ tickets simultaneously and observe no deferred-wrapper cascades in `MIKA_SERVER_LOG_FILE` (`grep deferred_dispatch_promoted` shows only legitimate promotions, not chains of 6+ for a single parent)
- [ ] Post-deploy: reaper does not fire `callback_delivered_without_pr_url` on parents whose only completed children are deferred wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)