### PR TITLE
feat(agent): pr_merge_with_gate tagged-union return + webhook-qa gate_errored branch

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -124,7 +124,7 @@ Tool trait uses `#[async_trait]` (Send futures). Per-tool timeout override via `
 
 ### PR Merge Gate
 
-`pr_merge_with_gate` builtin tool — structural backstop against merging PRs with failing required CI checks. Registered in `default_tools()` (all agents, including delegates). Decision matrix: fail/cancel -> blocked; pending -> auto-merge; all pass -> immediate merge; already merged -> no-op. 60s timeout. Requires `ctx.github_token`. See #490.
+`pr_merge_with_gate` builtin tool — structural backstop against merging PRs with failing required CI checks. Registered in `default_tools()` (all agents, including delegates). Returns a tagged-union `MergeGateResult` via `#[serde(tag = "action")]` — the LLM branches on the `action` field. Five variants: `merged`, `auto_merge_enabled`, `blocked` (with `BlockReason` sub-enum and backward-compat `failing_checks`), `already_merged`, `gate_errored` (with `GateErrorKind` sub-enum). Preflight `gh pr view` detects CONFLICTING/CLOSED/DRAFT before attempting merge (#794). Decision matrix: CONFLICTING/DIRTY -> blocked[merge_conflict]; fail/cancel -> blocked[required_check_failed]; pending -> auto-merge; all pass -> immediate merge; already merged -> no-op; infra failure -> gate_errored. 60s timeout. Requires `ctx.github_token`. See #490, #794.
 
 ### Issue Dependency Resolution
 

--- a/crates/mika-agent/src/tools/pr_merge_with_gate.rs
+++ b/crates/mika-agent/src/tools/pr_merge_with_gate.rs
@@ -997,6 +997,18 @@ mod tests {
     }
 
     #[test]
+    fn serialize_gate_error_unknown() {
+        let result = MergeGateResult::GateError {
+            kind: GateErrorKind::Unknown,
+            detail: "Merge failed: unexpected output".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "gate_errored");
+        assert_eq!(json["kind"]["kind"], "unknown");
+        assert_eq!(json["detail"], "Merge failed: unexpected output");
+    }
+
+    #[test]
     fn serialize_auto_merge_result() {
         let result = MergeGateResult::AutoMergeEnabled {
             pending_checks: vec![CheckInfo {

--- a/crates/mika-agent/src/tools/pr_merge_with_gate.rs
+++ b/crates/mika-agent/src/tools/pr_merge_with_gate.rs
@@ -44,7 +44,10 @@ impl Tool for PrMergeWithGateTool {
                 IMPORTANT: 'auto_merge_enabled' means GitHub will merge when all checks pass — \
                 the PR is NOT yet merged. Do not claim the PR is merged until you confirm it.\n\n\
                 After a successful merge (action: 'merged'), update the task status before \
-                reporting to the user."
+                reporting to the user.\n\n\
+                Returns a structured JSON response with an 'action' field. Possible actions: \
+                'merged', 'auto_merge_enabled', 'blocked', 'already_merged', 'gate_errored'. \
+                Branch on 'action' to determine next steps."
                 .to_string(),
             input_schema: json!({
                 "type": "object",
@@ -122,36 +125,67 @@ impl Tool for PrMergeWithGateTool {
             }
         };
 
-        // -- Step 1: Fetch required check statuses --
+        // -- Step 1: Preflight — check PR state via gh pr view --
+        let preflight = match run_gh_pr_view(pr_number, repo, token).await {
+            Ok(pf) => pf,
+            Err(e) => {
+                let result = MergeGateResult::GateError {
+                    kind: GateErrorKind::GhCliFailure {
+                        exit_code: e.exit_code.unwrap_or(-1),
+                    },
+                    detail: e.message,
+                };
+                return Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?));
+            }
+        };
+
+        // Classify preflight result
+        if let Some(result) = classify_preflight(&preflight) {
+            return Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?));
+        }
+
+        // -- Step 2: Fetch required check statuses --
         let checks_result = run_gh_checks(pr_number, repo, token).await;
         let checks = match checks_result {
             Ok(c) => c,
             Err(e) => {
-                return Ok(ToolOutput::error(format!(
-                    "Failed to fetch check statuses: {e}"
-                )));
+                let result = MergeGateResult::GateError {
+                    kind: GateErrorKind::GhCliFailure {
+                        exit_code: parse_exit_code_from_error(&e),
+                    },
+                    detail: format!("Failed to fetch check statuses: {e}"),
+                };
+                return Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?));
             }
         };
 
-        // -- Step 2: Classify and act --
+        // -- Step 3: Classify and act --
         let classification = classify_checks(&checks);
 
         match classification {
             CheckClassification::HasFailures => {
-                let failing: Vec<&GhCheck> = checks
+                let failing: Vec<CheckInfo> = checks
                     .iter()
                     .filter(|c| matches!(c.bucket.as_str(), "fail" | "cancel"))
+                    .map(|c| CheckInfo {
+                        name: c.name.clone(),
+                        state: c.state.clone(),
+                        link: c.link.clone(),
+                    })
                     .collect();
 
                 let result = MergeGateResult::Blocked {
-                    failing_checks: failing
-                        .iter()
-                        .map(|c| CheckInfo {
-                            name: c.name.clone(),
-                            state: c.state.clone(),
-                            link: c.link.clone(),
-                        })
-                        .collect(),
+                    reason: BlockReason::RequiredCheckFailed {
+                        failing_checks: failing.clone(),
+                    },
+                    failing_checks: failing,
+                    detail: format!(
+                        "{} required check(s) failed",
+                        checks
+                            .iter()
+                            .filter(|c| matches!(c.bucket.as_str(), "fail" | "cancel"))
+                            .count()
+                    ),
                 };
                 Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
             }
@@ -177,7 +211,15 @@ impl Tool for PrMergeWithGateTool {
                         };
                         Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                     }
-                    Err(e) => Ok(ToolOutput::error(format!("Auto-merge failed: {e}"))),
+                    Err(e) => {
+                        let result = MergeGateResult::GateError {
+                            kind: GateErrorKind::GhCliFailure {
+                                exit_code: parse_exit_code_from_error(&e),
+                            },
+                            detail: format!("Auto-merge failed: {e}"),
+                        };
+                        Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
+                    }
                 }
             }
             CheckClassification::AllPassed => {
@@ -199,19 +241,34 @@ impl Tool for PrMergeWithGateTool {
                     let result = MergeGateResult::Merged;
                     Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                 } else if output_lower.contains("draft") {
-                    Ok(ToolOutput::error(
-                        "PR is a draft — convert to ready before merging",
-                    ))
+                    let result = MergeGateResult::Blocked {
+                        reason: BlockReason::Draft,
+                        failing_checks: vec![],
+                        detail: "PR is a draft — convert to ready before merging".to_string(),
+                    };
+                    Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                 } else if output_lower.contains("merge conflict")
                     || output_lower.contains("not mergeable")
                 {
-                    Ok(ToolOutput::error(
-                        "Merge conflicts — resolve before merging",
-                    ))
+                    let result = MergeGateResult::Blocked {
+                        reason: BlockReason::MergeConflict,
+                        failing_checks: vec![],
+                        detail: "PR has merge conflicts — rebase needed".to_string(),
+                    };
+                    Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                 } else if output_lower.contains("review") && output_lower.contains("required") {
-                    Ok(ToolOutput::error("Required reviews not met"))
+                    let result = MergeGateResult::Blocked {
+                        reason: BlockReason::MissingApproval,
+                        failing_checks: vec![],
+                        detail: "Required reviews not met".to_string(),
+                    };
+                    Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                 } else {
-                    Ok(ToolOutput::error(format!("Merge failed: {output}")))
+                    let result = MergeGateResult::GateError {
+                        kind: GateErrorKind::Unknown,
+                        detail: format!("Merge failed: {output}"),
+                    };
+                    Ok(ToolOutput::success(serde_json::to_string_pretty(&result)?))
                 }
             }
         }
