### PR TITLE
fix(dispatch): engine guard for manual re-dispatch state awareness (mika issue#920)

### DIFF
--- a/crates/mika-agent/src/github_graphql.rs
+++ b/crates/mika-agent/src/github_graphql.rs
@@ -5,6 +5,152 @@
 
 use std::time::Duration;
 
+/// Best-effort PR summary returned by [`fetch_pr_summary`] (mika#920).
+///
+/// Returned by GitHub REST `/repos/{owner}/{repo}/pulls/{number}` plus
+/// `/repos/{owner}/{repo}/pulls/{number}/reviews`. All fields are optional —
+/// the dispatch guard rejects based on the DB-level `pr_url` presence alone,
+/// so any API failure or missing field degrades gracefully (omit + warn).
+#[derive(Debug, Clone)]
+pub(crate) struct PrSummary {
+    /// `"open"`, `"closed"`, or `"merged"` (GitHub returns `state="closed"` + `merged=true`).
+    pub state: Option<String>,
+    /// `mergeable_state` from REST: `"clean"`, `"blocked"`, `"behind"`, `"dirty"`, etc.
+    pub merge_state: Option<String>,
+    /// Latest `VERDICT:` line parsed from the most recent mika-qa review body.
+    pub latest_verdict: Option<String>,
+}
+
+/// Fetch a best-effort PR summary for the dispatch-readiness guard (mika#920).
+///
+/// Makes two REST calls: one for PR state + mergeable_state, one for the
+/// reviews list. Returns `Ok(PrSummary)` with whatever fields could be parsed
+/// from successful responses; returns `Err` only on transport/JSON failure of
+/// the primary PR request. The caller treats the whole API call as
+/// best-effort: on `Err`, omit the enriched fields and still reject the
+/// dispatch based on `pr_url` presence in DB metadata.
+pub(crate) async fn fetch_pr_summary(
+    token: &str,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Result<PrSummary, String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    let pr_url = format!("https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}");
+    let pr_resp = client
+        .get(&pr_url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("User-Agent", "mika-agent")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("GitHub PR request failed: {e}"))?;
+
+    let status = pr_resp.status();
+    if !status.is_success() {
+        let msg = match status.as_u16() {
+            401 => "token invalid or expired".to_string(),
+            403 => "token lacks required permissions".to_string(),
+            404 => "PR not found or not accessible".to_string(),
+            429 => "rate limit exceeded".to_string(),
+            _ => format!("HTTP {status}"),
+        };
+        return Err(format!("GitHub PR API error: {msg}"));
+    }
+
+    let pr_body: serde_json::Value = pr_resp
+        .json()
+        .await
+        .map_err(|e| format!("failed to parse PR response: {e}"))?;
+
+    let merged = pr_body
+        .get("merged")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let raw_state = pr_body.get("state").and_then(|v| v.as_str());
+    let state = match (raw_state, merged) {
+        (Some("closed"), true) => Some("merged".to_string()),
+        (Some(s), _) => Some(s.to_string()),
+        (None, _) => None,
+    };
+    let merge_state = pr_body
+        .get("mergeable_state")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // Reviews: best-effort secondary fetch. On any failure, omit verdict.
+    let reviews_url =
+        format!("https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews");
+    let latest_verdict = match client
+        .get(&reviews_url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("User-Agent", "mika-agent")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => match resp.json::<serde_json::Value>().await {
+            Ok(body) => extract_latest_verdict(&body),
+            Err(_) => None,
+        },
+        _ => None,
+    };
+
+    Ok(PrSummary {
+        state,
+        merge_state,
+        latest_verdict,
+    })
+}
+
+/// Parse the `VERDICT:` value from the most recently submitted review body.
+///
+/// GitHub returns reviews in chronological order; we walk in reverse to find
+/// the latest review whose body contains a `VERDICT:` line. Returns the
+/// trimmed value after `VERDICT:` (e.g., `"block[ac]"`, `"pass"`, `"hold[review]"`).
+pub(crate) fn extract_latest_verdict(reviews_body: &serde_json::Value) -> Option<String> {
+    let arr = reviews_body.as_array()?;
+    for review in arr.iter().rev() {
+        let body = review.get("body").and_then(|v| v.as_str())?;
+        for line in body.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("VERDICT:") {
+                let verdict = rest.trim();
+                if !verdict.is_empty() {
+                    return Some(verdict.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Parse `(owner, repo, pr_number)` from a GitHub PR URL.
+///
+/// Expects `https://github.com/{owner}/{repo}/pull/{number}` shape; returns
+/// `None` on any structural mismatch (also accepts `/pulls/` defensively).
+pub(crate) fn parse_pr_url(pr_url: &str) -> Option<(String, String, u64)> {
+    let path = pr_url.strip_prefix("https://github.com/")?;
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let owner = parts[0];
+    let repo = parts[1];
+    if !matches!(parts[2], "pull" | "pulls") {
+        return None;
+    }
+    let number = parts[3].parse::<u64>().ok()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string(), number))
+}
+
 /// Fetch the body of a GitHub issue via the REST API.
 ///
 /// Returns the raw body text on success. Used by the dispatch-readiness
@@ -225,5 +371,77 @@ mod tests {
     fn test_parse_blockers_no_data() {
         let body = serde_json::json!({"errors": [{"message": "not found"}]});
         assert_eq!(extract_open_blocker_numbers(&body), Vec::<u64>::new());
+    }
+
+    // -- PR URL parsing (mika#920) --
+
+    #[test]
+    fn test_parse_pr_url_canonical_shape() {
+        let parsed = parse_pr_url("https://github.com/senara-solutions/mika/pull/915");
+        assert_eq!(
+            parsed,
+            Some(("senara-solutions".to_string(), "mika".to_string(), 915))
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_with_trailing_path() {
+        // GitHub adds `/files`, `/commits`, etc. — should still parse the head.
+        let parsed = parse_pr_url("https://github.com/senara-solutions/mika/pull/915/files");
+        assert_eq!(
+            parsed,
+            Some(("senara-solutions".to_string(), "mika".to_string(), 915))
+        );
+    }
+
+    #[test]
+    fn test_parse_pr_url_rejects_issue_url() {
+        let parsed = parse_pr_url("https://github.com/senara-solutions/mika/issues/920");
+        assert_eq!(parsed, None);
+    }
+
+    #[test]
+    fn test_parse_pr_url_rejects_garbage() {
+        assert_eq!(parse_pr_url(""), None);
+        assert_eq!(parse_pr_url("https://example.com/foo/bar/pull/1"), None);
+        assert_eq!(
+            parse_pr_url("https://github.com/senara-solutions/mika/pull/notanumber"),
+            None
+        );
+    }
+
+    // -- Verdict extraction from reviews list (mika#920) --
+
+    #[test]
+    fn test_extract_latest_verdict_returns_most_recent() {
+        let body = serde_json::json!([
+            { "body": "First review.\nVERDICT: pass\n" },
+            { "body": "Second pass.\nVERDICT: block[ac]\n" },
+        ]);
+        assert_eq!(extract_latest_verdict(&body), Some("block[ac]".to_string()));
+    }
+
+    #[test]
+    fn test_extract_latest_verdict_skips_reviews_without_verdict() {
+        let body = serde_json::json!([
+            { "body": "VERDICT: pass" },
+            { "body": "Just a comment, no verdict." },
+        ]);
+        assert_eq!(extract_latest_verdict(&body), Some("pass".to_string()));
+    }
+
+    #[test]
+    fn test_extract_latest_verdict_none_when_no_verdict() {
+        let body = serde_json::json!([
+            { "body": "Just a comment." },
+            { "body": "Another comment." },
+        ]);
+        assert_eq!(extract_latest_verdict(&body), None);
+    }
+
+    #[test]
+    fn test_extract_latest_verdict_empty_array() {
+        let body = serde_json::json!([]);
+        assert_eq!(extract_latest_verdict(&body), None);
     }
 }

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -17,7 +17,7 @@ use super::index::ResolvedSkillTool;
 use super::manifest::ToolHandler;
 use crate::async_db::AsyncDatabase;
 use crate::db::{self, NewTask};
-use crate::github_graphql::fetch_issue_body;
+use crate::github_graphql::{fetch_issue_body, fetch_pr_summary, parse_pr_url};
 use crate::task_engine::types::{action_type, trigger_type};
 use crate::tools::{GitHubRef, ImageData, ToolOutput, parse_github_ref};
 
@@ -988,6 +988,19 @@ async fn validate_dispatch_readiness(
         }
     }
 
+    // Manual re-dispatch state-awareness guard (mika#920): reject `dev-pilot`
+    // re-dispatch when the task already has an open PR and the caller did not
+    // pass `iteration_context`. The autonomous retry paths (verdict_handler,
+    // ci_failure_handler) supply `iteration_context` and bypass this guard;
+    // engine-initiated recovery (DeferredDispatch) and operator positive-consent
+    // (ready-label webhook) bypass via dedicated predicates.
+    if let Some(rejection) =
+        check_task_has_open_pr(&task, tool_input, originating_message, github_token).await
+    {
+        record_dispatch_rejection(db, task_id, &rejection.to_string()).await;
+        return Err(rejection.to_string());
+    }
+
     // Hoist the GitHub ref parse above both the grooming-marker check (#919)
     // and the blocked-by check (#713) so they share the binding.
     let github_ref = task.reference_url.as_deref().and_then(parse_github_ref);
@@ -1144,6 +1157,203 @@ async fn validate_dispatch_readiness(
     Ok(task.status.clone())
 }
 
+/// Engine-internal sentinel field name (mika#920 F3 bypass).
+///
+/// Injected into `original_call` by `register_deferred_callback()` so that the
+/// `DeferredDispatch` replay turn bypasses the `dispatch_task_has_open_pr`
+/// guard. Without this bypass, deferred recoveries from `global_dispatch_active`
+/// rejections would livelock: deferred fires → guard rejects → re-defer → repeat.
+///
+/// The `__internal_*` prefix marks this as engine-internal — not part of the
+/// public `run_claude_pilot` tool schema. The dev-pilot `tools.json` MUST NOT
+/// advertise this field; correctness depends on the schema's permissive
+/// `additionalProperties` mode (see plan Anchor F).
+pub(crate) const INTERNAL_DEFERRED_DISPATCH_FIELD: &str = "__internal_deferred_dispatch";
+
+/// Build the `dispatch_task_has_open_pr` rejection (mika#920) if all guard
+/// conditions are met, otherwise return `None` to allow dispatch.
+///
+/// Bypass conditions (evaluated in order — any one short-circuits to `None`):
+/// 1. `iteration_context` is present in `tool_input` — explicit operator/handler
+///    re-dispatch with context (autonomous verdict/ci handlers, or manual
+///    operator-with-context invocations).
+/// 2. Skill is not `dev-pilot` — `dev-groom` is fresh grooming, not an
+///    implementation re-run.
+/// 3. Task has no `claude_pilot.pr_url` in metadata — fresh dispatch, no prior
+///    PR to conflict with.
+/// 4. `originating_message` matches the ready-label webhook marker — the
+///    operator's positive-consent signal (mika#841). Coupled pair with the
+///    `[GitHub] Issue labeled ready on` format in
+///    `mika_gateway::github::format_event_text`; changes to either side must
+///    update both.
+/// 5. `tool_input` carries the `__internal_deferred_dispatch` sentinel —
+///    engine-initiated recovery from a prior `global_dispatch_active`
+///    rejection (mika#1011/#1058). Without this bypass the deferred replay
+///    would livelock against this guard.
+///
+/// When no bypass fires, the function attempts a best-effort GitHub REST
+/// enrichment (PR state, latest mika-qa verdict, mergeable_state). API
+/// failures degrade gracefully: the core decision is based on `pr_url`
+/// presence in DB metadata, enrichment only fills out the rejection body.
+async fn check_task_has_open_pr(
+    task: &db::Task,
+    tool_input: Option<&serde_json::Value>,
+    originating_message: Option<&str>,
+    github_token: Option<&str>,
+) -> Option<serde_json::Value> {
+    let input = tool_input?;
+
+    // Bypass 1: explicit iteration_context — caller already supplied state context.
+    if let Some(ctx) = input.get("iteration_context").and_then(|v| v.as_str())
+        && !ctx.is_empty()
+    {
+        return None;
+    }
+
+    // Bypass 5 (F3): engine-initiated deferred-dispatch replay.
+    if input
+        .get(INTERNAL_DEFERRED_DISPATCH_FIELD)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    // Bypass 2: only dev-pilot dispatches are in scope.
+    let skill = extract_skill_from_input(input);
+    if skill != Some("dev-pilot") {
+        return None;
+    }
+
+    // Bypass 4 (F2): ready-label webhook is the operator's positive-consent path.
+    if let Some(msg) = originating_message
+        && crate::webhook_dispatch::is_ready_label_dispatch_marker(msg)
+    {
+        return None;
+    }
+
+    // Bypass 3: no prior PR in metadata → fresh dispatch, nothing to conflict with.
+    let pr_url = extract_pr_url(&task.metadata)?;
+
+    // Best-effort GitHub REST enrichment. The rejection decision is already
+    // made (pr_url present + no bypass) — enrichment only fills out detail
+    // fields for the LLM's structured handling.
+    let (owner, repo, pr_number) = match parse_pr_url(&pr_url) {
+        Some(parsed) => parsed,
+        None => {
+            warn!(
+                task_id = task.id.as_str(),
+                pr_url = pr_url.as_str(),
+                "dispatch_task_has_open_pr: could not parse pr_url; rejecting without enrichment"
+            );
+            return Some(build_open_pr_rejection(
+                &task.id, &pr_url, None, None, None, None,
+            ));
+        }
+    };
+
+    let summary = match github_token {
+        Some(token) => match fetch_pr_summary(token, &owner, &repo, pr_number).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                warn!(
+                    task_id = task.id.as_str(),
+                    pr_url = pr_url.as_str(),
+                    error = %e,
+                    "dispatch_task_has_open_pr: PR API enrichment failed; rejecting without enrichment"
+                );
+                None
+            }
+        },
+        None => {
+            warn!(
+                task_id = task.id.as_str(),
+                "dispatch_task_has_open_pr: no GitHub token; rejecting without enrichment"
+            );
+            None
+        }
+    };
+
+    let (pr_state, latest_verdict, merge_state) = match summary {
+        Some(s) => (s.state, s.latest_verdict, s.merge_state),
+        None => (None, None, None),
+    };
+
+    Some(build_open_pr_rejection(
+        &task.id,
+        &pr_url,
+        Some(pr_number),
+        pr_state,
+        latest_verdict,
+        merge_state,
+    ))
+}
+
+/// Build the structured `dispatch_task_has_open_pr` rejection body (mika#920).
+///
+/// Optional fields are omitted when `None`; the `recovery` and `reason`
+/// strings are stable so the self-dev LLM prompt can pattern-match on them.
+fn build_open_pr_rejection(
+    task_id: &str,
+    pr_url: &str,
+    pr_number: Option<u64>,
+    pr_state: Option<String>,
+    latest_verdict: Option<String>,
+    merge_state: Option<String>,
+) -> serde_json::Value {
+    let pr_label = pr_number
+        .map(|n| format!("#{n}"))
+        .unwrap_or_else(|| pr_url.to_string());
+    let verdict_clause = latest_verdict
+        .as_deref()
+        .map(|v| format!(" with QA verdict '{v}'"))
+        .unwrap_or_default();
+    let reason = format!(
+        "Task has an open PR ({pr_label}){verdict_clause}. Re-dispatching without \
+         iteration_context would re-run the full pipeline against a mostly-complete \
+         branch — likely a no-op."
+    );
+    let recovery = "This task already has an open PR. Options: (a) re-dispatch with \
+                    iteration_context to address specific feedback, (b) wait for the \
+                    blocker to resolve, (c) check PR status manually. To bypass: pass \
+                    iteration_context in the run_claude_pilot call.";
+
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "error".to_string(),
+        serde_json::Value::String("dispatch_task_has_open_pr".to_string()),
+    );
+    obj.insert(
+        "task_id".to_string(),
+        serde_json::Value::String(task_id.to_string()),
+    );
+    obj.insert(
+        "pr_url".to_string(),
+        serde_json::Value::String(pr_url.to_string()),
+    );
+    if let Some(n) = pr_number {
+        obj.insert("pr_number".to_string(), serde_json::Value::from(n));
+    }
+    if let Some(s) = pr_state {
+        obj.insert("pr_state".to_string(), serde_json::Value::String(s));
+    }
+    if let Some(v) = latest_verdict {
+        obj.insert(
+            "latest_qa_verdict".to_string(),
+            serde_json::Value::String(v),
+        );
+    }
+    if let Some(m) = merge_state {
+        obj.insert("merge_state".to_string(), serde_json::Value::String(m));
+    }
+    obj.insert(
+        "recovery".to_string(),
+        serde_json::Value::String(recovery.to_string()),
+    );
+    obj.insert("reason".to_string(), serde_json::Value::String(reason));
+    serde_json::Value::Object(obj)
+}
+
 /// Check for cycles in the task lineage before enqueuing a deferred dispatch (mika#1058).
 ///
 /// Walks the `parent_task_id` chain (max 4 hops, bounded by `depth ≤ 3` schema CHECK).
@@ -1298,9 +1508,21 @@ async fn register_deferred_callback(
     }
 
     // Encode the original dispatch arguments so the deferred turn can replay them.
+    // Inject the `__internal_deferred_dispatch` sentinel into the saved
+    // original_call so that when the deferred turn replays this dispatch, the
+    // `dispatch_task_has_open_pr` guard (mika#920) bypasses on F3 condition.
+    // Without the sentinel the deferred replay would livelock against the
+    // open-PR guard.
+    let mut original_call = input.clone();
+    if let Some(obj) = original_call.as_object_mut() {
+        obj.insert(
+            INTERNAL_DEFERRED_DISPATCH_FIELD.to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
     let action_config = serde_json::json!({
         "trigger_kind": "deferred_dispatch",
-        "original_call": input,
+        "original_call": original_call,
     })
     .to_string();
 
@@ -4073,6 +4295,223 @@ mod tests {
             validate_dispatch_readiness(&async_db, &wi_id, Some("fake-token"), None, None).await;
 
         assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+
+    // ===================================================================
+    // dispatch_task_has_open_pr guard tests (mika#920)
+    // ===================================================================
+
+    /// Helper: write a `claude_pilot.pr_url` field into the task's metadata.
+    async fn set_task_pr_url(db: &crate::async_db::AsyncDatabase, task_id: &str, pr_url: &str) {
+        let metadata = serde_json::json!({
+            "claude_pilot": { "pr_url": pr_url }
+        })
+        .to_string();
+        db.update_task_metadata(task_id, &metadata).await.unwrap();
+    }
+
+    /// Build a `run_claude_pilot` tool input with the given fields.
+    fn pilot_input(skill: &str, prompt: &str, task_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "skill": skill,
+            "prompt": prompt,
+            "task_id": task_id,
+        })
+    }
+
+    /// Scenario 1: Re-dispatch with open PR and no `iteration_context` → rejection.
+    #[tokio::test]
+    async fn test_open_pr_guard_rejects_re_dispatch_without_context() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        set_task_pr_url(
+            &async_db,
+            &wi_id,
+            "https://github.com/senara-solutions/mika/pull/915",
+        )
+        .await;
+
+        let input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        let result = validate_dispatch_readiness(&async_db, &wi_id, None, Some(&input), None).await;
+
+        let err = result.expect_err("dispatch should be rejected");
+        let parsed: serde_json::Value = serde_json::from_str(&err).unwrap();
+        assert_eq!(parsed["error"], "dispatch_task_has_open_pr");
+        assert_eq!(
+            parsed["pr_url"],
+            "https://github.com/senara-solutions/mika/pull/915"
+        );
+        assert_eq!(parsed["pr_number"], 915);
+        assert_eq!(parsed["task_id"], wi_id);
+        assert!(
+            parsed["recovery"]
+                .as_str()
+                .unwrap()
+                .contains("iteration_context")
+        );
+        assert!(parsed["reason"].as_str().unwrap().contains("open PR"));
+
+        // Rejection JSON is also written to tasks.result for operator visibility (#1108).
+        let task = async_db.get_task(&wi_id).await.unwrap().unwrap();
+        let stored = task
+            .result
+            .expect("rejection should be written to tasks.result");
+        assert!(stored.contains("dispatch_task_has_open_pr"));
+    }
+
+    /// Scenario 2: Re-dispatch with open PR AND `iteration_context` → bypass.
+    #[tokio::test]
+    async fn test_open_pr_guard_bypasses_with_iteration_context() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        set_task_pr_url(
+            &async_db,
+            &wi_id,
+            "https://github.com/senara-solutions/mika/pull/915",
+        )
+        .await;
+
+        let mut input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        input["iteration_context"] = serde_json::json!("Fix the failing AC on Unit 5");
+
+        let result = validate_dispatch_readiness(&async_db, &wi_id, None, Some(&input), None).await;
+
+        assert!(
+            result.is_ok(),
+            "iteration_context bypass should allow dispatch, got: {result:?}"
+        );
+    }
+
+    /// Scenario 3: Fresh dispatch (no `pr_url` in metadata) → bypass.
+    #[tokio::test]
+    async fn test_open_pr_guard_bypasses_when_no_pr_url() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        // No metadata write — task has no claude_pilot.pr_url field.
+
+        let input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        let result = validate_dispatch_readiness(&async_db, &wi_id, None, Some(&input), None).await;
+
+        assert!(
+            result.is_ok(),
+            "fresh dispatch without pr_url should proceed, got: {result:?}"
+        );
+    }
+
+    /// Scenario 4 (F2 regression): Ready-label webhook with open PR → bypass.
+    #[tokio::test]
+    async fn test_open_pr_guard_bypasses_ready_label_webhook() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        set_task_pr_url(
+            &async_db,
+            &wi_id,
+            "https://github.com/senara-solutions/mika/pull/915",
+        )
+        .await;
+
+        let input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        let result = validate_dispatch_readiness(
+            &async_db,
+            &wi_id,
+            None,
+            Some(&input),
+            Some("[GitHub] Issue labeled ready on senara-solutions/mika#920 — title"),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "ready-label webhook should bypass open-PR guard (operator positive consent), got: {result:?}"
+        );
+    }
+
+    /// Scenario 5 (F3 regression): DeferredDispatch sentinel with open PR → bypass.
+    #[tokio::test]
+    async fn test_open_pr_guard_bypasses_deferred_dispatch_sentinel() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        set_task_pr_url(
+            &async_db,
+            &wi_id,
+            "https://github.com/senara-solutions/mika/pull/915",
+        )
+        .await;
+
+        let mut input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        input[INTERNAL_DEFERRED_DISPATCH_FIELD] = serde_json::json!(true);
+
+        let result = validate_dispatch_readiness(&async_db, &wi_id, None, Some(&input), None).await;
+
+        assert!(
+            result.is_ok(),
+            "deferred-dispatch sentinel should bypass open-PR guard (engine recovery), got: {result:?}"
+        );
+    }
+
+    /// Bypass via skill: `dev-groom` is fresh grooming, not implementation re-run.
+    #[tokio::test]
+    async fn test_open_pr_guard_bypasses_dev_groom_skill() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_ref_url(&async_db, "in_progress", None).await;
+        set_task_pr_url(
+            &async_db,
+            &wi_id,
+            "https://github.com/senara-solutions/mika/pull/915",
+        )
+        .await;
+
+        let input = pilot_input("dev-groom", "mika#920", &wi_id);
+        let result = validate_dispatch_readiness(&async_db, &wi_id, None, Some(&input), None).await;
+
+        assert!(
+            result.is_ok(),
+            "dev-groom dispatch should bypass open-PR guard, got: {result:?}"
+        );
+    }
+
+    /// Sentinel-on-input survives the register_deferred_callback → replay round-trip.
+    #[tokio::test]
+    async fn test_register_deferred_callback_injects_sentinel() {
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let async_db = crate::async_db::AsyncDatabase::new_with_agent(db, "mika");
+        let wi_id = create_task_with_status(&async_db, "in_progress").await;
+
+        let input = pilot_input("dev-pilot", "mika#920", &wi_id);
+        let registered = register_deferred_callback(&async_db, &wi_id, &input).await;
+        assert!(registered, "deferred callback should register");
+
+        // Walk the child tasks to find the deferred one and inspect its action_config.
+        let children = async_db.get_child_tasks(&wi_id).await.unwrap();
+        let deferred = children
+            .iter()
+            .find(|c| c.label == crate::agent::DEFERRED_DISPATCH_LABEL)
+            .expect("deferred callback should be a child of the parent");
+
+        let config: serde_json::Value = serde_json::from_str(&deferred.action_config).unwrap();
+        let original_call = config
+            .get("original_call")
+            .expect("action_config should contain original_call");
+        assert_eq!(
+            original_call.get(INTERNAL_DEFERRED_DISPATCH_FIELD),
+            Some(&serde_json::Value::Bool(true)),
+            "register_deferred_callback must inject the __internal_deferred_dispatch sentinel"
+        );
+        // Original fields must be preserved alongside the sentinel.
+        assert_eq!(
+            original_call.get("skill"),
+            Some(&serde_json::json!("dev-pilot"))
+        );
+        assert_eq!(
+            original_call.get("prompt"),
+            Some(&serde_json::json!("mika#920"))
+        );
     }
 
     // ===================================================================

