### PR TITLE
fix(kg): invalidate no_match resolutions when domain graph adds entities (#960)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -259,7 +259,9 @@ See `tests/eval/grounding_regressions/README.md` for the full vocabulary, capabi
 
 **Failure policy:** Rebuild failures log `warn!` — the server continues to boot. KG queries return stale or empty results until the next successful rebuild. **Staleness contract:** Domain graph reflects registry state as of the last server boot.
 
-**Observability:** Single `trace_id` per rebuild invocation, INFO-level structured logs (`domain_rebuild_start`, `domain_rebuild_entities`, `domain_rebuild_edges`, `domain_rebuild_complete`). No `audit_events` rows (per conventions C3.1).
+**Resolution invalidation on type expansion (#960):** When `rebuild()` adds N≥1 entities of type T, all `kg_resolutions_log` rows with `outcome='no_match'` for subjects where `kg_subject_entities.type = T` are deleted in the same transaction. The next resolver tick re-attempts those subjects against the expanded domain graph. Per-type invalidation counts surface via the `domain_rebuild_invalidated_resolutions` log event. `matched_*` outcomes are NOT invalidated (re-ranking against a better-matched entity is a separate ranking concern). Sub-namespace over-invalidation explicitly accepted: adding one `concept:infra:*` entity invalidates `no_match` rows for all `concept`-typed subjects; cost bounded by `MIKA_KG_BATCH_BUDGET`. First restart after deploy may see elevated `pending_before` on the next resolver tick.
+
+**Observability:** Single `trace_id` per rebuild invocation, INFO-level structured logs (`domain_rebuild_start`, `domain_rebuild_entities`, `domain_rebuild_edges`, `domain_rebuild_invalidated_resolutions`, `domain_rebuild_complete`). No `audit_events` rows (per conventions C3.1).
 
 **Cross-cutting conventions:** See `docs/architecture/kg-implementation-conventions.md` (C1–C3) and `docs/architecture/kg-id-convention.md` for the `<type>:<name>` entity key format.
 

--- a/crates/mika-agent/src/kg/domain_builder.rs
+++ b/crates/mika-agent/src/kg/domain_builder.rs
@@ -15,6 +15,11 @@
 //! `agent:*`, `problem_type:*`, and `concept:*` namespaces. No other code path
 //! writes these entity_keys. See `docs/solutions/logic-errors/a2a-dual-write-duplicate-rows.md`.
 //!
+//! Additionally, this module **deletes** `kg_resolutions_log` rows with
+//! `outcome='no_match'` when entity types gain new entities (#960). This is a
+//! consequent of the domain-graph mutation, not an independent concern — same
+//! pattern as `prune_stale_entities`.
+//!
 //! ## Invariants
 //!
 //! - Runs once per server boot, after `SkillRegistry::apply_overrides()`.
@@ -206,6 +211,10 @@ pub struct RebuildStats {
     pub edges_depends_on: usize,
     pub edges_provides: usize,
     pub duration_ms: u128,
+    /// Per-type counts of `outcome='no_match'` resolution log rows invalidated
+    /// this rebuild. Populated when entity types gain new entities; empty when
+    /// no type had `added > 0`. See #960.
+    pub invalidated_no_match: HashMap<String, usize>,
 }
 
 /// Information about an agent to include in the domain graph.
@@ -416,6 +425,38 @@ impl<'a> DomainGraphBuilder<'a> {
                     stmt.raw_execute()?
                 };
 
+                // 2d. Invalidate `no_match` resolution log rows for types that
+                // gained new entities (#960). This lets the next resolver tick
+                // re-attempt those subjects against the expanded domain graph.
+                let mut invalidated_no_match: HashMap<String, usize> = HashMap::new();
+                for (type_name, stats) in &type_stats {
+                    if stats.added == 0 {
+                        continue;
+                    }
+                    if !KG_DOMAIN_ENTITY_TYPES.contains(&type_name.as_str()) {
+                        warn!(
+                            trace_id = %trace_id,
+                            unknown_type = %type_name,
+                            event = "domain_rebuild_invalidation_skipped_unknown_type",
+                            "skipping invalidation for type not in KG_DOMAIN_ENTITY_TYPES — \
+                             review this code path if a new domain type was added",
+                        );
+                        continue;
+                    }
+                    let invalidated = tx.execute(
+                        "DELETE FROM kg_resolutions_log
+                         WHERE outcome = 'no_match'
+                           AND subject_entity_id IN (
+                             SELECT id FROM kg_subject_entities WHERE type = ?1
+                           )",
+                        rusqlite::params![type_name],
+                    )?;
+                    if invalidated > 0 {
+                        invalidated_no_match
+                            .insert(type_name.clone(), invalidated);
+                    }
+                }
+
                 tx.commit()?;
 
                 // Compute aggregate stats
@@ -426,11 +467,12 @@ impl<'a> DomainGraphBuilder<'a> {
                     total_updated += s.updated;
                 }
 
-                Ok((total_added, total_updated, removed, type_stats, edge_stats))
+                Ok((total_added, total_updated, removed, type_stats, edge_stats, invalidated_no_match))
             })
             .await?;
 
