### PR TITLE
fix(tui): supervise agent-worker tokio::spawn (mika#1149)

### DIFF
--- a/crates/mika-agent/docs/slash-commands.md
+++ b/crates/mika-agent/docs/slash-commands.md
@@ -12,7 +12,7 @@ Slash commands are client-side actions executed directly in the Mika TUI. They a
 database and renders output in-place, while typing a regular message (no `/` prefix)
 sends it to the Claude-backed agent loop as usual.
 
-All 23 commands are defined in a single `COMMANDS` array
+All 24 commands are defined in a single `COMMANDS` array
 (`crates/mika-cli/src/tui/commands/mod.rs`), dispatched through pattern matching in
 `handlers.rs`, and surfaced via an autocomplete popup driven by `autocomplete.rs`.
 
@@ -546,6 +546,33 @@ The rewind engine automatically reverses memory mutations (core memory edits, fa
 Cross-session rewinds are supported -- if the target messages are in a different session than the current one, the marker notes the originating session.
 
 Errors: `Cannot rewind while agent is busy.` or `No messages to rewind.`
+
+---
+
+### /restart
+
+Recover from an agent-worker crash. The TUI runs the agent loop in a supervised
+`tokio::spawn` task; if that worker panics or exits prematurely, a banner appears
+("Agent worker crashed: <reason>. Use /restart to recover."). `/restart` tears the
+dead worker down and spawns a fresh one for the same agent (mika#1149).
+
+**Aliases:** None | **Arguments:** None
+
+**On a healthy worker** -- refuses:
+```
+/restart only applies after the worker has crashed. Use /clear to start a new session on a healthy worker.
+```
+
+**After a crash** -- arms the restart and the chat loop spawns a replacement on
+its next iteration:
+```
+Restarting agent worker… (the lost prompt is not replayed — please re-send it after the worker comes back up.)
+```
+
+The lost in-flight prompt is **not** replayed; the operator must re-type. Background
+callback tasks survive the restart and continue delivering to the new worker.
+The `agent_worker_silenced` structured `error!` event is emitted to the per-agent
+log on every crash for post-incident triage.
 
 ---
 

--- a/crates/mika-cli/CLAUDE.md
+++ b/crates/mika-cli/CLAUDE.md
@@ -2,6 +2,10 @@
 
 TUI CLI binary (`mika`): ratatui chat interface with clap subcommands.
 
+## Crate layout
+
+`src/main.rs` is the binary entry point and owns the full module tree under it (`init`, `commands`, `tui`, `wizard`). `src/lib.rs` is a minimal library surface (currently re-exporting `supervision` only) for types and primitives that need to be reachable from integration tests under `crates/mika-cli/tests/`. The binary tree and the library tree are independent — the binary accesses lib re-exports as `mika_cli::*`. Keep `lib.rs` minimal; do not bloat it to make arbitrary binary modules reachable from tests (most logic stays binary-private and is tested via inline `#[cfg(test)] mod tests`).
+
 ## Subcommands
 
 `status`, `memory`, `reminders`, `config`, `setup`, `mcp`, `skills`, `tasks`, `ask`, `doctor`, `dashboard`, `token`, `credential-helper`, `provider`, `model`, `agents`, `teams`, `webhook`, `kg`, `logs`.
@@ -38,8 +42,9 @@ Scoped flags: `--agent <name>` (override active agent, most subcommands), `--tea
 
 ## TUI Features
 
-- **Slash commands:** `/clear`, `/model`, `/provider`, `/think`, `/agent`, `/undo`, `/rewind`, `/inbox`
+- **Slash commands:** `/clear`, `/model`, `/provider`, `/think`, `/agent`, `/undo`, `/rewind`, `/inbox`, `/restart`
 - `/clear` ends the current session, creates a new one, notifies the agent worker, drains stale responses from `agent_rx`, and resets all transient state; user preferences (`thinking_level`, model, provider) are preserved; `active_background_task_count` is intentionally NOT reset (agent-scoped, not session-scoped)
+- `/restart` tears down a crashed agent-worker tokio task and spawns a fresh worker for the same agent (mika#1149). Refuses on a healthy worker — `/clear` is the right tool for starting a new session. The lost in-flight prompt is NOT replayed; the operator must re-type. Background callback tasks survive the restart and continue delivering to the new worker
 - `/provider` and `/model` pre-validate via `Settings::make_llm_provider()` before updating the UI. `/provider` switch persists default `{provider}_model` when none exists, warns about stale fields and max_tokens limits, and spawns a background `get_models()` to pre-warm the model list cache. `/model` lists available models from cache/API, supports aliases and direct `provider/model` format with cross-provider switching
 - **Footer badges:** `[N tasks]` (Cyan) for pending reminders, `[N running]` (Yellow) for active background callback tasks (polled every ~5s), `[N hidden]` (DarkGray) for suppressed internal messages in inbox mode, and dashboard status indicator with clickable `[start]`/`[stop]` and `[open]` buttons
 - **Inbox mode:** Default on — hides internal (agent-to-agent) messages from the chat view. `/inbox` toggles between inbox mode (filtered) and audit mode (all messages visible). Reloads message history from DB on toggle. `hidden_internal_count` tracks new internal messages arriving during the session

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -714,7 +714,16 @@ pub async fn run(
                 &mut worker.supervisor_handle,
                 tokio::spawn(async {}), // placeholder
             );
-            let _ = tokio::time::timeout(Duration::from_secs(2), old_supervisor).await;
+            if tokio::time::timeout(Duration::from_secs(2), old_supervisor)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    target_agent = %target_name,
+                    "old agent worker did not shut down within 2s during agent switch; \
+                     supervisor task abandoned"
+                );
+            }
 
             // Initialize the new agent
             match init::init_for_agent(&target_name) {
@@ -797,7 +806,15 @@ pub async fn run(
                 &mut worker.supervisor_handle,
                 tokio::spawn(async {}), // placeholder
             );
-            let _ = tokio::time::timeout(Duration::from_secs(2), old_supervisor).await;
+            if tokio::time::timeout(Duration::from_secs(2), old_supervisor)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    "old agent worker did not shut down within 2s during /restart; \
+                     supervisor task abandoned"
+                );
+            }
 
             match init::init_for_agent(agent_name) {
                 Ok(new_ctx) => {
@@ -882,10 +899,14 @@ pub async fn run(
     worker.poller_handle.abort();
 
     // Wait for the supervisor (which owns the worker JoinHandle). It exits
-    // silently because shutdown_initiated was set above; we just need to
-    // join it within a bounded window.
-    worker.shutdown_initiated.store(true, Ordering::Release);
-    let _ = tokio::time::timeout(Duration::from_secs(2), worker.supervisor_handle).await;
+    // silently because shutdown_initiated was set in the Quit branch above
+    // (before agent_tx.send(Quit), which is the load-bearing ordering).
+    if tokio::time::timeout(Duration::from_secs(2), worker.supervisor_handle)
+        .await
+        .is_err()
+    {
+        tracing::warn!("agent worker supervisor did not shut down within 2s; abandoning task");
+    }
 
     // Database shutdown happens automatically via Drop on worker._ctx
     Ok(())

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -35,10 +35,17 @@ use mika_common::llm::LlmImage;
 use mika_common::team;
 use std::path::Path;
 
-/// Holds the agent worker task handle, poller handle, and the AppContext (for DB shutdown).
+/// Holds the agent worker supervisor handle, poller handle, the AppContext (for DB shutdown),
+/// and the shutdown-initiated flag the supervisor reads to distinguish operator-driven
+/// shutdown from worker death (mika#1149).
 struct AgentWorker {
-    handle: JoinHandle<()>,
+    /// Supervisor task — owns the worker's JoinHandle and forwards unexpected exits
+    /// as `AgentResponse::WorkerCrashed` events.
+    supervisor_handle: JoinHandle<()>,
     poller_handle: JoinHandle<()>,
+    /// Set to `true` before tearing down the worker (Quit, agent switch, /restart)
+    /// so the supervisor exits silently on the resulting `Ok(())` from the worker loop.
+    shutdown_initiated: Arc<AtomicBool>,
     _ctx: AppContext,
 }
 
@@ -205,6 +212,9 @@ async fn spawn_agent_worker(
 
     let (user_tx, mut user_rx) = mpsc::unbounded_channel::<AgentRequest>();
     let (agent_tx, agent_rx) = mpsc::unbounded_channel::<AgentResponse>();
+    // Cloned for the supervisor task so a worker crash can surface to the TUI
+    // after the worker's own `agent_tx` has been dropped (mika#1149).
+    let supervisor_agent_tx = agent_tx.clone();
 
     let worker_db = ctx.async_db.clone();
     let mut worker_llm = ctx.llm.clone();
@@ -318,14 +328,14 @@ async fn spawn_agent_worker(
                     };
 
                     let response = match result {
-                        Ok(output) => AgentResponse {
+                        Ok(output) => AgentResponse::Reply {
                             content: output.text.unwrap_or_default(),
                             is_error: false,
                             thinking: output.thinking,
                             input_tokens: output.usage.as_ref().map(|u| u.input_tokens as u32),
                             updated_skills,
                         },
-                        Err(e) => AgentResponse {
+                        Err(e) => AgentResponse::Reply {
                             content: format!("{e}"),
                             is_error: true,
                             thinking: None,
@@ -405,7 +415,7 @@ async fn spawn_agent_worker(
                     .await;
 
                     let response = match callback_result {
-                        Ok(output) => AgentResponse {
+                        Ok(output) => AgentResponse::Reply {
                             content: output.text.unwrap_or_default(),
                             is_error: false,
                             thinking: output.thinking,
@@ -426,7 +436,7 @@ async fn spawn_agent_worker(
                                     "failed to unclaim callback task after agent error"
                                 );
                             }
-                            AgentResponse {
+                            AgentResponse::Reply {
                                 content: format!("Failed to process callback result: {e}"),
                                 is_error: true,
                                 thinking: None,
@@ -477,9 +487,36 @@ async fn spawn_agent_worker(
     let model = ctx.settings.active_model_display();
     let identity_name = identity.name.clone();
 
+    // Supervise the worker task (mika#1149). The supervisor awaits `handle` and
+    // forwards `JoinError` (panic) or premature `Ok(())` (user_rx closed while the
+    // session is still active) as `AgentResponse::WorkerCrashed`. The chat loop sets
+    // `shutdown_initiated = true` before tearing the worker down so expected exits
+    // (Quit, agent switch, /restart) are silenced.
+    let shutdown_initiated = Arc::new(AtomicBool::new(false));
+    let supervisor_shutdown = shutdown_initiated.clone();
+    let supervisor_agent_id = ctx.async_db.agent_id().to_string();
+    let supervisor_session_id = session_id.clone();
+    let supervisor_handle = tokio::spawn(async move {
+        mika_cli::supervision::supervise(handle, supervisor_shutdown, move |failure| {
+            tracing::error!(
+                target: "mika::otel",
+                event = "agent_worker_silenced",
+                agent_id = %supervisor_agent_id,
+                session_id = %supervisor_session_id,
+                reason = %failure.reason,
+                "TUI agent worker entered failure state; pending prompt dropped"
+            );
+            let _ = supervisor_agent_tx.send(AgentResponse::WorkerCrashed {
+                reason: failure.reason,
+            });
+        })
+        .await;
+    });
+
     let worker = AgentWorker {
-        handle,
+        supervisor_handle,
         poller_handle,
+        shutdown_initiated,
         _ctx: ctx,
     };
 
@@ -665,13 +702,19 @@ pub async fn run(
                 tracing::warn!(error = %e, "failed to end session on agent switch");
             }
 
-            // Abort the old poller and wait for the worker to stop (with timeout)
+            // Silence the supervisor before tearing down the old worker — dropping
+            // app.agent_tx + sending Quit would otherwise resolve as
+            // `Ok(())` and trip the WorkerCrashed path (mika#1149).
+            worker.shutdown_initiated.store(true, Ordering::Release);
+
+            // Abort the old poller and wait for the supervisor (and its worker) to
+            // stop, with a timeout in case the worker is mid-LLM-call.
             worker.poller_handle.abort();
-            let old_handle = std::mem::replace(
-                &mut worker.handle,
+            let old_supervisor = std::mem::replace(
+                &mut worker.supervisor_handle,
                 tokio::spawn(async {}), // placeholder
             );
-            let _ = tokio::time::timeout(Duration::from_secs(2), old_handle).await;
+            let _ = tokio::time::timeout(Duration::from_secs(2), old_supervisor).await;
 
             // Initialize the new agent
             match init::init_for_agent(&target_name) {
@@ -736,7 +779,89 @@ pub async fn run(
             app.needs_redraw = true;
         }
 
+        // Handle /restart: tear down the crashed worker + supervisor and spin up a
+        // fresh pair for the same agent (mika#1149 §S1.2). Reuses the agent-switch
+        // shape but skips re-init for a different agent.
+        if app.pending_restart {
+            app.pending_restart = false;
+
+            // End the old session before restarting so the dashboard shows it as
+            // completed rather than ongoing.
+            if let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await {
+                tracing::warn!(error = %e, "failed to end session on /restart");
+            }
+
+            worker.shutdown_initiated.store(true, Ordering::Release);
+            worker.poller_handle.abort();
+            let old_supervisor = std::mem::replace(
+                &mut worker.supervisor_handle,
+                tokio::spawn(async {}), // placeholder
+            );
+            let _ = tokio::time::timeout(Duration::from_secs(2), old_supervisor).await;
+
+            match init::init_for_agent(agent_name) {
+                Ok(new_ctx) => {
+                    match spawn_agent_worker(new_ctx, agent_name, &http_client, None).await {
+                        Ok((
+                            new_worker,
+                            new_tx,
+                            new_rx,
+                            new_session,
+                            new_model,
+                            _new_identity,
+                            new_skills,
+                        )) => {
+                            app.agent_tx = new_tx;
+                            app.agent_rx = new_rx;
+                            app.session_id = new_session;
+                            app.model = new_model;
+                            app.db = new_worker._ctx.async_db.clone();
+                            app.llm = new_worker._ctx.llm.clone();
+                            app.skills = new_skills;
+                            app.worker_crashed = false;
+
+                            worker = new_worker;
+
+                            app.load_thinking_level().await;
+
+                            app.messages.push(ChatMessage {
+                                role: ChatRole::System,
+                                content:
+                                    "Agent worker restarted. In-flight callback caches were lost; pending background tasks will still deliver."
+                                        .to_string(),
+                                rendered: None,
+                                channel: None,
+                            });
+                        }
+                        Err(e) => {
+                            // Worker stays absent; the WorkerCrashed banner remains.
+                            app.messages.push(ChatMessage {
+                                role: ChatRole::System,
+                                content: format!("Failed to restart agent worker: {e}"),
+                                rendered: None,
+                                channel: None,
+                            });
+                        }
+                    }
+                }
+                Err(e) => {
+                    app.messages.push(ChatMessage {
+                        role: ChatRole::System,
+                        content: format!("Failed to restart agent worker: {e}"),
+                        rendered: None,
+                        channel: None,
+                    });
+                }
+            }
+
+            app.scroll_offset = 0;
+            app.needs_redraw = true;
+        }
+
         if app.should_quit {
+            // Mark shutdown so the supervisor stays silent when the worker's
+            // while-let loop exits via the Quit branch (mika#1149).
+            worker.shutdown_initiated.store(true, Ordering::Release);
             let _ = app.agent_tx.send(AgentRequest::Quit);
             break;
         }
@@ -756,14 +881,11 @@ pub async fn run(
     // Stop the reminder poller
     worker.poller_handle.abort();
 
-    // Check agent worker for panics
-    if worker.handle.is_finished() {
-        if let Err(e) = worker.handle.await {
-            eprintln!("Agent worker error: {e}");
-        }
-    } else {
-        worker.handle.abort();
-    }
+    // Wait for the supervisor (which owns the worker JoinHandle). It exits
+    // silently because shutdown_initiated was set above; we just need to
+    // join it within a bounded window.
+    worker.shutdown_initiated.store(true, Ordering::Release);
+    let _ = tokio::time::timeout(Duration::from_secs(2), worker.supervisor_handle).await;
 
     // Database shutdown happens automatically via Drop on worker._ctx
     Ok(())

--- a/crates/mika-cli/src/lib.rs
+++ b/crates/mika-cli/src/lib.rs
@@ -1,0 +1,7 @@
+//! Library surface for `mika-cli`.
+//!
+//! The binary tree (rooted at `main.rs`) is independent of this lib. This file
+//! exposes only the pieces that need to be reachable from integration tests
+//! under `tests/`. Keep it minimal — most code stays binary-private.
+
+pub mod supervision;

--- a/crates/mika-cli/src/supervision.rs
+++ b/crates/mika-cli/src/supervision.rs
@@ -1,0 +1,166 @@
+//! Supervisor for the TUI agent-worker `tokio::spawn`.
+//!
+//! The TUI runs the agent loop locally in a worker task. Without supervision,
+//! a panic inside that task silently kills the receiver: subsequent UI sends
+//! succeed (mpsc::SendError only fires when the receiver is *dropped*, not when
+//! the task owning it panics mid-iteration) and the user sees no feedback.
+//! See mika#1149 for the full bug class and forensic context.
+//!
+//! [`supervise`] awaits the worker's [`JoinHandle`] and reports any unexpected
+//! exit — panic *or* premature clean exit — to the caller via a closure.
+//! The caller decides how to surface the failure (e.g., send an
+//! `AgentResponse::WorkerCrashed { reason }` variant up the agent channel).
+//!
+//! Two failure modes are reported:
+//! - [`JoinError`] from a panic — `is_panic()` true, reason captures the panic
+//!   payload via best-effort downcast.
+//! - `Ok(())` — the worker's `while let` loop returned without an operator
+//!   shutdown signal (e.g., `user_rx` closed because senders were dropped).
+//!
+//! A shared [`AtomicBool`] (`shutdown_initiated`) lets the operator suppress
+//! the false-positive on clean shutdown paths (Quit, agent-switch, /restart):
+//! set it to `true` before dropping senders or sending [`AgentRequest::Quit`],
+//! and the supervisor exits silently when the worker resolves.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::task::JoinHandle;
+
+/// Failure reported by the supervisor when the worker exits unexpectedly.
+pub struct WorkerFailure {
+    /// Human-readable reason. Prefixes:
+    /// - `"worker panicked: <payload>"` on `JoinError::is_panic()`.
+    /// - `"worker task error: <err>"` on other `JoinError` shapes (e.g.,
+    ///   cancellation via `JoinHandle::abort`).
+    /// - `"worker exited before session closed"` on premature `Ok(())`.
+    pub reason: String,
+}
+
+/// Await the worker handle and forward any unexpected exit to `on_failure`.
+///
+/// When `shutdown_initiated` is `true` at the moment the handle resolves,
+/// the supervisor returns silently — the worker exited as the operator asked.
+/// Otherwise both `Err(JoinError)` and `Ok(())` invoke `on_failure` with a
+/// reason string the caller can surface.
+pub async fn supervise<F>(
+    worker_handle: JoinHandle<()>,
+    shutdown_initiated: Arc<AtomicBool>,
+    on_failure: F,
+) where
+    F: FnOnce(WorkerFailure),
+{
+    let join_result = worker_handle.await;
+
+    if shutdown_initiated.load(Ordering::Acquire) {
+        return;
+    }
+
+    let reason = match join_result {
+        Err(join_err) if join_err.is_panic() => {
+            let payload = join_err.into_panic();
+            let panic_msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+            format!("worker panicked: {panic_msg}")
+        }
+        Err(join_err) => format!("worker task error: {join_err}"),
+        Ok(()) => "worker exited before session closed".to_string(),
+    };
+
+    on_failure(WorkerFailure { reason });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn shutdown_initiated_silences_clean_exit() {
+        let worker = tokio::spawn(async {});
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+
+        supervise(worker, shutdown, move |failure| {
+            *sink.lock().unwrap() = Some(failure.reason);
+        })
+        .await;
+
+        assert!(captured.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn premature_clean_exit_is_reported_with_reason() {
+        let worker = tokio::spawn(async {});
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+
+        supervise(worker, shutdown, move |failure| {
+            *sink.lock().unwrap() = Some(failure.reason);
+        })
+        .await;
+
+        let reason = captured.lock().unwrap().clone().expect("reason captured");
+        assert!(
+            reason.contains("exited before session closed"),
+            "unexpected reason: {reason}",
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_payload_is_extracted_into_reason() {
+        let worker = tokio::spawn(async {
+            panic!("simulated worker panic");
+        });
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+
+        supervise(worker, shutdown, move |failure| {
+            *sink.lock().unwrap() = Some(failure.reason);
+        })
+        .await;
+
+        let reason = captured.lock().unwrap().clone().expect("reason captured");
+        assert!(
+            reason.contains("panicked"),
+            "missing panic marker: {reason}"
+        );
+        assert!(
+            reason.contains("simulated worker panic"),
+            "missing panic payload: {reason}",
+        );
+    }
+
+    #[tokio::test]
+    async fn aborted_worker_is_reported() {
+        let worker = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        let handle_for_abort = worker.abort_handle();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+
+        handle_for_abort.abort();
+
+        supervise(worker, shutdown, move |failure| {
+            *sink.lock().unwrap() = Some(failure.reason);
+        })
+        .await;
+
+        let reason = captured.lock().unwrap().clone().expect("reason captured");
+        assert!(
+            reason.contains("worker task error"),
+            "unexpected reason: {reason}",
+        );
+    }
+}

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -2006,4 +2006,108 @@ mod tests {
         assert!(!output.contains("Agents:"));
         assert!(output.contains("Done"));
     }
+
+    // === tick_agent_mode WorkerCrashed handling (mika#1149) ===
+
+    /// Build a minimal `App` whose `agent_rx` is paired with the returned sender,
+    /// so a test can simulate the supervisor delivering events to the TUI.
+    async fn app_with_response_sender() -> (
+        App<'static>,
+        mpsc::UnboundedSender<AgentResponse>,
+        tempfile::TempDir,
+    ) {
+        use mika_agent::async_db::AsyncDatabase;
+        use mika_agent::db::Database;
+        use mika_agent::skills::SkillRegistry;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let home_dir = temp_dir.path().to_path_buf();
+        let global_home = temp_dir.path().to_path_buf();
+        let db = Database::open_in_memory().unwrap();
+        let async_db = AsyncDatabase::new(db);
+        let session_id = uuid::Uuid::new_v4().to_string();
+        async_db
+            .create_session(&session_id, "mika", "cli")
+            .await
+            .unwrap();
+
+        let (agent_tx, _request_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel();
+
+        let app = App::new(
+            agent_tx,
+            response_rx,
+            session_id,
+            "test-model".to_string(),
+            "Mika".to_string(),
+            async_db,
+            mika_common::llm::dummy_provider(),
+            home_dir,
+            Arc::new(SkillRegistry::empty()),
+            "mika".to_string(),
+            global_home,
+            mika_common::llm::ProviderKind::Anthropic,
+        );
+
+        (app, response_tx, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn tick_agent_mode_surfaces_worker_crashed_event() {
+        let (mut app, response_tx, _td) = app_with_response_sender().await;
+        app.status = AgentStatus::Thinking; // simulate an in-flight prompt
+
+        response_tx
+            .send(AgentResponse::WorkerCrashed {
+                reason: "worker panicked: simulated tool panic".to_string(),
+            })
+            .unwrap();
+
+        app.tick_agent_mode().await;
+
+        assert!(app.worker_crashed, "must arm /restart by flipping the flag");
+        assert_eq!(app.status, AgentStatus::Idle, "must clear the spinner");
+        let last = app.messages.last().expect("banner pushed");
+        assert!(
+            matches!(last.role, ChatRole::System),
+            "banner must be a System message, got {:?}",
+            last.role
+        );
+        assert!(
+            last.content.contains("Agent worker crashed"),
+            "banner must mention the crash: {}",
+            last.content
+        );
+        assert!(
+            last.content.contains("simulated tool panic"),
+            "banner must include the supervisor's reason: {}",
+            last.content
+        );
+        assert!(
+            last.content.contains("/restart"),
+            "banner must point at the recovery affordance: {}",
+            last.content
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_agent_mode_replies_do_not_set_worker_crashed() {
+        let (mut app, response_tx, _td) = app_with_response_sender().await;
+        app.status = AgentStatus::Thinking;
+
+        response_tx
+            .send(AgentResponse::Reply {
+                content: "hello".to_string(),
+                is_error: false,
+                thinking: None,
+                input_tokens: None,
+                updated_skills: None,
+            })
+            .unwrap();
+
+        app.tick_agent_mode().await;
+
+        assert!(!app.worker_crashed, "Reply must not arm /restart");
+        assert_eq!(app.pending_response.as_deref(), Some("hello"));
+    }
 }

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -309,13 +309,21 @@ pub enum AgentRequest {
     Quit,
 }
 
-pub struct AgentResponse {
-    pub content: String,
-    pub is_error: bool,
-    pub thinking: Option<String>,
-    pub input_tokens: Option<u32>,
-    /// If skills were hot-reloaded during this turn, contains the new registry.
-    pub updated_skills: Option<Arc<SkillRegistry>>,
+/// Events the worker sends back to the TUI. `Reply` carries the normal
+/// turn result; `WorkerCrashed` is emitted by the worker supervisor when
+/// the spawned worker task exits unexpectedly (panic or premature clean exit
+/// while the session is still active). See mika#1149.
+pub enum AgentResponse {
+    Reply {
+        content: String,
+        is_error: bool,
+        thinking: Option<String>,
+        input_tokens: Option<u32>,
+        /// If skills were hot-reloaded during this turn, contains the new registry.
+        updated_skills: Option<Arc<SkillRegistry>>,
+    },
+    /// The agent worker task exited unexpectedly. `/restart` recovers.
+    WorkerCrashed { reason: String },
 }
 
 /// Shell-like input history with draft saving and optional disk persistence.
@@ -562,6 +570,15 @@ pub struct App<'a> {
     /// If set, the chat loop should switch to this agent after the current worker stops.
     pub pending_switch: Option<String>,
 
+    /// True after the worker supervisor reported a crash (mika#1149). Set by
+    /// `tick_agent_mode` on `AgentResponse::WorkerCrashed`. Cleared by a
+    /// successful `/restart`. Gates `/restart`'s healthy-worker refusal.
+    pub worker_crashed: bool,
+
+    /// If true, the chat loop should tear down the dead worker and spawn a
+    /// fresh one on the next iteration. Set by the `/restart` handler.
+    pub pending_restart: bool,
+
     // Image attachments pending send
     pub pending_images: Vec<ImageAttachment>,
 
@@ -678,6 +695,8 @@ impl<'a> App<'a> {
             agent_name,
             global_home,
             pending_switch: None,
+            worker_crashed: false,
+            pending_restart: false,
             pending_images: Vec::new(),
             thinking_level: None,
             context_tokens: None,
@@ -765,6 +784,8 @@ impl<'a> App<'a> {
             agent_name: String::new(),
             global_home,
             pending_switch: None,
+            worker_crashed: false,
+            pending_restart: false,
             pending_images: Vec::new(),
             thinking_level: None,
             context_tokens: None,
@@ -1232,28 +1253,34 @@ impl<'a> App<'a> {
     /// Tick handler for agent mode: poll agent_rx for responses.
     async fn tick_agent_mode(&mut self) {
         match self.agent_rx.try_recv() {
-            Ok(response) => {
+            Ok(AgentResponse::Reply {
+                content,
+                is_error,
+                thinking,
+                input_tokens,
+                updated_skills,
+            }) => {
                 // Update skills if hot-reloaded during this turn
-                if let Some(new_skills) = response.updated_skills {
+                if let Some(new_skills) = updated_skills {
                     self.skills = new_skills;
                 }
 
                 // Update context token tracking
-                if let Some(tokens) = response.input_tokens {
+                if let Some(tokens) = input_tokens {
                     self.context_tokens = Some(tokens);
                 }
 
-                if response.is_error {
+                if is_error {
                     self.messages.push(ChatMessage {
                         role: ChatRole::System,
-                        content: format!("Error: {}", response.content),
+                        content: format!("Error: {content}"),
                         rendered: None,
                         channel: None,
                     });
                     self.status = AgentStatus::Idle;
                 } else {
                     // Show thinking block (instantly, not progressively revealed)
-                    if let Some(thinking) = response.thinking {
+                    if let Some(thinking) = thinking {
                         let rendered = Self::render_thinking(&thinking);
                         self.messages.push(ChatMessage {
                             role: ChatRole::Thinking,
@@ -1263,7 +1290,7 @@ impl<'a> App<'a> {
                         });
                     }
 
-                    if response.content.is_empty() {
+                    if content.is_empty() {
                         // Agent responded with tool-use only (no text) — show feedback
                         self.messages.push(ChatMessage {
                             role: ChatRole::System,
@@ -1273,15 +1300,32 @@ impl<'a> App<'a> {
                         });
                         self.status = AgentStatus::Idle;
                     } else {
-                        self.pending_response = Some(response.content);
+                        self.pending_response = Some(content);
                         self.reveal_index = 0;
                         self.status = AgentStatus::Responding(0);
                     }
                 }
                 self.needs_redraw = true;
             }
+            Ok(AgentResponse::WorkerCrashed { reason }) => {
+                // Worker died — surface a visible error, clear the spinner,
+                // and arm /restart. Silent toasts defeat the point (mika#1149).
+                self.messages.push(ChatMessage {
+                    role: ChatRole::System,
+                    content: format!(
+                        "\u{26a0} Agent worker crashed: {reason}. Use /restart to recover."
+                    ),
+                    rendered: None,
+                    channel: None,
+                });
+                self.status = AgentStatus::Idle;
+                self.worker_crashed = true;
+                self.needs_redraw = true;
+            }
             Err(mpsc::error::TryRecvError::Disconnected) => {
-                // Agent worker crashed or exited unexpectedly
+                // Channel closed without a WorkerCrashed event in flight. With
+                // supervision (mika#1149) this is rare — typically only happens
+                // if the supervisor itself is torn down ahead of the channel.
                 if self.status == AgentStatus::Thinking {
                     self.messages.push(ChatMessage {
                         role: ChatRole::System,
@@ -1290,6 +1334,7 @@ impl<'a> App<'a> {
                         channel: None,
                     });
                     self.status = AgentStatus::Idle;
+                    self.worker_crashed = true;
                     self.needs_redraw = true;
                 }
             }

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -2191,4 +2191,41 @@ mod tests {
             "should NOT create qwen_model, config: {config_content}"
         );
     }
+
+    // --- /restart command tests (mika#1149) ---
+
+    #[tokio::test]
+    async fn test_restart_refuses_on_healthy_worker() {
+        let (mut app, _rx, _td) = test_app().await;
+        // Default state: worker_crashed = false. /restart must refuse.
+        let output = handle_restart(&mut app);
+        assert!(
+            !app.pending_restart,
+            "must not arm restart on healthy worker"
+        );
+        assert!(
+            output.contains("only applies after"),
+            "refusal message should mention the precondition: {output}"
+        );
+        assert!(
+            output.contains("/clear"),
+            "refusal should redirect to /clear: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restart_arms_pending_restart_after_crash() {
+        let (mut app, _rx, _td) = test_app().await;
+        app.worker_crashed = true;
+        let output = handle_restart(&mut app);
+        assert!(app.pending_restart, "must arm pending_restart");
+        assert!(
+            output.contains("Restarting"),
+            "confirmation should announce restart: {output}"
+        );
+        assert!(
+            output.contains("not replayed"),
+            "confirmation should warn the prompt is lost: {output}"
+        );
+    }
 }

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -72,10 +72,23 @@ pub async fn dispatch(app: &mut App<'_>, input: &str) -> Option<String> {
         "attach" | "img" => Some(handle_attach(app, args)),
         "undo" => Some(handle_undo(app).await),
         "rewind" => Some(handle_rewind(app, args).await),
+        "restart" => Some(handle_restart(app)),
         _ => Some(format!(
             "Unknown command: /{cmd_name}. Type /help for available commands."
         )),
     }
+}
+
+/// Tear down the dead agent worker and spawn a fresh one (mika#1149).
+/// Refuses on a healthy worker — `/clear` is the right tool for "start a new
+/// session." The actual respawn is performed by the chat loop on the next
+/// iteration once `pending_restart` is set.
+fn handle_restart(app: &mut App<'_>) -> String {
+    if !app.worker_crashed {
+        return "/restart only applies after the worker has crashed. Use /clear to start a new session on a healthy worker.".to_string();
+    }
+    app.pending_restart = true;
+    "Restarting agent worker… (the lost prompt is not replayed — please re-send it after the worker comes back up.)".to_string()
 }
 
 fn handle_help() -> String {

--- a/crates/mika-cli/src/tui/commands/mod.rs
+++ b/crates/mika-cli/src/tui/commands/mod.rs
@@ -194,6 +194,13 @@ pub const COMMANDS: &[SlashCommand] = &[
         args_hint: Some("[<count> | to <message_id>]"),
         completer: None,
     },
+    SlashCommand {
+        name: "restart",
+        aliases: &[],
+        description: "Restart the agent worker after a crash (mika#1149)",
+        args_hint: None,
+        completer: None,
+    },
 ];
 
 /// Resolve a thinking level keyword to (budget_tokens, level_name).

--- a/crates/mika-cli/tests/agent_worker_supervision.rs
+++ b/crates/mika-cli/tests/agent_worker_supervision.rs
@@ -1,0 +1,129 @@
+//! Integration tests for the TUI agent-worker supervisor (mika#1149).
+//!
+//! These exercise the supervisor primitive (`mika_cli::supervision::supervise`)
+//! against the two failure shapes the production wiring depends on:
+//!
+//! 1. **Panic path** — a `#[tokio::main]` worker task that panics inside its
+//!    body. `JoinHandle::await` resolves as `Err(JoinError::is_panic)` and the
+//!    supervisor surfaces a `worker panicked: <payload>` reason.
+//! 2. **Premature clean exit** — a worker task that returns `Ok(())` while the
+//!    session is still active (mirrors the production case where the worker's
+//!    `while let Some(req) = user_rx.recv().await` loop exits because all
+//!    senders were dropped without an operator-driven shutdown). The
+//!    supervisor surfaces a `worker exited before session closed` reason.
+//!
+//! Both shapes must be observable so the TUI can re-render with a visible
+//! error state and arm `/restart`. Silent-drop regressions on either branch
+//! would re-introduce the mika#850 P0 failure mode.
+//!
+//! We test the supervisor primitive directly rather than spinning up the
+//! whole `spawn_agent_worker` stack: the contract under test is
+//! "what does the supervisor do when its worker handle resolves," and the
+//! integration with `run_agent` (a `#[cfg(test)]`-gated `PanicTool` would just
+//! exercise tokio's panic propagation, which is already well-covered upstream).
+//! The supervisor's behaviour is the load-bearing piece — if it stays correct,
+//! any future worker body that panics or exits cleanly is automatically
+//! surfaced.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use mika_cli::supervision::{WorkerFailure, supervise};
+
+/// Returns a closure that writes the failure reason into `slot`. Lets each
+/// test capture the supervisor's report without channel plumbing.
+fn record_reason(slot: &Arc<Mutex<Option<String>>>) -> impl FnOnce(WorkerFailure) + Send + 'static {
+    let slot = slot.clone();
+    move |failure: WorkerFailure| {
+        *slot.lock().unwrap() = Some(failure.reason);
+    }
+}
+
+#[tokio::test]
+async fn worker_panic_surfaces_as_worker_crashed_reason() {
+    // Mirrors the production failure: a tool execution panics inside the
+    // worker's `tokio::spawn`; supervisor must surface it.
+    let worker = tokio::spawn(async {
+        panic!("simulated tool panic");
+    });
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        supervise(worker, shutdown, record_reason(&captured)),
+    )
+    .await
+    .expect("supervisor did not resolve within 2s");
+
+    let reason = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("supervisor must report a reason on worker panic");
+    assert!(
+        reason.contains("panicked"),
+        "expected panic marker in reason: {reason}"
+    );
+    assert!(
+        reason.contains("simulated tool panic"),
+        "expected panic payload in reason: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn worker_premature_clean_exit_surfaces_as_worker_crashed_reason() {
+    // Production analog: the worker's `while let Some(req) = user_rx.recv().await`
+    // loop exits because all `agent_tx` senders were dropped (e.g., a refactor
+    // accidentally drops them before issuing `AgentRequest::Quit`). The session
+    // is still active from the user's perspective.
+    let worker = tokio::spawn(async {
+        // Simulate the loop running briefly, then exiting cleanly.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    });
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        supervise(worker, shutdown, record_reason(&captured)),
+    )
+    .await
+    .expect("supervisor did not resolve within 2s");
+
+    let reason = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("supervisor must report a reason on premature clean exit");
+    assert!(
+        reason.contains("exited before session closed"),
+        "expected premature-exit marker in reason: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn operator_initiated_shutdown_silences_supervisor() {
+    // Production analog: the chat loop sets shutdown_initiated = true before
+    // sending AgentRequest::Quit. The worker then exits Ok(()), but that's
+    // expected — supervisor must not surface a false-positive crash.
+    let worker = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    });
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        supervise(worker, shutdown, record_reason(&captured)),
+    )
+    .await
+    .expect("supervisor did not resolve within 2s");
+
+    assert!(
+        captured.lock().unwrap().is_none(),
+        "supervisor must stay silent on operator-initiated shutdown"
+    );
+}

--- a/docs/plans/2026-05-16-001-fix-server-tui-user-message-silently-dropped-plan.md
+++ b/docs/plans/2026-05-16-001-fix-server-tui-user-message-silently-dropped-plan.md
@@ -1,0 +1,347 @@
+---
+title: Supervise the TUI agent-worker task (mika#850 P0 finding extraction)
+ticket: mika#1149
+parent_ticket: mika#850
+type: fix
+status: groomed
+created: 2026-05-16
+revision: 3 (post second-pass mika-arch GROOMED — F3 extraction)
+---
+
+# Plan: Supervise the TUI agent-worker task (mika#1149, F3 extraction of mika#850)
+
+> **Dispatch scope (mika#1149):** Implement the supervision fix only. The forensic verification phases below — Phase 0 pinning slices that reference mika#850's server-side paths (P0.1, P0.2, P0.3, P0.5, P0.6), the §F1 forensic re-investigation, and any §G acceptance gates that depend on forensic outcomes — are **out of scope for this PR per mika#1149 § Out of scope**. They remain mika#850's responsibility and will be addressed by the operator's separate forensic verification on `~/.mika/agents/<name>/logs/mika.log.2026-04-{27,28}`.
+>
+> **In scope for mika#1149:** §F2 (Supervise the TUI agent-worker task) — both the panic path and the premature-clean-exit (`Ok(())`) path; §F4 (TUI `/restart` slash command); the integration tests in §T (panic path + premature-clean-exit path). Use the issue body of mika#1149 as the implementation contract for failure-mode coverage, `AgentResponse::WorkerCrashed` variant shape, and acceptance criteria. If any §F2/§F4 step here conflicts with mika#1149's body, the body wins.
+
+## TL;DR
+
+mika#850 reports a verified silent failure: row 23632 in `messages` exists for the user prompt `implement mika issue#848`, but neither `llm_calls` nor `server.log` records any agent-loop activity for that trace_id. A pinned code read shows the ticket's stated mechanism (per-session listener binding that dies on server restart) does not exist in production code — and that `mika chat --agent <name>` runs the agent loop locally in the TUI process via an unsupervised `tokio::spawn` (a silent-panic bug class regardless of mika#850 specifically).
+
+**Revised plan shape (post mika-arch first-pass ITERATE):** Make the fix unconditional — supervise the TUI agent worker's tokio task and surface its failure modes to the chat UI. The forensic re-investigation becomes a verification + spec-divergence reconciliation step (not a gate), with explicit time-boxing and fallback. If forensics shows mika#850's incident was caused by a *different* mechanism than the one Branch A defends, escalate before merging.
+
+## Phase 0 — Pin (load-bearing source slices)
+
+**Base commit:** `db3cdc1d156d` on `origin/main` (2026-05-16).
+
+Six sites determine the plan's load-bearing claims. Verbatim slices:
+
+### P0.1 — `POST /message` always creates a fresh `session_id`
+
+`crates/mika-agent/src/server/handlers.rs:751`:
+
+```rust
+    let session_id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) =
+        a.db.create_session(&session_id, a.db.agent_id(), &req.channel)
+            .await
+    {
+        warn!(error = %e, "failed to create session");
+    }
+```
+
+There is no code path between the HTTP boundary and `create_session` that consults a client-supplied session_id.
+
+### P0.2 — `MessageRequest` carries no `session_id` field
+
+`crates/mika-agent/src/server/types.rs:11–28`:
+
+```rust
+/// Inbound message from the gateway.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MessageRequest {
+    pub text: String,
+    #[serde(default)]
+    pub chat_id: Option<i64>,
+    pub channel: String,
+    pub request_id: String,
+    #[serde(default)]
+    pub agent: String,
+    #[serde(default)]
+    pub images: Option<Vec<ImagePayload>>,
+}
+```
+
+No `session_id` field. The Gateway protocol does not support session_id continuity for `POST /message`.
+
+### P0.3 — Only broadcast registry is task-keyed (not session-keyed)
+
+`crates/mika-agent/src/server/state.rs:90–91`:
+
+```rust
+    /// Active A2A task broadcasters for SSE streaming (keyed by task ID).
+    pub a2a_broadcasters: Arc<DashMap<String, broadcast::Sender<StreamEvent>>>,
+```
+
+No session-keyed sender registry exists anywhere in `AppState` or `AgentState`.
+
+### P0.4 — TUI agent worker is unsupervised `tokio::spawn`
+
+`crates/mika-cli/src/commands/chat.rs:215, 224`:
+
+```rust
+    let mut worker_session = session_id.clone();
+    // … (worker state clones)
+    let handle = tokio::spawn(async move {
+        while let Some(request) = user_rx.recv().await {
+            match request {
+                AgentRequest::Message { text, images, thinking_budget } => {
+                    // …
+                    let result = agent::run_agent(&AgentParams { /* … */ }).await;
+                    // …
+                }
+                // …
+            }
+        }
+    });
+```
+
+The `handle: JoinHandle<()>` is bound but its result is never observed. A panic inside the loop body silently kills the receiver; subsequent UI sends at `tui/app.rs:883` succeed (mpsc unbounded) and are silently discarded.
+
+### P0.5 — UI send path is fire-and-forget
+
+`crates/mika-cli/src/tui/app.rs:883`:
+
+```rust
+        // Send to agent worker
+        let _ = self.agent_tx.send(AgentRequest::Message {
+            text,
+            images,
+            thinking_budget,
+        });
+        self.status = AgentStatus::Thinking;
+```
+
+The `let _ =` discards `SendError` (only fires when the receiver is *dropped* — not when the worker task panics mid-iteration with the receiver still owned by the spawned future).
+
+### P0.6 — TUI run_agent invocation
+
+`crates/mika-cli/src/commands/chat.rs:265–292` (call site for the local agent loop, channel `"cli"`, session_id from `worker_session`):
+
+```rust
+                    let result = agent::run_agent(&AgentParams {
+                        db: &worker_db,
+                        // …
+                        channel_type: "cli",
+                        session_id: &worker_session,
+                        // …
+                    })
+                    .await;
+```
+
+This is the only direct `run_agent` call site in `mika-cli` (excluding the callback variant at chat.rs:377). The TUI does not POST messages to mika-server.
+
+**P0 pin confirms** the plan's three pillars: (a) server has no session-listener registry; (b) TUI runs the agent locally with no supervision around the worker spawn; (c) message-arrival-via-restart hypothesis from the ticket has no underlying mechanism in this codebase.
+
+## Scope and contract
+
+- **In scope:**
+  - Supervise the TUI agent worker tokio task; surface failures (panic, drop, await error) as a visible UI state.
+  - Forensic re-investigation of mika#850's 2026-04-27 incident (time-boxed; verification, not gating).
+  - Reconcile the issue body with the confirmed mechanism (mika-arch F3 — issue-as-versioned-contract).
+  - One integration test that reproduces the worker-panic class deterministically.
+  - One structured observability event emitted from the worker-supervision path.
+- **Out of scope:**
+  - `mika logs` CLI subcommand (companion ticket — separate work).
+  - KG subject-extractor malformed-JSON retry loop (acknowledged in ticket as compounding, not causal).
+  - Server-side `POST /message` supervision (Branch B from revision 1 of this plan, now reclassified — see § Branch B disposition).
+  - Net-new global message-arrival event bus (explicitly rejected — see § Rejected directions).
+
+## Step 1 — Supervise the TUI agent worker (UNCONDITIONAL fix)
+
+The unsupervised `tokio::spawn` at `chat.rs:224` is a bug class regardless of mika#850's specific mechanism. Fixing it defends the silent-drop symptom (user message persisted, no response) for any failure of the worker task, including: panic in tool execution, panic in skill resolution, panic in `run_agent` itself, or a future code change that introduces a new panic-prone site.
+
+### S1.1 — Retain the `JoinHandle`, observe its completion
+
+Replace the current fire-and-forget pattern with a supervisor task that awaits the worker `JoinHandle` and forwards `JoinError` (panic) or unexpected completion (`Ok(())` from the `while let` loop terminating because `user_rx` closed) as a new `AgentResponse::WorkerCrashed { reason: String }` variant up the existing `agent_rx` channel.
+
+The supervisor itself is a second `tokio::spawn`; its lifetime is bound to the chat command. The TUI's existing `tick()` loop consumes `AgentResponse` events and now also handles `WorkerCrashed` by:
+
+1. Pushing a single `ChatRole::Command`-styled error line to the message list: `⚠ Agent worker crashed: <reason>. Use /restart to recover.`
+2. Setting `self.status = AgentStatus::Idle` (clears the "Thinking" spinner left dangling by the lost send).
+3. Recording the failure in `audit_events` via `db.log_audit_event("system", "agent_worker_crashed", …)` — this is the existing audit-write API; no schema change.
+
+### S1.2 — `/restart` slash command
+
+Add a `/restart` handler to `crates/mika-cli/src/tui/commands/handlers.rs` that:
+
+1. Verifies the worker is in `WorkerCrashed` state (refuses on healthy worker; tells operator to use `/clear` for normal new-session flow).
+2. Calls the existing `spawn_agent_worker` helper from chat.rs to spin up a fresh worker.
+3. Rebinds the `agent_tx` channel on the `ChatApp` so subsequent sends route to the new worker.
+4. Pushes a confirmation line: `Agent worker restarted.`
+
+`/restart` does not replay the lost message; it restores the ability to send new ones. Replay would require either a "last-prompt" buffer (out of scope, adds state) or operator re-typing (preferred, no state).
+
+### S1.3 — Touched files
+
+- `crates/mika-cli/src/commands/chat.rs` — `JoinHandle` supervision (S1.1), `spawn_agent_worker` re-invocation path for `/restart`.
+- `crates/mika-cli/src/tui/app.rs` — new `ChatMessage` variant / styling for crash line; `WorkerCrashed` handling in `tick()`; `agent_tx` rebind support.
+- `crates/mika-cli/src/tui/commands/handlers.rs` — `/restart` slash command.
+- (no changes outside `crates/mika-cli/` for Step 1)
+
+## Step 2 — Reproduction test (red on main, green after S1)
+
+Add `crates/mika-cli/tests/agent_worker_supervision.rs` (new integration test file under `crates/mika-cli/tests/`).
+
+### S2.1 — Test approach
+
+`MockLlmProvider` (`crates/mika-common/src/llm/mock.rs:86`) supports `MockResponse::Error(LlmError)` but not direct panic injection (NF2 from mika-arch). The reproduction does NOT need to panic the LLM provider — it needs to panic *the worker task* in a way that mirrors the production silent-drop shape.
+
+Approach: write a thin integration test that spawns the agent worker with a panicking tool handler (a custom `Tool` impl whose `execute()` calls `panic!()`). The agent loop will:
+1. Receive `AgentRequest::Message`.
+2. Call `run_agent`.
+3. `run_agent` schedules a tool call (mocked LLM response specifies the tool).
+4. Tool execution panics.
+5. `run_agent` returns `Err` OR the panic propagates up the `tokio::spawn` → `JoinHandle::Err(JoinError)`.
+
+Both shapes (`run_agent` error vs. JoinError panic) must be observable through Step 1's supervision path. The test asserts: (a) a `WorkerCrashed` event arrives on `agent_rx` within 2 seconds; (b) the user message was persisted to DB (`messages` row exists); (c) no `llm_calls` row exists for that trace_id (matching the mika#850 forensic signature).
+
+### S2.2 — Mock infrastructure check
+
+If panicking-tool injection requires extending `mika-agent`'s `Tool` trait helpers, prefer adding a `#[cfg(test)]`-gated `PanicTool` rather than modifying production tool registration. Place it adjacent to the test file. No production-code change for test scaffolding.
+
+### S2.3 — Test on main fails; on branch passes
+
+The test must fail (timeout waiting for `WorkerCrashed`) against `db3cdc1d` (the pin). After S1 lands, the test passes within the 2-second window.
+
+## Step 3 — Forensic verification (time-boxed; not a gate on S1)
+
+**Purpose:** confirm that Step 1's supervision would have caught mika#850's specific incident. Decoupled from the fix itself.
+
+### S3.1 — Time box
+
+90 minutes maximum on the queries below. If forensic data has rotated past the window of useful inspection, mark inconclusive and proceed.
+
+### S3.2 — Queries
+
+```sql
+-- Channel of session 63be052e
+SELECT id, agent_id, channel_type, created_at, ended_at
+FROM sessions WHERE id = '63be052e-40b4-4a4a-b418-b3bac03df405';
+
+-- Metadata + trace_id for the dropped message
+SELECT id, session_id, agent_id, role, trace_id, metadata, internal, created_at
+FROM messages WHERE id = 23632;
+
+-- Adjacent activity on the session
+SELECT id, role, created_at, length(content)
+FROM messages WHERE session_id = '63be052e-40b4-4a4a-b418-b3bac03df405'
+  AND created_at BETWEEN '2026-04-27T23:43:00Z' AND '2026-04-27T23:53:00Z'
+ORDER BY created_at;
+
+-- audit_events around the incident window
+SELECT created_at, event_type, payload FROM audit_events
+WHERE agent_id IN ('mika-dev', 'mika')
+  AND created_at BETWEEN '2026-04-27T23:45:00Z' AND '2026-04-27T23:55:00Z'
+ORDER BY created_at;
+```
+
+### S3.3 — Logs (correct sink)
+
+Per `crates/mika-agent/CLAUDE.md` § Log Sinks: CLI invocations write to `~/.mika/agents/<name>/logs/mika.log.YYYY-MM-DD`, NOT to `MIKA_SERVER_LOG_FILE`. The ticket's 2.5 GB `server.log` search was the wrong sink for a CLI-channel session.
+
+```bash
+grep -F "d68e1285167a4fc0978bd655929e1cbe" \
+  ~/.mika/agents/{mika-dev,mika}/logs/mika.log.2026-04-{27,28} 2>/dev/null
+grep -F "63be052e-40b4-4a4a-b418-b3bac03df405" \
+  ~/.mika/agents/{mika-dev,mika}/logs/mika.log.2026-04-{27,28} 2>/dev/null
+grep -F "issue#848" \
+  ~/.mika/agents/*/logs/mika.log.2026-04-{27,28} 2>/dev/null
+```
+
+### S3.4 — Three forensic outcomes
+
+| Outcome | Meaning | Action |
+|---------|---------|--------|
+| **(a) channel_type='cli' + CLI log shows worker-task absence** | mika#850 was a TUI worker drop. S1's supervision covers it directly. | Reconcile issue body (S4). Proceed to merge. |
+| **(b) channel_type='cli' + CLI log shows run_agent entry but no LLM call** | TUI worker reached run_agent but bailed pre-LLM (panic, deadline, context-build error). S1's supervision still catches the resulting JoinError or `Err` return. | Reconcile issue body (S4). Proceed to merge. |
+| **(c) channel_type ≠ 'cli' OR forensic data rotated/inconclusive** | S1's mechanism may not be the same one that caused the incident. | Escalate to operator BEFORE merging. Document in S4 reconciliation that S1's fix is unconditional (defends a real bug class) but does not claim to have caught mika#850's specific incident. Operator decides merge disposition. |
+
+## Step 4 — Reconcile the issue body (mika-arch F3 — issue-as-versioned-contract)
+
+The plan reframes mika#850's hypothesis from "session-listener binding doesn't survive server restart" to "unsupervised TUI agent worker task; silent panic loses the in-flight prompt." Per the user_summary operating principle, the issue body must reflect the confirmed mechanism so that future readers of the issue see a consistent record.
+
+### S4.1 — When (depending on S3 outcome)
+
+- Outcomes **(a)** and **(b)** above: update the issue body to replace the "Root cause hypothesis" section with the confirmed mechanism. Add an edit-notice comment citing this plan's Phase 0 pins and the forensic findings from S3.2/S3.3. Closure annotation: cite both the original ticket framing and the corrected one.
+- Outcome **(c)**: do NOT update the issue body unilaterally. Plan-on-branch retains the reframed analysis; issue body stays as-is pending operator's call. Add an edit-notice comment that says: "Phase 0 pin confirms the listener-binding mechanism is absent from current code (citations: handlers.rs:751, state.rs:91, types.rs:13–28). Forensic re-investigation [inconclusive | found a different channel]. Operator decision needed on whether to close as 'fixed by adjacent improvement' or hold open for further investigation."
+
+### S4.2 — Audit trail format
+
+```markdown
+> **Hypothesis re-framed (mika-arch F3 reconciliation):**
+> Original ticket hypothesis was "session-listener binding does not survive server restart."
+> Phase 0 pinning against base commit db3cdc1d156d confirmed no such binding exists in current code.
+> Confirmed mechanism: unsupervised tokio::spawn'd agent worker in mika-cli (chat.rs:224); on panic,
+> mpsc-channel sends from UI succeed but the worker never runs run_agent.
+> Forensic verification: <outcome a/b/c summary>.
+> Fix: PR #<N> supervises the worker, surfaces failures as observable chat state, adds /restart.
+```
+
+## Step 5 — Observability event
+
+One structured `error!` event, emitted from the supervisor task in S1.1 when the worker enters a failure state:
+
+```rust
+tracing::error!(
+    target: "mika::otel",
+    event = "agent_worker_silenced",
+    agent_id = %agent_id,
+    session_id = %session_id,
+    reason = %reason,         // "panic" | "task_dropped" | "loop_exited"
+    last_message_id = ?last_message_id,
+    seconds_since_message_persist = ?elapsed_secs,
+    "TUI agent worker entered failure state; pending prompt dropped"
+);
+```
+
+NF3 reconciliation: this event fires from **the same `JoinHandle` error path** as S1.1's supervisor, not from a separate timer. `seconds_since_message_persist` is computed by recording the timestamp when `AgentRequest::Message` was sent and subtracting at crash time. No new timer infrastructure.
+
+## Step 6 — Ship
+
+1. `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`.
+2. Run the integration test from S2 (specifically: `cargo test -p mika-cli --test agent_worker_supervision`).
+3. Smoke-test (`feedback_smoke_before_claiming_done.md`): run `mika chat --agent mika-dev`, send a message, inject a panic via the test scaffolding (or comment out the supervision temporarily to confirm the symptom), verify both the symptom on `main` and the fix behavior on the branch.
+4. Open PR; "Verification" section cites Phase 0 pin SHAs, S3 forensic outcome, and the test name.
+
+## Branch B disposition
+
+Revision 1 of this plan had a "Branch B — Server-mode POST /message tokio-spawn abort class" as an alternative fix shape. mika-arch NF1 correctly noted it was underspecified relative to Branch A. Disposition:
+
+- Branch B is OUT OF SCOPE for mika#850. The Phase 0 pin confirms the TUI does not POST to the server; mika#850's incident channel cannot be Branch B's. Even forensic outcome (c) would not justify implementing Branch B — it would justify investigating which path was actually involved, which is a separate ticket if it surfaces.
+- A future ticket may justify supervising `handlers.rs:288`'s spawned tasks for server-mode resilience. That ticket can cite this plan's reasoning. Not in scope here.
+
+## Rejected directions (ticket suggestions; explicit rejection)
+
+1. **"TUI side: detect server restart, start a fresh session."** The TUI's local agent worker does not communicate with mika-server for `mika chat`. There is no server connection to detect a restart of. Suggestion does not apply to current architecture.
+2. **"Server side: subscribe by agent_id, not session_id."** Presupposes a per-session listener that does not exist (Phase 0 P0.3). Implementing it would be a net-new event-bus subsystem, not a fix. YAGNI + orthogonality reject this.
+3. **"Observability: 'message-persisted-but-no-loop-tick-within-Ns' metric."** Replaced by Step 5's tighter `agent_worker_silenced` event, fired from the supervision path. The polling/timer shape implied by the ticket's framing is replaced by an event-driven shape that uses the same mechanism as the fix.
+
+## Risks and open questions
+
+1. **Forensic outcome (c) requires operator gate.** If S3 finds the incident channel was not `cli` (e.g., the forensic DB row pre-dates a code refactor that has since changed the session-creation contract), S1's fix is still a real bug-class fix but mika#850's specific incident remains unresolved. Operator must decide closure shape.
+2. **Mock-tool panic harness may need a small `#[cfg(test)] PanicTool`.** Acknowledged in S2.2. Adds <30 LoC if needed; not a blocker.
+3. **`/restart` interaction with active background tasks.** If the operator restarts the worker while background callback tasks are in-flight (counted in the footer `[N running]` badge), the new worker inherits the same agent state (DB, skills, identity) but loses any in-memory caches. Document this in the `/restart` confirmation message; do not implement in-memory state migration.
+4. **No mika-cloud or mika-skills coordination needed.** Single-repo PR.
+
+## Citations (Phase 0 source-of-truth)
+
+All citations are pinned to base commit `db3cdc1d156d` on `origin/main`.
+
+- `crates/mika-agent/src/server/handlers.rs:751` — `let session_id = uuid::Uuid::new_v4().to_string();`
+- `crates/mika-agent/src/server/types.rs:11–28` — `MessageRequest` (no session_id field)
+- `crates/mika-agent/src/server/state.rs:90–91` — `a2a_broadcasters` is the only broadcast registry; task-keyed
+- `crates/mika-cli/src/commands/chat.rs:215, 224, 265–292` — worker spawn site; run_agent call site
+- `crates/mika-cli/src/tui/app.rs:879–895` — UI send path; fire-and-forget `let _ = self.agent_tx.send(…)`
+- `crates/mika-common/src/llm/mock.rs:86–158` — MockLlmProvider scope; supports Error injection, not panic injection
+- `crates/mika-agent/CLAUDE.md` § Log Sinks — server.log vs. per-agent CLI log distinction
+
+## Sequence
+
+1. Phase 0 — already done (pins captured above).
+2. Step 1 — supervise the worker (UNCONDITIONAL fix).
+3. Step 2 — reproduction test (red → green).
+4. Step 3 — forensic verification (90-min time box).
+5. Step 4 — reconcile issue body per S3 outcome.
+6. Step 5 — observability event (co-shipped with Step 1's supervisor).
+7. Step 6 — ship.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -12,7 +12,7 @@ Slash commands are client-side actions executed directly in the Mika TUI. They a
 database and renders output in-place, while typing a regular message (no `/` prefix)
 sends it to the Claude-backed agent loop as usual.
 
-All 23 commands are defined in a single `COMMANDS` array
+All 24 commands are defined in a single `COMMANDS` array
 (`crates/mika-cli/src/tui/commands/mod.rs`), dispatched through pattern matching in
 `handlers.rs`, and surfaced via an autocomplete popup driven by `autocomplete.rs`.
 
@@ -546,6 +546,33 @@ The rewind engine automatically reverses memory mutations (core memory edits, fa
 Cross-session rewinds are supported -- if the target messages are in a different session than the current one, the marker notes the originating session.
 
 Errors: `Cannot rewind while agent is busy.` or `No messages to rewind.`
+
+---
+
+### /restart
+
+Recover from an agent-worker crash. The TUI runs the agent loop in a supervised
+`tokio::spawn` task; if that worker panics or exits prematurely, a banner appears
+("Agent worker crashed: <reason>. Use /restart to recover."). `/restart` tears the
+dead worker down and spawns a fresh one for the same agent (mika#1149).
+
+**Aliases:** None | **Arguments:** None
+
+**On a healthy worker** -- refuses:
+```
+/restart only applies after the worker has crashed. Use /clear to start a new session on a healthy worker.
+```
+
+**After a crash** -- arms the restart and the chat loop spawns a replacement on
+its next iteration:
+```
+Restarting agent worker… (the lost prompt is not replayed — please re-send it after the worker comes back up.)
+```
+
+The lost in-flight prompt is **not** replayed; the operator must re-type. Background
+callback tasks survive the restart and continue delivering to the new worker.
+The `agent_worker_silenced` structured `error!` event is emitted to the per-agent
+log on every crash for post-incident triage.
 
 ---
 

--- a/docs/solutions/best-practices/supervise-tokio-spawn-with-shutdown-flag-2026-05-16.md
+++ b/docs/solutions/best-practices/supervise-tokio-spawn-with-shutdown-flag-2026-05-16.md
@@ -1,0 +1,155 @@
+---
+module: process-supervision
+tags: [tokio, spawn, supervisor, joinhandle, mpsc, silent-drop, shutdown, atomic-flag]
+problem_type: reliability
+category: best-practices
+related_issues: [1149, 1150, 959, 203]
+---
+
+# Supervise Long-Lived `tokio::spawn` Tasks with a Shutdown Flag (mika#1149)
+
+## Context
+
+`tokio::spawn` returns a `JoinHandle`, but binding it without observing it is the load-bearing mistake behind multiple silent-drop incidents in this workspace:
+
+- **mika#1149** — TUI agent worker spawned at `crates/mika-cli/src/commands/chat.rs:224`. Panic inside the worker silently killed the receiver: the spawned future owned `user_rx`, so subsequent UI sends via `let _ = self.agent_tx.send(...)` kept succeeding because `mpsc::SendError` only fires when the receiver is *dropped*, not when the task holding it panics mid-iteration. The user prompt persisted to `messages` and the agent loop never ran.
+- **mika#959** — server-side analogue: callback subprocess crashed without delivering, jamming the dispatch queue. Fixed with a `/proc/<pid>/stat` watchdog.
+- **mika#203** — DB delivery queries filtered `status = 'completed'` only, hiding failed tasks — the write side couldn't distinguish a live consumer from a dead one.
+
+The pattern recurs because **the channel-send API is the wrong signal for worker death**, and **JoinHandle is silent unless explicitly observed**.
+
+## Guidance
+
+For any `tokio::spawn` body that runs the main loop of a long-lived process (TUI worker, background callback handler, gateway router, etc.), wire a supervisor primitive that:
+
+1. **Owns the worker's JoinHandle** and awaits it on a separate `tokio::spawn` (the supervisor task).
+2. **Forwards both failure shapes** — `Err(JoinError)` for panics AND `Ok(())` for premature clean exit (the worker's loop returned because all senders were dropped or `break` was hit unexpectedly). Both are "worker died with in-flight work lost" from the operator's perspective.
+3. **Reports failure via a callback**, not a hardcoded channel — keeps the primitive reusable across surfaces (TUI sees `AgentResponse::WorkerCrashed`; a server-side handler may want a structured log + metric + alert).
+4. **Reads a shared `Arc<AtomicBool>` shutdown flag** before reporting failure. Operator-driven shutdown paths (Quit, agent switch, restart) set the flag *before* dropping senders or sending the termination request. The supervisor then exits silently when the worker resolves `Ok(())` for the expected reason.
+5. **Clones the response sender** before moving the original into the worker closure. When the worker drops its sender on death, the supervisor's clone keeps the receiver open long enough to deliver the crash event.
+
+The reusable primitive in mika lives at `crates/mika-cli/src/supervision.rs`. Its surface is small enough to copy or vendor into any crate that needs it:
+
+```rust
+pub struct WorkerFailure { pub reason: String }
+
+pub async fn supervise<F>(
+    worker_handle: JoinHandle<()>,
+    shutdown_initiated: Arc<AtomicBool>,
+    on_failure: F,
+) where F: FnOnce(WorkerFailure)
+{
+    let join_result = worker_handle.await;
+    if shutdown_initiated.load(Ordering::Acquire) { return; }
+    let reason = match join_result {
+        Err(e) if e.is_panic() => format!("worker panicked: {}", extract_panic_payload(e)),
+        Err(e) => format!("worker task error: {e}"),
+        Ok(()) => "worker exited before session closed".to_string(),
+    };
+    on_failure(WorkerFailure { reason });
+}
+```
+
+## Why This Matters
+
+Without supervision, a panic inside the worker is **completely invisible to the UI** because:
+
+- The panic unwinds the spawned future's stack and drops the worker's locals — including its end of the mpsc channel.
+- The UI's `agent_tx` clone is still alive (held by `App`), so `agent_tx.send(...)` returns `Ok` — the channel still has a sender, the message lands in the unbounded buffer.
+- Nothing ever reads from the buffer (the worker is dead) and `agent_tx.send()` does not detect "no reader" — `SendError` only fires on receiver *drop*, not on consumer death.
+- The user types, sees the spinner, never gets a response.
+
+The supervisor pattern flips the signal: **the JoinHandle is the authoritative death signal**, not the channel. Once observed, both panic and premature `Ok(())` get the same user-visible treatment.
+
+The `shutdown_initiated` flag prevents false-positive crash events on legitimate teardown paths. Store-Release on the setter side, Load-Acquire on the supervisor side; the store-before-drop ordering is the load-bearing invariant. If a future teardown path skips the store, the bug reintroduces — see mika#1150 finding F5 for the encapsulation follow-up (a `signal_shutdown()` method on the worker struct that owns the flag, making omission a compile-time gap).
+
+## When to Apply
+
+Apply this pattern when:
+
+- A `tokio::spawn` runs a `while let` loop over an mpsc receiver and the consumer cannot observe its death via the channel API alone.
+- A user-facing surface depends on the worker for liveness signal (TUI, dashboard, gateway).
+- The session lifetime is bounded but longer than a single request (server worker pools, persistent agent loops).
+
+**Don't bother** for:
+
+- Fire-and-forget tasks that don't have a consumer waiting (e.g., a one-shot logging emit). The panic still unwinds; the consumer never knew it existed.
+- Tasks already managed by a higher-level supervisor (the tokio runtime aborts everything on process exit anyway).
+- Background tasks with their own liveness mechanism (mika#959 uses `/proc/<pid>/stat` for subprocesses — the right signal for that surface).
+
+**Adjacent unguarded sites in this workspace** (filed in mika#1150's "Out of scope" section as a separate follow-up): `crates/mika-gateway/src/github.rs` has six `tokio::spawn` calls at lines 813, 2296, 2584, 2633, 2941, 2968 that may benefit from the same primitive if their failure modes can silent-drop. Evaluate per-site.
+
+## Examples
+
+### Before (mika#1149's pre-fix state — chat.rs:224)
+
+```rust
+let handle = tokio::spawn(async move {
+    while let Some(req) = user_rx.recv().await {
+        match req {
+            AgentRequest::Message { text, .. } => {
+                let result = agent::run_agent(...).await;
+                // If run_agent panics, this whole closure unwinds.
+                // user_rx is dropped, but agent_tx (held by App) keeps succeeding.
+                let _ = agent_tx.send(response);
+            }
+            // ...
+        }
+    }
+});
+// handle is bound but never awaited. JoinError silently lost.
+```
+
+### After (mika#1149's fix — chat.rs:499 + supervision.rs)
+
+```rust
+// In spawn_agent_worker:
+let supervisor_agent_tx = agent_tx.clone();      // clone BEFORE move
+let handle = tokio::spawn(async move {
+    while let Some(req) = user_rx.recv().await { /* ... */ }
+});
+
+let shutdown_initiated = Arc::new(AtomicBool::new(false));
+let supervisor_shutdown = shutdown_initiated.clone();
+let supervisor_handle = tokio::spawn(async move {
+    mika_cli::supervision::supervise(handle, supervisor_shutdown, move |failure| {
+        tracing::error!(
+            target: "mika::otel",
+            event = "agent_worker_silenced",
+            reason = %failure.reason,
+            "TUI agent worker entered failure state; pending prompt dropped"
+        );
+        let _ = supervisor_agent_tx.send(AgentResponse::WorkerCrashed {
+            reason: failure.reason,
+        });
+    }).await;
+});
+
+// In every teardown path (Quit, switch, /restart), BEFORE dropping senders:
+worker.shutdown_initiated.store(true, Ordering::Release);
+let _ = app.agent_tx.send(AgentRequest::Quit);
+```
+
+### Test discipline
+
+The supervisor primitive is testable without spinning up the agent loop — see `crates/mika-cli/tests/agent_worker_supervision.rs`. Three scenarios cover the contract:
+
+```rust
+#[tokio::test]
+async fn worker_panic_surfaces_as_worker_crashed_reason() { /* ... */ }
+
+#[tokio::test]
+async fn worker_premature_clean_exit_surfaces_as_worker_crashed_reason() { /* ... */ }
+
+#[tokio::test]
+async fn operator_initiated_shutdown_silences_supervisor() { /* ... */ }
+```
+
+The wiring seam between the supervisor primitive and the surrounding lifecycle (clone ordering, store-before-drop, supervisor-handle replacement) is *not* covered by these tests — see mika#1150 finding T-03 for the wiring-test follow-up. The primitive contract is the load-bearing piece; the wiring is a separate test surface.
+
+## Related
+
+- [mika#959 callback watchdog (server-side analogue)](../959-callback-watchdog-stale-subprocess-detection.md) — same shutdown-silencing pattern (grace period instead of atomic flag), different liveness signal (`/proc/<pid>/stat`). The supervisor primitive here is the in-process equivalent.
+- [mika#1066 TUI exit while busy](../1066-tui-exit-while-busy.md) — the `/restart` fast-path discipline this PR built on. Slash commands meant to recover from a stuck state must not gate on `AgentStatus::Idle`.
+- mika#203 (failed callback tasks silently dropped) — same silent-failure class at the DB delivery layer. `AgentResponse::WorkerCrashed` is the type-level fix that doc points toward.
+- mika#1150 — lifecycle-hardening follow-up cohort: agent-switch failure path, post-crash send guard, missing Quit on switch, restart/switch identity split, shutdown_initiated encapsulation. See [bug-class-fix-scope-vs-lifecycle-cohort](../workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md) for the framing rationale.

--- a/docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md
+++ b/docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md
@@ -1,0 +1,111 @@
+---
+module: workflow
+tags: [scope, follow-up, code-review, lifecycle, cohort-framing, ticket-vocabulary]
+problem_type: workflow_pattern
+category: workflow-issues
+related_issues: [1149, 1150]
+---
+
+# Frame Review-Found Adjacent Issues as a Forward-Looking Lifecycle Cohort, Not a Retroactive Patch
+
+## Context
+
+A bug fix's `/ce:review` often surfaces **parallel holes in the surrounding wiring** — paths that are not the panic path the fix closed, but exhibit the same failure class. For mika#1149 (supervised the TUI agent-worker tokio::spawn so panic surfaces as a visible TUI error), the review produced:
+
+- 1× P1: agent-switch failure path silently drops the next message (same bug class, different trigger).
+- 4× P2: post-crash send guard, missing Quit on agent-switch, restart+switch identity split, shutdown_initiated encapsulation.
+
+The natural temptation is to either (a) widen mika#1149's scope and ship them all together, or (b) file each P-finding as its own follow-up ticket. Both have failure modes:
+
+- (a) **widening** breaks dispatch-scope discipline ("mika#1149 fixes the panic path"); the PR description drifts away from the issue body's contract; reviewers lose the anchor they signed off on.
+- (b) **splitting per-finding** loses the cohort framing. The P1 is the *lead item* of a lifecycle-hardening cohort, not a peer to be groomed in isolation. Reviewing F2 (post-crash send) without F1 (switch-failure dead channel) and F5 (shutdown_initiated encapsulation) produces three smaller fixes that drift apart and re-relitigate the same wiring decisions.
+
+## Guidance
+
+When `/ce:review` surfaces a P1 plus 2+ P2s that compose into a coherent failure pattern around the same lifecycle/state machine the original fix touched:
+
+1. **Land the original PR with its original scope.** Apply only safe_auto cleanups (tests, doc updates, log additions, trivial deletions). Don't widen the diff.
+2. **File ONE follow-up ticket bundling P1 + N×P2** as a named **lifecycle-hardening cohort**.
+3. **Title forward-looking, not retroactive.** Use "<surface> lifecycle hardening" (e.g., *"tui: harden agent-worker lifecycle wiring around the mika#1149 supervisor"*), not "complete mika#1149" or "follow-ups for #1149". The framing signals: the original fix was correct for its scope; this is the next iteration on a shared concern, not a patch on a half-finished job.
+4. **Lead with the cohort thesis in the ticket body.** Open with the shared root pattern, the shared fix surface, and the shared test discipline. Then enumerate the findings as F1..Fn. List F1 as the lead item explicitly; mention that it composes with F2..Fn rather than being a standalone P1 bug.
+5. **Keep follow-up scope tight to the cohort's seam.** Other reviewer findings (P3 cleanups, advisory items, adjacent unguarded code in other crates) go in the new ticket's "Out of scope" section as separate-ticket suggestions. Don't pile them into the cohort just because they were found in the same review.
+
+## Why This Matters
+
+Cohort framing preserves three things:
+
+- **Architectural coherence in review.** A reviewer evaluating F1 alone sees a small null-check fix. The same reviewer evaluating F1+F2+F3+F4+F5 as one PR sees the shared state-machine seam (`AgentWorker { agent_tx, shutdown_initiated, worker_crashed }`) and can sign off on the encapsulation (F5) once instead of relitigating it on each per-finding PR.
+- **Operator trust in the original PR.** When the next dispatch happens after merge of the original PR and the operator sees mika#1150 in the queue with title *"complete mika#1149"*, they reasonably ask "what's incomplete about it?" — undermining confidence in what was actually correct work. *"TUI worker lifecycle hardening"* answers the implicit question: this is the forward-looking next step, not a retroactive band-aid.
+- **Grooming agent reasoning.** mika-arch (the grooming reviewer) sees the cohort framing in the ticket body and recognizes that F1's "fix" should be evaluated against the same encapsulation choice (F5) rather than as a standalone null-check. The grooming pass converges faster.
+
+The retroactive-patch framing also misuses the ticket vocabulary established in CLAUDE.md § Ticket vocabulary: *milestone* (single-repo grouping), *project* (cross-repo or sprint-scoped grouping), *sub-issue* (parent-child link only). A cohort of 5 P-findings is structurally a *grouping*, not a *sub-issue of the parent fix*. Filing as a peer ticket with cohort framing respects the vocabulary; filing as a sub-issue of mika#1149 implies the parent is incomplete.
+
+## When to Apply
+
+Use this pattern when:
+
+- `/ce:review` finds 1× P1 + 2+ P2 that share a state machine, file surface, or lifecycle seam touched by the original fix.
+- The findings are not exploitable by the same trigger as the original bug — they're parallel holes in adjacent paths.
+- The original PR's scope was anchored to a specific issue body's "Proposed fix" section, and widening would break the dispatch contract.
+
+**Don't apply** when:
+
+- The findings are P0 / actively exploitable — fix in the original PR or block the merge.
+- The findings are unrelated to the original bug class (filed as separate tickets per their own surface).
+- The original PR was a small standalone fix and the cohort would be 70% of the original scope — at that point, widen the original PR instead.
+
+## Examples
+
+### Bad — retroactive-patch framing
+
+```
+Title: complete mika#1149: missed adjacent silent-drop paths
+Body:
+  CE review on the supervisor fix found 5 additional findings that weren't
+  caught in the original PR. This ticket cleans them up.
+  - F1: agent-switch dead channel
+  - F2: post-crash send guard
+  - ...
+```
+
+Problems: operator reads it as "the original fix was incomplete"; reviewer evaluates each F-item individually; grooming agent looks for "what was missed" rather than "what coherent improvement comes next"; vocabulary implies parent-child where peer-cohort is correct.
+
+### Good — forward-looking lifecycle cohort
+
+```
+Title: tui: harden agent-worker lifecycle wiring around the mika#1149 supervisor
+
+## Why
+mika#1149 supervised the TUI agent-worker tokio::spawn, closing the panic-path
+silent drop. /ce:review on the PR surfaced a coherent cohort of lifecycle
+wiring holes around the supervisor that re-introduce or compose with the same
+silent-drop class. They were intentionally deferred to keep mika#1149's scope
+tight ("fix the panic path") and to land the supervision primitive cleanly.
+This ticket bundles them as a single lifecycle-hardening cohort because they
+share the same root pattern (the agent_tx/agent_rx/worker_crashed/
+shutdown_initiated state machine), the same fix surface, and the same test
+discipline.
+
+## In scope
+### F1 — Agent-switch failure path leaves a dead channel with no /restart affordance (P1, lead item)
+...
+### F2 — Post-crash send_message_with_thinking silently enqueues to dead worker (P2)
+...
+### F5 — shutdown_initiated has no encapsulation (P2)
+...
+
+## Out of scope
+- The 6 unguarded tokio::spawn sites in crates/mika-gateway/src/github.rs.
+  File separately for server-side gateway supervision; the supervision
+  primitive is reusable there.
+- Panic-payload secret scrubbing (low severity, narrow trigger).
+- Supervisor upper-bound timeout for non-LLM deadlocks (low severity).
+```
+
+The cohort framing makes the shared state-machine seam visible (F1 + F2 + F5 all touch the same flag transitions), gives F5's encapsulation choice the chance to be evaluated against all four use sites in one review pass, and signals to operators that mika#1149 is complete and this is the next iteration on a shared concern. Filed as mika#1150 on 2026-05-16.
+
+## Related
+
+- [supervise-tokio-spawn-with-shutdown-flag](../best-practices/supervise-tokio-spawn-with-shutdown-flag-2026-05-16.md) — the technical pattern that mika#1149 introduced and mika#1150 hardens.
+- CLAUDE.md § Ticket vocabulary — the milestone/project/sub-issue contract this pattern composes with.
+- `feedback_implementation_scope_bundling.md` (auto memory) — "During implementation, file separate ticket for adjacent improvements; never silently fold into in-progress commit." This pattern is the next iteration: when adjacent improvements form a coherent cohort, file ONE follow-up rather than N separate tickets.


### PR DESCRIPTION
## Why

The TUI agent worker was spawned via `tokio::spawn` at `crates/mika-cli/src/commands/chat.rs:224` with the `JoinHandle` bound but never observed. A panic inside the worker silently killed the receiver: the spawned future owned `user_rx`, so subsequent UI sends via `let _ = self.agent_tx.send(...)` kept succeeding because `mpsc::SendError` only fires when the receiver is *dropped*, not when the task holding it panics mid-iteration. The user prompt persisted to `messages` and the agent loop never ran. Same silent-failure class as mika#959 (callback subprocess watchdog) and mika#203 (failed callbacks dropped at the DB delivery layer), one layer up in the stack.

## What changed

1. **New supervisor primitive** (`crates/mika-cli/src/supervision.rs`, exposed via a minimal `src/lib.rs` for test reachability). Awaits the worker's `JoinHandle` and forwards both failure shapes — `Err(JoinError)` panic AND `Ok(())` premature clean exit — to a caller-supplied callback. Gated on a shared `Arc<AtomicBool>` `shutdown_initiated` flag so operator-driven teardown stays silent.
2. **`AgentResponse` widened from struct to enum** with `Reply { ... }` (the previous shape, unchanged) and new `WorkerCrashed { reason }`. No neighbouring variants touched per the issue's Out-of-scope clause.
3. **Wiring in `chat.rs::spawn_agent_worker`** — supervisor task spawned alongside the worker, cloning `agent_tx` so it survives worker-drop and can deliver the crash event. All four teardown paths (Quit, agent switch, /restart, run() cleanup) set `shutdown_initiated` before dropping senders, with warn-logs when the 2s shutdown timeout fires.
4. **`tick_agent_mode`** handles `WorkerCrashed` — renders a visible system banner ("⚠ Agent worker crashed: <reason>. Use /restart to recover."), clears the spinner, and arms `/restart`.
5. **`/restart` slash command** — refuses on a healthy worker (`/clear` is the right tool for a new session); on a crashed worker, sets `pending_restart=true` and the chat loop tears down + respawns on the next iteration.
6. **One structured `error!` event** (`event=agent_worker_silenced`, `target=mika::otel`) from the supervisor for grep-friendly post-incident triage.

## Test plan

- [x] `cargo test -p mika-cli` — 296 unit + 3 integration + 4 lib supervision tests pass.
- [x] `cargo clippy -p mika-cli --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check -p mika-cli` clean.
- [x] `bash scripts/verify-pipeline.sh` clean — plan + compound doc present.
- [x] `bash scripts/sync-agent-docs.sh` run after the `/restart` slash-command doc edit; `cargo build -p mika-agent` picks up the synced copy.
- [ ] Smoke test in TUI: run `mika chat --agent mika`, send a message, panic the worker by editing `chat.rs` temporarily (or wait for a real panic). Verify the banner + `/restart` + new worker actually serves the next prompt. *Skipped here — requires interactive TUI; not reachable from this orchestration session. Should be smoke-tested before merge.*

### Test coverage shape

Three layers exercise the supervisor contract:

- **`supervision::tests` (inline)** — 4 unit tests on the primitive itself: panic payload extraction, premature clean exit, shutdown-silenced clean exit, aborted handle.
- **`tests/agent_worker_supervision.rs` (integration)** — 3 tests via the public `mika_cli::supervision` surface: panic, premature clean exit, operator-shutdown.
- **`tui::app::tests` + `tui::commands::handlers::tests`** — 4 new tests on the consumer side: `tick_agent_mode` surfaces `WorkerCrashed` correctly + arms the flag, `Reply` does not arm, `/restart` refuses on healthy worker, `/restart` arms `pending_restart` after a crash.

The wiring seam between the primitive and `spawn_agent_worker` is **not** covered (testing finding T-03 in the review); see follow-up below.

## Review pass

`/ce:review` dispatched 8 reviewers (correctness, testing, maintainability, project-standards, agent-native, learnings, reliability, adversarial). One P1 + four P2 findings compose into a coherent **lifecycle-hardening cohort** — the fix is correct for the panic path but the surrounding wiring has parallel holes (agent-switch failure dead channel, post-crash send guard, missing Quit on switch, restart+switch identity split, shutdown_initiated encapsulation).

**Per the operator's call:** keep this PR's scope tight (just the panic path), apply safe_auto cleanups only, file the cohort as **one forward-looking follow-up** rather than splitting into per-finding tickets. See [mika#1150](https://github.com/senara-solutions/mika/issues/1150) — *"tui: harden agent-worker lifecycle wiring around the mika#1149 supervisor"*. The cohort framing rationale is compounded at [`docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md`](docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md).

### Safe_auto fixes applied in this PR (review round 2)

- Removed redundant `shutdown_initiated.store(true)` at run() cleanup (the load-bearing store is at the Quit branch immediately before `agent_tx.send(Quit)`).
- `warn!`-log on 2s supervisor-shutdown timeout instead of silent `let _ =`.
- Documented `/restart` in `crates/mika-cli/CLAUDE.md` § TUI Features and `docs/slash-commands.md`.
- Documented the binary+library layout in `crates/mika-cli/CLAUDE.md` so future contributors understand the intentional minimalism of `src/lib.rs`.
- Added unit tests for both `/restart` branches and both `tick_agent_mode` event types (Reply vs WorkerCrashed).

## Plan

Plan: [docs/plans/2026-05-16-001-fix-server-tui-user-message-silently-dropped-plan.md](docs/plans/2026-05-16-001-fix-server-tui-user-message-silently-dropped-plan.md)

Architect-validated (mika-arch second-pass GROOMED). The plan was originally on `fix/850/server-tui-user-message-silently-dropped` and migrated here at the start of dispatch — front-matter updated to point at mika#1149, scope note added to defer the forensic phases (`P0.1/2/3/5/6`, `§F1`, `§G`) to mika#850 per this issue's Out-of-scope clause. The in-scope cuts (`§F2` supervision, `§F4` /restart, `§T` integration tests, `§F5` observability event) are what shipped.

## Prior art / compounded learnings

- **mika#959** — server-side analogue: callback subprocess watchdog via `/proc/<pid>/stat`. Same shutdown-silencing pattern (grace period instead of atomic flag), different liveness signal. This PR's primitive is the in-process equivalent.
- **mika#203** — failed callbacks silently dropped at the DB delivery layer. Same silent-failure class; `AgentResponse::WorkerCrashed` is the type-level fix that doc points toward.
- **mika#1066** — TUI `/exit` fast-path discipline that `/restart` mirrors. Slash commands meant to recover from a stuck state must not gate on `AgentStatus::Idle`.

New compounded learnings from this work:
- [`docs/solutions/best-practices/supervise-tokio-spawn-with-shutdown-flag-2026-05-16.md`](docs/solutions/best-practices/supervise-tokio-spawn-with-shutdown-flag-2026-05-16.md) — reusable supervision pattern for any long-lived `tokio::spawn` in the workspace.
- [`docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md`](docs/solutions/workflow-issues/bug-class-fix-scope-vs-lifecycle-cohort-2026-05-16.md) — the cohort framing meta-pattern.

## Adjacent (out of scope; flagged for follow-up)

- **6 unguarded `tokio::spawn` sites** in `crates/mika-gateway/src/github.rs` (lines 813, 2296, 2584, 2633, 2941, 2968) flagged by the agent-native reviewer. The `mika_cli::supervision::supervise` primitive is already reusable for those — file separately when prioritized.
- mika#850 itself stays open pending the operator's forensic verification on `~/.mika/agents/<name>/logs/mika.log.2026-04-{27,28}`. Per the body's Out-of-scope clause, this PR does not modify mika#850's body, labels, or status.

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)