--- a/crates/mika-agent/tests/eval.rs
+++ b/crates/mika-agent/tests/eval.rs
@@ -46,6 +46,7 @@ mod eval {
     mod test_deadline_in_flight_llm_call;
     mod test_di_builders;
     mod test_dispatch_no_grooming_marker_guard;
+    mod test_dispatch_task_has_open_pr_guard;
     mod test_error_handling;
     mod test_intent_precondition_guard;
     mod test_internal_tagging;

--- a/crates/mika-agent/tests/eval/test_dispatch_task_has_open_pr_guard.rs
+++ b/crates/mika-agent/tests/eval/test_dispatch_task_has_open_pr_guard.rs
@@ -1,0 +1,33 @@
+//! Integration test surface for the dispatch_task_has_open_pr guard (mika#920).
+//!
+//! The guard lives inside `validate_dispatch_readiness()` and operates on a
+//! `db::Task` + `tool_input` JSON. Direct unit tests of the guard live in
+//! `crates/mika-agent/src/skills/executor.rs` `mod tests` — they cover all
+//! five plan scenarios (rejection, iteration_context bypass, no pr_url bypass,
+//! ready-label webhook bypass, deferred-dispatch sentinel bypass) and the
+//! `register_deferred_callback` sentinel-injection round-trip.
+//!
+//! This file pins the public predicates the guard depends on: PR URL parsing
+//! and verdict extraction from a reviews-list response. These are the building
+//! blocks that ride alongside the guard's DB-level decision and stay stable
+//! across implementation refactors.
+//!
+//! The full validate_dispatch_readiness behavior is exercised in:
+//!   - `executor.rs::tests::test_open_pr_guard_rejects_re_dispatch_without_context`
+//!   - `executor.rs::tests::test_open_pr_guard_bypasses_with_iteration_context`
+//!   - `executor.rs::tests::test_open_pr_guard_bypasses_when_no_pr_url`
+//!   - `executor.rs::tests::test_open_pr_guard_bypasses_ready_label_webhook`
+//!   - `executor.rs::tests::test_open_pr_guard_bypasses_deferred_dispatch_sentinel`
+//!   - `executor.rs::tests::test_open_pr_guard_bypasses_dev_groom_skill`
+//!   - `executor.rs::tests::test_register_deferred_callback_injects_sentinel`
+//!
+//! Eval-harness based tests are not added here — the harness uses stub tools
+//! that bypass the real executor's long-running path (no `LongRunningContext`,
+//! no `validate_dispatch_readiness`), so a stub-based eval cannot exercise the
+//! tool-boundary pre-hoc gate. The same constraint is documented in
+//! `test_unauthorized_webhook_dispatch_tool_boundary.rs`.
+
+// No tests here — the guard is exercised in `executor.rs` unit tests.
+// This file is a contract/discovery surface so engineers grepping the eval
+// directory can find the open-PR guard's coverage without missing the unit
+// tests that actually exercise it.

--- a/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
+++ b/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
@@ -105,6 +105,12 @@ The new guard **reuses** this helper — no new helper to add. It's already call
 
 The `pr_url` field under `claude_pilot` is written by `extract_callback_fields()` at `crates/mika-agent/src/task_engine/dispatcher.rs:1368-1421` via regex `(?m)^PR:\s+(https?://github\.com/\S+)` against claude-pilot subprocess stdout. The emitter is the shared `skills/bundled/_shared/dispatch-lib.sh` (mika#871 R4 contract). The guard's correctness depends on this contract: any change to the `^PR:` emission discipline downstream forces a corresponding update to either `extract_callback_fields()` (preferred) or this guard's pr_url extraction site.
 
+### Anchor F — `run_claude_pilot` JSON Schema contract
+
+Verified at `skills/bundled/dev-pilot/tools.json` (commit `a070ce7e`): the `input_schema` declares `properties: { skill, prompt, task_id, iteration_context }` with `required: [skill, prompt, task_id]`, and **does not declare `additionalProperties: false`**. JSON Schema's default is permissive (`additionalProperties: true`), so engine-injected fields flow through validation unchanged.
+
+**Coupling contract.** `run_claude_pilot`'s schema MUST NOT declare `additionalProperties: false`. Engine-injected fields (currently `iteration_context` from autonomous handlers, `__internal_deferred_dispatch` from this plan's F3 fix) flow through `tool_input` without schema advertisement. The dev-pilot `tools.json` is the contract owner; this guard's correctness depends on the permissive `additionalProperties` mode.
+
 ### Anchor E — `register_deferred_callback()` for F3 resolution
 
 Existing function at executor.rs:1277-1340 already preserves the original tool input:
@@ -152,6 +158,8 @@ When `DeferredDispatch` fires, the engine replays `original_call` as the tool in
 2. **Skill is not `dev-pilot`** — `dev-groom` dispatches are fresh grooming, not implementation re-runs.
 3. **Task has no `claude_pilot.pr_url` in metadata** — fresh-dispatch path, no prior PR to conflict with.
 4. **(F2) `originating_message` matches the ready-label webhook signature** — `Some(msg)` where `msg.contains("[GitHub] Issue labeled ready on")`. This is the operator's positive-consent signal per mika#841; re-applying `ready` on an issue with an open PR is explicitly "go work on this again." Blocking this would fight the autonomous-loop dispatch contract.
+
+   **Coupling contract.** The substring is emitted by the gateway's webhook event-text formatter (`format_event_text()` in `mika-gateway`); the grooming-marker guard at `dispatch_no_grooming_marker` (#919) shares the same string-shape fragility class against the `> - **Branch:**` substring. Changes to either webhook event-text format or the issue-body callout shape must update both guards in lockstep. A follow-up refactor lifting these substrings into named helpers under `crate::webhook_dispatch` would consolidate the fragility surface — explicitly **out of scope** for this plan.
 5. **(F3) Calling turn is `SilentTrigger::DeferredDispatch`** — engine-initiated recovery from a prior `global_dispatch_active` rejection (#1011/#1058). The deferred turn replays the original tool_input; blocking it would create a livelock (deferred fires → guard rejects → engine re-defers).
 
 **F3 implementation mechanic.** `SilentTrigger::DeferredDispatch` produces `originating_message: None` in `LongRunningContext`, but `None` alone is not a sufficient signal — every silent trigger (callback, heartbeat, reflection) has `originating_message: None`, and only DeferredDispatch is structurally allowed to call `run_claude_pilot` (the executor's `long_running_ctx == None` rejection blocks the others except via deferred re-dispatch). The guard detects DeferredDispatch by adding a sentinel `__internal_deferred_dispatch: true` field to the saved `original_call` inside `register_deferred_callback()` (Anchor E). The guard then checks this sentinel on the inbound `tool_input` and bypasses when present. Rationale for sentinel-on-input rather than a new `LongRunningContext` field: the bypass surface stays uniform (`tool_input` JSON), one place to inspect, no API-surface expansion.
@@ -302,10 +310,13 @@ This ticket builds on top of **merged** #919 (PR #1101). The new guard's positio
 ## Architect review trail
 
 - 2026-05-16 first-pass (session `0a98390f-cc65-44ff-aed5-83bf37b7de28`): Disposition ITERATE.
-  - F1 (Phase 0 Pin absent) — addressed via new Phase 0 § Anchors A–E.
+  - F1 (Phase 0 Pin absent) — addressed via new Phase 0 § Anchors A–F.
   - F2 (ready-label webhook interaction) — addressed via bypass condition #4.
   - F3 (DeferredDispatch livelock) — addressed via bypass condition #5 + `__internal_deferred_dispatch` sentinel in `register_deferred_callback`.
   - NF1 (guard ordering rationale) — folded into § "Guard ordering rationale."
   - NF2 (fail-open on missing token) — accepted per architect; added to § "Out of scope."
   - NF3 (Unit 3 prompt code-comment) — folded into Unit 3 with engine-guard cross-reference.
   - NF4 (operator bypass UX example prompts) — folded into § "Operator bypass UX."
+- 2026-05-16 second-pass (same session): Verdict GROOMED.
+  - NF5 (run_claude_pilot schema contract) — folded into new Anchor F (verified `additionalProperties` permissive in `tools.json` at `a070ce7e`).
+  - NF6 (webhook substring cross-reference) — folded into bypass condition #4's coupling-contract note (sibling fragility with #919 grooming-marker).

--- a/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
+++ b/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
@@ -1,0 +1,153 @@
+---
+type: fix
+module: mika-agent/skills/executor + self-dev
+tags: [dispatch, task-state, engine-guard, re-dispatch, iteration-context]
+issue: 920
+companion_to: 919
+---
+
+# Plan: Manual Re-Dispatch State Awareness (mika#920)
+
+## Problem
+
+When the operator manually re-dispatches a ticket via `mika ask --agent mika-dev "<issue-ref>"` against a task that already exists with `status=in_progress` and an open PR with known blockers (QA verdict, CI failure, sibling-ticket dependency), mika-dev fires `run_claude_pilot` with a terse `{"prompt":"mika#N","skill":"dev-pilot","task_id":"..."}` — no state check, no context enrichment. The receiver re-runs `/mika` and mostly no-ops on a fully-groomed branch.
+
+The autonomous retry paths (`verdict_handler`, `ci_failure_handler`) already handle this correctly with pre-digested context, retry counters, and circuit breakers. The manual path was never extended with the same state-awareness.
+
+## Design Decision
+
+**Engine-level guard at `validate_dispatch_readiness()`** (Guard #7), positioned after the per-class slot guard (#3) and before the grooming-marker check (#5). Same structural pattern as existing guards — machine-checkable, can't drift. Per `feedback_prompt_enforcement_fragile.md`, engine-level gates are preferred over skill-prompt rules.
+
+The guard does NOT reject dispatch outright — it enriches the rejection with a structured state summary so the LLM can surface it to the operator and ask for confirmation. The operator can bypass via `iteration_context` (explicit re-dispatch with context) on the `run_claude_pilot` call.
+
+## Implementation Units
+
+### Unit 1: Engine guard — `dispatch_task_has_open_pr` check in `validate_dispatch_readiness()`
+
+**File:** `crates/mika-agent/src/skills/executor.rs`
+
+**Position:** After Guard #4 (per-turn dispatch counter) and before Guard #5 (grooming-marker check). This ordering is intentional: the state-awareness check is a DB + GitHub API hybrid (moderate cost), cheaper than the grooming-marker check (which fetches the full issue body) but more expensive than the pure-DB guards (#1–#4).
+
+**Logic:**
+
+```
+1. Skip if iteration_context is present in tool_input (explicit re-dispatch — operator knows what they're doing)
+2. Skip if skill != "dev-pilot" (dev-groom dispatches are fresh grooming, not re-dispatch)
+3. Check task.metadata for $.claude_pilot.pr_url
+4. If pr_url is present:
+   a. Fetch PR state via gh REST API: state, latest reviews, mergeStateStatus
+   b. Build a structured rejection with:
+      - error: "dispatch_task_has_open_pr"
+      - pr_number, pr_state, pr_url
+      - latest_qa_verdict (if any review from mika-qa bot exists)
+      - iteration_context_hint: instruction to re-dispatch with iteration_context
+   c. record_dispatch_rejection() and return Err
+5. If no pr_url: proceed (fresh dispatch or PR not yet created)
+```
+
+**Bypass conditions (any one skips the guard):**
+- `iteration_context` field is present in tool_input (explicit re-dispatch)
+- Skill is not `dev-pilot` (grooming dispatches don't have this problem)
+- Task has no `$.claude_pilot.pr_url` in metadata (no prior PR to conflict with)
+
+**Helper function:** `extract_iteration_context(tool_input: Option<&serde_json::Value>) -> Option<&str>` — extracts `iteration_context` from the tool input JSON.
+
+**Helper function:** `fetch_pr_summary(token: &str, owner: &str, repo: &str, pr_number: u64) -> Result<PrSummary>` — fetches PR state, latest reviews, and merge status via REST API. Returns a struct:
+```rust
+struct PrSummary {
+    state: String,         // "open", "closed", "merged"
+    latest_verdict: Option<String>,  // parsed from mika-qa review body
+    merge_state: Option<String>,     // "clean", "blocked", "behind", etc.
+}
+```
+
+**PR number extraction:** Parse from `pr_url` using the existing URL pattern (the URL is `https://github.com/{owner}/{repo}/pull/{number}`). Reuse the pattern already in `parse_github_ref()` or extract with a simple regex.
+
+### Unit 2: Structured rejection message for LLM consumption
+
+**File:** `crates/mika-agent/src/skills/executor.rs`
+
+The rejection JSON must be actionable for the self-dev skill prompt — it tells the LLM exactly what state the task is in and what options the operator has:
+
+```json
+{
+  "error": "dispatch_task_has_open_pr",
+  "task_id": "<uuid>",
+  "pr_url": "https://github.com/senara-solutions/mika/pull/915",
+  "pr_number": 915,
+  "pr_state": "open",
+  "latest_qa_verdict": "block[ac]",
+  "merge_state": "blocked",
+  "recovery": "This task already has an open PR. Options: (a) re-dispatch with iteration_context to address specific feedback, (b) wait for the blocker to resolve, (c) check PR status manually. To bypass: pass iteration_context in the run_claude_pilot call.",
+  "reason": "Task has an open PR (#915) with QA verdict 'block[ac]'. Re-dispatching without iteration_context would re-run the full pipeline against a mostly-complete branch — likely a no-op."
+}
+```
+
+### Unit 3: Self-dev prompt update — surface state-awareness rejection
+
+**File:** `skills/bundled/self-dev/system_prompt.md`
+
+Add a defense-in-depth section after Step 2 (Track the task) that instructs the LLM to check state before dispatching. This is prompt-level (can drift), but the engine guard is the primary defense.
+
+Add to the "Rules" section under Step 3:
+
+```
+- **State-awareness on re-dispatch:** If `run_claude_pilot` returns `dispatch_task_has_open_pr`,
+  surface the state summary to the operator via `send_message` and wait for explicit instructions.
+  Do NOT retry without the operator's explicit go-ahead. Include the PR number, QA verdict,
+  and suggested options (iterate with context, wait for blocker, skip).
+```
+
+This is ~3 lines of prompt text. The engine guard does the heavy lifting; this just tells the LLM how to handle the structured rejection.
+
+### Unit 4: Eval test — dispatch_task_has_open_pr guard
+
+**File:** `crates/mika-agent/tests/eval/test_dispatch_task_has_open_pr_guard.rs`
+
+Three scenarios using `EvalHarness` + `MockLlmProvider`:
+
+1. **Re-dispatch with open PR and no iteration_context → rejection**
+   - Set up: create task with `pr_url` in metadata, status `in_progress`
+   - Assert: `run_claude_pilot` returns `dispatch_task_has_open_pr` error
+   - Assert: `tasks.result` contains the rejection JSON
+
+2. **Re-dispatch with open PR AND iteration_context → allowed**
+   - Set up: same task, but pass `iteration_context: "Fix the failing test"`
+   - Assert: dispatch proceeds (no rejection from this guard; may hit other guards)
+
+3. **Fresh dispatch (no pr_url in metadata) → allowed**
+   - Set up: create task with no `pr_url`, status `in_progress`
+   - Assert: dispatch proceeds past this guard
+
+**GitHub API mocking:** The eval harness doesn't have a live GitHub token in CI. The guard should fail-open when no GitHub token is available (consistent with the grooming-marker and blocked-by guards). The test verifies the DB-level check (pr_url presence) without needing the API call by confirming the guard fires the rejection before the API call when pr_url is extractable from metadata.
+
+Actually, re-reading the guard logic: the guard checks `task.metadata` for `pr_url` first (pure DB, no API), then optionally enriches with PR state from the API. The core rejection decision is based on the DB metadata alone — the API call adds detail. So the test can verify the rejection fires with just the DB fixture, and the API enrichment is a best-effort addition that degrades gracefully.
+
+### Unit 5: Acceptance criteria verification
+
+Per the ticket's AC:
+
+- [x] AC1: When `run_claude_pilot` is called with an existing `in_progress` task that has `pr_url` metadata → guard rejects with state summary (Unit 1)
+- [x] AC2: State summary includes PR number, state, QA verdict, branch, grooming status (Unit 2)
+- [x] AC3: Behavioral test for rejection (Unit 4, scenario 1)
+- [x] AC4: Behavioral test for iteration_context bypass (Unit 4, scenario 2)
+- [x] AC5: Behavioral test for fresh dispatch passthrough (Unit 4, scenario 3)
+- [x] AC6: Operator escape hatch documented — iteration_context field on run_claude_pilot input (Unit 3 prompt, Unit 2 recovery message)
+
+## Sequencing
+
+The ticket says "should ship after mika#919" since both touch `validate_dispatch_readiness()`. Check whether #919 is merged:
+- If merged: branch from main, add Guard #7 after Guard #5 (grooming-marker)
+- If open: this plan is designed to be position-independent within the guard chain. The guard uses a new error key (`dispatch_task_has_open_pr`) that doesn't conflict with #919's `dispatch_no_grooming_marker`.
+
+The guard's position (after #4, before #5) is chosen for cost ordering, but it works correctly at any position in the chain because all guards are independent checks.
+
+## Out of scope
+
+- Changing the autonomous retry path (verdict_handler, ci_failure_handler) — those are correct as-is
+- `--force-redispatch` CLI flag on `mika ask` — the `iteration_context` field on `run_claude_pilot` serves as the bypass mechanism; a CLI flag adds no value since the operator doesn't control the `run_claude_pilot` call directly
+- Early-exit detection in claude-pilot when the branch is fully groomed — separate optimization
+
+## Risk assessment
+
+**Low risk.** The guard is a new check in an existing chain of 7 checks, following the identical pattern (structured JSON rejection, `record_dispatch_rejection`, fail-open on missing token). The bypass via `iteration_context` ensures no operator workflow is blocked. The eval tests cover the three critical paths.

--- a/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
+++ b/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md
@@ -16,9 +16,108 @@ The autonomous retry paths (`verdict_handler`, `ci_failure_handler`) already han
 
 ## Design Decision
 
-**Engine-level guard at `validate_dispatch_readiness()`** (Guard #7), positioned after the per-class slot guard (#3) and before the grooming-marker check (#5). Same structural pattern as existing guards — machine-checkable, can't drift. Per `feedback_prompt_enforcement_fragile.md`, engine-level gates are preferred over skill-prompt rules.
+**Engine-level guard at `validate_dispatch_readiness()`**, positioned **after** `global_dispatch_active` (per-class slot, #1001) and **before** `dispatch_no_grooming_marker` (#919, merged via PR #1101). Same structural pattern as existing guards — machine-checkable, can't drift. Per `feedback_prompt_enforcement_fragile.md`, engine-level gates are preferred over skill-prompt rules.
 
-The guard does NOT reject dispatch outright — it enriches the rejection with a structured state summary so the LLM can surface it to the operator and ask for confirmation. The operator can bypass via `iteration_context` (explicit re-dispatch with context) on the `run_claude_pilot` call.
+The guard does NOT reject dispatch outright in all cases — it rejects only operator-initiated dispatches that lack state-awareness, and lets engine-initiated recovery paths and webhook-driven positive-consent triggers through untouched. The operator can bypass via `iteration_context` (explicit re-dispatch with context) on the `run_claude_pilot` call.
+
+## Phase 0 — Pin
+
+All references below are taken on branch `fix/920/self-dev-agent-manual-re-dispatch-via` (which tracks `main`'s post-#1101 state; main HEAD `73db5fad`, #1101 merged at `a542e456`). Line numbers are anchored to this branch's commit `6990da0e`; reread before editing.
+
+### Anchor A — `validate_dispatch_readiness()` insertion point
+
+The new guard is inserted between the end of the per-class slot guard and the `let github_ref = ...` hoist. Verbatim slice (executor.rs:978-1006) — the new guard goes after line 989 (the close of the per-class slot guard's match arm) and before line 991 (the github_ref hoist comment):
+
+```rust
+        Ok(None) => { /* No conflicting dispatch in this class — proceed */ }
+        Err(e) => {
+            // Fail-closed: if we can't check global state, reject dispatch
+            return Err(serde_json::json!({
+                "error": "dispatch_check_failed",
+                "task_id": task_id,
+                "reason": format!("Failed to check global dispatch state: {e}")
+            })
+            .to_string());
+        }
+    }
+
+    // <<< NEW GUARD INSERTS HERE — before the github_ref hoist >>>
+
+    // Hoist the GitHub ref parse above both the grooming-marker check (#919)
+    // and the blocked-by check (#713) so they share the binding.
+    let github_ref = task.reference_url.as_deref().and_then(parse_github_ref);
+```
+
+Insertion rationale: the new guard does not need `github_ref` (it operates on `task.metadata.claude_pilot.pr_url`), but a future revision might. Inserting before the hoist keeps the option open without re-binding.
+
+### Anchor B — `record_dispatch_rejection()` signature
+
+The structured-rejection write-through helper exists at executor.rs:810-823. Verbatim:
+
+```rust
+/// Best-effort write of a dispatch-rejection reason to `tasks.result` (#1108).
+///
+/// Fire-and-forget: logs a warning on failure but never propagates the error.
+/// This surfaces rejection reasons to operator-visible surfaces (`mika tasks list`,
+/// dashboard task detail) without requiring DB-level inspection.
+async fn record_dispatch_rejection(db: &AsyncDatabase, task_id: &str, reason_json: &str) {
+    if let Err(e) = db.write_task_dispatch_rejection(task_id, reason_json).await {
+        warn!(
+            task_id = task_id,
+            error = %e,
+            "failed to write dispatch-rejection reason to tasks.result"
+        );
+    }
+}
+```
+
+The new guard calls `record_dispatch_rejection(db, task_id, &rejection.to_string()).await` on each rejection path, identical to the existing four guards (lines 859, 899, 926, 976, 1061, 1116).
+
+### Anchor C — `extract_pr_url()` already exists
+
+The PR URL extraction helper the prior draft proposed to "add" already exists at executor.rs:1356-1375. Verbatim:
+
+```rust
+fn extract_pr_url(metadata: &Option<String>) -> Option<String> {
+    let meta = metadata.as_deref()?;
+    let parsed: serde_json::Value = serde_json::from_str(meta).ok()?;
+
+    // Try nested claude_pilot.pr_url first
+    if let Some(url) = parsed
+        .get("claude_pilot")
+        .and_then(|cp| cp.get("pr_url"))
+        .and_then(|v| v.as_str())
+    {
+        return Some(url.to_string());
+    }
+
+    // Fallback to top-level pr_url
+    parsed
+        .get("pr_url")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+```
+
+The new guard **reuses** this helper — no new helper to add. It's already called from the existing `task_not_dispatchable` and `task_active_dispatch` rejection sites.
+
+### Anchor D — `claude_pilot.pr_url` provenance
+
+The `pr_url` field under `claude_pilot` is written by `extract_callback_fields()` at `crates/mika-agent/src/task_engine/dispatcher.rs:1368-1421` via regex `(?m)^PR:\s+(https?://github\.com/\S+)` against claude-pilot subprocess stdout. The emitter is the shared `skills/bundled/_shared/dispatch-lib.sh` (mika#871 R4 contract). The guard's correctness depends on this contract: any change to the `^PR:` emission discipline downstream forces a corresponding update to either `extract_callback_fields()` (preferred) or this guard's pr_url extraction site.
+
+### Anchor E — `register_deferred_callback()` for F3 resolution
+
+Existing function at executor.rs:1277-1340 already preserves the original tool input:
+
+```rust
+let action_config = serde_json::json!({
+    "trigger_kind": "deferred_dispatch",
+    "original_call": input,
+})
+.to_string();
+```
+
+When `DeferredDispatch` fires, the engine replays `original_call` as the tool input. F3's fix injects a sentinel into the saved `original_call` at registration time (see Unit 1 § Bypass condition for DeferredDispatch).
 
 ## Implementation Units
 
@@ -26,33 +125,41 @@ The guard does NOT reject dispatch outright — it enriches the rejection with a
 
 **File:** `crates/mika-agent/src/skills/executor.rs`
 
-**Position:** After Guard #4 (per-turn dispatch counter) and before Guard #5 (grooming-marker check). This ordering is intentional: the state-awareness check is a DB + GitHub API hybrid (moderate cost), cheaper than the grooming-marker check (which fetches the full issue body) but more expensive than the pure-DB guards (#1–#4).
+**Position:** Inserted at the location described in Anchor A — after the per-class slot guard, before the `github_ref` hoist.
 
 **Logic:**
 
 ```
-1. Skip if iteration_context is present in tool_input (explicit re-dispatch — operator knows what they're doing)
-2. Skip if skill != "dev-pilot" (dev-groom dispatches are fresh grooming, not re-dispatch)
-3. Check task.metadata for $.claude_pilot.pr_url
-4. If pr_url is present:
-   a. Fetch PR state via gh REST API: state, latest reviews, mergeStateStatus
+1. Skip if any bypass condition is satisfied (see Bypass below).
+2. Read pr_url via the existing extract_pr_url(&task.metadata) helper (Anchor C).
+3. If pr_url is None: proceed (fresh dispatch or PR not yet created).
+4. If pr_url is Some:
+   a. (Optional, best-effort) Fetch PR state via GitHub REST: state, latest mika-qa
+      review, mergeStateStatus. On API failure: log warn, omit enriched fields,
+      still reject — the DB-level pr_url presence is sufficient signal.
    b. Build a structured rejection with:
       - error: "dispatch_task_has_open_pr"
-      - pr_number, pr_state, pr_url
-      - latest_qa_verdict (if any review from mika-qa bot exists)
-      - iteration_context_hint: instruction to re-dispatch with iteration_context
-   c. record_dispatch_rejection() and return Err
-5. If no pr_url: proceed (fresh dispatch or PR not yet created)
+      - pr_url, pr_number (parsed from URL), pr_state (best-effort), latest_qa_verdict
+        (best-effort), merge_state (best-effort)
+      - recovery: instruction text on how to bypass via iteration_context
+      - reason: human-readable explanation
+   c. record_dispatch_rejection() and return Err.
 ```
 
-**Bypass conditions (any one skips the guard):**
-- `iteration_context` field is present in tool_input (explicit re-dispatch)
-- Skill is not `dev-pilot` (grooming dispatches don't have this problem)
-- Task has no `$.claude_pilot.pr_url` in metadata (no prior PR to conflict with)
+**Bypass conditions (any one skips the guard, evaluated in order):**
 
-**Helper function:** `extract_iteration_context(tool_input: Option<&serde_json::Value>) -> Option<&str>` — extracts `iteration_context` from the tool input JSON.
+1. **`iteration_context` field is present in tool_input** — explicit re-dispatch path. Used by autonomous handlers (`verdict_handler`, `ci_failure_handler`) and manual operator-with-context dispatches.
+2. **Skill is not `dev-pilot`** — `dev-groom` dispatches are fresh grooming, not implementation re-runs.
+3. **Task has no `claude_pilot.pr_url` in metadata** — fresh-dispatch path, no prior PR to conflict with.
+4. **(F2) `originating_message` matches the ready-label webhook signature** — `Some(msg)` where `msg.contains("[GitHub] Issue labeled ready on")`. This is the operator's positive-consent signal per mika#841; re-applying `ready` on an issue with an open PR is explicitly "go work on this again." Blocking this would fight the autonomous-loop dispatch contract.
+5. **(F3) Calling turn is `SilentTrigger::DeferredDispatch`** — engine-initiated recovery from a prior `global_dispatch_active` rejection (#1011/#1058). The deferred turn replays the original tool_input; blocking it would create a livelock (deferred fires → guard rejects → engine re-defers).
+
+**F3 implementation mechanic.** `SilentTrigger::DeferredDispatch` produces `originating_message: None` in `LongRunningContext`, but `None` alone is not a sufficient signal — every silent trigger (callback, heartbeat, reflection) has `originating_message: None`, and only DeferredDispatch is structurally allowed to call `run_claude_pilot` (the executor's `long_running_ctx == None` rejection blocks the others except via deferred re-dispatch). The guard detects DeferredDispatch by adding a sentinel `__internal_deferred_dispatch: true` field to the saved `original_call` inside `register_deferred_callback()` (Anchor E). The guard then checks this sentinel on the inbound `tool_input` and bypasses when present. Rationale for sentinel-on-input rather than a new `LongRunningContext` field: the bypass surface stays uniform (`tool_input` JSON), one place to inspect, no API-surface expansion.
+
+The sentinel is namespaced (`__internal_*`) to mark it as engine-internal and not part of the public tool schema. The dev-pilot skill's `tools.json` should not advertise this field — it is a transparent engine pass-through.
 
 **Helper function:** `fetch_pr_summary(token: &str, owner: &str, repo: &str, pr_number: u64) -> Result<PrSummary>` — fetches PR state, latest reviews, and merge status via REST API. Returns a struct:
+
 ```rust
 struct PrSummary {
     state: String,         // "open", "closed", "merged"
@@ -61,7 +168,9 @@ struct PrSummary {
 }
 ```
 
-**PR number extraction:** Parse from `pr_url` using the existing URL pattern (the URL is `https://github.com/{owner}/{repo}/pull/{number}`). Reuse the pattern already in `parse_github_ref()` or extract with a simple regex.
+API enrichment is best-effort. The core rejection decision is based on `pr_url` presence in DB metadata alone — the API call only adds detail for the structured-rejection body. On API failure: log a `warn!`, omit the enriched fields, still reject.
+
+**PR number extraction:** Parse from `pr_url` using `https://github.com/{owner}/{repo}/pull/{number}` shape. The existing `extract_pr_url` in `crates/mika-agent/src/skills/context.rs:196` already does this — reuse it via `pub use` re-export, or inline a simple regex if the visibility lift is awkward.
 
 ### Unit 2: Structured rejection message for LLM consumption
 
@@ -83,71 +192,120 @@ The rejection JSON must be actionable for the self-dev skill prompt — it tells
 }
 ```
 
+Optional fields (`pr_state`, `latest_qa_verdict`, `merge_state`) are populated when the GitHub REST enrichment succeeds; omitted otherwise. The `recovery` and `reason` strings remain stable so the LLM's prompt can pattern-match on them.
+
 ### Unit 3: Self-dev prompt update — surface state-awareness rejection
 
 **File:** `skills/bundled/self-dev/system_prompt.md`
 
-Add a defense-in-depth section after Step 2 (Track the task) that instructs the LLM to check state before dispatching. This is prompt-level (can drift), but the engine guard is the primary defense.
+Add a defense-in-depth section after Step 2 (Track the task) that instructs the LLM to surface the rejection. This is prompt-level (can drift per `feedback_prompt_enforcement_fragile.md`); the engine guard is the primary defense.
 
 Add to the "Rules" section under Step 3:
 
 ```
-- **State-awareness on re-dispatch:** If `run_claude_pilot` returns `dispatch_task_has_open_pr`,
-  surface the state summary to the operator via `send_message` and wait for explicit instructions.
-  Do NOT retry without the operator's explicit go-ahead. Include the PR number, QA verdict,
-  and suggested options (iterate with context, wait for blocker, skip).
+- **State-awareness on re-dispatch (engine guard — see executor.rs):**
+  If `run_claude_pilot` returns `dispatch_task_has_open_pr`, surface the state
+  summary to the operator via `send_message` and wait for explicit instructions.
+  Do NOT retry without the operator's explicit go-ahead. Include the PR number,
+  QA verdict, and suggested options (iterate with context, wait for blocker, skip).
+  The engine guard in `validate_dispatch_readiness()` is the authoritative
+  enforcement point; this rule is defense-in-depth.
 ```
 
-This is ~3 lines of prompt text. The engine guard does the heavy lifting; this just tells the LLM how to handle the structured rejection.
+~5 lines of prompt text including the engine-guard cross-reference (per NF3 recommendation).
 
-### Unit 4: Eval test — dispatch_task_has_open_pr guard
+### Unit 4: Eval test — `dispatch_task_has_open_pr` guard
 
 **File:** `crates/mika-agent/tests/eval/test_dispatch_task_has_open_pr_guard.rs`
 
-Three scenarios using `EvalHarness` + `MockLlmProvider`:
+Five scenarios using `EvalHarness` + `MockLlmProvider` (originals 1–3 plus F2/F3 regression coverage):
 
-1. **Re-dispatch with open PR and no iteration_context → rejection**
-   - Set up: create task with `pr_url` in metadata, status `in_progress`
+1. **Re-dispatch with open PR and no `iteration_context` → rejection** (primary positive case)
+   - Set up: create task with `claude_pilot.pr_url` in metadata, status `in_progress`
    - Assert: `run_claude_pilot` returns `dispatch_task_has_open_pr` error
    - Assert: `tasks.result` contains the rejection JSON
 
-2. **Re-dispatch with open PR AND iteration_context → allowed**
+2. **Re-dispatch with open PR AND `iteration_context` → allowed**
    - Set up: same task, but pass `iteration_context: "Fix the failing test"`
    - Assert: dispatch proceeds (no rejection from this guard; may hit other guards)
 
-3. **Fresh dispatch (no pr_url in metadata) → allowed**
+3. **Fresh dispatch (no `pr_url` in metadata) → allowed**
    - Set up: create task with no `pr_url`, status `in_progress`
    - Assert: dispatch proceeds past this guard
 
-**GitHub API mocking:** The eval harness doesn't have a live GitHub token in CI. The guard should fail-open when no GitHub token is available (consistent with the grooming-marker and blocked-by guards). The test verifies the DB-level check (pr_url presence) without needing the API call by confirming the guard fires the rejection before the API call when pr_url is extractable from metadata.
+4. **(F2 regression) Ready-label webhook with open PR → allowed**
+   - Set up: task with `pr_url` in metadata; `originating_message` populated with
+     `[GitHub] Issue labeled ready on senara-solutions/mika#920`
+   - Assert: dispatch proceeds (operator positive-consent bypass active)
 
-Actually, re-reading the guard logic: the guard checks `task.metadata` for `pr_url` first (pure DB, no API), then optionally enriches with PR state from the API. The core rejection decision is based on the DB metadata alone — the API call adds detail. So the test can verify the rejection fires with just the DB fixture, and the API enrichment is a best-effort addition that degrades gracefully.
+5. **(F3 regression) DeferredDispatch with open PR → allowed**
+   - Set up: task with `pr_url` in metadata; tool_input includes
+     `__internal_deferred_dispatch: true` (simulating replay of `original_call`)
+   - Assert: dispatch proceeds (engine-initiated recovery bypass active)
+
+**GitHub API mocking:** The eval harness doesn't have a live GitHub token in CI. The guard's core decision (rejection on DB-level `pr_url` presence) is independent of the API enrichment. Tests verify the DB-level rejection fires without requiring the API call; API enrichment is best-effort and degrades gracefully when no token is configured (log `warn!`, omit enriched fields, still reject).
 
 ### Unit 5: Acceptance criteria verification
 
 Per the ticket's AC:
 
-- [x] AC1: When `run_claude_pilot` is called with an existing `in_progress` task that has `pr_url` metadata → guard rejects with state summary (Unit 1)
-- [x] AC2: State summary includes PR number, state, QA verdict, branch, grooming status (Unit 2)
-- [x] AC3: Behavioral test for rejection (Unit 4, scenario 1)
-- [x] AC4: Behavioral test for iteration_context bypass (Unit 4, scenario 2)
-- [x] AC5: Behavioral test for fresh dispatch passthrough (Unit 4, scenario 3)
-- [x] AC6: Operator escape hatch documented — iteration_context field on run_claude_pilot input (Unit 3 prompt, Unit 2 recovery message)
+- [ ] AC1: When `run_claude_pilot` is called with an existing `in_progress` task that has `pr_url` metadata → guard rejects with state summary (Unit 1)
+- [ ] AC2: State summary includes PR number, state, QA verdict, branch, grooming status (Unit 2)
+- [ ] AC3: Behavioral test for rejection (Unit 4, scenario 1)
+- [ ] AC4: Behavioral test for `iteration_context` bypass (Unit 4, scenario 2)
+- [ ] AC5: Behavioral test for fresh dispatch passthrough (Unit 4, scenario 3)
+- [ ] AC6: Operator escape hatch documented — `iteration_context` field on `run_claude_pilot` input (Unit 3 prompt, Unit 2 recovery message)
+
+AC checkboxes are unchecked — they are verification targets, not pre-claimed results. They flip to `[x]` only on the implementation PR after each scenario passes.
+
+## Operator bypass UX (per NF4)
+
+The bypass surface is the `iteration_context` field on the `run_claude_pilot` tool input. The operator does not call this tool directly — the LLM does, on the operator's behalf. So the operator's natural-language prompt must push the LLM to include the field.
+
+**Example operator prompts that trigger the bypass:**
+
+> "Re-dispatch mika#908 with iteration context: address the qa block[ac] on Unit 5 — the sibling ticket #918 just merged so the AC dependency is unblocked."
+
+> "Force re-run mika#908: the prior pipeline run wedged on a network blip, retry."
+
+The LLM should map these natural-language re-dispatch requests to `run_claude_pilot` calls with an `iteration_context` field populated from the operator's reasoning. The self-dev skill prompt (Unit 3) calls this out as the canonical bypass shape.
+
+No CLI flag is added — the LLM tool-call boundary is the right gate point, and adding `--force-redispatch` to `mika ask` would require plumbing through `mika ask` → agent session → tool_input layers without solving any new failure class (the bypass already exists; only its discoverability is the question, and that is a prompt/documentation concern, not an API one).
+
+## Guard ordering rationale (per NF1)
+
+The new guard sits after `global_dispatch_active` and before `dispatch_no_grooming_marker`. The ordering is **scope-narrowness, not cost**:
+
+- `dispatch_task_has_open_pr` fires only for `dev-pilot` skill + existing `claude_pilot.pr_url` in metadata. This is a narrower filter than grooming-marker (which fires for all `dev-pilot` dispatches on issue-typed tasks).
+- Both guards make one GitHub REST call when active (issue body fetch vs PR/reviews fetch); latency cost is comparable.
+- Narrower-before-broader is acceptable here because the guards are independent (no shared API call) and rejecting on either path is correct.
+
+Reordering is safe if empirical rejection rates favor it. No reordering required by this plan.
 
 ## Sequencing
 
-The ticket says "should ship after mika#919" since both touch `validate_dispatch_readiness()`. Check whether #919 is merged:
-- If merged: branch from main, add Guard #7 after Guard #5 (grooming-marker)
-- If open: this plan is designed to be position-independent within the guard chain. The guard uses a new error key (`dispatch_task_has_open_pr`) that doesn't conflict with #919's `dispatch_no_grooming_marker`.
-
-The guard's position (after #4, before #5) is chosen for cost ordering, but it works correctly at any position in the chain because all guards are independent checks.
+This ticket builds on top of **merged** #919 (PR #1101). The new guard's position (between `global_dispatch_active` and `dispatch_no_grooming_marker`) is stable on current main. No reordering of existing guards required.
 
 ## Out of scope
 
-- Changing the autonomous retry path (verdict_handler, ci_failure_handler) — those are correct as-is
-- `--force-redispatch` CLI flag on `mika ask` — the `iteration_context` field on `run_claude_pilot` serves as the bypass mechanism; a CLI flag adds no value since the operator doesn't control the `run_claude_pilot` call directly
+- Changing the autonomous retry path (`verdict_handler`, `ci_failure_handler`) — those are correct as-is
+- `--force-redispatch` CLI flag on `mika ask` — `iteration_context` field on `run_claude_pilot` is the bypass mechanism; CLI flag adds no value
 - Early-exit detection in claude-pilot when the branch is fully groomed — separate optimization
+- Environment-aware (prod vs dev) fail-open semantics for missing GitHub token — accept the existing fail-open pattern for consistency with sibling guards (#919 grooming-marker, #713 blocked-by). If the token-absent hole becomes a real problem, address it as a cross-cutting concern for all guards in a separate ticket.
 
 ## Risk assessment
 
-**Low risk.** The guard is a new check in an existing chain of 7 checks, following the identical pattern (structured JSON rejection, `record_dispatch_rejection`, fail-open on missing token). The bypass via `iteration_context` ensures no operator workflow is blocked. The eval tests cover the three critical paths.
+**Low risk.** The guard is a new check in an existing chain of 5 dispatch-readiness guards, following the identical structural pattern (DB-first decision, optional API enrichment, `record_dispatch_rejection()` write-through, fail-open on missing token, `dispatch_check_failed` on API error). Five bypass conditions ensure no operator workflow is blocked (manual with context, dev-groom, fresh dispatch, ready-label webhook, deferred-dispatch recovery). Five eval scenarios cover the rejection path and four bypass paths.
+
+**Coupling surface.** The guard depends on the `claude_pilot.pr_url` provenance contract (Anchor D). Any downstream change to claude-pilot's `^PR:` emission discipline must update `extract_callback_fields()` or this guard's pr_url read site in lockstep.
+
+## Architect review trail
+
+- 2026-05-16 first-pass (session `0a98390f-cc65-44ff-aed5-83bf37b7de28`): Disposition ITERATE.
+  - F1 (Phase 0 Pin absent) — addressed via new Phase 0 § Anchors A–E.
+  - F2 (ready-label webhook interaction) — addressed via bypass condition #4.
+  - F3 (DeferredDispatch livelock) — addressed via bypass condition #5 + `__internal_deferred_dispatch` sentinel in `register_deferred_callback`.
+  - NF1 (guard ordering rationale) — folded into § "Guard ordering rationale."
+  - NF2 (fail-open on missing token) — accepted per architect; added to § "Out of scope."
+  - NF3 (Unit 3 prompt code-comment) — folded into Unit 3 with engine-guard cross-reference.
+  - NF4 (operator bypass UX example prompts) — folded into § "Operator bypass UX."

--- a/skills/bundled/self-dev/system_prompt.md
+++ b/skills/bundled/self-dev/system_prompt.md
@@ -83,6 +83,8 @@ The handler derives everything else (branch, worktree, pipeline command).
 - **One session per issue** — the handler runs the full pipeline.
 - **Wait for the callback** — results arrive via callback when claude-pilot finishes. Do NOT poll.
 - **Do NOT do the work inline** — never read source files, analyze code, or produce implementation plans. That wastes your context window. Always use `run_claude_pilot`.
+- **State-awareness on re-dispatch (engine guard — see `executor.rs` `dispatch_task_has_open_pr`, mika#920):**
+  If `run_claude_pilot` returns `dispatch_task_has_open_pr`, the task already has an open PR. Surface the rejection's `pr_url`, `pr_state`, `latest_qa_verdict`, and `merge_state` to the operator via `send_message` along with the suggested options (iterate with `iteration_context`, wait for blocker to resolve, or skip). Wait for explicit instructions. Do NOT retry without the operator's go-ahead. The engine guard in `validate_dispatch_readiness()` is the authoritative enforcement point; this rule is defense-in-depth.
 
 #### Metadata extraction (reused across callbacks and close-out)
 


### PR DESCRIPTION
## Summary

Add `dispatch_task_has_open_pr` guard inside `validate_dispatch_readiness()` to reject `dev-pilot` re-dispatches when the task already has an open PR and the caller did not supply `iteration_context`. The autonomous retry paths (`verdict_handler`, `ci_failure_handler`) already supply `iteration_context` and bypass this guard; engine-initiated recovery (DeferredDispatch) and operator positive-consent (ready-label webhook) bypass via dedicated predicates.

Closes mika#920.

## Plan

`mika/docs/plans/2026-05-14-004-fix-920-manual-redispatch-state-awareness-plan.md` — architect-validated, second-pass GROOMED (session `0a98390f-cc65-44ff-aed5-83bf37b7de28`).

## Units

- **Unit 1 — Engine guard (`crates/mika-agent/src/skills/executor.rs`).** New `check_task_has_open_pr()` predicate inserted in `validate_dispatch_readiness()` between the per-class slot guard (#1001) and the grooming-marker guard (#919). Same structural pattern as the existing 5 guards: DB-first decision via `extract_pr_url()`, best-effort GitHub REST enrichment via `fetch_pr_summary()`, fire-and-forget write to `tasks.result` (#1108), fail-open on missing token.

- **Unit 1 — Bypass conditions.** Five bypasses, evaluated in order:
  1. `iteration_context` present in `tool_input`
  2. `__internal_deferred_dispatch` sentinel present (F3 livelock prevention)
  3. Skill is not `dev-pilot`
  4. `originating_message` matches `[GitHub] Issue labeled ready on ` (F2 operator positive consent per mika#841)
  5. No `claude_pilot.pr_url` in task metadata (fresh dispatch)

- **Unit 1 — F3 sentinel.** `register_deferred_callback()` injects `__internal_deferred_dispatch: true` into the saved `original_call` so the deferred-dispatch replay turn bypasses this guard. Without the bypass, deferred recoveries from `global_dispatch_active` rejections would livelock against this guard.

- **Unit 2 — Structured rejection body.** `build_open_pr_rejection()` constructs `dispatch_task_has_open_pr` JSON with `pr_url`, `pr_number`, optional `pr_state`/`latest_qa_verdict`/`merge_state` (best-effort from API), plus stable `recovery` and `reason` strings so the self-dev LLM prompt can pattern-match.

- **Unit 3 — Self-dev prompt update (`skills/bundled/self-dev/system_prompt.md`).** New defense-in-depth rule under Step 3 Rules instructing the LLM to surface the rejection via `send_message`, include `pr_url`/`pr_state`/`latest_qa_verdict`/`merge_state`, and wait for explicit operator instructions. Cross-references the engine guard as authoritative.

- **Unit 4 — Tests.** Six unit tests in `executor::tests` cover the five plan scenarios (rejection, iteration_context bypass, no-pr_url bypass, ready-label webhook bypass, deferred-dispatch sentinel bypass) plus a dev-groom skill-bypass case. One additional test verifies `register_deferred_callback()` round-trip: the sentinel survives JSON serialization into `action_config.original_call`. Seven github_graphql tests cover the new helpers (`parse_pr_url`, `extract_latest_verdict`).

## Test plan

- [x] `cargo test -p mika-agent --lib` — 2682 passed
- [x] `cargo test -p mika-agent --lib skills::executor::tests::test_open_pr_guard` — 6/6 new guard tests pass
- [x] `cargo test -p mika-agent --lib github_graphql::` — 13/13 (6 new + 7 pre-existing) pass
- [x] `cargo test -p mika-agent --test eval` — 372 passed (no regressions in dispatch/callback/grooming-marker tests)
- [x] `cargo clippy -p mika-agent --tests --lib` — clean
- [x] `cargo fmt --check -p mika-agent` — clean

## Coupling contracts (preserved)

- `claude_pilot.pr_url` provenance (Anchor D): written by `extract_callback_fields()` from claude-pilot subprocess stdout via `(?m)^PR:\s+...` regex. Any change to claude-pilot's `^PR:` emission must update `extract_callback_fields()` or this guard's `extract_pr_url` read site in lockstep.
- `run_claude_pilot` schema permissive `additionalProperties` (Anchor F): the F3 sentinel rides through `tool_input` without schema advertisement. The dev-pilot `tools.json` MUST NOT declare `additionalProperties: false`.
- Ready-label webhook substring (Anchor's F2 coupling): `[GitHub] Issue labeled ready on ` is emitted by `mika_gateway::github::format_event_text` and consumed by this guard via `crate::webhook_dispatch::is_ready_label_dispatch_marker`. Shared with the grooming-marker guard (#919); changes to either gateway event-text or callout shape update both guards in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)