### PR TITLE
ci(verify-pipeline): inherit `documentation` label from linked issue to exempt docs-only PRs (#861)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify pipeline artifacts
+        env:
+          GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: bash scripts/verify-pipeline.sh origin/main
 
   security:

--- a/docs/plans/2026-04-29-005-ci-verify-pipeline-label-inheritance-plan.md
+++ b/docs/plans/2026-04-29-005-ci-verify-pipeline-label-inheritance-plan.md
@@ -1,0 +1,252 @@
+---
+title: "ci(verify-pipeline): inherit documentation label from linked issue to exempt docs-only PRs"
+type: ci
+status: active
+date: 2026-04-29
+ticket: senara-solutions/mika#861
+branch: ci/861/verify-pipeline-inherit-documentation
+origin: senara-solutions/mika#860 (bucket-comparison + Pipeline-Exempt trailer port to mika)
+related: senara-solutions/mika-platform#17 (sprint post-mortem establishing docs/source-balance protection), senara-solutions/mika-platform#18 (canonical bucket-comparison logic), senara-solutions/mika-platform#49 (extend Pipeline Artifacts to mika-platform's branch protection — companion)
+---
+
+# ci(verify-pipeline): inherit documentation label from linked issue to exempt docs-only PRs
+
+## Overview
+
+mika#861 layers label-driven exemption on top of the bucket-comparison + `Pipeline-Exempt:` trailer mechanism that PR #860 ported from mika-platform. The `documentation` label on a linked issue exempts the docs-only rejection; the trailer remains as a residual escape hatch with a `warn:` nudge toward the with-reason form.
+
+Issue body is fully designed: 5-case stress test (A-E), sub-task breakdown (3), explicit one-directional asymmetry (`documentation` exempts source-required, NOT docs-required-when-source-changes), explicit rejection of path-pattern fallback with rationale. This plan pins script-implementation details and file paths against the current state of `scripts/verify-pipeline.sh`.
+
+## Problem Frame
+
+### Observed friction (from issue body + #860)
+
+The current `Pipeline-Exempt:` trailer at `scripts/verify-pipeline.sh:82-106` (verified shape this turn) requires per-commit trailer text. PR #860 hit this friction shipping two `/ce:compound` outputs to `docs/solutions/best-practices/` — docs-only ship, no linked source changes, blocked by the bucket check until the trailer was added. The trailer mechanism is functional but client-side, easy to forget, and shifts the burden to commit-time.
+
+### Why label-inheritance is the cleaner mechanism
+
+Per the issue body's "Design (committed)" section: labels are observable in PR/issue UI, deterministic from issue classification, and honor `as above, so below` (issue-level classification → PR-level exemption). Server-side reads-at-check let operators label issues retroactively after PR open without rewriting commit history.
+
+### Asymmetry is load-bearing
+
+Cases A-E from the issue body, restated:
+- **(A) `documentation` issue, docs-only diff** → PASS. Label exempts source-required check.
+- **(B) `documentation` issue, mixed diff** → PASS. Both checks satisfied independently.
+- **(C) `documentation` issue, source-only diff** → **FAIL**. The label is NOT a get-out-of-jail card for the docs-when-source check. Preserves mika-platform#17's protection.
+- **(D) Unlabeled issue, docs-only** → FAIL. Label is the explicit classification; absence means no exemption.
+- **(E) No linked issue, docs-only** → FAIL (or use trailer with reason). Compound docs deserve tracked rationale.
+
+The asymmetry — `documentation` exempts source-required ONLY, not docs-required-when-source-changes — is the structural invariant the existing bucket comparison enforces.
+
+## Requirements Trace
+
+- **R1.** Sub-task 1: server-side label inheritance in `scripts/verify-pipeline.sh`. Parse `Closes #N` from PR body (`GITHUB_PR_BODY` env var when running in CI; falls back to `gh pr view --json body` if unset; local invocations skip if no PR context). **F2 resolution — branch-name fallback DROPPED.** The branch-name `/[0-9]+/` pattern silently misfires on branches like `feature/v2/new-thing` (extracts `2` → wrong-issue lookup → no `documentation` label found → reject arm fires with "label not found" rather than the truth "no linked issue"). Silent misfire is worse than no fallback per the explicit-over-silent principle established by mika-platform#17's path-pattern rejection. v1 reads only from `GITHUB_PR_BODY` (CI-injected, reliable) → `gh pr view --json body` (git context, reliable). If neither yields a `Closes #N` reference, fall through to trailer/reject — no implicit derivation. Call `gh api repos/{owner}/{repo}/issues/{N} --jq '.labels[].name'` to fetch issue labels. If `documentation` is present, exempt the docs-only rejection at line 91. New log line: `[pipeline-exempt: label] docs-only PR allowed by linked-issue documentation label (#N)` (per F5 structured-prefix sharpening). Asymmetry preserved: the code-only check at lines 102-106 remains untouched.
+- **R2.** Sub-task 2: trailer reason-required warning. Current regex at line 82 is `^Pipeline-Exempt: docs-only(\s.*)?$` (verified — accepts both bare and with-reason). Extend the matching arm to:
+  - With-reason form (capture group `\s+(.+)$`) → `[pipeline-exempt: trailer] docs-only PR allowed by Pipeline-Exempt trailer with reason: <reason>` (no warn).
+  - Bare form → `warn: [pipeline-exempt: trailer] bare Pipeline-Exempt: docs-only trailer detected; prefer 'Pipeline-Exempt: docs-only — <reason>' for audit trail`.
+  Same dual-form treatment for `code-only` at lines 85, 102. Backwards compat preserved (bare still passes). Structured prefix `[pipeline-exempt: trailer]` per F5 sharpening — paired with `[pipeline-exempt: label]` (R1) and `[pipeline-exempt: none]` (reject arm) for log triage.
+- **R3.** Sub-task 3: documented rejection of path-pattern fallback + design rationale block. Add a header-comment block to `scripts/verify-pipeline.sh` (after the existing decision matrix at lines 14-21) explicitly covering:
+  - **Path-pattern auto-exemption rejected** with the issue body's three-point rationale (visibility erosion, artifact-vs-classification inversion, DRY against `.github/labels.yml`).
+  - **F3 — bare-trailer warn rationale:** "bare `Pipeline-Exempt: docs-only` is accepted for backward compatibility (PR #860 shipped both forms) but the with-reason form is required for auditability — bare emits a warn directing operators to the with-reason form."
+  - **F4 — cross-repo `Closes` non-handling:** "v1 treats cross-repo `Closes senara-solutions/<other>#N` as no-link-in-this-repo (the `gh api repos/$repo/issues/$N` call would 404). The cross-repo close-pattern is what mika-platform#17 protects against; non-handling is intentional. Use trailer with reason for legitimate cross-repo docs-only ships."
+  - **F1 — exemption priority order rationale:** "Label is checked FIRST as the classification-driven mechanism (issue body explicitly designates trailer as 'residual escape hatch'). Trailer is the explicit per-instance override. Three-path order: label → trailer → reject."
+  Same comment block in PR description per the issue body's acceptance criteria #3.
+- **R4.** Tests: bash test fixture covering all 5 cases A-E. Mock the `gh api repos/.../issues/N` call via a function override or `GH_API_MOCK_RESPONSES` env var (decided at implementation against the existing test idioms in `scripts/`). Each case asserts the exit code and the relevant log line in stderr. Trailer test: with-reason form produces `info:` line, bare form produces `warn:` line, both pass; malformed (e.g., `Pipeline-Exempt: docs-only-`) rejected. CI integration: open a draft PR per shape and confirm the check's outcome — implementer-discretion for which subset of A-E warrants a real CI dry-run vs. unit-test-only coverage.
+- **R5.** No `gh` token scope expansion. The `gh api repos/.../issues/N --jq '.labels[].name'` call uses the existing `GITHUB_TOKEN` available in the workflow at `ci.yml:117-130`. The Pipeline Artifacts job already runs `bash scripts/verify-pipeline.sh origin/main` at line 130; `GITHUB_TOKEN` is implicitly available via `gh auth status` from the actions checkout step. Verify in implementation that the read-only `issues:read` scope is sufficient (likely yes — issue labels are public on public repos and accessible with default `GITHUB_TOKEN` permissions).
+- **R6.** No new files. Single-file script edit + ci.yml unchanged + comment-block update. Test fixture is either inline in the script or a sibling `scripts/verify-pipeline-test.sh` (decision deferred to implementation).
+
+## Proposed Fix
+
+### Sub-task 1 — label inheritance in `verify-pipeline.sh`
+
+**Where:** insert label-fetching logic after the existing `COMMIT_BODIES` extraction (line 81-ish, before the regex matching at line 82). Pseudocode:
+
+```bash
+# mika#861: fetch linked issue's labels for documentation-exemption check.
+# Read in priority order: GITHUB_PR_BODY env, gh pr view (fallback when env empty), branch name.
+linked_issue=""
+if [ -n "${GITHUB_PR_BODY:-}" ]; then
+    linked_issue=$(echo "$GITHUB_PR_BODY" | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+')
+fi
+if [ -z "$linked_issue" ] && command -v gh >/dev/null 2>&1; then
+    pr_body=$(gh pr view --json body --jq .body 2>/dev/null || echo "")
+    linked_issue=$(echo "$pr_body" | grep -oE 'Closes #[0-9]+' | head -1 | grep -oE '[0-9]+')
+fi
+if [ -z "$linked_issue" ]; then
+    # Branch-name fallback: feat/<n>/..., fix/<n>/..., etc.
+    branch_name=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    linked_issue=$(echo "$branch_name" | grep -oE '/[0-9]+/' | head -1 | tr -d '/')
+fi
+
+issue_has_documentation_label=false
+if [ -n "$linked_issue" ]; then
+    repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
+    if [ -n "$repo" ]; then
+        labels=$(gh api "repos/$repo/issues/$linked_issue" --jq '.labels[].name' 2>/dev/null || echo "")
+        if echo "$labels" | grep -qx "documentation"; then
+            issue_has_documentation_label=true
+        fi
+    fi
+fi
+```
+
+Then in the docs-only rejection arm (line 91 currently), add a label-check branch BEFORE the trailer check:
+
+```bash
+if [ "$has_docs" = true ] && [ "$has_source" = false ]; then
+    if [ "$issue_has_documentation_label" = true ]; then
+        echo "info: docs-only PR allowed by linked-issue documentation label (#$linked_issue)" >&2
+        exit 0
+    fi
+    if [ "$exempt_docs_only" = true ]; then
+        # ... existing trailer-based exemption (with R2 reason-required warn) ...
+    fi
+    # ... existing reject ...
+fi
+```
+
+The label check is consulted FIRST, then trailer, then reject. Three exits from the docs-only branch: label → exit 0 with info, trailer → exit 0 with info-or-warn (per R2), reject → exit 1.
+
+**Code-only branch unchanged.** The asymmetry is structural: label exempts source-required, NOT docs-required-when-source-changes.
+
+### Sub-task 2 — trailer reason-required warning
+
+**Where:** lines 82-106 (`Pipeline-Exempt:` regex matches and warn lines). Replace the bare-only matches with dual-form matching:
+
+```bash
+if echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: docs-only\s+.+$'; then
+    exempt_docs_only=true
+    exempt_docs_reason=$(echo "$COMMIT_BODIES" | grep -oE '^Pipeline-Exempt: docs-only\s+.+$' | head -1 | sed 's/^Pipeline-Exempt: docs-only\s*//')
+elif echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: docs-only$'; then
+    exempt_docs_only=true
+    exempt_docs_reason=""
+fi
+# ... same dual-match for code-only ...
+```
+
+Then in the exemption arm:
+
+```bash
+if [ "$exempt_docs_only" = true ]; then
+    if [ -n "$exempt_docs_reason" ]; then
+        echo "info: docs-only PR allowed by Pipeline-Exempt trailer with reason: $exempt_docs_reason" >&2
+    else
+        echo "warn: bare Pipeline-Exempt: docs-only trailer detected; prefer 'Pipeline-Exempt: docs-only — <reason>' for audit trail" >&2
+    fi
+    exit 0
+fi
+```
+
+### Sub-task 3 — header comment + PR description note
+
+Add to `scripts/verify-pipeline.sh` after the existing decision matrix (lines 14-21):
+
+```bash
+# Path-pattern auto-exemption was considered and rejected. Rationale:
+# (1) Silent green CI with three exemption paths (label + trailer + path-pattern)
+#     erodes structural visibility — operators can't tell at a glance which path
+#     allowed a green check.
+# (2) Path-touching is an artifact of classification, not the classification itself
+#     (a docs-only PR is one whose intent is documentation, not one whose paths
+#     happen to start with `docs/`). Gating on the artifact rather than the
+#     decision is an inversion that erodes protections over time.
+# (3) Creates a parallel taxonomy alongside `.github/labels.yml` (DRY violation).
+# Two mechanisms (label = classification-driven, trailer = explicit override) is
+# fine. Three is not. See mika#861 for the design discussion.
+```
+
+PR description carries the same note (per issue body acceptance criteria #3).
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `scripts/verify-pipeline.sh` | Sub-task 1: label-fetch logic + label-check branch in docs-only arm (~line 91). Sub-task 2: dual-form trailer matching (~lines 82-106) with reason-required warn on bare. Sub-task 3: header comment block (~lines 14-21+). |
+| `scripts/verify-pipeline-test.sh` | New file (or appended inline test mode in the main script) — bash fixture covering cases A-E + trailer dual-form. Implementation chooses between sibling test script vs. inline self-test mode. |
+| (no changes to `.github/workflows/ci.yml`) | The Pipeline Artifacts job at line 130 already runs `bash scripts/verify-pipeline.sh origin/main`; `GITHUB_TOKEN` available implicitly via the actions checkout step. |
+| `CHANGELOG.md` | Add entry under "Changed" — "ci: verify-pipeline.sh now inherits the `documentation` label from linked issue to exempt docs-only PRs. Trailer mechanism remains as residual escape hatch with reason-required warn on bare form. Closes #861." |
+
+No schema changes. No new dependencies. No new env vars (the new env-var read of `GITHUB_PR_BODY` is the existing actions convention; ci.yml passes it via `pull_request` event context).
+
+## Verification
+
+### Unit (bash test fixture)
+
+```bash
+cd /data/workspace/mika-platform/.claude/worktrees/ci-861-verify-pipeline-inherit-documentation/mika
+bash scripts/verify-pipeline-test.sh
+```
+
+The test fixture mocks `gh api repos/.../issues/N` via function override and asserts the exit code + relevant stderr line for each of cases A-E. Trailer dual-form has its own three sub-cases (with-reason → info, bare → warn, malformed → reject).
+
+### CI integration (manual, post-merge)
+
+1. Create a draft PR with a `documentation`-labeled linked issue and docs-only diff. Confirm Pipeline Artifacts check passes with `info: docs-only PR allowed by linked-issue documentation label (#N)` in logs.
+2. Same setup but the diff includes source changes. Confirm bucket-comparison still passes (mixed diff is the green path regardless of label).
+3. Same setup but the diff is source-only. Confirm Pipeline Artifacts FAILS — the docs-when-source-changes check fires regardless of label (case C, the asymmetry under test).
+4. Unlabeled linked issue + docs-only diff. Confirm Pipeline Artifacts FAILS unless trailer is present (case D).
+
+### Backwards compatibility
+
+PR #860's bare-trailer form still passes. The new warn line is informational only; no behavior change for existing exemption-by-trailer workflows.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `gh api` call fails (network, rate-limit, missing scope) — script silently fails-open and rejects an exemptable PR. | The `2>/dev/null || echo ""` pattern fails closed (treats as no label). The trailer mechanism remains as fallback. Operator's audit trail shows the gh failure (via `gh auth status` line) if they investigate. Real risk: a transient network glitch could cause spurious rejection; the trailer is the documented escape. Acceptable. |
+| `Closes #N` parsing misses non-canonical close-keywords (`Fixes`, `Resolves`). | v1 parses only `Closes` — the existing convention in mika PR bodies. If `Fixes`/`Resolves` shapes appear, extend the regex; documented as a sentinel in Out of Scope. |
+| Branch-name fallback wrongly picks up `release-plz-...` or other non-issue branches. | The fallback grep targets `/[0-9]+/` between slashes — release-plz branches don't match the pattern. False-positive rate negligible. |
+| Operator mislabels an issue as `documentation` when it should be `bug` + `documentation`. | The label is checked for presence, not exclusivity. A `documentation+bug` issue exempts the docs-only check (intent is documentation-driven, even if there's also a bug aspect). Aligns with the issue body's design intent. |
+| Rate-limit hit on `gh api` for high-PR-volume repos. | One call per PR check-run is well under any reasonable rate limit. If a workflow flakes due to rate limits, that's a broader CI concern, not specific to this script. |
+
+## Out of Scope
+
+- **Auto-applying labels from issue → PR at creation time.** Server-side check reads from issue at check-run, so PR doesn't need its own label. Client-side label inheritance (mika-dev dispatch path) is a separate possible enhancement that this ticket does not depend on.
+- **Removing the trailer mechanism entirely.** Two mechanisms with crisp non-overlapping purposes (label = classification-driven, trailer = explicit override) is fine.
+- **Other close-keywords (`Fixes`, `Resolves`).** v1 parses `Closes` only per existing mika convention. Sentinel: extend if those shapes appear in real PR bodies.
+- **Cross-repo label sync.** `.github/labels.yml` + `EndBug/label-sync` already keeps `documentation` consistent across repos. This script reads labels at check-run; consistency is upstream.
+- **mika-platform#49 — extend Pipeline Artifacts to mika-platform's branch protection.** Companion ticket, separate ship; consumes this script's behavior.
+
+## Open Questions for mika-arch
+
+1. **`Closes #N` cross-repo references.** Current parsing assumes the linked issue is in the SAME repo as the PR. If the PR body says `Closes senara-solutions/mika-skills#102`, the `gh api repos/.../issues/N` call against the PR's repo would 404. My read: cross-repo close-references are rare and historically mishandled (the cross-repo split pattern from mika-platform#17 is what we're protecting against, not enabling). v1 treats cross-repo `Closes` as "no linked issue in this repo" → no label exemption → trailer fallback. Defer-to-architect if a different read is preferred.
+2. **Test-fixture isolation.** Mocking `gh api` in bash via function override is the canonical pattern, but if the team prefers a Python/Rust test runner, the fixture moves out-of-script. My read: bash-native test is appropriate scope for a bash script. Defer-to-architect.
+3. **Label name canonicalization.** `documentation` is the literal label name (per `.github/labels.yml`). If the label gets renamed, the script breaks silently (no exemption, all docs-only rejected unless trailered). Defer-to-architect on whether to add a label-existence pre-check or accept the manual-coordination cost.
+
+---
+
+## Architect first-pass concerns (resolved in this revision)
+
+This revision applies the six findings from mika-arch's first-pass review (session `2f02cec3-aee4-4d2e-bebd-a0c65a0af88b`).
+
+### F1 — Exemption priority order pinned to label-first per issue body (BLOCKING, resolved)
+
+The issue body's "Design (committed)" section explicitly designates the trailer as a "residual escape hatch, with required reason (target form)." "Residual" + "escape hatch" wording confirms label is the PRIMARY mechanism (classification-driven) and trailer is the FALLBACK / explicit per-instance override. Architect's option (a) applies — issue body specifies label-first explicitly. Plan's three-path order (label → trailer → reject) conforms. R3 now documents the priority-order rationale in the header comment block so future maintainers see the issue-body citation alongside the path-pattern rejection rationale.
+
+### F2 — Branch-name fallback dropped (BLOCKING, resolved)
+
+R1 now states the branch-name fallback is DROPPED for v1. Silent-misfire risk on branches like `feature/v2/...` (extracts `2` → wrong-issue lookup → reject arm with misleading "label not found" message) is worse than no fallback. Per the explicit-over-silent principle from mika-platform#17. v1 reads only from `GITHUB_PR_BODY` env (CI-injected) → `gh pr view --json body` (git context) → trailer/reject. No implicit derivation.
+
+### F3 — Bare-trailer warn rationale in header comment (sharpening, applied)
+
+R3's header-comment block now includes the bare-trailer warn rationale alongside the path-pattern rejection rationale. Future maintainers see why bare wasn't hard-rejected in the same place they see why path-pattern wasn't accepted.
+
+### F4 — Cross-repo `Closes` non-handling in header comment (sharpening, applied)
+
+R3's header-comment block now documents the cross-repo `Closes` non-handling explicitly. Maintainers seeing a cross-repo PR that needs a trailer will find the rationale in-place.
+
+### F5 — Structured log prefix `[pipeline-exempt: <path>]` (sharpening, applied)
+
+All three exemption-decision log lines now use the structured prefix: `[pipeline-exempt: label]`, `[pipeline-exempt: trailer]`, `[pipeline-exempt: none]`. CI log triage becomes a `grep '\[pipeline-exempt:` invocation.
+
+### F6 — Asymmetry test in case fixture (non-blocking, addressed by issue body)
+
+The issue body's case table already covers asymmetry: case C (`documentation` label + source-only diff → FAIL because docs-when-source-changes check fires regardless of label). Plan's R4 test fixture covers all 5 cases A-E from the issue body, which includes case C. No additional fixture needed; the asymmetry assertion is implicit in case C's expected exit-code-1 outcome.
+
+---
+
+## Architect verdict
+
+- **First-pass (mika-arch session `2f02cec3-aee4-4d2e-bebd-a0c65a0af88b`):** ITERATE. Two blockers (F1 priority order, F2 branch-name fallback) + four sharpenings (F3 warn-bare rationale, F4 cross-repo non-handling, F5 structured prefix, F6 asymmetry coverage). All resolved in this revision.
+- **Second-pass:** pending.

--- a/docs/plans/2026-04-29-005-ci-verify-pipeline-label-inheritance-plan.md
+++ b/docs/plans/2026-04-29-005-ci-verify-pipeline-label-inheritance-plan.md
@@ -170,6 +170,20 @@ No schema changes. No new dependencies. No new env vars (the new env-var read of
 
 ## Verification
 
+### Phase 0 — pre-implementation issue-body verification (F1 residual sharpening)
+
+Before writing any implementation code, run:
+
+```bash
+gh issue view 861 --repo senara-solutions/mika --json body | grep -q "residual escape hatch"
+```
+
+**Expected:** match found (confirming the issue body's "residual escape hatch" trailer characterization that grounds R1's label-first priority order).
+
+**Fallback if no match:** the priority-order claim is ungrounded against the issue body's current wording. Re-evaluate against whatever the body actually says — if body specifies trailer-first or is silent, swap the priority order to trailer → label → reject and update R1/R3 accordingly.
+
+This Phase 0 verification was performed during grooming (the brief's "residual escape hatch" citation came from the issue-body content available in this session's context). Re-run at implementation time as a pre-commit gate so the priority-order claim stays grounded if the issue body is edited between groom and implementation. Same pre-commit-discovery discipline applied across mika#863 F8, mika#821 F6, mika-platform#52 F2.
+
 ### Unit (bash test fixture)
 
 ```bash
@@ -249,4 +263,4 @@ The issue body's case table already covers asymmetry: case C (`documentation` la
 ## Architect verdict
 
 - **First-pass (mika-arch session `2f02cec3-aee4-4d2e-bebd-a0c65a0af88b`):** ITERATE. Two blockers (F1 priority order, F2 branch-name fallback) + four sharpenings (F3 warn-bare rationale, F4 cross-repo non-handling, F5 structured prefix, F6 asymmetry coverage). All resolved in this revision.
-- **Second-pass:** pending.
+- **Second-pass (same session, continuity preserved):** GROOMED. All six findings resolved (F1 conditionally — pending Phase 0 grep verification gate). Two remaining uncertainties correctly deferred (test-fixture format = implementation-detail; dual-form regex shape = readability-over-cleverness deferred). One residual: F1 grounded on the brief's citation of "residual escape hatch" wording from the issue body — Phase 0 grep gate (`gh issue view 861 ... | grep -q "residual escape hatch"`) added to verify the priority-order claim before the first implementation commit. Output-format compatibility confirmed: exit-code contract unchanged, new structured `[pipeline-exempt: ...]` log lines are additive (no downstream parser consumes them).

--- a/scripts/verify-pipeline-test.sh
+++ b/scripts/verify-pipeline-test.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# Test fixture for scripts/verify-pipeline.sh (mika#861)
+#
+# Covers 5-case stress test (A-E) from the issue body + trailer dual-form tests.
+# Uses a temporary git repo to simulate different PR shapes and mocks `gh` commands
+# via a mock executable placed on PATH ahead of the real gh.
+#
+# Usage:
+#   bash scripts/verify-pipeline-test.sh
+#
+# Exit codes:
+#   0 - all tests passed
+#   1 - one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFY_SCRIPT="$SCRIPT_DIR/verify-pipeline.sh"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# --- Helpers ---
+
+setup_test_repo() {
+  TEST_DIR=$(mktemp -d)
+  cd "$TEST_DIR"
+  git init --initial-branch main -q
+  mkdir -p scripts
+  # Copy the verify script into the test repo
+  cp "$VERIFY_SCRIPT" scripts/verify-pipeline.sh
+  chmod +x scripts/verify-pipeline.sh
+
+  # Create initial commit on main
+  echo "initial" > README.md
+  git add README.md scripts/
+  git commit -q -m "initial commit"
+}
+
+cleanup_test_repo() {
+  cd /
+  rm -rf "$TEST_DIR"
+}
+
+# Write a mock gh script that responds to repo view and api calls.
+# Args: $1 = "documentation" label response or "enhancement" or ""
+write_mock_gh() {
+  local label_response="${1:-}"
+  local mock_gh="$TEST_DIR/gh"
+  cat > "$mock_gh" <<'MOCKEOF'
+#!/usr/bin/env bash
+# Mock gh CLI for verify-pipeline-test.sh
+LABEL_RESPONSE="__LABEL_PLACEHOLDER__"
+
+case "$1" in
+  repo)
+    if [[ "${2:-}" == "view" ]]; then
+      echo "test-owner/test-repo"
+      exit 0
+    fi
+    ;;
+  api)
+    arg2="${2:-}"
+    if [[ "$arg2" == repos/test-owner/test-repo/issues/* ]]; then
+      if [ -n "$LABEL_RESPONSE" ]; then
+        echo "$LABEL_RESPONSE"
+      fi
+      exit 0
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      exit 1
+    fi
+    ;;
+esac
+exit 1
+MOCKEOF
+  # Replace placeholder with actual label value
+  sed -i "s|__LABEL_PLACEHOLDER__|$label_response|" "$mock_gh"
+  chmod +x "$mock_gh"
+}
+
+# Write a mock gh that always fails (simulates no gh / no context)
+write_mock_gh_unavailable() {
+  local mock_gh="$TEST_DIR/gh"
+  cat > "$mock_gh" <<'MOCKEOF'
+#!/usr/bin/env bash
+exit 1
+MOCKEOF
+  chmod +x "$mock_gh"
+}
+
+run_verify() {
+  local pr_body="${1:-}"
+  local exit_code=0
+  local output
+  output=$(PATH="$TEST_DIR:$PATH" GITHUB_PR_BODY="$pr_body" bash scripts/verify-pipeline.sh main 2>&1) || exit_code=$?
+  echo "$output"
+  return $exit_code
+}
+
+assert_pass() {
+  local test_name="$1"
+  local exit_code="$2"
+  local output="$3"
+  local expected_pattern="${4:-}"
+  TOTAL=$((TOTAL + 1))
+  if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: $test_name (expected exit 0, got $exit_code)"
+    echo "  output: $output"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ -n "$expected_pattern" ]; then
+    if ! echo "$output" | grep -qF "$expected_pattern"; then
+      echo "FAIL: $test_name (expected pattern '$expected_pattern' not found in output)"
+      echo "  output: $output"
+      FAIL=$((FAIL + 1))
+      return
+    fi
+  fi
+  echo "PASS: $test_name"
+  PASS=$((PASS + 1))
+}
+
+assert_fail() {
+  local test_name="$1"
+  local exit_code="$2"
+  local output="$3"
+  local expected_pattern="${4:-}"
+  TOTAL=$((TOTAL + 1))
+  if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: $test_name (expected exit 1, got 0)"
+    echo "  output: $output"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ -n "$expected_pattern" ]; then
+    if ! echo "$output" | grep -qF "$expected_pattern"; then
+      echo "FAIL: $test_name (expected pattern '$expected_pattern' not found in output)"
+      echo "  output: $output"
+      FAIL=$((FAIL + 1))
+      return
+    fi
+  fi
+  echo "PASS: $test_name"
+  PASS=$((PASS + 1))
+}
+
+# =========================================================================
+# Test Cases A-E from mika#861 issue body
+# =========================================================================
+
+echo "=== Case A: documentation label + docs-only diff → PASS ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Case A: documentation label + docs-only → PASS" "$exit_code" "$output" "[pipeline-exempt: issue-label] docs-only PR allowed by linked-issue documentation label (#42)"
+cleanup_test_repo
+
+echo ""
+echo "=== Case B: documentation label + mixed diff → PASS ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/plans src
+echo "plan" > docs/plans/test-plan.md
+echo "code" > src/main.rs
+git add docs/plans/test-plan.md src/main.rs
+git commit -q -m "feat: add plan and code"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Case B: documentation label + mixed diff → PASS" "$exit_code" "$output" "Pipeline verification passed"
+cleanup_test_repo
+
+echo ""
+echo "=== Case C: documentation label + source-only diff → FAIL ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p src
+echo "code" > src/main.rs
+git add src/main.rs
+git commit -q -m "feat: code only"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_fail "Case C: documentation label + source-only → FAIL (asymmetry)" "$exit_code" "$output" "[pipeline-exempt: none] REJECT: code-only PR"
+cleanup_test_repo
+
+echo ""
+echo "=== Case D: no documentation label + docs-only diff → FAIL ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_fail "Case D: no documentation label + docs-only → FAIL" "$exit_code" "$output" "[pipeline-exempt: none] REJECT: docs-only PR"
+cleanup_test_repo
+
+echo ""
+echo "=== Case E: no linked issue + docs-only diff → FAIL ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution"
+write_mock_gh_unavailable
+output="" ; exit_code=0
+output=$(run_verify "") || exit_code=$?
+assert_fail "Case E: no linked issue + docs-only → FAIL" "$exit_code" "$output" "[pipeline-exempt: none] REJECT: docs-only PR"
+cleanup_test_repo
+
+# =========================================================================
+# Trailer dual-form tests
+# =========================================================================
+
+echo ""
+echo "=== Trailer: docs-only with reason → PASS (info) ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution
+
+Pipeline-Exempt: docs-only — standalone compound shipment"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Trailer: docs-only with reason → PASS (info)" "$exit_code" "$output" "[pipeline-exempt: trailer] docs-only PR allowed by Pipeline-Exempt trailer with reason:"
+cleanup_test_repo
+
+echo ""
+echo "=== Trailer: docs-only bare → PASS (warn) ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution
+
+Pipeline-Exempt: docs-only"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Trailer: docs-only bare → PASS (warn)" "$exit_code" "$output" "warn: [pipeline-exempt: trailer] bare Pipeline-Exempt: docs-only trailer detected"
+cleanup_test_repo
+
+echo ""
+echo "=== Trailer: code-only with reason → PASS (info) ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p src
+echo "code" > src/main.rs
+git add src/main.rs
+git commit -q -m "fix: hotfix
+
+Pipeline-Exempt: code-only — emergency hotfix, docs follow-up filed"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Trailer: code-only with reason → PASS (info)" "$exit_code" "$output" "[pipeline-exempt: trailer] code-only PR allowed by Pipeline-Exempt trailer with reason:"
+cleanup_test_repo
+
+echo ""
+echo "=== Trailer: code-only bare → PASS (warn) ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p src
+echo "code" > src/main.rs
+git add src/main.rs
+git commit -q -m "fix: hotfix
+
+Pipeline-Exempt: code-only"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Trailer: code-only bare → PASS (warn)" "$exit_code" "$output" "warn: [pipeline-exempt: trailer] bare Pipeline-Exempt: code-only trailer detected"
+cleanup_test_repo
+
+echo ""
+echo "=== Trailer: malformed → FAIL ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution
+
+Pipeline-Exempt: docs-only-typo"
+write_mock_gh "enhancement"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_fail "Trailer: malformed (docs-only-typo) → FAIL" "$exit_code" "$output" "[pipeline-exempt: none] REJECT"
+cleanup_test_repo
+
+# =========================================================================
+# Label takes priority over trailer (both present)
+# =========================================================================
+
+echo ""
+echo "=== Priority: label checked before trailer ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution
+
+Pipeline-Exempt: docs-only — also has trailer"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Closes #42") || exit_code=$?
+assert_pass "Priority: label wins over trailer" "$exit_code" "$output" "[pipeline-exempt: issue-label]"
+# Should NOT contain trailer message since label takes priority
+TOTAL=$((TOTAL + 1))
+if echo "$output" | grep -qF "[pipeline-exempt: trailer]"; then
+  echo "FAIL: Priority test — trailer message should not appear when label exempts"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS: Priority: label suppresses trailer message"
+  PASS=$((PASS + 1))
+fi
+cleanup_test_repo
+
+# =========================================================================
+# Closes keyword variants (Fixes, Resolves)
+# =========================================================================
+
+echo ""
+echo "=== Fixes keyword parsed ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Fixes #99") || exit_code=$?
+assert_pass "Fixes keyword parsed → label exemption (#99)" "$exit_code" "$output" "[pipeline-exempt: issue-label] docs-only PR allowed by linked-issue documentation label (#99)"
+cleanup_test_repo
+
+echo ""
+echo "=== Resolves keyword parsed ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/solutions
+echo "solution" > docs/solutions/test-solution.md
+git add docs/solutions/test-solution.md
+git commit -q -m "docs: add solution"
+write_mock_gh "documentation"
+output="" ; exit_code=0
+output=$(run_verify "Resolves #77") || exit_code=$?
+assert_pass "Resolves keyword parsed → label exemption (#77)" "$exit_code" "$output" "[pipeline-exempt: issue-label] docs-only PR allowed by linked-issue documentation label (#77)"
+cleanup_test_repo
+
+# =========================================================================
+# Summary
+# =========================================================================
+
+echo ""
+echo "========================================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/verify-pipeline.sh
+++ b/scripts/verify-pipeline.sh
@@ -16,10 +16,57 @@
 #   !docs && source          -> REJECT (code-only PR)
 #   !docs && !source         -> warn + pass (pure config or no diff)
 #
-# Exemptions:
-#   pipeline-exempt PR label    -> bypass docs-only rejection (preferred, mika#1067)
-#   Pipeline-Exempt: docs-only  -> bypass docs-only rejection (trailer fallback)
-#   Pipeline-Exempt: code-only  -> bypass code-only rejection
+# Exemption mechanisms for docs-only PRs (checked in this order; first match wins):
+#
+#   1. Issue `documentation` label inheritance (mika#861):
+#      If the PR body contains `Closes #N` and issue N carries the
+#      `documentation` label, the docs-only rejection is bypassed. This is
+#      the PRIMARY classification-driven path — the linked issue is the
+#      single source of truth for whether work is docs-only.
+#
+#   2. PR `pipeline-exempt` label (mika#1067):
+#      Set by an operator directly on the PR. Read from
+#      `GITHUB_EVENT_PATH` (no gh CLI / token needed). Useful when the
+#      linked issue can't be re-labelled (cross-repo, immutable, or
+#      already-closed) or for one-off operator overrides.
+#
+#   3. `Pipeline-Exempt:` commit trailer (mika#860):
+#      Any commit in base..HEAD with
+#        Pipeline-Exempt: docs-only — <reason>   (preferred, audit trail)
+#        Pipeline-Exempt: docs-only               (accepted, warns)
+#        Pipeline-Exempt: code-only — <reason>    (preferred)
+#        Pipeline-Exempt: code-only               (accepted, warns)
+#      Bare form still passes for backwards compat (PR #860 shipped both
+#      forms) but emits a warning directing operators to the with-reason
+#      form for auditability. Trailer is the residual escape hatch.
+#
+#   4. Reject — no exemption found, exit 1.
+#
+# One-directional asymmetry (load-bearing):
+#   The `documentation` issue label and the `pipeline-exempt` PR label
+#   exempt the source-required check ONLY. They do NOT exempt the
+#   docs-required-when-source-changes check. A PR with source changes
+#   still needs a plan/solution doc regardless of label. This preserves
+#   the protection from mika-platform#17. Only the `Pipeline-Exempt:
+#   code-only` trailer bypasses the code-only rejection.
+#
+# Path-pattern auto-exemption was considered and rejected (mika#861):
+#   (1) Silent green CI with multiple exemption paths erodes structural
+#       visibility — operators can't tell at a glance which path allowed
+#       a green check.
+#   (2) Path-touching is an artifact of classification, not the
+#       classification itself (a docs-only PR is one whose intent is
+#       documentation, not one whose paths happen to start with `docs/`).
+#       Gating on the artifact rather than the decision is an inversion
+#       that erodes protections over time.
+#   (3) Creates a parallel taxonomy alongside `.github/labels.yml`
+#       (DRY violation).
+#
+# Cross-repo `Closes` references (e.g., `Closes senara-solutions/other#N`)
+#   are treated as "no linked issue in this repo" — the `gh api` call would
+#   404. This is intentional: the cross-repo split pattern is what
+#   mika-platform#17 protects against. Use the PR `pipeline-exempt` label
+#   or the trailer with reason for legitimate cross-repo docs-only ships.
 #
 # Note: this script previously enforced an unconditional plan-doc-presence
 # AND compound-doc-presence check. Both were strictly subsumed by the bucket
@@ -28,8 +75,7 @@
 # provide the escape hatch for legitimate docs-only / code-only PRs (e.g.
 # standalone /ce:compound shipments). Running the strict checks in addition
 # rejected legitimate /ce:compound docs-only PRs with no escape mechanism.
-# Aligned with mika-platform/scripts/verify-pipeline.sh; mika#861 tracks
-# layering label-inheritance on top of this for the as-above-so-below path.
+# Aligned with mika-platform/scripts/verify-pipeline.sh.
 #
 # Usage:
 #   ./scripts/verify-pipeline.sh              # local (compares to main)
@@ -76,48 +122,99 @@ else
   OTHER_BUCKET=""
 fi
 
-# Exempt trailers: scan commit messages in base..HEAD
-COMMIT_BODIES=$(git log --format=%B "${MERGE_BASE}..HEAD" 2>/dev/null || true)
-EXEMPT_DOCS_ONLY=0
-EXEMPT_CODE_ONLY=0
-if echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: docs-only(\s.*)?$'; then
-  EXEMPT_DOCS_ONLY=1
+# --- mika#861: Label inheritance from linked issue ---
+# Parse `Closes #N` from PR body to identify linked issue.
+# Sources (priority order): GITHUB_PR_BODY env var (CI), gh pr view (fallback).
+# Branch-name fallback intentionally omitted — silent misfire on branches like
+# `feature/v2/...` is worse than no fallback (see plan F2).
+LINKED_ISSUE=""
+if [ -n "${GITHUB_PR_BODY:-}" ]; then
+  LINKED_ISSUE=$(echo "$GITHUB_PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
 fi
-if echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: code-only(\s.*)?$'; then
-  EXEMPT_CODE_ONLY=1
+if [ -z "$LINKED_ISSUE" ] && command -v gh >/dev/null 2>&1; then
+  _pr_body=$(gh pr view --json body --jq .body 2>/dev/null || echo "")
+  LINKED_ISSUE=$(echo "$_pr_body" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
 fi
 
-# Label-based exemption: read PR labels from GitHub Actions event payload
-# GITHUB_EVENT_PATH is always set in GitHub Actions; contains the full event JSON.
-# For pull_request events, labels are at .pull_request.labels[].name.
-# No gh CLI or GITHUB_TOKEN needed — reads a local file.
-EXEMPT_LABEL_DOCS=0
-if [[ -n "${GITHUB_EVENT_PATH:-}" ]]; then
-  if jq -e '.pull_request.labels[]? | select(.name == "pipeline-exempt")' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
-    EXEMPT_LABEL_DOCS=1
+ISSUE_HAS_DOCUMENTATION_LABEL=false
+if [ -n "$LINKED_ISSUE" ]; then
+  _repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
+  if [ -n "$_repo" ]; then
+    _labels=$(gh api "repos/$_repo/issues/$LINKED_ISSUE" --jq '.labels[].name' 2>/dev/null || echo "")
+    if echo "$_labels" | grep -qx "documentation"; then
+      ISSUE_HAS_DOCUMENTATION_LABEL=true
+    fi
   fi
 fi
 
+# --- Exempt trailers: scan commit messages in base..HEAD ---
+COMMIT_BODIES=$(git log --format=%B "${MERGE_BASE}..HEAD" 2>/dev/null || true)
+EXEMPT_DOCS_ONLY=0
+EXEMPT_CODE_ONLY=0
+EXEMPT_DOCS_REASON=""
+EXEMPT_CODE_REASON=""
+
+# Dual-form matching: with-reason (preferred) vs bare (backwards compat, warns)
+if echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: docs-only[[:space:]]+.+$'; then
+  EXEMPT_DOCS_ONLY=1
+  EXEMPT_DOCS_REASON=$(echo "$COMMIT_BODIES" | grep -oE '^Pipeline-Exempt: docs-only[[:space:]]+.+$' | head -1 | sed 's/^Pipeline-Exempt: docs-only[[:space:]]*//')
+elif echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: docs-only[[:space:]]*$'; then
+  EXEMPT_DOCS_ONLY=1
+  EXEMPT_DOCS_REASON=""
+fi
+
+if echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: code-only[[:space:]]+.+$'; then
+  EXEMPT_CODE_ONLY=1
+  EXEMPT_CODE_REASON=$(echo "$COMMIT_BODIES" | grep -oE '^Pipeline-Exempt: code-only[[:space:]]+.+$' | head -1 | sed 's/^Pipeline-Exempt: code-only[[:space:]]*//')
+elif echo "$COMMIT_BODIES" | grep -qE '^Pipeline-Exempt: code-only[[:space:]]*$'; then
+  EXEMPT_CODE_ONLY=1
+  EXEMPT_CODE_REASON=""
+fi
+
+# --- PR `pipeline-exempt` label exemption (mika#1067) ---
+# Read PR labels from GitHub Actions event payload. GITHUB_EVENT_PATH is always
+# set in GitHub Actions; contains the full event JSON. For pull_request events,
+# labels are at .pull_request.labels[].name. No gh CLI or GITHUB_TOKEN needed —
+# reads a local file.
+EXEMPT_PR_LABEL_DOCS=0
+if [[ -n "${GITHUB_EVENT_PATH:-}" ]]; then
+  if jq -e '.pull_request.labels[]? | select(.name == "pipeline-exempt")' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
+    EXEMPT_PR_LABEL_DOCS=1
+  fi
+fi
+
+# --- Docs-only check (labels exempt source-required; trailer is escape hatch) ---
 if [[ -n "$DOCS_BUCKET" && -z "$SOURCE_BUCKET" ]]; then
-  if [[ "$EXEMPT_DOCS_ONLY" == "1" || "$EXEMPT_LABEL_DOCS" == "1" ]]; then
-    if [[ "$EXEMPT_LABEL_DOCS" == "1" ]]; then
-      echo "warn: docs-only PR allowed by pipeline-exempt label" >&2
+  if [ "$ISSUE_HAS_DOCUMENTATION_LABEL" = true ]; then
+    echo "info: [pipeline-exempt: issue-label] docs-only PR allowed by linked-issue documentation label (#$LINKED_ISSUE)" >&2
+  elif [[ "$EXEMPT_PR_LABEL_DOCS" == "1" ]]; then
+    echo "info: [pipeline-exempt: pr-label] docs-only PR allowed by pipeline-exempt PR label" >&2
+  elif [[ "$EXEMPT_DOCS_ONLY" == "1" ]]; then
+    if [ -n "$EXEMPT_DOCS_REASON" ]; then
+      echo "info: [pipeline-exempt: trailer] docs-only PR allowed by Pipeline-Exempt trailer with reason: $EXEMPT_DOCS_REASON" >&2
     else
-      echo "warn: docs-only PR allowed by Pipeline-Exempt: docs-only trailer" >&2
+      echo "warn: [pipeline-exempt: trailer] bare Pipeline-Exempt: docs-only trailer detected; prefer 'Pipeline-Exempt: docs-only — <reason>' for audit trail" >&2
     fi
   else
-    echo "REJECT: docs-only PR: plan/solution present but no source changes" >&2
-    echo "        Apply the 'pipeline-exempt' label to the PR (preferred), or add" >&2
-    echo "        'Pipeline-Exempt: docs-only — <reason>' trailer to a commit." >&2
+    echo "[pipeline-exempt: none] REJECT: docs-only PR: plan/solution present but no source changes" >&2
+    echo "        Add the 'documentation' label to the linked issue (preferred), or apply" >&2
+    echo "        the 'pipeline-exempt' label to the PR, or add" >&2
+    echo "        'Pipeline-Exempt: docs-only — <reason>' trailer to a commit" >&2
+    echo "        if this docs-only ship is intentional (e.g. standalone /ce:compound)." >&2
     ERRORS=$((ERRORS + 1))
   fi
 fi
 
+# --- Code-only check (label does NOT exempt docs-required-when-source-changes) ---
 if [[ -z "$DOCS_BUCKET" && -n "$SOURCE_BUCKET" ]]; then
   if [[ "$EXEMPT_CODE_ONLY" == "1" ]]; then
-    echo "warn: code-only PR allowed by Pipeline-Exempt: code-only trailer" >&2
+    if [ -n "$EXEMPT_CODE_REASON" ]; then
+      echo "info: [pipeline-exempt: trailer] code-only PR allowed by Pipeline-Exempt trailer with reason: $EXEMPT_CODE_REASON" >&2
+    else
+      echo "warn: [pipeline-exempt: trailer] bare Pipeline-Exempt: code-only trailer detected; prefer 'Pipeline-Exempt: code-only — <reason>' for audit trail" >&2
+    fi
   else
-    echo "REJECT: code-only PR: source changes present but no plan/solution doc" >&2
+    echo "[pipeline-exempt: none] REJECT: code-only PR: source changes present but no plan/solution doc" >&2
     echo "        Add 'Pipeline-Exempt: code-only — <reason>' trailer to a commit" >&2
     echo "        if this code-only ship is intentional." >&2
     ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
## Summary

Adds a third exemption mechanism to `scripts/verify-pipeline.sh`: when a PR body contains `Closes #N` and issue N carries the `documentation` label, the docs-only rejection is bypassed.

Closes #861.

## Exemption mechanisms (after this PR)

Three paths now exist for docs-only PRs (checked in order; first match wins):

1. **Issue `documentation` label inheritance (this PR, mika#861)** — primary classification-driven path. The linked issue is the single source of truth for whether work is docs-only.
2. **PR `pipeline-exempt` label (mika#1067)** — operator override on the PR itself. Read from `GITHUB_EVENT_PATH` (no `gh` CLI / token needed). Useful when the linked issue can't be re-labelled (cross-repo, immutable, or already-closed).
3. **`Pipeline-Exempt:` commit trailer (mika#860)** — residual escape hatch with optional reason.

The three log-tag forms (`[pipeline-exempt: issue-label]`, `[pipeline-exempt: pr-label]`, `[pipeline-exempt: trailer]`) let operators tell at a glance which path allowed a green check.

## One-directional asymmetry (load-bearing)

Both label paths exempt the source-required check ONLY. They do NOT exempt the docs-required-when-source-changes check. A PR with source changes still needs a plan/solution doc regardless of label. This preserves mika-platform#17's protection. Only the `Pipeline-Exempt: code-only` trailer bypasses the code-only rejection.

## Tests

`scripts/verify-pipeline-test.sh` — 14 self-tests covering all 5 design cases (A–E) + trailer dual-form + keyword variants (`Closes`/`Fixes`/`Resolves`) + priority (label wins over trailer). All 14 pass locally.

## CI integration

`.github/workflows/ci.yml` — adds `GITHUB_PR_BODY` env var to the Verify pipeline artifacts step so the script can parse `Closes #N` from the PR body when running in CI.

## Rebase note

The branch was 131 commits behind main. Resolved a conflict in `scripts/verify-pipeline.sh` with mika#1067 (PR `pipeline-exempt` label) — both mechanisms preserved, log tags disambiguated.

## Test plan

- [x] `bash scripts/verify-pipeline-test.sh` — 14 pass, 0 fail
- [x] `bash -n scripts/verify-pipeline.sh` — syntax OK
- [ ] CI Pipeline Artifacts job passes (this PR is its own docs+source change, so all three buckets non-empty → trivial pass)
- [ ] Manual: a docs-only PR with `Closes #N` for a `documentation`-labelled issue should log `[pipeline-exempt: issue-label]` and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)