-        let (total_added, total_updated, removed, type_stats, edge_stats) = stats;
+        let (total_added, total_updated, removed, type_stats, edge_stats, invalidated_no_match) =
+            stats;
         let duration_ms = start.elapsed().as_millis();
 
         // Log per-type stats
@@ -462,6 +504,15 @@ impl<'a> DomainGraphBuilder<'a> {
                 count,
             );
         }
+        // Log per-type invalidation counts (#960)
+        for (type_name, count) in &invalidated_no_match {
+            info!(
+                trace_id = %self.trace_id,
+                added_type = %type_name,
+                invalidated_no_match = count,
+                event = "domain_rebuild_invalidated_resolutions",
+            );
+        }
         info!(
             trace_id = %self.trace_id,
             event = "domain_rebuild_complete",
@@ -475,6 +526,7 @@ impl<'a> DomainGraphBuilder<'a> {
             edges_depends_on: edge_stats.get("DEPENDS_ON").map_or(0, |s| s.count),
             edges_provides: edge_stats.get("PROVIDES").map_or(0, |s| s.count),
             duration_ms,
+            invalidated_no_match,
         })
     }
 
@@ -1425,5 +1477,179 @@ mod tests {
             .await
             .expect("count concepts");
         assert_eq!(total_concepts, 20);
+    }
+
+    // --- #960: invalidation of no_match resolutions on type expansion ---
+
+    /// Helper: seed an agent, subject entities, and resolution log rows for
+    /// invalidation tests.
+    async fn seed_subjects_with_resolutions(
+        db: &AsyncDatabase,
+        entity_type: &str,
+        count: usize,
+        outcome: &str,
+    ) -> Vec<i64> {
+        let entity_type = entity_type.to_string();
+        let outcome = outcome.to_string();
+        // Use a unique prefix per call to avoid entity_key collisions.
+        let prefix = uuid::Uuid::new_v4().to_string()[..8].to_string();
+        db.with_db(move |db| {
+            db.conn.execute(
+                "INSERT OR IGNORE INTO agents (id, name, home_dir) VALUES ('test', 'test', '/tmp')",
+                [],
+            )?;
+            let mut subject_ids = Vec::new();
+            for i in 0..count {
+                db.conn.execute(
+                    "INSERT INTO kg_subject_entities (docs_root_hash, docs_root, entity_key, type, name, confidence)
+                     VALUES ('0000000000000000', '/test', ?1, ?2, ?3, 0.9)",
+                    rusqlite::params![
+                        format!("{entity_type}:{prefix}-{i}"),
+                        entity_type,
+                        format!("{prefix}-{i}"),
+                    ],
+                )?;
+                let subject_id = db.conn.last_insert_rowid();
+                let trace_id = format!("trace{prefix}{i:024}");
+                db.conn.execute(
+                    "INSERT INTO kg_resolutions_log (agent_id, subject_entity_id, outcome, resolution_trace_id)
+                     VALUES ('test', ?1, ?2, ?3)",
+                    rusqlite::params![subject_id, outcome, trace_id],
+                )?;
+                subject_ids.push(subject_id);
+            }
+            Ok(subject_ids)
+        })
+        .await
+        .expect("seed subjects with resolutions")
+    }
+
+    /// Helper: count resolution log rows for given subject ids.
+    async fn count_resolution_log_rows(db: &AsyncDatabase, subject_ids: &[i64]) -> usize {
+        let ids = subject_ids.to_vec();
+        db.with_db(move |db| {
+            let placeholders: String = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "SELECT COUNT(*) FROM kg_resolutions_log WHERE subject_entity_id IN ({placeholders})"
+            );
+            let mut stmt = db.conn.prepare(&sql)?;
+            for (i, id) in ids.iter().enumerate() {
+                stmt.raw_bind_parameter(i + 1, *id)?;
+            }
+            let mut rows = stmt.raw_query();
+            let count: usize = rows.next()?.unwrap().get(0)?;
+            Ok(count)
+        })
+        .await
+        .expect("count resolution log rows")
+    }
+
+    #[tokio::test]
+    async fn rebuild_invalidates_no_match_when_type_adds_entities() {
+        let db = make_async_db();
+
+        // First rebuild: seeds concept entities into the domain graph.
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&[]);
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder.rebuild().await.expect("first rebuild");
+
+        // Seed 5 concept-typed subjects with outcome='no_match'.
+        let subject_ids = seed_subjects_with_resolutions(&db, "concept", 5, "no_match").await;
+        assert_eq!(count_resolution_log_rows(&db, &subject_ids).await, 5);
+
+        // Now simulate a rebuild that adds a new concept entity by adding a new
+        // skill (which changes `entities_added` for the skill type but not
+        // concept). We need concept to have `added > 0`. The trick: clear all
+        // concept entities so the next rebuild re-adds them.
+        db.with_db(|db| {
+            db.conn
+                .execute("DELETE FROM kg_entities WHERE type = 'concept'", [])?;
+            Ok(())
+        })
+        .await
+        .expect("clear concepts");
+
+        // Rebuild — concepts are re-added (added > 0), triggering invalidation.
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let stats = builder2.rebuild().await.expect("second rebuild");
+
+        // Assert: all 5 no_match rows deleted.
+        assert_eq!(count_resolution_log_rows(&db, &subject_ids).await, 0);
+        assert_eq!(
+            *stats.invalidated_no_match.get("concept").unwrap_or(&0),
+            5,
+            "should invalidate 5 concept no_match rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_does_not_invalidate_when_type_added_zero() {
+        let db = make_async_db();
+
+        // First rebuild: seeds problem_type entities.
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&[]);
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder.rebuild().await.expect("first rebuild");
+
+        // Seed 3 problem_type subjects with outcome='no_match'.
+        let subject_ids = seed_subjects_with_resolutions(&db, "problem_type", 3, "no_match").await;
+        assert_eq!(count_resolution_log_rows(&db, &subject_ids).await, 3);
+
+        // Second rebuild with same sources — problem_type added == 0.
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let stats = builder2.rebuild().await.expect("second rebuild");
+
+        // Assert: no invalidation.
+        assert_eq!(count_resolution_log_rows(&db, &subject_ids).await, 3);
+        assert!(
+            !stats.invalidated_no_match.contains_key("problem_type"),
+            "should not invalidate when no entities added"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_does_not_invalidate_matched_outcomes() {
+        let db = make_async_db();
+
+        // First rebuild: seeds concept entities.
+        let registry = SkillRegistry::empty();
+        let tool_registry = make_tool_registry(&[]);
+        let builder = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        builder.rebuild().await.expect("first rebuild");
+
+        // Seed 2 concept subjects with outcome='matched_llm' and 2 with 'no_match'.
+        let matched_ids = seed_subjects_with_resolutions(&db, "concept", 2, "matched_llm").await;
+        let no_match_ids = seed_subjects_with_resolutions(&db, "concept", 2, "no_match").await;
+
+        // Clear concept entities to force adds on next rebuild.
+        db.with_db(|db| {
+            db.conn
+                .execute("DELETE FROM kg_entities WHERE type = 'concept'", [])?;
+            Ok(())
+        })
+        .await
+        .expect("clear concepts");
+
+        let builder2 = DomainGraphBuilder::new(&db, &registry, &tool_registry, None, &[]);
+        let stats = builder2.rebuild().await.expect("second rebuild");
+
+        // Assert: matched_llm rows survive, no_match rows deleted.
+        assert_eq!(
+            count_resolution_log_rows(&db, &matched_ids).await,
+            2,
+            "matched_llm rows should survive"
+        );
+        assert_eq!(
+            count_resolution_log_rows(&db, &no_match_ids).await,
+            0,
+            "no_match rows should be deleted"
+        );
+        assert_eq!(
+            *stats.invalidated_no_match.get("concept").unwrap_or(&0),
+            2,
+            "should only invalidate 2 no_match rows"
+        );
     }
 }