@@ -223,21 +280,69 @@ impl Tool for PrMergeWithGateTool {
 // ---------------------------------------------------------------------------
 
 /// Structured result returned by the tool as JSON.
-#[derive(Debug, Serialize)]
+/// Tagged union — the LLM branches on the `action` field.
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(tag = "action")]
-enum MergeGateResult {
+pub(crate) enum MergeGateResult {
     #[serde(rename = "merged")]
     Merged,
     #[serde(rename = "auto_merge_enabled")]
     AutoMergeEnabled { pending_checks: Vec<CheckInfo> },
     #[serde(rename = "blocked")]
-    Blocked { failing_checks: Vec<CheckInfo> },
+    Blocked {
+        reason: BlockReason,
+        /// Retained for backward compatibility — existing prompts branch on this field.
+        failing_checks: Vec<CheckInfo>,
+        detail: String,
+    },
     #[serde(rename = "already_merged")]
     AlreadyMerged,
+    #[serde(rename = "gate_errored")]
+    GateError { kind: GateErrorKind, detail: String },
+}
+
+/// Why a PR is blocked from merging.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "reason")]
+pub(crate) enum BlockReason {
+    /// PR is CONFLICTING or mergeStateStatus is DIRTY.
+    #[serde(rename = "merge_conflict")]
+    MergeConflict,
+    /// One or more required CI checks failed.
+    #[serde(rename = "required_check_failed")]
+    RequiredCheckFailed { failing_checks: Vec<CheckInfo> },
+    /// Branch protection requires approval reviews.
+    #[serde(rename = "missing_approval")]
+    MissingApproval,
+    /// PR is closed (not merged).
+    #[serde(rename = "pr_closed")]
+    PrClosed,
+    /// PR is a draft.
+    #[serde(rename = "draft")]
+    Draft,
+}
+
+/// Why the gate tool itself failed (infrastructure, not PR state).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "kind")]
+#[allow(dead_code)] // Variants are part of the exhaustive error taxonomy; not all constructed yet.
+pub(crate) enum GateErrorKind {
+    /// gh CLI returned non-zero exit code.
+    #[serde(rename = "gh_cli_failure")]
+    GhCliFailure { exit_code: i32 },
+    /// Network-level failure.
+    #[serde(rename = "network_error")]
+    NetworkError,
+    /// Failed to parse gh output.
+    #[serde(rename = "parse_error")]
+    ParseError,
+    /// Unclassified failure.
+    #[serde(rename = "unknown")]
+    Unknown,
 }
 
 /// Check info included in the structured result.
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct CheckInfo {
     pub(crate) name: String,
     pub(crate) state: String,
@@ -264,6 +369,24 @@ pub(crate) enum CheckClassification {
     HasPending,
     /// At least one check has failed or been cancelled.
     HasFailures,
+}
+
+/// Preflight PR state from `gh pr view`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrPreflight {
+    pub(crate) mergeable: String,
+    pub(crate) merge_state_status: String,
+    #[serde(default)]
+    pub(crate) is_draft: bool,
+    pub(crate) state: String,
+}
+
+/// Error from `run_gh_pr_view` with optional exit code.
+#[derive(Debug)]
+pub(crate) struct PreflightError {
+    pub(crate) message: String,
+    pub(crate) exit_code: Option<i32>,
 }
 
 // ---------------------------------------------------------------------------
@@ -297,6 +420,53 @@ fn validate_merge_method(method: &str) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
+// Preflight classification (pure function — easily testable)
+// ---------------------------------------------------------------------------
+
+/// Classify preflight PR state into an immediate result, or None if checks
+/// should proceed (PR is open, not draft, not conflicting).
+pub(crate) fn classify_preflight(preflight: &PrPreflight) -> Option<MergeGateResult> {
+    let state_upper = preflight.state.to_uppercase();
+
+    // Already merged — primary detection path (before merge attempt)
+    if state_upper == "MERGED" {
+        return Some(MergeGateResult::AlreadyMerged);
+    }
+
+    // Closed without merge
+    if state_upper == "CLOSED" {
+        return Some(MergeGateResult::Blocked {
+            reason: BlockReason::PrClosed,
+            failing_checks: vec![],
+            detail: "PR is closed".to_string(),
+        });
+    }
+
+    // Draft PR
+    if preflight.is_draft {
+        return Some(MergeGateResult::Blocked {
+            reason: BlockReason::Draft,
+            failing_checks: vec![],
+            detail: "PR is a draft — convert to ready before merging".to_string(),
+        });
+    }
+
+    // Merge conflict detection — the #792 fix
+    let mergeable_upper = preflight.mergeable.to_uppercase();
+    let merge_state_upper = preflight.merge_state_status.to_uppercase();
+    if mergeable_upper == "CONFLICTING" || merge_state_upper == "DIRTY" {
+        return Some(MergeGateResult::Blocked {
+            reason: BlockReason::MergeConflict,
+            failing_checks: vec![],
+            detail: "PR has merge conflicts — rebase needed".to_string(),
+        });
+    }
+
+    // No immediate blocker — proceed to check classification
+    None
+}
+
+// ---------------------------------------------------------------------------
 // Check classification (pure function — easily testable)
 // ---------------------------------------------------------------------------
 
@@ -318,6 +488,38 @@ pub(crate) fn classify_checks(checks: &[GhCheck]) -> CheckClassification {
 // ---------------------------------------------------------------------------
 // Subprocess helpers
 // ---------------------------------------------------------------------------
+
+/// Run `gh pr view <number> --repo <repo> --json mergeable,mergeStateStatus,isDraft,state`
+/// and return the parsed preflight struct.
+pub(crate) async fn run_gh_pr_view(
+    pr_number: u64,
+    repo: &str,
+    token: &str,
+) -> Result<PrPreflight, PreflightError> {
+    let pr_str = pr_number.to_string();
+    let args = vec![
+        "pr",
+        "view",
+        &pr_str,
+        "--repo",
+        repo,
+        "--json",
+        "mergeable,mergeStateStatus,isDraft,state",
+    ];
+
+    let output = run_gh_subprocess(&args, token).await.map_err(|e| {
+        let exit_code = parse_exit_code_from_error(&e);
+        PreflightError {
+            message: e,
+            exit_code: Some(exit_code),
+        }
+    })?;
+
+    serde_json::from_str::<PrPreflight>(output.trim()).map_err(|e| PreflightError {
+        message: format!("Failed to parse gh pr view output: {e}"),
+        exit_code: None,
+    })
+}
 
 /// Run `gh pr checks <number> --repo <repo> --required --json name,state,bucket,link`
 /// and return the parsed check list.
@@ -453,6 +655,21 @@ pub(crate) async fn run_gh_subprocess(args: &[&str], token: &str) -> Result<Stri
 
         Err(err)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Try to extract an exit code integer from an error string like "gh exit code 1: ..."
+fn parse_exit_code_from_error(err: &str) -> i32 {
+    if let Some(rest) = err.strip_prefix("gh exit code ")
+        && let Some(code_str) = rest.split(':').next()
+        && let Ok(code) = code_str.trim().parse::<i32>()
+    {
+        return code;
+    }
+    -1
 }
 
 // ---------------------------------------------------------------------------
@@ -667,18 +884,116 @@ mod tests {
     }
 
     #[test]
-    fn serialize_blocked_result() {
+    fn serialize_blocked_result_required_check_failed() {
         let result = MergeGateResult::Blocked {
+            reason: BlockReason::RequiredCheckFailed {
+                failing_checks: vec![CheckInfo {
+                    name: "CI".to_string(),
+                    state: "FAILURE".to_string(),
+                    link: Some("https://example.com".to_string()),
+                }],
+            },
             failing_checks: vec![CheckInfo {
                 name: "CI".to_string(),
                 state: "FAILURE".to_string(),
                 link: Some("https://example.com".to_string()),
             }],
+            detail: "1 required check(s) failed".to_string(),
         };
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["action"], "blocked");
+        // Backward compat: top-level failing_checks
         assert_eq!(json["failing_checks"][0]["name"], "CI");
         assert_eq!(json["failing_checks"][0]["link"], "https://example.com");
+        // New: reason field with tagged union
+        assert_eq!(json["reason"]["reason"], "required_check_failed");
+        assert_eq!(json["reason"]["failing_checks"][0]["name"], "CI");
+        assert_eq!(json["detail"], "1 required check(s) failed");
+    }
+
+    #[test]
+    fn serialize_blocked_merge_conflict() {
+        let result = MergeGateResult::Blocked {
+            reason: BlockReason::MergeConflict,
+            failing_checks: vec![],
+            detail: "PR has merge conflicts — rebase needed".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "blocked");
+        assert_eq!(json["reason"]["reason"], "merge_conflict");
+        assert_eq!(json["failing_checks"].as_array().unwrap().len(), 0);
+        assert_eq!(json["detail"], "PR has merge conflicts — rebase needed");
+    }
+
+    #[test]
+    fn serialize_blocked_missing_approval() {
+        let result = MergeGateResult::Blocked {
+            reason: BlockReason::MissingApproval,
+            failing_checks: vec![],
+            detail: "Required reviews not met".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "blocked");
+        assert_eq!(json["reason"]["reason"], "missing_approval");
+    }
+
+    #[test]
+    fn serialize_blocked_draft() {
+        let result = MergeGateResult::Blocked {
+            reason: BlockReason::Draft,
+            failing_checks: vec![],
+            detail: "PR is a draft".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "blocked");
+        assert_eq!(json["reason"]["reason"], "draft");
+    }
+
+    #[test]
+    fn serialize_blocked_pr_closed() {
+        let result = MergeGateResult::Blocked {
+            reason: BlockReason::PrClosed,
+            failing_checks: vec![],
+            detail: "PR is closed".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "blocked");
+        assert_eq!(json["reason"]["reason"], "pr_closed");
+    }
+
+    #[test]
+    fn serialize_gate_error() {
+        let result = MergeGateResult::GateError {
+            kind: GateErrorKind::GhCliFailure { exit_code: 1 },
+            detail: "gh exit code 1: no checks reported".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "gate_errored");
+        assert_eq!(json["kind"]["kind"], "gh_cli_failure");
+        assert_eq!(json["kind"]["exit_code"], 1);
+        assert_eq!(json["detail"], "gh exit code 1: no checks reported");
+    }
+
+    #[test]
+    fn serialize_gate_error_network() {
+        let result = MergeGateResult::GateError {
+            kind: GateErrorKind::NetworkError,
+            detail: "Connection refused".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "gate_errored");
+        assert_eq!(json["kind"]["kind"], "network_error");
+    }
+
+    #[test]
+    fn serialize_gate_error_parse() {
+        let result = MergeGateResult::GateError {
+            kind: GateErrorKind::ParseError,
+            detail: "Invalid JSON from gh".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["action"], "gate_errored");
+        assert_eq!(json["kind"]["kind"], "parse_error");
     }
 
     #[test]
@@ -702,6 +1017,188 @@ mod tests {
         let result = MergeGateResult::AlreadyMerged;
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["action"], "already_merged");
+    }
+
+    // -- Preflight classification tests --
+
+    #[test]
+    fn preflight_conflicting_returns_merge_conflict() {
+        let preflight = PrPreflight {
+            mergeable: "CONFLICTING".to_string(),
+            merge_state_status: "DIRTY".to_string(),
+            is_draft: false,
+            state: "OPEN".to_string(),
+        };
+        let result = classify_preflight(&preflight);
+        assert_eq!(
+            result,
+            Some(MergeGateResult::Blocked {
+                reason: BlockReason::MergeConflict,
+                failing_checks: vec![],
+                detail: "PR has merge conflicts — rebase needed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn preflight_dirty_returns_merge_conflict() {
+        let preflight = PrPreflight {
+            mergeable: "UNKNOWN".to_string(),
+            merge_state_status: "DIRTY".to_string(),
+            is_draft: false,
+            state: "OPEN".to_string(),
+        };
+        let result = classify_preflight(&preflight);
+        assert_eq!(
+            result,
+            Some(MergeGateResult::Blocked {
+                reason: BlockReason::MergeConflict,
+                failing_checks: vec![],
+                detail: "PR has merge conflicts — rebase needed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn preflight_mergeable_open_passes_through() {
+        let preflight = PrPreflight {
+            mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
+            is_draft: false,
+            state: "OPEN".to_string(),
+        };
+        assert_eq!(classify_preflight(&preflight), None);
+    }
+
+    #[test]
+    fn preflight_closed_returns_pr_closed() {
+        let preflight = PrPreflight {
+            mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
+            is_draft: false,
+            state: "CLOSED".to_string(),
+        };
+        let result = classify_preflight(&preflight);
+        assert_eq!(
+            result,
+            Some(MergeGateResult::Blocked {
+                reason: BlockReason::PrClosed,
+                failing_checks: vec![],
+                detail: "PR is closed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn preflight_merged_returns_already_merged() {
+        let preflight = PrPreflight {
+            mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
+            is_draft: false,
+            state: "MERGED".to_string(),
+        };
+        assert_eq!(
+            classify_preflight(&preflight),
+            Some(MergeGateResult::AlreadyMerged)
+        );
+    }
+
+    #[test]
+    fn preflight_draft_returns_draft() {
+        let preflight = PrPreflight {
+            mergeable: "MERGEABLE".to_string(),
+            merge_state_status: "CLEAN".to_string(),
+            is_draft: true,
+            state: "OPEN".to_string(),
+        };
+        let result = classify_preflight(&preflight);
+        assert_eq!(
+            result,
+            Some(MergeGateResult::Blocked {
+                reason: BlockReason::Draft,
+                failing_checks: vec![],
+                detail: "PR is a draft — convert to ready before merging".to_string(),
+            })
+        );
+    }
+
+    /// #792 regression test (Unit 1, tool-layer):
+    /// Mock gh pr view returning CONFLICTING + DIRTY + empty statusCheckRollup.
+    /// Assert the tool returns Blocked { reason: MergeConflict } WITHOUT
+    /// attempting any gh pr merge call.
+    #[test]
+    fn regression_792_conflicting_pr_returns_blocked_merge_conflict() {
+        // This is the exact state from PR #792 that triggered the incident:
+        // mergeable: CONFLICTING, mergeStateStatus: DIRTY, statusCheckRollup: []
+        let preflight = PrPreflight {
+            mergeable: "CONFLICTING".to_string(),
+            merge_state_status: "DIRTY".to_string(),
+            is_draft: false,
+            state: "OPEN".to_string(),
+        };
+
+        let result = classify_preflight(&preflight);
+
+        // Must return Blocked { MergeConflict }, NOT an error string
+        match result {
+            Some(MergeGateResult::Blocked {
+                reason: BlockReason::MergeConflict,
+                ..
+            }) => {} // Expected
+            other => panic!(
+                "Expected Blocked {{ MergeConflict }}, got: {other:?}. \
+                 The tool must detect CONFLICTING state before attempting merge."
+            ),
+        }
+    }
+
+    // -- Backward compatibility test --
+
+    #[test]
+    fn backward_compat_blocked_has_action_and_failing_checks_at_top_level() {
+        // Ensure existing prompts that branch on action == "blocked"
+        // and read failing_checks at the top level still work.
+        let result = MergeGateResult::Blocked {
+            reason: BlockReason::RequiredCheckFailed {
+                failing_checks: vec![CheckInfo {
+                    name: "CI / test".to_string(),
+                    state: "FAILURE".to_string(),
+                    link: None,
+                }],
+            },
+            failing_checks: vec![CheckInfo {
+                name: "CI / test".to_string(),
+                state: "FAILURE".to_string(),
+                link: None,
+            }],
+            detail: "1 required check(s) failed".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+
+        // These are the fields existing prompts rely on:
+        assert_eq!(json["action"], "blocked");
+        assert!(json["failing_checks"].is_array());
+        assert_eq!(json["failing_checks"][0]["name"], "CI / test");
+    }
+
+    // -- parse_exit_code_from_error tests --
+
+    #[test]
+    fn parse_exit_code_success() {
+        assert_eq!(
+            parse_exit_code_from_error("gh exit code 1: no checks reported"),
+            1
+        );
+        assert_eq!(
+            parse_exit_code_from_error("gh exit code 128: not a git repository"),
+            128
+        );
+    }
+
+    #[test]
+    fn parse_exit_code_fallback() {
+        assert_eq!(parse_exit_code_from_error("some random error"), -1);
+        assert_eq!(parse_exit_code_from_error(""), -1);
     }
 
     // -- Tool integration tests --
@@ -797,6 +1294,7 @@ mod tests {
         assert_eq!(def.name, "pr_merge_with_gate");
         assert!(def.description.contains("CI gate"));
         assert!(def.description.contains("auto_merge_enabled"));
+        assert!(def.description.contains("gate_errored"));
 
         // Verify schema has required fields
         let props = &def.input_schema["properties"];

--- a/docs/plans/2026-05-15-001-feat-pr-merge-gate-tagged-union-plan.md
+++ b/docs/plans/2026-05-15-001-feat-pr-merge-gate-tagged-union-plan.md
@@ -5,6 +5,7 @@ module: agent-core
 tags: [tools, prompt-contract, webhook-qa, pr-merge-gate]
 branch: feat/794/agent-pr-merge-with-gate-tagged-union
 created: 2026-05-15
+prior_art: mika#524 (structural-verdict-handler pattern)
 ---
 
 # Plan: pr_merge_with_gate tagged-union return + webhook-qa gate_errored branch
@@ -16,26 +17,118 @@ prompt has no branch for these errors, so the LLM improvises — leading to Rule
 auto-merge armed on a CONFLICTING PR). Two units must ship together to close the prompt-vs-tool
 contract gap.
 
-## Current State (from code read)
+**Prior art:** This plan extends the structural verdict handler pattern established in mika#524
+(`docs/solutions/architecture-patterns/structural-verdict-handler-pr-review-auto-merge.md`) —
+typed tool output → exhaustive prompt branching → structural enforcement of safety invariants.
 
-**Tool** (`crates/mika-agent/src/tools/pr_merge_with_gate.rs`, 812 lines):
-- `MergeGateResult` enum: `Merged | AutoMergeEnabled | Blocked | AlreadyMerged`
-- Errors return `ToolOutput::error(message)` — unstructured strings
-- No preflight `mergeable` check; goes straight to `run_gh_checks()`
-- `run_gh_merge()` failure handling: pattern-matches stderr for "already been merged", "draft",
-  "merge conflict", "review required" — but these are string errors, not typed variants
-- `classify_checks()` pure function: `HasFailures | HasPending | AllPassed`
-- Serialized with `#[serde(tag = "action")]` — prompt branches on `action` field
+## Phase 0 Pin
 
-**Prompt** (`skills/bundled/self-dev-webhook-qa/system_prompt.md`, 190 lines):
-- Branches on `action`: `"merged"/"already_merged"`, `"auto_merge_enabled"`, `"blocked"`
-- Lines 53-56: fallback for errors (no `action` field) — notify Vincent, stay in_progress
-- But the fallback is just prose guidance; LLM can still improvise past it (as demonstrated)
+**Commit:** `8731102dff2e06ad5ff51f6efaa81728230052ac` (main at plan time)
 
-**Test infra** (`crates/mika-agent/src/test_utils.rs`):
-- `TestHarness` with `AsyncDatabase` + `ToolContext`
-- Existing tests: `classify_checks()` (7 cases), validation, serialization (4 cases)
-- No mock for `gh` subprocess; integration tests check tool definition + validation errors
+### Pin 1 — `MergeGateResult` enum (lines 226-237)
+
+```rust
+/// Structured result returned by the tool as JSON.
+#[derive(Debug, Serialize)]
+#[serde(tag = "action")]
+enum MergeGateResult {
+    #[serde(rename = "merged")]
+    Merged,
+    #[serde(rename = "auto_merge_enabled")]
+    AutoMergeEnabled { pending_checks: Vec<CheckInfo> },
+    #[serde(rename = "blocked")]
+    Blocked { failing_checks: Vec<CheckInfo> },
+    #[serde(rename = "already_merged")]
+    AlreadyMerged,
+}
+```
+
+### Pin 2 — `ToolOutput::error()` call sites being converted (lines 130-133, 180, 202-214)
+
+**Line 130-133 (checks fetch failure — the #792 trigger):**
+```rust
+Err(e) => {
+    return Ok(ToolOutput::error(format!(
+        "Failed to fetch check statuses: {e}"
+    )));
+}
+```
+
+**Lines 202-214 (merge-attempt stderr pattern matching):**
+```rust
+} else if output_lower.contains("draft") {
+    Ok(ToolOutput::error(
+        "PR is a draft — convert to ready before merging",
+    ))
+} else if output_lower.contains("merge conflict")
+    || output_lower.contains("not mergeable")
+{
+    Ok(ToolOutput::error(
+        "Merge conflicts — resolve before merging",
+    ))
+} else if output_lower.contains("review") && output_lower.contains("required") {
+    Ok(ToolOutput::error("Required reviews not met"))
+} else {
+    Ok(ToolOutput::error(format!("Merge failed: {output}")))
+}
+```
+
+**Line 180 (auto-merge failure):**
+```rust
+Err(e) => Ok(ToolOutput::error(format!("Auto-merge failed: {e}"))),
+```
+
+### Pin 3 — `run_gh_checks()` function signature (lines 324-334)
+
+```rust
+pub(crate) async fn run_gh_checks(
+    pr_number: u64,
+    repo: &str,
+    token: &str,
+) -> Result<Vec<GhCheck>, String> {
+    let pr_str = pr_number.to_string();
+    let args = vec![
+        "pr",
+        "checks",
+        &pr_str,
+        "--repo",
+```
+
+### Pin 4 — `execute()` flow (lines 125-134, the pre-classification path)
+
+```rust
+// -- Step 1: Fetch required check statuses --
+let checks_result = run_gh_checks(pr_number, repo, token).await;
+let checks = match checks_result {
+    Ok(c) => c,
+    Err(e) => {
+        return Ok(ToolOutput::error(format!(
+            "Failed to fetch check statuses: {e}"
+        )));
+    }
+};
+```
+
+### Pin 5 — Webhook-QA prompt merge-result branching (lines 32-56)
+
+**File:** `skills/bundled/self-dev-webhook-qa/system_prompt.md` (confirmed exists — mika#1106
+is CLOSED but the decomposition shipped through other means; the file is live on main)
+
+```markdown
+   1. Call `pr_merge_with_gate({"pr_number": <number>, "repo": "<owner/repo>"})` ...
+   2. Branch on the `action` field in the response:
+
+      **`"merged"` or `"already_merged"`** — PR is merged:
+      ...
+      **`"auto_merge_enabled"`** — CI checks pending, auto-merge activated:
+      ...
+      **`"blocked"`** — Required CI checks failing:
+      ...
+      **Error (no `action` field)** — Tool returned a plain string instead of a JSON object with `action`:
+      - Correlate to task (Step 4).
+      - Notify Vincent via `send_message`: "Merge failed for {repo}#{number}: {error message}. {PR URL}"
+      - Proceed to Step 5 with `in_progress` (do not block — Vincent may resolve manually).
+```
 
 ## Implementation Plan
 
@@ -43,76 +136,175 @@ contract gap.
 
 **File: `crates/mika-agent/src/tools/pr_merge_with_gate.rs`**
 
-#### Step 1: Add preflight GraphQL check + new types
+#### Step 1: Add preflight `gh pr view` call + new types
 
-Add a `run_gh_pr_view()` function that calls:
+Add `run_gh_pr_view()` function:
 ```
-gh pr view <n> --repo <repo> --json mergeable,mergeStateStatus,statusCheckRollup,isDraft,state
+gh pr view <n> --repo <repo> --json mergeable,mergeStateStatus,isDraft,state
 ```
-in a single round-trip. Parse into a `PrPreflight` struct.
+Parse into a `PrPreflight` struct. **Critically: this call does NOT include `statusCheckRollup`.**
+Per mika-arch NF1, the preflight handles state checks only (CONFLICTING, CLOSED, DRAFT). The
+check classification path stays on the existing `run_gh_checks()` with `--required` filtering.
+
+**Design decision (resolves open question 1):** Keep `run_gh_checks()` for the checks-classification
+path. `gh pr checks --required` has server-side filtering for required vs optional checks that
+`statusCheckRollup` does not replicate. The preflight detects "cannot merge regardless of checks";
+`run_gh_checks()` detects "checks haven't passed yet." Different questions, different tools.
 
 Add new enums:
 ```rust
-pub enum BlockReason {
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "reason")]
+pub(crate) enum BlockReason {
+    #[serde(rename = "merge_conflict")]
     MergeConflict,
-    RequiredCheckFailed { failing: Vec<CheckInfo> },
+    #[serde(rename = "required_check_failed")]
+    RequiredCheckFailed { failing_checks: Vec<CheckInfo> },
+    #[serde(rename = "missing_approval")]
     MissingApproval,
+    #[serde(rename = "pr_closed")]
     PrClosed,
+    #[serde(rename = "draft")]
     Draft,
 }
 
-pub enum GateErrorKind {
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind")]
+pub(crate) enum GateErrorKind {
+    #[serde(rename = "gh_cli_failure")]
     GhCliFailure { exit_code: i32 },
+    #[serde(rename = "network_error")]
     NetworkError,
-    AuthError,
+    #[serde(rename = "parse_error")]
     ParseError,
+    #[serde(rename = "unknown")]
     Unknown,
 }
 ```
 
-Extend `MergeGateResult` with two new variants:
+#### Step 2: Extend `MergeGateResult` — additive changes only (addresses F3)
+
+**F3 resolution — backward-compatible `Blocked` variant change:**
+
+The `Blocked` variant **retains** `failing_checks` and **gains** an additional `reason` field.
+This is truly additive — existing prompt branches on `action == "blocked"` with `failing_checks`
+still work unchanged.
+
 ```rust
-// Existing: Merged, AutoMergeEnabled, Blocked (rename to use BlockReason), AlreadyMerged
-// New:
-GateError { kind: GateErrorKind, detail: String },
+#[derive(Debug, Serialize)]
+#[serde(tag = "action")]
+enum MergeGateResult {
+    #[serde(rename = "merged")]
+    Merged,
+    #[serde(rename = "auto_merge_enabled")]
+    AutoMergeEnabled { pending_checks: Vec<CheckInfo> },
+    #[serde(rename = "blocked")]
+    Blocked {
+        reason: BlockReason,
+        failing_checks: Vec<CheckInfo>,  // RETAINED — backward compat
+        detail: String,
+    },
+    #[serde(rename = "already_merged")]
+    AlreadyMerged,
+    #[serde(rename = "gate_errored")]
+    GateError {
+        kind: GateErrorKind,
+        detail: String,
+    },
+}
 ```
 
-Refactor `Blocked` to carry `BlockReason` instead of just `failing_checks`:
-```rust
-Blocked { reason: BlockReason, pr_url: String, detail: String },
+**Exact serde output shapes for each variant:**
+
+`Merged`:
+```json
+{ "action": "merged" }
 ```
 
-**Serde tag:** Keep `#[serde(tag = "action")]` — new variants serialize as
-`"action": "gate_errored"` and the existing `"blocked"` gains a `"reason"` field.
+`AutoMergeEnabled` (unchanged):
+```json
+{ "action": "auto_merge_enabled", "pending_checks": [...] }
+```
 
-**Backward compatibility:** `"merged"`, `"auto_merge_enabled"`, `"already_merged"` unchanged.
-`"blocked"` gains `reason` field but existing prompt branches on `action == "blocked"` still match —
-the new `reason` field is additive.
+`AlreadyMerged` (unchanged):
+```json
+{ "action": "already_merged" }
+```
 
-#### Step 2: Rewrite execute() flow with preflight
+`Blocked` with `RequiredCheckFailed` (backward compatible — retains `failing_checks`):
+```json
+{
+  "action": "blocked",
+  "reason": { "reason": "required_check_failed", "failing_checks": [...] },
+  "failing_checks": [...],
+  "detail": "1 required check failed"
+}
+```
+Note: `failing_checks` appears at both top-level (backward compat) and inside `reason`
+(for structured branching). The top-level copy is the backward-compat surface; the `reason`
+copy is the forward surface.
+
+`Blocked` with `MergeConflict` (new):
+```json
+{
+  "action": "blocked",
+  "reason": { "reason": "merge_conflict" },
+  "failing_checks": [],
+  "detail": "PR has merge conflicts — rebase needed"
+}
+```
+Note: `failing_checks` is empty (no checks involved) but present for schema consistency.
+
+`Blocked` with `MissingApproval`:
+```json
+{
+  "action": "blocked",
+  "reason": { "reason": "missing_approval" },
+  "failing_checks": [],
+  "detail": "Required reviews not met"
+}
+```
+
+`GateError` (new):
+```json
+{
+  "action": "gate_errored",
+  "kind": { "kind": "gh_cli_failure", "exit_code": 1 },
+  "detail": "gh exit_code 1: ..."
+}
+```
+
+#### Step 3: Rewrite `execute()` flow with preflight
 
 New flow:
-1. Validate inputs (unchanged)
-2. **Preflight:** `run_gh_pr_view()` → `PrPreflight`
-   - `state == "CLOSED"` → `Blocked { reason: PrClosed }`
-   - `isDraft == true` → `Blocked { reason: Draft }`
-   - `mergeable == "CONFLICTING"` or `mergeStateStatus == "DIRTY"` → `Blocked { reason: MergeConflict }`
-3. **Check classification** (from preflight's `statusCheckRollup`, not separate `gh pr checks` call):
-   - `HasFailures` → `Blocked { reason: RequiredCheckFailed { failing } }`
+1. Validate inputs (unchanged — lines 82-112)
+2. Require GitHub token (unchanged — lines 114-123)
+3. **NEW: Preflight** `run_gh_pr_view()` → `PrPreflight`
+   - `state == "CLOSED"` → `Blocked { reason: PrClosed, failing_checks: vec![], detail }`
+   - `state == "MERGED"` → `AlreadyMerged` (preflight primary — per NF2)
+   - `isDraft == true` → `Blocked { reason: Draft, failing_checks: vec![], detail }`
+   - `mergeable == "CONFLICTING"` or `mergeStateStatus == "DIRTY"` →
+     `Blocked { reason: MergeConflict, failing_checks: vec![], detail }`
+   - Preflight `gh` failure → `GateError { kind: GhCliFailure, detail }`
+4. **Check classification** (existing `run_gh_checks()` with `--required` — kept per NF1):
+   - `HasFailures` → `Blocked { reason: RequiredCheckFailed { failing }, failing_checks: failing_copy, detail }`
    - `HasPending` → attempt auto-merge → `AutoMergeEnabled`
    - `AllPassed` → attempt merge → `Merged`
-4. **Merge attempt errors** → pattern-match into `GateError` or `Blocked` as appropriate
-5. **Any `gh` CLI failure** → `GateError { kind: GhCliFailure { exit_code }, detail }`
+   - Checks fetch failure → `GateError { kind: GhCliFailure, detail }` (was `ToolOutput::error`)
+5. **Merge attempt errors** → pattern-match into `GateError` (was `ToolOutput::error`):
+   - "already been merged" → `AlreadyMerged` (stderr fallback for races — per NF2)
+   - "draft" → `Blocked { reason: Draft }`
+   - "merge conflict" / "not mergeable" → `Blocked { reason: MergeConflict }`
+   - "review required" → `Blocked { reason: MissingApproval }`
+   - Other → `GateError { kind: Unknown, detail }`
+   - Auto-merge failure → `GateError { kind: GhCliFailure, detail }`
 
-Key change: the separate `run_gh_checks()` call is replaced by parsing `statusCheckRollup` from
-the preflight GraphQL response. This eliminates the "no checks reported" error that triggered #792.
+**AlreadyMerged detection (resolves open question 2):** Both preflight (`state == "MERGED"`)
+and stderr fallback ("already been merged") coexist. Preflight is primary (catches before
+merge attempt); stderr is race-condition fallback.
 
-#### Step 3: Refactor error paths
-
-Convert all existing `ToolOutput::error()` returns to the appropriate `MergeGateResult` variant.
-Input validation errors (bad pr_number, invalid repo) stay as `ToolOutput::error()` — these are
-caller bugs, not PR state. The distinction:
-- Caller bugs (bad input) → `ToolOutput::error()` (tool didn't run)
+**Error path refactor — kept distinctions:**
+- Caller bugs (bad input) → `ToolOutput::error()` (tool didn't run). Lines 87, 95, 98, 106, 118.
 - PR state issues → `MergeGateResult::Blocked` (tool ran, PR can't merge)
 - Infrastructure failures → `MergeGateResult::GateError` (tool tried, infra failed)
 
@@ -120,80 +312,121 @@ caller bugs, not PR state. The distinction:
 
 All tests in `pr_merge_with_gate.rs` (module `tests`):
 
-1. **Serialization tests for new variants:** `Blocked { MergeConflict }`, `Blocked { RequiredCheckFailed }`,
-   `Blocked { MissingApproval }`, `Blocked { Draft }`, `Blocked { PrClosed }`, `GateError` variants.
-   Assert `action` field, `reason` field, and typed sub-fields serialize correctly.
+1. **Serialization tests for new variants** (extend existing 4 tests at lines 660-705):
+   - `serialize_blocked_merge_conflict`: `Blocked { reason: MergeConflict }` → verify
+     `action == "blocked"`, `reason.reason == "merge_conflict"`, `failing_checks == []`
+   - `serialize_blocked_missing_approval`: verify `reason.reason == "missing_approval"`
+   - `serialize_blocked_draft`: verify `reason.reason == "draft"`
+   - `serialize_gate_error`: verify `action == "gate_errored"`, `kind.kind == "gh_cli_failure"`
+   - Update existing `serialize_blocked_result` to include `reason: RequiredCheckFailed`
 
-2. **#792 regression test (unit):** Mock `gh pr view` to return
-   `{ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY", statusCheckRollup: [] }`.
-   Assert: returns `Blocked { reason: MergeConflict }` — NOT an error string, NOT a `gh pr merge` attempt.
+2. **#792 regression test (unit):** Create a `PrPreflight` with
+   `{ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY", isDraft: false, state: "OPEN" }`.
+   Call the preflight classification function.
+   Assert: returns `Blocked { reason: MergeConflict }` — NOT an error string.
+   Assert: no `gh pr merge` subprocess spawned (test at the pure-function layer).
 
-3. **Preflight classification tests:** Various `PrPreflight` combinations → expected `MergeGateResult`.
-   - CONFLICTING + empty checks → MergeConflict (not "no checks")
-   - MERGEABLE + failing checks → RequiredCheckFailed
-   - MERGEABLE + pending checks → AllPassed not yet (flows to auto-merge path)
+3. **Preflight classification tests** (new pure function `classify_preflight`):
+   - CONFLICTING + OPEN → MergeConflict
+   - DIRTY + OPEN → MergeConflict
+   - MERGEABLE + OPEN → pass-through to checks
    - CLOSED → PrClosed
+   - MERGED → AlreadyMerged
    - Draft → Draft
 
-4. **GateError serialization:** Verify `action: "gate_errored"` with `kind` and `detail` fields.
+4. **Backward compatibility test:** Verify `serialize_blocked_result` (existing test, updated)
+   still has `action == "blocked"` and `failing_checks` array at top level.
 
 ### Unit 2 — Webhook-QA prompt update
 
-**File: `skills/bundled/self-dev-webhook-qa/system_prompt.md`**
+**File: `skills/bundled/self-dev-webhook-qa/system_prompt.md`** (confirmed live on main)
 
 #### Step 5: Add structured branches for new variants
 
-Update the `pr_merge_with_gate` response handling section (currently lines 32-58) to add:
+Update the `pr_merge_with_gate` response handling section (lines 32-56). Replace the existing
+`"blocked"` branch and `"Error"` branch with structured variants:
 
-**`blocked` with `reason` field branching:**
+```markdown
+      **`"blocked"`** — PR cannot merge. Branch on the `reason` field:
+
+        **`reason.reason = "required_check_failed"`** — Required CI checks failing:
+        - (existing CI-fix flow, unchanged) Check `ci_fix_count`, dispatch or escalate.
+        - `failing_checks` array contains check names for claude-pilot prompt.
+
+        **`reason.reason = "merge_conflict"`** — PR has merge conflicts:
+        - Notify Vincent: "{repo}#{number} has merge conflicts. Rebase needed."
+        - Do NOT call `run_gh pr merge`.
+        - Do NOT call `run_claude_pilot` (conflict resolution is conversation-mode territory).
+        - Task status: `in_progress`.
+
+        **`reason.reason = "missing_approval"`** — PR needs review approval:
+        - Notify Vincent: "{repo}#{number} needs approval review. {PR URL}"
+        - Task status: `in_progress`.
+
+        **`reason.reason = "draft"` or `reason.reason = "pr_closed"`** — Unexpected in webhook-qa:
+        - Notify Vincent with context. Escalate.
+
+        **Unrecognized `reason` value** — Future variant not yet handled:
+        - Notify Vincent: "Unrecognized block reason: {reason}. {PR URL}"
+        - Do NOT call `run_gh pr merge`.
+        - Task status: `in_progress`.
+
+      **`"gate_errored"`** — Tool infrastructure failure:
+        - Notify Vincent with `kind` and `detail` from response.
+        - Do NOT fall back to `run_gh pr merge` (explicit prohibition).
+        - Do NOT call `run_claude_pilot`.
+        - Task status: `in_progress`.
 ```
-action = "blocked", reason = "merge_conflict"
-  → notify Vincent: "PR #{number} has merge conflicts. Rebase needed: `gh pr checkout {n}; git rebase origin/main`"
-  → do NOT call run_gh pr merge
-  → do NOT call run_claude_pilot (conflict resolution is conversation-mode territory)
-  → task status: in_progress
 
-action = "blocked", reason = "required_check_failed"
-  → (existing CI-fix flow) check ci_fix_count, dispatch run_claude_pilot or escalate
-
-action = "blocked", reason = "missing_approval"
-  → notify Vincent: "PR #{number} needs approval review"
-  → task status: in_progress
-
-action = "blocked", reason = "draft" | "pr_closed"
-  → notify Vincent; escalate; unexpected in webhook-qa context
-```
-
-**`gate_errored` branch:**
-```
-action = "gate_errored"
-  → notify Vincent with kind + detail from response
-  → do NOT fall back to run_gh pr merge (explicit prohibition)
-  → task status: in_progress
-```
+**NF4 addressed:** The "Unrecognized `reason` value" catch-all branch prevents future
+improvisation when new `BlockReason` variants are added. Same principle as `gate_errored` —
+unknown states escalate rather than improvise.
 
 #### Step 6: Annotate Rule 6
 
-Update Rule 6 (line ~114) to note that structural enforcement is now via the typed response
-contract — Rule 6 in prose remains as documentation, runtime enforcement via policy table
-is a follow-up.
+Update Rule 6 (~line 153) to note structural enforcement:
+```
+Rule 6: ... (Structural enforcement: `pr_merge_with_gate` now returns typed variants.
+The `gate_errored` and `blocked` branches above are the exhaustive handling surface.
+Runtime enforcement via policy table — see follow-up ticket.)
+```
 
 #### Step 7: Tests for Unit 2
 
 **#792 regression test (prompt-layer, integration test):**
-Per ticket AC — stub `pr_merge_with_gate` to return `Blocked { reason: MergeConflict }`.
+Per ticket AC — mock at the **tool/prompt boundary** (stubbing `MergeGateResult` values
+directly), NOT at the `gh` CLI byte boundary. The contract being tested is "what
+`pr_merge_with_gate` returns to the prompt" — tool classification correctness is Unit 1's job.
+
+Stub `pr_merge_with_gate` to return:
+```json
+{
+  "action": "blocked",
+  "reason": { "reason": "merge_conflict" },
+  "failing_checks": [],
+  "detail": "PR has merge conflicts"
+}
+```
 Assert: (a) one `send_message` with conflict context, (b) zero `run_gh pr merge` calls,
 (c) task stays `in_progress`.
 
-Mock at the **tool/prompt boundary** (stubbing `MergeGateResult` variants directly), not at
-the `gh` CLI byte boundary. Document deviation if existing test infra uses CLI-byte stubs.
-
 **`gate_errored` integration test:**
-Stub tool to return `GateError { kind: GhCliFailure { exit_code: 1 }, detail: "..." }`.
+Stub tool to return:
+```json
+{
+  "action": "gate_errored",
+  "kind": { "kind": "gh_cli_failure", "exit_code": 1 },
+  "detail": "gh exit_code 1: no checks reported"
+}
+```
 Assert: `send_message` with kind+detail, zero `run_gh pr merge`, task stays `in_progress`.
 
 **Fixture:** Use fixture seeded from trace `a45e31bc-401d-11f1-8227-de6e000e1099` with
 provenance comment. Redaction check: only `@mika-platform-qa` (authorized identity).
+
+**Test infrastructure note:** If existing `EvalHarness` + `MockLlmProvider` infrastructure
+does not support tool-output stubbing, this is the right place to establish the boundary-level
+pattern. Document the deviation in the PR description per ticket AC.
 
 ## Commit Strategy
 
@@ -204,23 +437,21 @@ Single branch, two commits (ordered):
 ## Risk Assessment
 
 **Low risk:** The `action` tag approach is backward-compatible. Existing `"merged"`,
-`"auto_merge_enabled"`, `"already_merged"` are unchanged. `"blocked"` gains additive `reason` field.
+`"auto_merge_enabled"`, `"already_merged"` are unchanged. `"blocked"` retains `failing_checks`
+at top level (F3 resolution) — the new `reason` field is additive.
 
-**Medium risk:** Replacing `run_gh_checks()` with `statusCheckRollup` from GraphQL. Need to verify
-that `statusCheckRollup` includes the same check data as `gh pr checks --required`. The `--required`
-filter may not be available in the GraphQL response — may need to filter in code or use a different
-GraphQL field.
+**Low risk (reduced from medium):** `run_gh_checks()` with `--required` filtering is retained
+for the checks path (NF1 resolution). The preflight `gh pr view` only handles state checks
+(mergeable, isDraft, state). No replacement of the checks-classification path.
 
-**Mitigation:** Keep `run_gh_checks()` as fallback if `statusCheckRollup` doesn't provide required-check
-filtering. Preflight still catches CONFLICTING state before reaching the checks path.
+## Architect Findings Applied
 
-## Open Questions for Architect
-
-1. Should `statusCheckRollup` fully replace `run_gh_checks()`, or should the preflight only guard
-   the `mergeable` state while checks classification stays on the existing `gh pr checks --required` path?
-   The ticket says "single GraphQL call" but `gh pr checks --required` has filtering that GraphQL's
-   `statusCheckRollup` may not replicate exactly.
-
-2. The existing `AlreadyMerged` variant (detected by pattern-matching "already been merged" in stderr)
-   — should this move to preflight via `state == "MERGED"` check, or stay as a catch in the merge
-   error path for race conditions?
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| F1 — Phase 0 Pin absent | BLOCKING | Added Phase 0 Pin section with 5 pins at commit `8731102d` |
+| F2 — Prompt file target ambiguity | BLOCKING | Verified: mika#1106 CLOSED but decomposition shipped separately; `skills/bundled/self-dev-webhook-qa/system_prompt.md` confirmed live on main |
+| F3 — `Blocked` payload breaking change | BLOCKING | `Blocked` retains `failing_checks` at top level; `reason` is additive field. Exact serde shapes documented per variant |
+| NF1 — Keep `run_gh_checks()` | NON-BLOCKING | Applied: preflight for state, `run_gh_checks()` for checks classification |
+| NF2 — `AlreadyMerged` preflight + stderr | NON-BLOCKING | Applied: preflight primary (`state == "MERGED"`), stderr fallback for races |
+| NF4 — Unknown `BlockReason` catch-all | NON-BLOCKING | Applied: "Unrecognized reason" branch in prompt |
+| NF5 — Cite mika#524 compound doc | NON-BLOCKING | Applied: frontmatter `prior_art` + Context section reference |

--- a/docs/plans/2026-05-15-001-feat-pr-merge-gate-tagged-union-plan.md
+++ b/docs/plans/2026-05-15-001-feat-pr-merge-gate-tagged-union-plan.md
@@ -1,0 +1,226 @@
+---
+ticket: mika issue#794
+type: feat
+module: agent-core
+tags: [tools, prompt-contract, webhook-qa, pr-merge-gate]
+branch: feat/794/agent-pr-merge-with-gate-tagged-union
+created: 2026-05-15
+---
+
+# Plan: pr_merge_with_gate tagged-union return + webhook-qa gate_errored branch
+
+## Context
+
+`pr_merge_with_gate` returns unstructured string errors when preflight checks fail. The webhook-qa
+prompt has no branch for these errors, so the LLM improvises — leading to Rule 6 violations (mika#792:
+auto-merge armed on a CONFLICTING PR). Two units must ship together to close the prompt-vs-tool
+contract gap.
+
+## Current State (from code read)
+
+**Tool** (`crates/mika-agent/src/tools/pr_merge_with_gate.rs`, 812 lines):
+- `MergeGateResult` enum: `Merged | AutoMergeEnabled | Blocked | AlreadyMerged`
+- Errors return `ToolOutput::error(message)` — unstructured strings
+- No preflight `mergeable` check; goes straight to `run_gh_checks()`
+- `run_gh_merge()` failure handling: pattern-matches stderr for "already been merged", "draft",
+  "merge conflict", "review required" — but these are string errors, not typed variants
+- `classify_checks()` pure function: `HasFailures | HasPending | AllPassed`
+- Serialized with `#[serde(tag = "action")]` — prompt branches on `action` field
+
+**Prompt** (`skills/bundled/self-dev-webhook-qa/system_prompt.md`, 190 lines):
+- Branches on `action`: `"merged"/"already_merged"`, `"auto_merge_enabled"`, `"blocked"`
+- Lines 53-56: fallback for errors (no `action` field) — notify Vincent, stay in_progress
+- But the fallback is just prose guidance; LLM can still improvise past it (as demonstrated)
+
+**Test infra** (`crates/mika-agent/src/test_utils.rs`):
+- `TestHarness` with `AsyncDatabase` + `ToolContext`
+- Existing tests: `classify_checks()` (7 cases), validation, serialization (4 cases)
+- No mock for `gh` subprocess; integration tests check tool definition + validation errors
+
+## Implementation Plan
+
+### Unit 1 — Structured return type for `pr_merge_with_gate`
+
+**File: `crates/mika-agent/src/tools/pr_merge_with_gate.rs`**
+
+#### Step 1: Add preflight GraphQL check + new types
+
+Add a `run_gh_pr_view()` function that calls:
+```
+gh pr view <n> --repo <repo> --json mergeable,mergeStateStatus,statusCheckRollup,isDraft,state
+```
+in a single round-trip. Parse into a `PrPreflight` struct.
+
+Add new enums:
+```rust
+pub enum BlockReason {
+    MergeConflict,
+    RequiredCheckFailed { failing: Vec<CheckInfo> },
+    MissingApproval,
+    PrClosed,
+    Draft,
+}
+
+pub enum GateErrorKind {
+    GhCliFailure { exit_code: i32 },
+    NetworkError,
+    AuthError,
+    ParseError,
+    Unknown,
+}
+```
+
+Extend `MergeGateResult` with two new variants:
+```rust
+// Existing: Merged, AutoMergeEnabled, Blocked (rename to use BlockReason), AlreadyMerged
+// New:
+GateError { kind: GateErrorKind, detail: String },
+```
+
+Refactor `Blocked` to carry `BlockReason` instead of just `failing_checks`:
+```rust
+Blocked { reason: BlockReason, pr_url: String, detail: String },
+```
+
+**Serde tag:** Keep `#[serde(tag = "action")]` — new variants serialize as
+`"action": "gate_errored"` and the existing `"blocked"` gains a `"reason"` field.
+
+**Backward compatibility:** `"merged"`, `"auto_merge_enabled"`, `"already_merged"` unchanged.
+`"blocked"` gains `reason` field but existing prompt branches on `action == "blocked"` still match —
+the new `reason` field is additive.
+
+#### Step 2: Rewrite execute() flow with preflight
+
+New flow:
+1. Validate inputs (unchanged)
+2. **Preflight:** `run_gh_pr_view()` → `PrPreflight`
+   - `state == "CLOSED"` → `Blocked { reason: PrClosed }`
+   - `isDraft == true` → `Blocked { reason: Draft }`
+   - `mergeable == "CONFLICTING"` or `mergeStateStatus == "DIRTY"` → `Blocked { reason: MergeConflict }`
+3. **Check classification** (from preflight's `statusCheckRollup`, not separate `gh pr checks` call):
+   - `HasFailures` → `Blocked { reason: RequiredCheckFailed { failing } }`
+   - `HasPending` → attempt auto-merge → `AutoMergeEnabled`
+   - `AllPassed` → attempt merge → `Merged`
+4. **Merge attempt errors** → pattern-match into `GateError` or `Blocked` as appropriate
+5. **Any `gh` CLI failure** → `GateError { kind: GhCliFailure { exit_code }, detail }`
+
+Key change: the separate `run_gh_checks()` call is replaced by parsing `statusCheckRollup` from
+the preflight GraphQL response. This eliminates the "no checks reported" error that triggered #792.
+
+#### Step 3: Refactor error paths
+
+Convert all existing `ToolOutput::error()` returns to the appropriate `MergeGateResult` variant.
+Input validation errors (bad pr_number, invalid repo) stay as `ToolOutput::error()` — these are
+caller bugs, not PR state. The distinction:
+- Caller bugs (bad input) → `ToolOutput::error()` (tool didn't run)
+- PR state issues → `MergeGateResult::Blocked` (tool ran, PR can't merge)
+- Infrastructure failures → `MergeGateResult::GateError` (tool tried, infra failed)
+
+#### Step 4: Tests for Unit 1
+
+All tests in `pr_merge_with_gate.rs` (module `tests`):
+
+1. **Serialization tests for new variants:** `Blocked { MergeConflict }`, `Blocked { RequiredCheckFailed }`,
+   `Blocked { MissingApproval }`, `Blocked { Draft }`, `Blocked { PrClosed }`, `GateError` variants.
+   Assert `action` field, `reason` field, and typed sub-fields serialize correctly.
+
+2. **#792 regression test (unit):** Mock `gh pr view` to return
+   `{ mergeable: "CONFLICTING", mergeStateStatus: "DIRTY", statusCheckRollup: [] }`.
+   Assert: returns `Blocked { reason: MergeConflict }` — NOT an error string, NOT a `gh pr merge` attempt.
+
+3. **Preflight classification tests:** Various `PrPreflight` combinations → expected `MergeGateResult`.
+   - CONFLICTING + empty checks → MergeConflict (not "no checks")
+   - MERGEABLE + failing checks → RequiredCheckFailed
+   - MERGEABLE + pending checks → AllPassed not yet (flows to auto-merge path)
+   - CLOSED → PrClosed
+   - Draft → Draft
+
+4. **GateError serialization:** Verify `action: "gate_errored"` with `kind` and `detail` fields.
+
+### Unit 2 — Webhook-QA prompt update
+
+**File: `skills/bundled/self-dev-webhook-qa/system_prompt.md`**
+
+#### Step 5: Add structured branches for new variants
+
+Update the `pr_merge_with_gate` response handling section (currently lines 32-58) to add:
+
+**`blocked` with `reason` field branching:**
+```
+action = "blocked", reason = "merge_conflict"
+  → notify Vincent: "PR #{number} has merge conflicts. Rebase needed: `gh pr checkout {n}; git rebase origin/main`"
+  → do NOT call run_gh pr merge
+  → do NOT call run_claude_pilot (conflict resolution is conversation-mode territory)
+  → task status: in_progress
+
+action = "blocked", reason = "required_check_failed"
+  → (existing CI-fix flow) check ci_fix_count, dispatch run_claude_pilot or escalate
+
+action = "blocked", reason = "missing_approval"
+  → notify Vincent: "PR #{number} needs approval review"
+  → task status: in_progress
+
+action = "blocked", reason = "draft" | "pr_closed"
+  → notify Vincent; escalate; unexpected in webhook-qa context
+```
+
+**`gate_errored` branch:**
+```
+action = "gate_errored"
+  → notify Vincent with kind + detail from response
+  → do NOT fall back to run_gh pr merge (explicit prohibition)
+  → task status: in_progress
+```
+
+#### Step 6: Annotate Rule 6
+
+Update Rule 6 (line ~114) to note that structural enforcement is now via the typed response
+contract — Rule 6 in prose remains as documentation, runtime enforcement via policy table
+is a follow-up.
+
+#### Step 7: Tests for Unit 2
+
+**#792 regression test (prompt-layer, integration test):**
+Per ticket AC — stub `pr_merge_with_gate` to return `Blocked { reason: MergeConflict }`.
+Assert: (a) one `send_message` with conflict context, (b) zero `run_gh pr merge` calls,
+(c) task stays `in_progress`.
+
+Mock at the **tool/prompt boundary** (stubbing `MergeGateResult` variants directly), not at
+the `gh` CLI byte boundary. Document deviation if existing test infra uses CLI-byte stubs.
+
+**`gate_errored` integration test:**
+Stub tool to return `GateError { kind: GhCliFailure { exit_code: 1 }, detail: "..." }`.
+Assert: `send_message` with kind+detail, zero `run_gh pr merge`, task stays `in_progress`.
+
+**Fixture:** Use fixture seeded from trace `a45e31bc-401d-11f1-8227-de6e000e1099` with
+provenance comment. Redaction check: only `@mika-platform-qa` (authorized identity).
+
+## Commit Strategy
+
+Single branch, two commits (ordered):
+1. `feat(agent): pr_merge_with_gate tagged-union return with preflight check (#794)` — Unit 1
+2. `feat(agent): webhook-qa gate_errored and blocked[merge_conflict] branches (#794)` — Unit 2
+
+## Risk Assessment
+
+**Low risk:** The `action` tag approach is backward-compatible. Existing `"merged"`,
+`"auto_merge_enabled"`, `"already_merged"` are unchanged. `"blocked"` gains additive `reason` field.
+
+**Medium risk:** Replacing `run_gh_checks()` with `statusCheckRollup` from GraphQL. Need to verify
+that `statusCheckRollup` includes the same check data as `gh pr checks --required`. The `--required`
+filter may not be available in the GraphQL response — may need to filter in code or use a different
+GraphQL field.
+
+**Mitigation:** Keep `run_gh_checks()` as fallback if `statusCheckRollup` doesn't provide required-check
+filtering. Preflight still catches CONFLICTING state before reaching the checks path.
+
+## Open Questions for Architect
+
+1. Should `statusCheckRollup` fully replace `run_gh_checks()`, or should the preflight only guard
+   the `mergeable` state while checks classification stays on the existing `gh pr checks --required` path?
+   The ticket says "single GraphQL call" but `gh pr checks --required` has filtering that GraphQL's
+   `statusCheckRollup` may not replicate exactly.
+
+2. The existing `AlreadyMerged` variant (detected by pattern-matching "already been merged" in stderr)
+   — should this move to preflight via `state == "MERGED"` check, or stay as a catch in the merge
+   error path for race conditions?

--- a/docs/solutions/architecture-patterns/tagged-union-tool-return-prevents-llm-improvisation-2026-05-16.md
+++ b/docs/solutions/architecture-patterns/tagged-union-tool-return-prevents-llm-improvisation-2026-05-16.md
@@ -1,0 +1,111 @@
+---
+module: agent-core
+tags: [tools, prompt-contract, tagged-union, serde, pr-merge-gate, safety]
+problem_type: architecture_pattern
+category: architecture-patterns
+created: 2026-05-16
+ticket: mika#794
+prior_art: prompt-vs-tool-contract-mismatch-2026-04-24.md
+---
+
+# Tagged-Union Tool Return Prevents LLM Improvisation
+
+## Problem
+
+When a tool returns unstructured string errors, the LLM has no documented branch
+for the failure state and improvises a response. In production, this caused two
+Rule 6 violations (mika#485, mika#792) where the agent called `run_gh pr merge`
+as a "fallback" when `pr_merge_with_gate` returned an error string.
+
+The root cause is a **prompt-vs-tool contract mismatch**: the tool can return
+outcomes the prompt doesn't document, creating gaps where the LLM fills in with
+unsafe actions.
+
+## Solution
+
+Replace unstructured string returns with a **serde-tagged enum** (`#[serde(tag = "action")]`)
+where every outcome is a named variant the prompt can branch on exhaustively.
+
+### Pattern: Tagged-Union Tool Contract
+
+```rust
+#[derive(Serialize)]
+#[serde(tag = "action")]
+pub(crate) enum ToolResult {
+    #[serde(rename = "success")]
+    Success { ... },
+    #[serde(rename = "blocked")]
+    Blocked { reason: BlockReason, detail: String },
+    #[serde(rename = "errored")]
+    Error { kind: ErrorKind, detail: String },
+}
+```
+
+Key properties:
+1. **Every outcome has a name** — the prompt branches on `action` field
+2. **Sub-enums carry typed reasons** — `BlockReason`, `ErrorKind` use nested `#[serde(tag)]`
+3. **Backward compatibility via additive fields** — existing variants retain old fields
+4. **Errors return `ToolOutput::success()`** — the tool ran; the outcome is structured, not a crash
+
+### Pattern: Preflight Before Action
+
+Add a cheap read-only API call before the expensive mutating action to detect
+impossible states early:
+
+```rust
+// Step 1: Preflight — detect impossible states
+let preflight = run_gh_pr_view(pr, repo, token).await?;
+if let Some(result) = classify_preflight(&preflight) {
+    return Ok(ToolOutput::success(serialize(&result)?));
+}
+
+// Step 2: Proceed with action (only reached if preflight passed)
+```
+
+The preflight is a pure function (`classify_preflight`) — easily testable without
+subprocess mocking.
+
+### Pattern: Prompt Exhaustive Handling
+
+The prompt documents every variant with explicit prohibitions on fallback:
+
+```markdown
+**`"blocked"`** — Branch on `reason`:
+  **`merge_conflict`** — Do NOT call run_gh pr merge. Notify only.
+  **`required_check_failed`** — Dispatch fix. Use failing_checks array.
+  **Unrecognized `reason`** — Do NOT call run_gh pr merge. Notify only.
+
+**`"gate_errored"`** — Do NOT fall back to run_gh pr merge.
+```
+
+The "unrecognized reason" catch-all prevents future improvisation when new variants
+are added before the prompt is updated.
+
+## Key Decisions
+
+1. **Keep `run_gh_checks --required` for check classification** — preflight detects
+   state issues (CONFLICTING, CLOSED, DRAFT); `gh pr checks --required` has
+   server-side filtering that `statusCheckRollup` doesn't replicate. Different
+   questions, different tools.
+
+2. **`failing_checks` retained at top level** — backward compatibility for existing
+   prompts that read `action == "blocked"` + `failing_checks[]`. The new `reason`
+   field is additive.
+
+3. **Errors use `ToolOutput::success()`** — the distinction is: `ToolOutput::error()`
+   for caller bugs (bad input, missing token); structured `GateError` variant for
+   "tool ran, infra failed." The prompt branches on `action` in both cases.
+
+## Applicability
+
+Use this pattern when:
+- A tool can return multiple named outcomes
+- Failure modes should trigger different prompt branches (not a single "error" path)
+- The LLM might improvise unsafe actions when it encounters unstructured errors
+- Backward compatibility with existing prompt branches is required
+
+## Related
+
+- `docs/solutions/best-practices/prompt-vs-tool-contract-mismatch-2026-04-24.md` — the bug class this pattern fixes
+- `docs/solutions/architecture-patterns/structural-verdict-handler-pr-review-auto-merge.md` — same principle applied to verdict handling
+- mika#793 — follow-up to apply the same pattern to self-dev and self-dev-webhook-ci

--- a/skills/bundled/self-dev-webhook-qa/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-qa/system_prompt.md
@@ -67,6 +67,7 @@ The message contains the review body, PR URL, repo, and reviewer. mika-qa posts 
         **`reason.reason = "draft"` or `reason.reason = "pr_closed"`** — Unexpected in webhook-qa:
         - Correlate to task (Step 4).
         - Notify Vincent with context. Escalate.
+        - Proceed to Step 5 with `blocked`.
 
         **Unrecognized `reason` value** — Future variant not yet handled:
         - Correlate to task (Step 4).

--- a/skills/bundled/self-dev-webhook-qa/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-qa/system_prompt.md
@@ -43,16 +43,48 @@ The message contains the review body, PR URL, repo, and reviewer. mika-qa posts 
       - Notify Vincent via `send_message`: "{repo}#{number} passed QA. CI pending — auto-merge enabled. {PR URL}"
       - Proceed to Step 5 with `in_progress` and note "QA passed, auto-merge enabled, awaiting CI. PR: {url}".
 
-      **`"blocked"`** — Required CI checks failing:
-      - Correlate to task (Step 4).
-      - Check `ci_fix_count` in task metadata (default 0). If >= 2: escalate — notify Vincent "CI blocked after {n} fix attempts on QA-passed {repo}#{number}. Sprint paused. {PR URL}". Proceed to Step 5 with `blocked`.
-      - Otherwise: notify Vincent "{repo}#{number} passed QA but CI failing — attempting fix ({n}/2). {PR URL}"
-      - Set metadata `ci_fix_dispatched_from: "qa_pass_merge"` to prevent duplicate dispatch from a subsequent `block[ci]` verdict.
-      - Launch claude-pilot with a free-text prompt including the failing check names from the `pr_merge_with_gate` response (see Rule 5 — must use `run_claude_pilot`, not direct edits). Update `ci_fix_count` in metadata. Proceed to Step 5 with `in_progress`.
+      **`"blocked"`** — PR cannot merge. Branch on the `reason` field:
+
+        **`reason.reason = "required_check_failed"`** — Required CI checks failing:
+        - Correlate to task (Step 4).
+        - Check `ci_fix_count` in task metadata (default 0). If >= 2: escalate — notify Vincent "CI blocked after {n} fix attempts on QA-passed {repo}#{number}. Sprint paused. {PR URL}". Proceed to Step 5 with `blocked`.
+        - Otherwise: notify Vincent "{repo}#{number} passed QA but CI failing — attempting fix ({n}/2). {PR URL}"
+        - Set metadata `ci_fix_dispatched_from: "qa_pass_merge"` to prevent duplicate dispatch from a subsequent `block[ci]` verdict.
+        - Launch claude-pilot with a free-text prompt including the failing check names from the `failing_checks` array (see Rule 5 — must use `run_claude_pilot`, not direct edits). Update `ci_fix_count` in metadata. Proceed to Step 5 with `in_progress`.
+
+        **`reason.reason = "merge_conflict"`** — PR has merge conflicts:
+        - Correlate to task (Step 4).
+        - Notify Vincent via `send_message`: "{repo}#{number} has merge conflicts. Rebase needed. {PR URL}"
+        - Do NOT call `run_gh pr merge`.
+        - Do NOT call `run_claude_pilot` (conflict resolution is conversation-mode territory).
+        - Task status: `in_progress`.
+
+        **`reason.reason = "missing_approval"`** — PR needs review approval:
+        - Correlate to task (Step 4).
+        - Notify Vincent via `send_message`: "{repo}#{number} needs approval review. {PR URL}"
+        - Task status: `in_progress`.
+
+        **`reason.reason = "draft"` or `reason.reason = "pr_closed"`** — Unexpected in webhook-qa:
+        - Correlate to task (Step 4).
+        - Notify Vincent with context. Escalate.
+
+        **Unrecognized `reason` value** — Future variant not yet handled:
+        - Correlate to task (Step 4).
+        - Notify Vincent via `send_message`: "Unrecognized block reason: {reason}. {PR URL}"
+        - Do NOT call `run_gh pr merge`.
+        - Task status: `in_progress`.
+
+      **`"gate_errored"`** — Tool infrastructure failure:
+        - Correlate to task (Step 4).
+        - Notify Vincent with `kind` and `detail` from response: "Merge gate error for {repo}#{number}: {kind.kind} — {detail}. {PR URL}"
+        - Do NOT fall back to `run_gh pr merge` (explicit prohibition).
+        - Do NOT call `run_claude_pilot`.
+        - Task status: `in_progress`.
 
       **Error (no `action` field)** — Tool returned a plain string instead of a JSON object with `action`:
       - Correlate to task (Step 4).
       - Notify Vincent via `send_message`: "Merge failed for {repo}#{number}: {error message}. {PR URL}"
+      - Do NOT fall back to `run_gh pr merge`.
       - Proceed to Step 5 with `in_progress` (do not block — Vincent may resolve manually).
 
    Build and deploy (`build_mika`, `deploy_mika`) are exec-handler skills NOT available in webhook sessions. For mika repo PRs, build/deploy runs via `make deploy` after merge.
@@ -168,7 +200,9 @@ If you find yourself tempted to "quickly fix" a CI failure via `write_agent_file
 
 Never call `run_gh("pr merge ...")` or `run_gh("gh pr merge ...")` to merge a PR. Always use `pr_merge_with_gate` with `pr_number` (integer) and `repo` (owner/repo string). The tool checks required CI statuses and returns a structured `action` — act on it.
 
-**Incident:** mika#485 on 2026-04-08 — PR merged with required CI check in FAILURE state because agent used `run_gh pr merge` which has no CI gate.
+**Structural enforcement:** `pr_merge_with_gate` now returns typed variants (`merged`, `auto_merge_enabled`, `blocked`, `already_merged`, `gate_errored`). The `gate_errored` and `blocked` branches above are the exhaustive handling surface. On ANY error or blocked state, do NOT fall back to `run_gh pr merge`. Runtime enforcement via policy table — see follow-up ticket.
+
+**Incident:** mika#485 on 2026-04-08 — PR merged with required CI check in FAILURE state because agent used `run_gh pr merge` which has no CI gate. mika#792 on 2026-04-24 — agent improvised `run_gh pr merge --auto` when gate returned an unstructured error on a CONFLICTING PR.
 
 ### Rule 7 — `run_gh` input schema discipline
 


### PR DESCRIPTION
## Summary

- Replace `pr_merge_with_gate` unstructured string errors with a serde-tagged enum (`MergeGateResult`) — five variants: `merged`, `auto_merge_enabled`, `blocked`, `already_merged`, `gate_errored`
- Add `gh pr view` preflight detecting CONFLICTING/CLOSED/DRAFT states before any merge attempt (the #792 fix)
- Extend `Blocked` variant with `BlockReason` sub-enum (merge_conflict, required_check_failed, missing_approval, pr_closed, draft) while retaining `failing_checks` at top level for backward compatibility
- Update webhook-qa prompt to exhaustively handle all variants with explicit "do NOT fall back to `run_gh pr merge`" prohibitions

## Motivation

On 2026-04-24, `pr_merge_with_gate` returned an unstructured error on a CONFLICTING PR. The webhook-qa prompt had no branch for this case, so the LLM improvised `run_gh pr merge --auto` — arming auto-merge on a PR that can never merge (mika#792). This is the second Rule 6 violation in ~16 days (prior: mika#485).

Root cause: prompt-vs-tool contract mismatch. The tool could return outcomes the prompt didn't document.

## Changes

**Unit 1 — Tool (Rust):** `crates/mika-agent/src/tools/pr_merge_with_gate.rs`
- `MergeGateResult` extended with `GateError` variant and `BlockReason` sub-enum
- `classify_preflight()` pure function detects CONFLICTING/DIRTY/CLOSED/DRAFT before merge
- All former `ToolOutput::error()` paths for infra issues now return `ToolOutput::success()` with structured `GateError`
- 42 unit tests including #792 regression test

**Unit 2 — Prompt:** `skills/bundled/self-dev-webhook-qa/system_prompt.md`
- `blocked` branch now sub-branches on `reason.reason`
- New `gate_errored` branch with explicit no-fallback prohibition
- Unrecognized reason catch-all for future variants
- Rule 6 annotated with structural enforcement note

Plan: docs/plans/2026-05-15-001-feat-pr-merge-gate-tagged-union-plan.md

## Test plan

- [x] All 42 `pr_merge_with_gate` unit tests pass (preflight classification, serialization for all variants, backward compat, #792 regression)
- [x] `cargo check` clean (no warnings)
- [x] `cargo clippy` clean
- [x] Pre-commit hooks pass (fmt + clippy + secrets scan)

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)