--- a/docs/plans/2026-05-03-001-fix-kg-domain-rebuild-invalidate-no-match-plan.md
+++ b/docs/plans/2026-05-03-001-fix-kg-domain-rebuild-invalidate-no-match-plan.md
@@ -1,0 +1,179 @@
+---
+ticket: mika issue#960
+type: fix
+component: kg
+sequence: 2026-05-03-001
+status: proposed
+---
+
+# fix(kg): domain-graph rebuild invalidates `no_match` resolutions for newly-added entity types
+
+## Goal
+
+When `domain_builder.rebuild()` adds N≥1 new entities of type T (skill / tool / agent / problem_type / concept), invalidate every `kg_resolutions_log` row where `outcome='no_match'` AND the subject's type is T, so the next resolver tick re-attempts those subjects against the expanded domain graph.
+
+Acceptance criteria from the ticket — restated for self-containment:
+
+- A1. After rebuild adds N entities of type T, the immediately-following resolver tick (or startup spawn) re-attempts all `outcome='no_match'` subjects where `kg_subject_entities.type = T`.
+- A2. Re-attempt count is observable via a new field on `kg_resolver_tick.complete` — `reattempted_no_match: u32`.
+- A3. Unit test: 1 `concept` domain entity added; 5 `concept`-typed subjects with prior `outcome='no_match'`; after invalidation+resolve, 5 are re-attempted with fresh `resolved_at`.
+- A4. New structured log event `domain_rebuild_invalidated_resolutions` carries per-type counts: `{added_type: "concept", invalidated_no_match: N}`.
+
+## Why this approach
+
+Two viable design points; I'm taking the first and naming the alternative.
+
+**Chosen — invalidate inside the rebuild transaction.** Right after entity UPSERT and before commit, run one `DELETE FROM kg_resolutions_log` per type with `entities_added_for_type[T] > 0`. The invalidation is atomic with the rebuild — if the transaction rolls back, the log rows survive. Resolutions and the domain graph stay consistent.
+
+**Rejected — invalidate in server init between rebuild and resolver_tick spawn.** This would split the semantic invariant ("expanded domain graph implies stale `no_match` rows") across two transactions. If the rebuild commits but the server crashes before the invalidation step, we end up in the exact failure state #960 is trying to prevent. Atomicity wins.
+
+## Files touched
+
+- `crates/mika-agent/src/kg/domain_builder.rs` — invalidation step + `RebuildStats` extension + log event
+- `crates/mika-agent/src/kg/resolver_tick.rs` — `reattempted_no_match` field on `kg_resolver_tick.complete`
+- `crates/mika-agent/src/kg/entity_resolver.rs` — count rows deleted when stale-extraction-trace branch fires (for the `reattempted_no_match` observability — see KTD-2 below)
+- `crates/mika-agent/src/db/kg_schema.rs` — no DDL change. The CHECK constraint on `outcome` already permits all values; we only DELETE.
+- Tests — new unit test in `domain_builder.rs::tests`; new fixture in `tests/eval/kg_fixtures/` if needed.
+
+No schema migration. No new env var. No public-API change to the `RebuildStats` struct fields beyond the additive `invalidated_no_match` HashMap.
+
+## Implementation
+
+### Step 1 — Track per-type adds in `RebuildStats`
+
+`domain_builder.rs::rebuild()` already iterates types and emits the `domain_rebuild_entities` log event with `added` counts (line 443). Aggregate the per-type `added` into a `HashMap<String, usize>` field on `RebuildStats`:
+
+```rust
+pub struct RebuildStats {
+    // existing fields...
+    /// Per-type counts of `outcome='no_match'` log rows invalidated this rebuild.
+    /// Populated after Step 2 runs. Empty when no type had `added > 0`.
+    pub invalidated_no_match: HashMap<String, usize>,
+}
+```
+
+### Step 2 — Invalidate `no_match` rows for types with new entities
+
+Inside the same transaction, after entity UPSERT and edge rebuild but before `tx.commit()`, for each `type` in `KG_DOMAIN_ENTITY_TYPES`:
+
+```rust
+if entities_added_per_type[type_name] > 0 {
+    let invalidated = tx.execute(
+        "DELETE FROM kg_resolutions_log
+         WHERE outcome = 'no_match'
+           AND subject_entity_id IN (
+             SELECT id FROM kg_subject_entities WHERE type = ?
+           )",
+        [type_name],
+    )?;
+    if invalidated > 0 {
+        invalidated_no_match.insert(type_name.to_string(), invalidated);
+    }
+}
+```
+
+Why DELETE not UPDATE: the resolver's pending-detection query (`entity_resolver.rs::count_pending`, lines 879-918) treats `r.id IS NULL` as pending. DELETE is the simplest signal. Adding a `superseded_at` column or similar marker is out of scope for v1.
+
+The CASCADE on `kg_subject_resolutions` is **not** triggered here because that table FKs to `kg_subject_entities`, not to `kg_resolutions_log`. The subject_resolution rows for these subjects don't exist yet (no_match never wrote them); only log rows exist.
+
+### Step 3 — Emit the structured log event
+
+After commit, emit one row per non-zero entry:
+
+```rust
+for (type_name, count) in &stats.invalidated_no_match {
+    info!(
+        target: "mika::otel",
+        trace_id = %self.trace_id,
+        added_type = %type_name,
+        invalidated_no_match = count,
+        event = "domain_rebuild_invalidated_resolutions",
+    );
+}
+```
+
+### Step 4 — Surface `reattempted_no_match` on resolver_tick
+
+The resolver tick already counts outcomes in `ResolutionStats`. Add a new field that increments when a subject the resolver processes was previously `no_match` and was deleted in this run. Implementation note: the resolver doesn't currently know the prior state of each subject — the invalidation already happened at rebuild time. Two options:
+
+**KTD-2a — count via post-tick query.** After the tick runs, query: how many subjects of types T (where T had invalidation this server-boot) were re-resolved this tick? This requires the rebuild-trace to persist somewhere queryable (currently it's only in logs).
+
+**KTD-2b — emit `reattempted_no_match` from the rebuild side, not the tick side.** The rebuild already knows the count (it just deleted them). The `kg_resolver_tick.complete` event would carry the running cumulative count of subjects whose log row is fresh-after-rebuild-invalidation. But this requires a "this subject was invalidated by rebuild" marker that the resolver checks.
+
+**KTD-2c — drop the field from acceptance.** The `domain_rebuild_invalidated_resolutions` event already gives operators the answer. The `reattempted_no_match` on `kg_resolver_tick.complete` is observability-only and partially redundant with `pending_before` jumping after a rebuild.
+
+I propose **KTD-2c** for v1 — meet acceptance A1, A3, A4 and document A2 as a follow-up. Adding the marker column or post-tick query is non-trivial and the operational signal is already present via the rebuild event. Surface this trade-off to the architect in pass 1.
+
+### Step 5 — Unit test
+
+Add `tests` module test in `domain_builder.rs`:
+
+```rust
+#[tokio::test]
+async fn rebuild_invalidates_no_match_when_type_adds_entities() {
+    // 1. Seed: 5 concept-typed kg_subject_entities + 5 kg_resolutions_log rows
+    //    with outcome='no_match' for those subject ids. Zero matched_* rows.
+    // 2. Run rebuild with at least 1 new concept entity.
+    // 3. Assert: kg_resolutions_log has 0 rows for those 5 subjects.
+    // 4. Assert: RebuildStats.invalidated_no_match["concept"] == 5.
+}
+
+#[tokio::test]
+async fn rebuild_does_not_invalidate_when_type_added_zero() {
+    // 1. Seed: 3 problem_type subjects with outcome='no_match'.
+    // 2. Run rebuild that adds 0 problem_type entities (steady state — all seeds present).
+    // 3. Assert: kg_resolutions_log still has 3 rows.
+    // 4. Assert: RebuildStats.invalidated_no_match.get("problem_type") is None.
+}
+
+#[tokio::test]
+async fn rebuild_does_not_invalidate_matched_outcomes() {
+    // 1. Seed: 2 concept subjects with outcome='matched_llm', 2 with outcome='no_match'.
+    // 2. Run rebuild with 1 new concept entity.
+    // 3. Assert: 2 matched_llm rows survive; 2 no_match rows are deleted.
+    // 4. Assert: RebuildStats.invalidated_no_match["concept"] == 2.
+}
+```
+
+The seed helpers in `tests/eval/kg_fixtures/mod.rs` (`seed_subject_entity`, `seed_resolution`) already cover what's needed.
+
+### Step 6 — Update CLAUDE.md
+
+`crates/mika-agent/CLAUDE.md` — append to the `## Knowledge Graph — Domain Graph Builder` section:
+
+> **Resolution invalidation on type expansion (#960):** When `rebuild()` adds N≥1 entities of type T, all `kg_resolutions_log` rows with `outcome='no_match'` for subjects where `kg_subject_entities.type = T` are deleted in the same transaction. The next resolver tick re-attempts those subjects against the expanded domain graph. Per-type invalidation counts surface via the `domain_rebuild_invalidated_resolutions` log event. `matched_*` outcomes are NOT invalidated (re-ranking against a better-matched entity is a separate ranking concern).
+
+## Risks and mitigations
+
+**R1 — first-restart-after-deploy invalidation storm.** When this fix ships, every rebuild that adds entities (which is every rebuild on a freshly-deployed node) will invalidate matching `no_match` rows. The next resolver tick then re-attempts them. For the primary mika corpus this could mean re-attempting thousands of subjects, hitting the LLM budget cap and emitting `kg_budget_exhausted`.
+
+**Mitigation:** The existing `MIKA_KG_BATCH_BUDGET` (default 500) caps the burst. Subsequent ticks drain the rest. Operators can temporarily raise the budget post-deploy if they want faster drain. No code change needed; document in the CLAUDE.md note.
+
+**R2 — well-known-only filter.** The resolver's `count_pending` only considers types in `('skill','tool','agent','problem_type','concept')`. The invalidation query in Step 2 has no such filter — it would invalidate `no_match` rows for any subject type. That's a no-op for "discovered" types (`solution_path`, `failure_mode`, `pattern`) because they're never actually resolved. But it's wasteful work.
+
+**Mitigation:** Add the same well-known-types filter to the DELETE WHERE clause. Single-line change.
+
+**R3 — sole-writer contract.** `domain_builder.rs` is the sole writer of `skill:*`/`tool:*`/`agent:*`/`problem_type:*`/`concept:*` entity_keys. Adding a writer to `kg_resolutions_log` from `domain_builder` extends its responsibility. Per the C1 cross-cutting conventions in `kg-implementation-conventions.md`, this is acceptable because the invalidation is consequent to a domain-graph mutation, not an independent concern.
+
+**Mitigation:** Document the new sole-writer relationship in the module docstring at the top of `domain_builder.rs`.
+
+## Out of scope
+
+- Invalidating non-`no_match` outcomes when domain graph expansion adds a potentially better entity (re-ranking concern; separate ticket).
+- Forcing re-extraction of source documents when the extractor's `APPROVED_ENTITY_TYPES` is updated (compile-time const, hot-reload not in scope).
+- Fan-out to per-agent corpus partitioning of the invalidation event — the DELETE is global by type because the domain graph is global.
+- Migrating mika-arch's primary mika corpus to retroactively fix the 17.6% baseline — the operational wipe of the secondary corpora applied 2026-05-03 is sufficient for milestone#19; primary baseline is its own conversation.
+
+## Sequencing
+
+Single PR, single commit conceptually. No upstream blockers. Can ship behind no flag — the change is observability-positive (more log events) and behavior-positive (more rows resolved).
+
+## Test plan
+
+1. `cargo test -p mika-agent kg::domain_builder` — covers Step 5 unit tests.
+2. `cargo test -p mika-agent kg::entity_resolver` — sanity check existing pending-detection still passes.
+3. Operational smoke: deploy to local mika-server, observe `domain_rebuild_invalidated_resolutions` log on next restart, verify next resolver tick fires with `pending_before > 0` for concept type.
+
+## Estimated diff size
+
+~80–120 lines in domain_builder.rs (invalidation + RebuildStats field + log emission + 3 tests) + ~10 lines in CLAUDE.md. No migration. No new dependency.

--- a/docs/plans/2026-05-03-001-fix-kg-domain-rebuild-invalidate-no-match-plan.md
+++ b/docs/plans/2026-05-03-001-fix-kg-domain-rebuild-invalidate-no-match-plan.md
@@ -15,7 +15,7 @@ When `domain_builder.rebuild()` adds N≥1 new entities of type T (skill / tool 
 Acceptance criteria from the ticket — restated for self-containment:
 
 - A1. After rebuild adds N entities of type T, the immediately-following resolver tick (or startup spawn) re-attempts all `outcome='no_match'` subjects where `kg_subject_entities.type = T`.
-- A2. Re-attempt count is observable via a new field on `kg_resolver_tick.complete` — `reattempted_no_match: u32`.
+- A2. **Deferred to companion ticket [mika#961](https://github.com/senara-solutions/mika/issues/961).** Per-tick observability of prior-`no_match` retries on `kg_resolver_tick.complete` is a distinct question from rebuild-side invalidation. The rebuild-side log event in A4 covers the operational signal "did the rebuild invalidate stale resolutions?"; the per-tick count answers "of this tick's resolves, how many were prior-no_match retries?" — different module, different signal. mika#960's issue body is being amended to move A2 to a "Deferred" section that points at #961.
 - A3. Unit test: 1 `concept` domain entity added; 5 `concept`-typed subjects with prior `outcome='no_match'`; after invalidation+resolve, 5 are re-attempted with fresh `resolved_at`.
 - A4. New structured log event `domain_rebuild_invalidated_resolutions` carries per-type counts: `{added_type: "concept", invalidated_no_match: N}`.
 
@@ -26,6 +26,8 @@ Two viable design points; I'm taking the first and naming the alternative.
 **Chosen — invalidate inside the rebuild transaction.** Right after entity UPSERT and before commit, run one `DELETE FROM kg_resolutions_log` per type with `entities_added_for_type[T] > 0`. The invalidation is atomic with the rebuild — if the transaction rolls back, the log rows survive. Resolutions and the domain graph stay consistent.
 
 **Rejected — invalidate in server init between rebuild and resolver_tick spawn.** This would split the semantic invariant ("expanded domain graph implies stale `no_match` rows") across two transactions. If the rebuild commits but the server crashes before the invalidation step, we end up in the exact failure state #960 is trying to prevent. Atomicity wins.
+
+**Architectural shape note (extend `domain_builder`, don't extract orchestrator).** Sole-writer contract per `kg-implementation-conventions.md` C1 extends from owning the entity_key namespaces to owning the consequents of mutating those keys. Same logic that placed `prune_stale_entities` inside `domain_builder` rather than a separate cleanup module — adds and removes are symmetric obligations of the writer. Orchestrator extraction (`kg::rebuild_orchestrator`) deferred until a second consequent emerges that does not belong inside `domain_builder` itself; today's surface is one consequent and ~30 LOC.
 
 ## Files touched
 
@@ -38,6 +40,43 @@ Two viable design points; I'm taking the first and naming the alternative.
 No schema migration. No new env var. No public-API change to the `RebuildStats` struct fields beyond the additive `invalidated_no_match` HashMap.
 
 ## Implementation
+
+### Phase 0 — Pin the transaction boundary
+
+The fix's correctness depends on the DELETE living inside the rebuild transaction. Concrete pin:
+
+- `crates/mika-agent/src/kg/domain_builder.rs::rebuild()` — function body spans ~lines 255–479.
+- Transaction opens at **line 270**: `let tx = conn.unchecked_transaction()?;` (inside the `with_db(move |db| { ... })` closure).
+- Entity UPSERT phase: lines 281–425 (insert-vs-update tracking + per-type writes via `entities_added_per_type` accumulator).
+- Edge rebuild phase: lines ~427–456 (`DEPENDS_ON` and `PROVIDES` relationships).
+- Stale-entity prune + post-loop logging: lines ~457–469.
+- Transaction commit/return: lines ~470–478 (`Ok(RebuildStats { ... })` is the implicit commit point as the closure returns `Ok` — `tx` is dropped after the struct is constructed; `unchecked_transaction` semantics commit on drop unless `tx.rollback()` was called).
+
+**Insertion site for the DELETE loop:** between the relationship-rebuild block (after line 456 — `domain_rebuild_edges` log emission complete) and the `domain_rebuild_complete` log at line 465. Specifically, the new code sits inside the `with_db` closure, before the `RebuildStats` struct is constructed and returned. The `tx` binding is in scope; the closure has direct access to `conn` (the `tx` is a borrow, but the rusqlite `Transaction` API uses `&self` for `.execute()`, so we can run DELETEs through the parent connection within the same transactional context — this is the existing pattern used by entity UPSERT and edge rebuild above).
+
+Quote of the surrounding code, from line 456 onward:
+
+```rust
+        for rel_type in DOMAIN_RELATIONSHIP_TYPES {
+            let count = edge_stats.get(*rel_type).map_or(0, |s| s.count);
+            info!(
+                trace_id = %self.trace_id,
+                event = "domain_rebuild_edges",
+                r#type = rel_type,
+                count,
+            );
+        }
+        // <-- new invalidation loop goes here -->
+        info!(
+            trace_id = %self.trace_id,
+            event = "domain_rebuild_complete",
+            duration_ms,
+        );
+
+        Ok(RebuildStats { ... })
+```
+
+The DELETE loop runs **inside the `with_db` closure**, **before** the closure returns `Ok`. It uses the same `db.conn` handle that `tx` was opened on — the `unchecked_transaction()` API returns a borrow that does not own the connection; subsequent DELETEs through `db.conn` participate in the same transaction until `tx` is dropped or committed. (This is how the existing UPSERT and edge rebuild code already operates.)
 
 ### Step 1 — Track per-type adds in `RebuildStats`
 
@@ -54,11 +93,29 @@ pub struct RebuildStats {
 
 ### Step 2 — Invalidate `no_match` rows for types with new entities
 
-Inside the same transaction, after entity UPSERT and edge rebuild but before `tx.commit()`, for each `type` in `KG_DOMAIN_ENTITY_TYPES`:
+Inside the same transaction, after entity UPSERT and edge rebuild but before the `Ok(RebuildStats{ ... })` return, for each `type` in `KG_DOMAIN_ENTITY_TYPES`:
 
 ```rust
-if entities_added_per_type[type_name] > 0 {
-    let invalidated = tx.execute(
+const WELL_KNOWN_DOMAIN_TYPES: &[&str] = &[
+    "skill", "tool", "agent", "problem_type", "concept",
+];
+
+let mut invalidated_no_match: HashMap<String, usize> = HashMap::new();
+for (type_name, added) in &entities_added_per_type {
+    if *added == 0 {
+        continue;
+    }
+    if !WELL_KNOWN_DOMAIN_TYPES.contains(&type_name.as_str()) {
+        warn!(
+            trace_id = %self.trace_id,
+            unknown_type = %type_name,
+            event = "domain_rebuild_invalidation_skipped_unknown_type",
+            "skipping invalidation for type not in WELL_KNOWN_DOMAIN_TYPES — \
+             review this code path if a new domain type was added",
+        );
+        continue;
+    }
+    let invalidated = db.conn.execute(
         "DELETE FROM kg_resolutions_log
          WHERE outcome = 'no_match'
            AND subject_entity_id IN (
@@ -67,12 +124,14 @@ if entities_added_per_type[type_name] > 0 {
         [type_name],
     )?;
     if invalidated > 0 {
-        invalidated_no_match.insert(type_name.to_string(), invalidated);
+        invalidated_no_match.insert(type_name.clone(), invalidated);
     }
 }
 ```
 
 Why DELETE not UPDATE: the resolver's pending-detection query (`entity_resolver.rs::count_pending`, lines 879-918) treats `r.id IS NULL` as pending. DELETE is the simplest signal. Adding a `superseded_at` column or similar marker is out of scope for v1.
+
+**Belt-and-suspenders type allowlist.** The `entities_added_per_type` keys already constrain T to known domain types because they come from the rebuild's own entity-write loop. The explicit `WELL_KNOWN_DOMAIN_TYPES` check (mirroring `prune_stale_entities`) is forward-compat insurance: if a future ticket adds a new entity type without reviewing this code path, the DELETE is skipped with a `warn!` event rather than silently invalidating against an untracked type. Same precedent pattern as KG #689 grooming.
 
 The CASCADE on `kg_subject_resolutions` is **not** triggered here because that table FKs to `kg_subject_entities`, not to `kg_resolutions_log`. The subject_resolution rows for these subjects don't exist yet (no_match never wrote them); only log rows exist.
 
@@ -102,7 +161,13 @@ The resolver tick already counts outcomes in `ResolutionStats`. Add a new field 
 
 **KTD-2c — drop the field from acceptance.** The `domain_rebuild_invalidated_resolutions` event already gives operators the answer. The `reattempted_no_match` on `kg_resolver_tick.complete` is observability-only and partially redundant with `pending_before` jumping after a rebuild.
 
-I propose **KTD-2c** for v1 — meet acceptance A1, A3, A4 and document A2 as a follow-up. Adding the marker column or post-tick query is non-trivial and the operational signal is already present via the rebuild event. Surface this trade-off to the architect in pass 1.
+I propose **KTD-2c** for v1 — meet acceptance A1, A3, A4 and document A2 as a follow-up. Adding the marker column or post-tick query is non-trivial and the operational signal is already present via the rebuild event.
+
+**Decision (post-architect-pass-1):** KTD-2c accepted. Companion ticket [mika#961](https://github.com/senara-solutions/mika/issues/961) filed for the per-tick `reattempted_no_match` field. Issue body of mika#960 amended to move A2 to a "Deferred" section pointing at #961.
+
+### Step 3b — Sub-namespace over-invalidation explicitly accepted (F3 resolution)
+
+`entities_added_per_type` is keyed on the bare `type` column (`'concept'`, not `'concept:cross-repo'`). The DELETE matches at top-level type, which means adding one `concept:infra:helm-chart` entity invalidates `no_match` rows for `concept:cross-repo:*` subjects too. Sub-namespace over-invalidation explicitly accepted: cost is bounded by `MIKA_KG_BATCH_BUDGET` (resolver Stage-2 LLM call cap, default 500/tick) — over-invalidated subjects re-resolve to `no_match` again on the next tick at LLM cost only, no correctness impact. Avoiding `entity_key` string introspection (parsing `concept:cross-repo:foo` to extract the sub-namespace) preserves decoupling from the `kg-id-convention.md` namespace convention; if the convention changes, the invalidation logic stays correct because it only knows `type`.
 
 ### Step 5 — Unit test
 
@@ -148,6 +213,8 @@ The seed helpers in `tests/eval/kg_fixtures/mod.rs` (`seed_subject_entity`, `see
 **R1 — first-restart-after-deploy invalidation storm.** When this fix ships, every rebuild that adds entities (which is every rebuild on a freshly-deployed node) will invalidate matching `no_match` rows. The next resolver tick then re-attempts them. For the primary mika corpus this could mean re-attempting thousands of subjects, hitting the LLM budget cap and emitting `kg_budget_exhausted`.
 
 **Mitigation:** The existing `MIKA_KG_BATCH_BUDGET` (default 500) caps the burst. Subsequent ticks drain the rest. Operators can temporarily raise the budget post-deploy if they want faster drain. No code change needed; document in the CLAUDE.md note.
+
+**R-Transaction-Scope.** Invalidation extends the rebuild transaction by 1–5 additional DELETE queries (one per type-with-adds, typically 1–2 in steady state). Accepted: rebuild is the sole writer of `kg_entities`, `kg_relationships`, `kg_subject_resolutions`, and now `kg_resolutions_log` in this code path; SQLite WAL readers do not block on writer locks (snapshot-isolation semantics); the DELETE cost is negligible relative to the entity UPSERT and edge rebuild that already run in this same transaction. No profiling required pre-merge; revisit only if production telemetry surfaces a regression.
 
 **R2 — well-known-only filter.** The resolver's `count_pending` only considers types in `('skill','tool','agent','problem_type','concept')`. The invalidation query in Step 2 has no such filter — it would invalidate `no_match` rows for any subject type. That's a no-op for "discovered" types (`solution_path`, `failure_mode`, `pattern`) because they're never actually resolved. But it's wasteful work.
 


### PR DESCRIPTION
Closes #960.

## Summary

When `domain_builder` adds entities in a previously-empty type namespace (or in a previously-empty subdivision of an existing namespace — e.g., a new `concept:cross-repo:*` prefix), `kg_resolutions_log` rows with `outcome='no_match'` for subjects of that type were NOT invalidated. The next resolver tick treated those subjects as already-resolved and skipped them. Domain-graph expansion was silently no-op for existing corpora until the source documents changed and re-extraction picked them up.

Implementation on branch:
- Plan groomed 2026-05-03 with mika-arch first-pass ITERATE + revisions (F1+F2+F3+F4 + 3 friend-review additions) → second-pass GROOMED.
- Plan: `docs/plans/2026-05-03-001-fix-kg-domain-rebuild-invalidate-no-match-plan.md`
- Implementation commit: `ed0c87ba` (pre-dates today's dispatch — branch was already complete)

## Why operator-side PR

Branch was already at terminal-implementation state when today's autonomous dispatch fired (3 prior dev-pilot attempts on this branch over the last 11 days). Today's dispatch correctly detected zero-new-commits via mika#940's just-deployed PIPELINE_INCOMPLETE classification. Branch is shippable; only missing step is `gh pr create`.

## Test plan

- [x] Plan architect-validated (second-pass GROOMED, original session intact in branch history)
- [ ] CI green
- [ ] mika-qa autonomous review → verdict
- [ ] Post-deploy: `grep kg_invalidated_no_match` in server log shows non-zero counts on domain-graph rebuild after a fresh entity type lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>