### PR TITLE
fix(dispatch-lib): strip recovery shim's unscoped plan fallback (mika#1144)

### DIFF
--- a/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
+++ b/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
@@ -1,0 +1,486 @@
+---
+title: Strip recovery shim's "any plan file" fallback — Class C body-callout drift
+ticket: mika#1144
+parent_ticket: mika#1123
+type: bug
+status: drafted
+created: 2026-05-16
+---
+
+# Plan: Strip recovery shim's "any plan file" fallback (mika#1144, Class C drift)
+
+## TL;DR
+
+The post-flight body-callout recovery shim in `skills/bundled/_shared/dispatch-lib.sh`
+(added by mika#1123) has a fallback that, when no issue-scoped plan file is found on
+the worktree, picks "any `*-plan.md` in `docs/plans/`, lexicographically last" and writes
+a body callout pointing at it. Because the worktree is branched from `main`, that
+fallback deterministically returns the most-recently-merged plan from some other ticket.
+Result: a fabricated callout that looks valid but routes the reader into stale,
+unrelated work (Class C body-callout drift).
+
+**Fix:** Remove the fallback entirely. When no issue-scoped plan exists, log a stderr
+warning and return without writing a callout. The orchestrator's Class A path (missing
+callout → dispatch dev-groom) handles it correctly. A missing callout is more
+recoverable than a wrong one.
+
+## Phase 0 — Pin (load-bearing source slices)
+
+**Base commit:** `31c1b0a5` (worktree HEAD = `origin/main` tip at grooming time,
+2026-05-16). The plan-staging commit (this plan file's eventual first commit) is
+the only delta on the branch; the source files pinned below are unchanged
+from `origin/main`.
+
+Five sites determine the load-bearing claims of this plan. P0.1, P0.4, and P0.5
+are the implementer-facing pins (the exact slices that are deleted, retained, or
+inserted-after). P0.2 and P0.3 are dispatch-gate / orchestrator-path context.
+
+### P0.1 — `_verify_and_write_body_callout()` plan-file lookup (delete + replace target)
+
+`skills/bundled/_shared/dispatch-lib.sh:185–196`:
+
+```bash
+    # 3. Find the plan file on the branch — scoped to issue number first
+    local plan_file
+    plan_file=$(find "$worktree_dir/docs/plans" -name "*-${issue_num}-*-plan.md" -size +500c \
+        2>/dev/null | sort -r | head -1)
+
+    # Fall back to any plan file if issue-scoped search finds nothing
+    if [ -z "$plan_file" ]; then
+        plan_file=$(find "$worktree_dir/docs/plans" -name "*-plan.md" -size +500c \
+            2>/dev/null | sort -r | head -1)
+    fi
+
+    [ -n "$plan_file" ] || return 0  # No valid plan file — can't write callout
+```
+
+The fallback at lines 191–194 is the source of Class C drift. When the worktree is
+branched from `main` (which carries every previously-merged plan in `docs/plans/`),
+the fallback returns the lexicographically-largest filename — typically a recent
+unrelated plan.
+
+### P0.2 — `check_grooming_markers()` dispatch gate (Pin B from mika#1123 plan)
+
+`crates/mika-agent/src/skills/executor.rs:794–808` (semantics — three substring
+checks: `> - **Branch:**`, `docs/plans/`, and `second-pass (GROOMED)` or
+`second-pass (READY, paraphrased GROOMED`). The recovery callout's "Grooming history"
+line intentionally does **not** contain a GROOMED marker, so the dispatch gate
+correctly rejects even when the recovery callout is wrong.
+
+This means Class C does **not** auto-dispatch implementation. The danger surface is
+operator visibility: an operator skimming the issue body sees a green-looking callout
+and may manually dispatch against the wrong plan.
+
+### P0.3 — Class A handling on the orchestrator side
+
+When the recovery shim writes no callout at all (Class A), the next autonomous
+dispatch hits the grooming-marker gate (mika#1108), the auto-groom path
+(mika#996) re-runs dev-groom, and dev-groom either writes the organic callout
+(the happy path) or repeats the drift (escalates upward). Either way, the failure
+mode stays loud and recoverable — no wrong-path side effect.
+
+### P0.4 — `$plan_file` consumption chain (untouched call site)
+
+`skills/bundled/_shared/dispatch-lib.sh:198–229`:
+
+```bash
+    local plan_relpath="${plan_file#"$worktree_dir/"}"
+    local head_sha
+    head_sha=$(git -C "$worktree_dir" rev-parse --short HEAD 2>/dev/null)
+
+    # 4. Construct recovery callout.
+    #    IMPORTANT: The grooming-history line does NOT contain "second-pass (GROOMED)"
+    #    because we cannot verify the architect actually issued that verdict from
+    #    branch state alone. This callout surfaces the drift for operator visibility
+    #    but does NOT pass the dispatch gate — the operator must verify and dispatch
+    #    manually (or re-run dev-groom which will write the organic callout).
+    local callout_block
+    callout_block=$(cat <<CALLOUT_EOF
+> - **Branch:** \`${branch}\`
+> - **Plan:** \`${plan_relpath}\` (committed on branch @ \`${head_sha}\`)
+> - **Grooming history:** body callout recovered by post-flight (mika#1123) — architect verdict not verified, operator dispatch required
+CALLOUT_EOF
+    )
+
+    # 5. Prepend callout to existing body and write
+    local new_body
+    new_body=$(printf '%s\n\n%s' "$callout_block" "$current_body")
+    local tmpfile
+    tmpfile=$(mktemp /tmp/body-callout-recover-XXXXXX.md)
+    printf '%s' "$new_body" > "$tmpfile"
+
+    if gh issue edit "$issue_num" --repo "senara-solutions/$repo" \
+        --body-file "$tmpfile" 2>/dev/null; then
+        echo "body_callout_drift_recovered: wrote missing callout to $repo#$issue_num (verdict NOT fabricated — operator dispatch required)" >&2
+    else
+        echo "WARN: body_callout_drift_recovery_failed for $repo#$issue_num" >&2
+    fi
+    rm -f "$tmpfile"
+}
+```
+
+`$plan_file` is consumed only at line 198 (`plan_relpath="${plan_file#...}"`).
+There is no earlier consumer between the discovery section (185–196) and this
+call site. The fallback's deletion is therefore safe — no downstream code reads
+`$plan_file` in any path that depends on the fallback ever firing. The callout
+construction (lines 202–214), the body prepend (216–221), and the `gh issue
+edit` invocation (223–228) are all unchanged by this PR.
+
+### P0.5 — Test ordinal for the new regression guard
+
+`skills/bundled/_shared/test-dispatch-lib.sh` contains seven tests today
+(Test 1 line 61, Test 2 line 81, Test 3 line 116, Test 4 line 130, Test 5 line
+148, Test 6 line 182, Test 7 line 228). The Summary block starts at line 262.
+The new test is **Test 8** and is inserted immediately before the Summary block
+(after line 260 / Test 7's last assertion).
+
+This pin guards against a concurrent test addition shifting the ordinal — if
+another PR lands a Test 8 before this one, the implementer must renumber to
+Test 9 at insertion time.
+
+## Problem
+
+Three classes of body-callout drift exist (per `feedback_body_callout_drift_two_classes`
+memory, extended to three classes 2026-05-16):
+
+| Class | Signal | Disposition |
+|-------|--------|-------------|
+| A | No callout at all | Re-dispatch dev-groom |
+| B | Callout present, verdict line has extra text in parens | `perl`-patch the verdict line |
+| C | Callout present with **wrong plan path** (points at an unrelated, previously-merged plan) | Strip callout + re-groom |
+
+Class C is the most dangerous: the callout passes a casual eyeball check (branch
+name matches the issue, plan path is real and on the branch — technically — because
+it was inherited from `main`), but the linked plan has nothing to do with the issue.
+
+**Canonical Class C instance:** mika#1142 grooming session 2026-05-16. dev-groom
+exited with zero commits ahead of main on worktree
+`bug-1142-claude-pilot-log-emits-zero-events-when`. Recovery shim ran:
+
+1. `find docs/plans -name '*-1142-*-plan.md'` → empty.
+2. Fallback: `find docs/plans -name '*-plan.md' | sort -r | head -1` →
+   `docs/plans/2026-05-15-923-fix-shared-dir-install-plan.md` (mika#923's plan,
+   already merged to main).
+3. Shim wrote a callout to mika#1142's body pointing at #923's plan.
+
+The "architect verdict not verified, operator dispatch required" hedge in the
+Grooming history line is the only barrier between the wrong callout and an
+operator-driven implementation dispatch against unrelated work.
+
+## Root cause
+
+The fallback at `dispatch-lib.sh:191–194` is structurally wrong. The worktree is
+branched from `main`; `find` scans the on-disk tree, not commits on this branch.
+Every plan file from every previously-merged PR is visible, and `sort -r | head -1`
+returns the lexicographically-largest filename — which, due to the
+`YYYY-MM-DD-NNN-*-plan.md` naming convention, is reliably the most recently-merged
+unrelated plan.
+
+The fallback was added (per mika#1123 plan § "Plan-file discovery scoped to issue
+number (NF1 resolution)") to handle non-standard plan filenames. Empirically, no
+real Class C drift incident has been caused by a properly-written plan with a
+non-standard name — the only observed cause is dev-groom drifting and writing
+**no plan at all**.
+
+## Approach: Strip the fallback (Option A from ticket)
+
+Remove lines 191–194 of `dispatch-lib.sh` (the fallback `if [ -z "$plan_file" ];
+then ... fi` block). When the issue-scoped lookup returns empty, log a stderr
+warning and `return 0` — the same exit path the function already takes when no
+plan file is found at all.
+
+The recommended fix from the ticket's "Fix proposal" section selects Option A
+explicitly: "Class C only occurs because we are trying too hard to write a callout
+when the real failure is upstream (dev-groom drift). Treat the absent-plan case as
+a hard failure of recovery, log to stderr, and let the orchestrator's 'no callout'
+check (Class A path) handle it the same as the no-recovery case."
+
+Option B (constrain the fallback via `git log --diff-filter=A --name-only
+main..HEAD`) is rejected for the same reason: it adds defensive complexity to
+preserve a fallback that has never recovered a real incident, only created them.
+
+### Why not write a sentinel "callout missing, run dev-groom again" placeholder?
+
+The shim has no canonical contract for partial state; adding one is more surface
+than removing the fallback. The orchestrator's Class A path already handles
+"no callout" cleanly. A sentinel placeholder would require teaching every consumer
+(dispatch gate, operator visual inspection, future dev-groom resume logic) to
+recognize it. Simpler to leave the body alone.
+
+## Implementation
+
+### Step 1: Remove the fallback in `dispatch-lib.sh`
+
+**File:** `skills/bundled/_shared/dispatch-lib.sh`
+**Location:** `_verify_and_write_body_callout()`, lines 185–196.
+
+**Before** (current shape):
+
+```bash
+    # 3. Find the plan file on the branch — scoped to issue number first
+    local plan_file
+    plan_file=$(find "$worktree_dir/docs/plans" -name "*-${issue_num}-*-plan.md" -size +500c \
+        2>/dev/null | sort -r | head -1)
+
+    # Fall back to any plan file if issue-scoped search finds nothing
+    if [ -z "$plan_file" ]; then
+        plan_file=$(find "$worktree_dir/docs/plans" -name "*-plan.md" -size +500c \
+            2>/dev/null | sort -r | head -1)
+    fi
+
+    [ -n "$plan_file" ] || return 0  # No valid plan file — can't write callout
+```
+
+**After:**
+
+```bash
+    # 3. Find the plan file on the branch — scoped to issue number only.
+    # Class C drift fix (mika#1144): no fallback to "any plan file". A worktree
+    # branched from main carries every previously-merged plan in docs/plans/, so
+    # an unscoped `find | sort -r | head -1` reliably returns the most recent
+    # unrelated plan. A missing callout (Class A) is more recoverable than a
+    # wrong one (Class C).
+    local plan_file
+    plan_file=$(find "$worktree_dir/docs/plans" -name "*-${issue_num}-*-plan.md" -size +500c \
+        2>/dev/null | sort -r | head -1)
+
+    if [ -z "$plan_file" ]; then
+        echo "body_callout_drift_recovery_skipped: no issue-scoped plan file found for $repo#$issue_num (Class A — orchestrator will re-dispatch dev-groom)" >&2
+        return 0
+    fi
+```
+
+**What changed:**
+
+- Deleted the `if [ -z "$plan_file" ]; then ... fi` fallback block (lines 191–194 in
+  the current file).
+- Replaced the silent `[ -n "$plan_file" ] || return 0` with an explicit stderr log
+  before returning. The log line uses a distinct key (`body_callout_drift_recovery_skipped`)
+  that operators and log scanners can grep for separately from the success log
+  (`body_callout_drift_recovered`).
+- Added a header comment explaining why the fallback was removed (anchors future
+  readers to the Class C incident).
+
+### Step 2: Update the function's header comment to document the new contract
+
+**File:** `skills/bundled/_shared/dispatch-lib.sh`
+**Location:** `_verify_and_write_body_callout()` header, lines 158–167.
+
+The current header reads:
+
+```bash
+_verify_and_write_body_callout() {
+    # Post-flight body-callout recovery (mika#1123): detect dev-groom drift where
+    # the plan is committed and pushed but the issue body never received the
+    # canonical callout block. If missing, write a recovery callout that surfaces
+    # the drift without fabricating an architect verdict.
+    #
+    # Dual-write documentation: body callouts can be written by two paths:
+    #   (1) the LLM in dev-groom step 18 (organic, passes dispatch gate)
+    #   (2) this structural recovery (partial, does NOT pass dispatch gate)
+```
+
+Append a third bullet to the dual-write documentation block to capture the new
+no-write case:
+
+```bash
+    # Dual-write documentation: body callouts can be written by two paths:
+    #   (1) the LLM in dev-groom step 18 (organic, passes dispatch gate)
+    #   (2) this structural recovery (partial, does NOT pass dispatch gate)
+    # When the issue-scoped plan file is missing (dev-groom drift produced no
+    # plan at all), this function logs body_callout_drift_recovery_skipped and
+    # exits without writing — the orchestrator's Class A path handles it
+    # (re-dispatch dev-groom). See mika#1144 for the Class C drift this guards
+    # against.
+```
+
+### Step 3: Add a structural test to `test-dispatch-lib.sh`
+
+**File:** `skills/bundled/_shared/test-dispatch-lib.sh`
+**Location:** Append after the existing Test 7 block (per Pin P0.5, last line 260),
+before the Summary section at line 262.
+
+The test is a **paired regression guard** (per architect first-pass F2): it must
+assert both that the unscoped fallback is **absent** AND that the issue-scoped
+find is **present**. A refactor that accidentally removed the scoped find too
+would otherwise pass a deletion-only test.
+
+**Grep patterns explicitly used in Test 8:**
+
+| Pattern | Purpose | Expected count |
+|---------|---------|----------------|
+| `find.*-name *"\*-\${issue_num}-\*-plan\.md"` | Scoped find — the retained call | ≥ 1 in `$VERIFY_FUNC` |
+| `plan_file=.*find.*-name *"\*-plan\.md"` followed by `grep -v issue_num` | Unscoped find — the deleted fallback (filter out the scoped find by requiring `issue_num` is absent on the same line) | 0 in `$VERIFY_FUNC` |
+| `body_callout_drift_recovery_skipped` | New stderr log key | ≥ 1 in `$VERIFY_FUNC` |
+| `return 0` and `>&2` inside the `if [ -z "$plan_file" ]` block | Early-return guard with stderr log | ≥ 1 each in `$SKIP_BLOCK` |
+
+Both production-shape assertions (positive scoped find, absent unscoped find) are
+scoped to `$VERIFY_FUNC` — the body of `_verify_and_write_body_callout()`
+extracted via `sed`. This mirrors the convention in Test 1 (sed-extracts
+`CLOSED_BLOCK`), Test 4 (sed-extracts `ISSUE_STATE_REGION`), and Test 6
+(sed-extracts `PLAN_FUNC`).
+
+```bash
+# --- Test 8: Recovery shim fallback removed (mika#1144) ---
+
+echo ""
+echo "Test 8: _verify_and_write_body_callout has no unscoped fallback"
+echo "-----------------------------------------------------------------"
+
+VERIFY_FUNC=$(sed -n '/_verify_and_write_body_callout()/,/^}/p' "$DISPATCH_LIB")
+
+# Assertion 1 (POSITIVE — F2 paired-test discipline): the issue-scoped find is
+# retained. If a refactor accidentally removes BOTH finds, this assertion fires.
+SCOPED_FIND_COUNT=$(printf '%s\n' "$VERIFY_FUNC" \
+    | grep -cE 'find.*-name *"\*-\$\{issue_num\}-\*-plan\.md"' || true)
+assert_eq "Issue-scoped find call retained" "1" "$SCOPED_FIND_COUNT"
+
+# Assertion 2 (NEGATIVE — the core mika#1144 regression guard): the unscoped
+# fallback find is gone. Detection shape: an assignment to plan_file with a
+# `find ... -name "*-plan.md"` glob that does NOT contain `${issue_num}`.
+# The scoped find above DOES contain `${issue_num}` and is filtered out by the
+# `grep -v issue_num` step.
+UNSCOPED_FALLBACK_COUNT=$(printf '%s\n' "$VERIFY_FUNC" \
+    | grep -E 'plan_file=.*find.*-name *"\*-plan\.md"' \
+    | grep -vc 'issue_num' || true)
+assert_eq "No unscoped fallback find call (mika#1144 strip)" "0" "$UNSCOPED_FALLBACK_COUNT"
+
+# Assertion 3: the new stderr log key is present (signals the skip path is
+# explicit, not silent).
+assert_contains "Skipped-recovery stderr log present" \
+    'body_callout_drift_recovery_skipped' "$VERIFY_FUNC"
+
+# Assertion 4: the function still has the early-return guard after the
+# issue-scoped find — no plan file → return 0, now with a log line on stderr.
+SKIP_BLOCK=$(printf '%s\n' "$VERIFY_FUNC" | sed -n '/if \[ -z "\$plan_file" \]/,/fi/p' | head -10)
+assert_contains "Skip block returns 0" "return 0" "$SKIP_BLOCK"
+assert_contains "Skip block logs to stderr" '>&2' "$SKIP_BLOCK"
+```
+
+The four assertions cover both directions of the structural change:
+
+- **Assertions 1 + 2** are paired: assertion 1 catches "scoped find accidentally
+  removed in a refactor"; assertion 2 catches "unscoped fallback re-added."
+  Together they nail the discovery-section shape.
+- **Assertion 3** verifies the skip path's observability (stderr key present).
+- **Assertion 4** verifies the skip path's control-flow shape (`return 0` + `>&2`
+  inside the `if [ -z "$plan_file" ]` block).
+
+The grep shapes are anchored on production code (`$VERIFY_FUNC` only, not the
+full file), so a future comment line that happens to mention `find ... -name
+"*-plan.md"` elsewhere in `dispatch-lib.sh` does not produce a false positive.
+
+### Step 4: Update operator memory note
+
+**File:** `~/.claude/projects/-data-workspace-mika-platform/memory/feedback_body_callout_drift_two_classes.md`
+
+This memory is the operator's diagnostic recipe for the three drift classes. The
+current file references "two classes" in its slug and only documents Classes A
+and B. The Class C entry should be appended (or the file renamed and rewritten
+to cover all three).
+
+**Out of scope for this PR.** Memory edits are operator-managed and cross-repo
+(memory lives in the orchestrator's home directory, not this repo). The plan
+flags the update as a follow-up so it doesn't get lost; the operator will apply
+it after merge.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `skills/bundled/_shared/dispatch-lib.sh` | Remove unscoped fallback in `_verify_and_write_body_callout()`; add explicit stderr log on skip; update header comment |
+| `skills/bundled/_shared/test-dispatch-lib.sh` | Add Test 8: structural regression guard for the removed fallback |
+
+No Rust code changes. No new dependencies. No schema changes.
+
+## Acceptance Criteria Mapping
+
+The ticket lists four acceptance criteria. Each maps to a verification step.
+
+- **AC-1 — Class C eliminated:** When dev-groom drifts on issue N and writes no
+  `*-N-*-plan.md` file, the recovery shim does NOT write a callout pointing at any
+  other plan. **Verified by:** Test 8 structural assertion that the unscoped
+  fallback is gone. **Behavioural verification (manual smoke):** create a worktree
+  branched from main with no plan file for issue X; run `_verify_and_write_body_callout
+  "mika" "X" "<worktree>" "<branch>"`; assert no `gh issue edit` is fired and
+  stderr contains `body_callout_drift_recovery_skipped`.
+
+- **AC-2 — Class A behavior preserved:** When truly no plan exists, the issue body
+  remains untouched and the orchestrator sees the missing callout. **Verified by:**
+  the new skip block returns 0 before reaching the `gh issue edit` call site
+  (Step 1 placement above the existing `plan_relpath`/`head_sha`/`callout_block`
+  code). Test 8's "Skip block returns 0" assertion checks this structurally.
+
+- **AC-3 — Class B path unaffected:** Verdict-line drift recovery (if any) is
+  separate. **Verified by:** this change touches only the plan-file discovery
+  section (lines 185–196). The callout construction and `gh issue edit` call
+  (lines 198–229 in the current file) are unchanged. Class B is currently handled
+  operator-side (perl-patch) per the memory note; no shim path changes.
+
+- **AC-4 — Regression: organic happy path:** When dev-groom DOES write a plan, the
+  issue-scoped match still fires and the callout is written correctly. **Verified
+  by:** the issue-scoped find call is unchanged (Test 8's "Issue-scoped find call
+  present" assertion). The downstream callout construction is unchanged. The only
+  behavioural delta is in the empty-result branch.
+
+## Verification
+
+Local verification before push:
+
+```bash
+# 1. Run the test suite (must show 1 new test, 0 failures)
+bash skills/bundled/_shared/test-dispatch-lib.sh
+
+# 2. Static check: confirm the fallback grep returns zero in the new shape
+grep -c 'find.*"\*-plan\.md"' skills/bundled/_shared/dispatch-lib.sh
+# Expect: 1 (only the issue-scoped find remains, which contains "${issue_num}")
+grep -c 'find.*"\*-${issue_num}-\*-plan\.md"' skills/bundled/_shared/dispatch-lib.sh
+# Expect: 1
+
+# 3. Static check: confirm the new stderr log key is present
+grep -c 'body_callout_drift_recovery_skipped' skills/bundled/_shared/dispatch-lib.sh
+# Expect: 1
+```
+
+End-to-end verification requires a real dispatch with a synthetic dev-groom drift —
+that is **out of scope for this PR** (would require provisioning a test agent and
+dispatching against a fake issue). The structural test + manual smoke covers the
+behavioural change with sufficient confidence given the small surface area.
+
+## Risk and rollback
+
+**Blast radius:** Bash-only change in a recovery code path that has never
+recovered a real incident (the fallback's only documented effect is generating
+Class C drift). Removing it cannot regress anything that wasn't already broken.
+
+**Rollback:** Revert the single commit. The pre-#1144 behavior is restored. Class
+C drift returns; Class A handling is unaffected.
+
+**Forward risk:** A future dev-groom drift that writes a plan with a non-standard
+filename (e.g., `docs/plans/2026-05-16-misc-fix.md`, no issue number) would now
+trigger Class A instead of Class C-with-wrong-path. Class A re-dispatches
+dev-groom, which would re-attempt the plan and either write a properly-named one
+or fail loudly. This is strictly better than Class C — but if there is hidden
+reliance on the fallback for non-standard names, this PR surfaces it as
+re-dispatch loops, which is observable.
+
+## Related
+
+- mika#1123 — parent ticket that added the recovery shim; this PR is a fix-on-top
+  of the shim's fallback behavior.
+- mika#1142 — Class C canary (the recursive grooming session that exposed this bug).
+- mika#1108 — the dispatch-readiness gate that correctly rejects even when the
+  wrong callout is written; this fix removes the upstream wrong-callout source.
+- mika#996 — auto-groom-on-dispatch (the Class A recovery path that this fix
+  routes drift into).
+- `docs/solutions/workflow-issues/recovery-shim-fallback-wrong-plan-path-class-c-2026-05-16.md`
+  — the solutions-doc characterization of Class C drift.
+
+## Out of scope
+
+- Operator memory note update (`feedback_body_callout_drift_two_classes.md` →
+  three classes) — managed in orchestrator home, not this repo.
+- Class B verdict-line drift handling improvements — separate failure mode,
+  separate ticket if/when it becomes worth automating.
+- End-to-end dispatch integration test — would require a test-agent fixture
+  beyond the scope of this fix.

--- a/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
+++ b/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
@@ -31,6 +31,15 @@ recoverable than a wrong one.
 the only delta on the branch; the source files pinned below are unchanged
 from `origin/main`.
 
+> **Naming note (mika-arch second-pass NF6):** The issue body of mika#1144
+> refers to the function as `recover_body_callout_drift()`. The actual function
+> name in `skills/bundled/_shared/dispatch-lib.sh` (verified via Pin P0.1 below
+> at line 158) is **`_verify_and_write_body_callout()`**. This plan and the
+> implementation target the underscore-prefixed name as it appears in the
+> source tree; the issue body's reference is inaccurate but functionally
+> unambiguous (the lines 185–196 citation pins the same code regardless of
+> what the function is called). No rename is in scope for this PR.
+
 Five sites determine the load-bearing claims of this plan. P0.1, P0.4, and P0.5
 are the implementer-facing pins (the exact slices that are deleted, retained, or
 inserted-after). P0.2 and P0.3 are dispatch-gate / orchestrator-path context.

--- a/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
+++ b/docs/plans/2026-05-16-002-bug-1144-dispatch-lib-recovery-fallback-class-c-plan.md
@@ -3,7 +3,7 @@ title: Strip recovery shim's "any plan file" fallback — Class C body-callout d
 ticket: mika#1144
 parent_ticket: mika#1123
 type: bug
-status: drafted
+status: completed
 created: 2026-05-16
 ---
 

--- a/docs/solutions/kg-investigations/2026-05-16-resolver-sonnet-baseline.md
+++ b/docs/solutions/kg-investigations/2026-05-16-resolver-sonnet-baseline.md
@@ -1,0 +1,139 @@
+---
+date: 2026-05-16
+module: mika-agent/kg
+tags: [kg, resolver, model-comparison, sonnet, gemini-flash-lite, fragmentation, mika-1152]
+problem_type: investigation
+category: kg-investigations
+related_tickets: [mika#1152, mika#1076, mika#1077, mika#1091, mika#14]
+status: complete
+---
+
+# KG resolver model-quality baseline — sonnet-4-6 vs gemini-2.5-flash-lite
+
+## TL;DR
+
+**Fragmentation hypothesis holds. Decision A (deprecate `query_knowledge_graph` for mika-arch, 2026-05-12) is ratified. Model-quality hypothesis is falsified.**
+
+Sonnet-4-6 was re-run against 87 distinct subjects that gemini-2.5-flash-lite had returned `no_match` on between 2026-05-01 and 2026-05-16. Sonnet matched **0/87 (0.0%)**. Total spend: $0.34.
+
+Root cause confirmed by orthogonal check: **0/87 of these subjects have any corresponding `kg_entities` row by entity_key OR by name** (case-insensitive). The miss is not the resolver failing to disambiguate — there is no candidate to disambiguate against. The bottleneck is upstream of the resolver: the subject extractor is producing subjects (e.g., `agent:vincent`, `agent:ci`, `agent:tower_http`, `tool:tailwind`) for which the domain graph has no canonical counterpart.
+
+Secondary finding (separate ticket-worthy): mika-arch's `search_content` only contains 1,722 indexed `kg_chunk` rows vs 2,700–2,900 for other agents — its chunk-context join misses on ~76% of its subjects, leaving the resolver to disambiguate against a name-only prompt. This explains some of mika-arch's elevated miss rate independent of the fragmentation finding above.
+
+## Sample shape
+
+- **Source query**: `kg_resolutions_log` rows where `model = 'google/gemini-2.5-flash-lite'`, `outcome = 'no_match'`, `resolved_at >= '2026-05-01'`, joined to `kg_subject_entities` filtered to the five resolvable types (`skill`, `tool`, `agent`, `problem_type`, `concept`).
+- **Stratification**: 20 per type via `ROW_NUMBER() OVER (PARTITION BY type ORDER BY RANDOM())` (problem_type yielded 18 unique subjects after dedup).
+- **Dedup**: 100 raw rows → 87 distinct `subject_entity_id` values (some subjects had `no_match` rows for multiple agents — prompt is agent-agnostic so duplicates were collapsed).
+- **Per-type distribution**: agent=14, concept=20, problem_type=18, skill=15, tool=20.
+- **Agent corpora represented**: mika-arch, mika-qa, mika-dev, mika.
+- **Time window**: gemini resolutions from `2026-05-01T00:00:00Z` through `2026-05-16T15:02:28Z` (~2 weeks of production data, immediately preceding this experiment).
+
+## Resolver code reference
+
+Reconstruction targets `crates/mika-agent/src/kg/entity_resolver.rs` (commit at HEAD on 2026-05-16):
+
+- **System prompt template**: `build_disambiguation_prompt()` lines 1605–1618 — copied verbatim into the experiment harness.
+- **User prompt construction**: lines 1620–1655 — `Extracted entity: {key} (confidence: {N.NN})\n\nSource prose:\n{chunk_ctx truncated to 2000 chars}\n\nCandidates:\n- {entity_key} — {description from properties_json}\n...`.
+- **Candidate selection** (`get_domain_candidates`, lines 1083–1119): SQL range scan `WHERE entity_key >= '{type}:' AND entity_key < '{type};'`, ordered by `entity_key ASC`, capped at `MAX_DISAMBIGUATION_CANDIDATES = 50`.
+- **Chunk context** (`get_chunk_context`, lines 1182–1216): joins `kg_chunk_subjects` × `search_content` filtered by `agent_id` and `docs_root_hash`, returns top-3 chunks joined by `\n\n---\n\n`.
+- **Response schema**: `{"match": "<entity_key>" | null, "confidence": 0.0-1.0}` — parsed via `parse_disambiguation_json` with markdown-fence tolerance.
+- **Production model**: `MIKA_KG_RESOLUTION_MODEL = openrouter/google/gemini-2.5-flash-lite` (verified in `~/.mika/.env`, 2026-05-16).
+
+The harness replicates the candidate query, chunk-context query, and prompt construction exactly. The only difference between production and the re-run is the LLM endpoint (Anthropic `claude-sonnet-4-6` instead of OpenRouter `google/gemini-2.5-flash-lite`).
+
+## Comparison
+
+### Gemini vs sonnet on the same subjects
+
+| Model | Sample | Matched | No-match | Match rate |
+|-------|--------|---------|----------|------------|
+| `google/gemini-2.5-flash-lite` (prod, recorded in `kg_resolutions_log`) | 87 | 0 | 87 | **0.0%** |
+| `claude-sonnet-4-6` (this experiment, 2026-05-16) | 87 | 0 | 87 | **0.0%** |
+
+**Delta: 0 percentage points.** No subject that gemini missed was caught by sonnet. The disagreement set is empty.
+
+### Historical context (advisory — different time window, different cohorts)
+
+`kg_resolutions_log` also contains 9,082 rows from an earlier sonnet run (2026-04-22 to 2026-04-25, before sonnet was rotated out for cost). On the 4,734 subjects where both models have at least one log row (joining ignoring agent):
+
+| Outcome cell | Distinct subjects | % |
+|--------------|--------------------|---|
+| both `no_match` | 3,434 | 72.5% |
+| gemini matched, sonnet `no_match` | 822 | 17.4% |
+| both matched | 308 | 6.5% |
+| sonnet matched, gemini `no_match` | 170 | 3.6% |
+
+Apparent historical match rates: gemini 23.9%, sonnet 10.1% (gemini 2.4× sonnet). This is **not load-bearing for the conclusion** because the two cohorts were resolved at different times against potentially different domain-graph snapshots, but it independently undermines the "stronger model recovers a meaningful fraction" prediction of the model-quality hypothesis.
+
+### Mean latency (advisory)
+
+- gemini-2.5-flash-lite (production-recorded): **537 ms/call**
+- sonnet-4-6 (this experiment, p50): **1,305 ms/call**, p95: **1,823 ms**
+- Sonnet is ~2.5× slower per call. Resolver runs in batched ticks (default 500 calls/30min, mika#906), so the latency delta would have direct cadence cost — independent reason to prefer the cheaper model when match rates are equal.
+
+## Failure-shape tabulation
+
+All 87 sonnet responses parsed cleanly as `{"match": null, "confidence": 0.0}` — none were prose evasions, fenced JSON, or schema deviations. Sonnet correctly refused to force a pick.
+
+Cross-checking why no candidates matched (the production resolver's no_match shape):
+
+| Check | Hits / 87 | Interpretation |
+|-------|-----------|----------------|
+| `LOWER(subject.entity_key)` exists in `kg_entities` | **0 / 87** | None of these subjects would have triggered Stage 1 exact match even with the case-insensitive lookup (which the resolver already does). |
+| `LOWER(subject.name)` matches any `kg_entities.name` (cross-type) | **0 / 87** | None of these subjects have a same-name entity under a different type either. They have no canonical counterpart in the domain graph at all. |
+| Subject reached resolver with `chunk_ctx_len = 0` | **58 / 87 (66.7%)** | Source prose unavailable to the LLM. Production resolver disambiguates these on name + candidate list only. |
+| Subject reached resolver with `chunk_ctx_len > 0` | **29 / 87 (33.3%)** | Sonnet had source prose and the same candidate set. Still returned no_match. |
+
+### Representative no-match subjects
+
+Examples of subjects that the extractor produced but for which no domain counterpart exists:
+
+- **agent** (domain holds 12 real mika agents like `agent:mika-arch`, `agent:mika-dev`): extractor produced `agent:vincent`, `agent:ci`, `agent:llm`, `agent:tower_http`, `agent:github_actions`, `agent:entity_resolver`, `agent:operator_claude`, `agent:bypass_actor`, `agent:reliability`, `agent:infrastructure_agent`, `agent:langfuse`.
+- **tool** (domain holds 894 entities, mostly real builtin tools): extractor produced `tool:tailwind`, `tool:react_router_link`, `tool:unixepoch_function`, `tool:sqlite_partial_index`, `tool:github_app_rs`, `tool:tokio_process_command`, `tool:database`.
+- **problem_type** (domain holds 5 seed entries — `ci_failure`, `merge_conflict`, `duplicate_pr`, `stale_uuid`, `fabrication`): extractor produced `problem_type:auth_failure`, `problem_type:best_practice`, `problem_type:investigation`, `problem_type:test_coverage_gap`, `problem_type:bug`, `problem_type:misread`.
+- **concept** (domain holds 20 hand-seeded `concept:cross-repo:*` and `concept:infra:*`): extractor produced `concept:groom`, `concept:self_dev`, `concept:pr_scope`, `concept:core_memory`, `concept:dispatch_gate`, `concept:webhook_ready_label_dispatch`.
+
+The pattern is consistent across types: the **subject extractor's NER pulls common nouns and code identifiers** from prose and types them into the five resolvable buckets, but the domain graph's entries for those types are a tightly curated set populated by `domain_builder.rs` from authoritative sources (`SkillRegistry`, `ToolRegistry`, agent configs, hardcoded seeds). The two populations don't overlap meaningfully on subjects that the extractor identifies in mika's `docs/solutions/` prose.
+
+### Secondary finding — mika-arch chunk index gap
+
+`search_content` row counts by agent, `source_type='kg_chunk'`:
+
+| Agent | Indexed kg_chunks |
+|-------|--------------------|
+| mika-dev | 2,905 |
+| mika-qa | 2,790 |
+| odds-engine-ceo | 2,737 |
+| mika | 2,703 |
+| ... | ... |
+| **mika-arch** | **1,722** |
+
+mika-arch — the **sole** well-known agent that consumes the KG (`mika/CLAUDE.md` § "well-known agent KG topology, #800") — has the smallest indexed chunk pool. For the multi-corpus mika-arch (`docs_roots` spans 6 repos), this manifests as: `kg_chunk_subjects` rows exist (subject extractor wrote them), but the agent-id-scoped `search_content` join in `get_chunk_context()` returns zero. Worked example: subject 34427 (`agent:bypass_actor`) has 1 `kg_chunk_subjects` row matching mika-arch's docs_root_hash; the corresponding chunk is indexed in `search_content` for `mika-relay` and `mika-qa` but not for `mika-arch` — so mika-arch's resolver sees a name-only prompt.
+
+This is independent of the fragmentation finding above (sonnet missed both with and without chunk context), but it explains some of mika-arch's elevated miss rate and is worth filing as a separate ticket.
+
+## Cost
+
+- Sonnet calls: 87
+- Total input tokens: 107,157
+- Total output tokens: 1,392
+- Total cost (at $3/M input, $15/M output): **$0.3424**
+- Budget per mika#1152: $1.50 target, $5.00 ceiling. Came in at 23% of target.
+- Wall-clock: ~3 minutes of API calls + ~30 minutes total session time.
+
+## Recommendation
+
+**Ratify Decision A.** Sonnet does not meaningfully outperform gemini-2.5-flash-lite on this resolver call. The model-quality hypothesis is falsified. The bottleneck is at the subject extraction layer, not at resolution.
+
+Subordinate next steps (each a separate decision, not implied by this finding):
+
+1. **Keep gemini-2.5-flash-lite as the production resolver model.** Sonnet's match rate is no better, its latency is 2.5× higher, and its cost is ~50× higher (gemini-flash-lite ≈ $0.20/M input vs sonnet $3/M). Cost-wise the current choice is correct.
+2. **The self-awareness umbrella tickets (mika#1076 corpora backfill, mika#1077 resolver no_match instrumentation, mika#1091 subject extractor MaxTokens) should stay paused under their current framing.** None of them would move the needle on the resolver miss rate as currently structured — the type mismatch is upstream.
+3. **Consider filing two new tickets** out of the secondary findings (operator decision, not implied):
+   - **(a) Subject extractor type-overreach** — the extractor is producing `agent:`/`tool:`/`problem_type:`/`concept:` subjects that have no domain counterpart. Either the extractor's prompt needs to be constrained to the closed set of domain entities (different shape — would change extractor semantics), or the domain graph's `agent`/`tool`/`problem_type`/`concept` types need a much wider canonical roster (different shape — would change `domain_builder.rs`), or the resolver's no_match-as-success outcome should be re-classified to differentiate "no candidate of this type exists for this subject" from "candidates exist but none match." All three are real options with different cost/quality tradeoffs.
+   - **(b) mika-arch chunk index gap** — 1,722 indexed chunks vs 2,700+ for sibling agents. Likely a lexical-ingestion-fairness bug specific to multi-corpus agents. Worth filing standalone since it affects the one well-known agent that still consumes the KG.
+
+These are surfaced for operator review; this experiment's mandate ends at the model-quality binary.
+
+Closes mika#1152.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -164,6 +164,11 @@ _verify_and_write_body_callout() {
     # Dual-write documentation: body callouts can be written by two paths:
     #   (1) the LLM in dev-groom step 18 (organic, passes dispatch gate)
     #   (2) this structural recovery (partial, does NOT pass dispatch gate)
+    # When the issue-scoped plan file is missing (dev-groom drift produced no
+    # plan at all), this function logs body_callout_drift_recovery_skipped and
+    # exits without writing — the orchestrator's Class A path handles it
+    # (re-dispatch dev-groom). See mika#1144 for the Class C drift this guards
+    # against.
     local repo="$1" issue_num="$2" worktree_dir="$3" branch="$4"
 
     # 1. Fetch current issue body
@@ -182,18 +187,20 @@ _verify_and_write_body_callout() {
         return 0  # All present, nothing to do
     fi
 
-    # 3. Find the plan file on the branch — scoped to issue number first
+    # 3. Find the plan file on the branch — scoped to issue number only.
+    # Class C drift fix (mika#1144): no fallback to "any plan file". A worktree
+    # branched from main carries every previously-merged plan in docs/plans/, so
+    # an unscoped `find | sort -r | head -1` reliably returns the most recent
+    # unrelated plan. A missing callout (Class A) is more recoverable than a
+    # wrong one (Class C).
     local plan_file
     plan_file=$(find "$worktree_dir/docs/plans" -name "*-${issue_num}-*-plan.md" -size +500c \
         2>/dev/null | sort -r | head -1)
 
-    # Fall back to any plan file if issue-scoped search finds nothing
     if [ -z "$plan_file" ]; then
-        plan_file=$(find "$worktree_dir/docs/plans" -name "*-plan.md" -size +500c \
-            2>/dev/null | sort -r | head -1)
+        echo "body_callout_drift_recovery_skipped: no issue-scoped plan file found for $repo#$issue_num (Class A — orchestrator will re-dispatch dev-groom)" >&2
+        return 0
     fi
-
-    [ -n "$plan_file" ] || return 0  # No valid plan file — can't write callout
 
     local plan_relpath="${plan_file#"$worktree_dir/"}"
     local head_sha

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -259,6 +259,41 @@ assert_eq "Multiple callouts: first one wins" "docs/plans/first.md" "$EXTRACTED4
 DRY_RUN_JQ=$(sed -n '/_handle_dry_run()/,/^}/p' "$DISPATCH_LIB")
 assert_contains "Dry run output includes entry_command" 'entry_command' "$DRY_RUN_JQ"
 
+# --- Test 8: Recovery shim fallback removed (mika#1144) ---
+
+echo ""
+echo "Test 8: _verify_and_write_body_callout has no unscoped fallback"
+echo "-----------------------------------------------------------------"
+
+VERIFY_FUNC=$(sed -n '/_verify_and_write_body_callout()/,/^}/p' "$DISPATCH_LIB")
+
+# Assertion 1 (POSITIVE — F2 paired-test discipline): the issue-scoped find is
+# retained. If a refactor accidentally removes BOTH finds, this assertion fires.
+SCOPED_FIND_COUNT=$(printf '%s\n' "$VERIFY_FUNC" \
+    | grep -cE 'find.*-name *"\*-\$\{issue_num\}-\*-plan\.md"' || true)
+assert_eq "Issue-scoped find call retained" "1" "$SCOPED_FIND_COUNT"
+
+# Assertion 2 (NEGATIVE — the core mika#1144 regression guard): the unscoped
+# fallback find is gone. Detection shape: an assignment to plan_file with a
+# `find ... -name "*-plan.md"` glob that does NOT contain `${issue_num}`.
+# The scoped find above DOES contain `${issue_num}` and is filtered out by the
+# `grep -v issue_num` step.
+UNSCOPED_FALLBACK_COUNT=$(printf '%s\n' "$VERIFY_FUNC" \
+    | grep -E 'plan_file=.*find.*-name *"\*-plan\.md"' \
+    | grep -vc 'issue_num' || true)
+assert_eq "No unscoped fallback find call (mika#1144 strip)" "0" "$UNSCOPED_FALLBACK_COUNT"
+
+# Assertion 3: the new stderr log key is present (signals the skip path is
+# explicit, not silent).
+assert_contains "Skipped-recovery stderr log present" \
+    'body_callout_drift_recovery_skipped' "$VERIFY_FUNC"
+
+# Assertion 4: the function still has the early-return guard after the
+# issue-scoped find — no plan file → return 0, now with a log line on stderr.
+SKIP_BLOCK=$(printf '%s\n' "$VERIFY_FUNC" | sed -n '/if \[ -z "\$plan_file" \]/,/^[[:space:]]*fi$/p' | head -10)
+assert_contains "Skip block returns 0" "return 0" "$SKIP_BLOCK"
+assert_contains "Skip block logs to stderr" '>&2' "$SKIP_BLOCK"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- **Removes** the "any `*-plan.md`" fallback in `_verify_and_write_body_callout()` that caused Class C body-callout drift — when dev-groom drifted without writing a plan, the fallback deterministically picked the most recently-merged unrelated plan from `main`
- **Adds** an explicit stderr log (`body_callout_drift_recovery_skipped`) when no issue-scoped plan exists, then returns without writing — routes the failure to the orchestrator's Class A path (re-dispatch dev-groom)
- **Adds** Test 8: paired structural regression guard asserting scoped find retained + unscoped fallback absent

## Context

Class C drift (mika#1142 canary): recovery shim wrote a callout pointing at mika#923's plan on mika#1142's issue body because the unscoped `find | sort -r | head -1` matched the lexicographically-last plan inherited from `main`. The fix: a missing callout is more recoverable than a wrong one.

Closes mika#1144. Parent: mika#1123.

## Test plan

- [x] `bash skills/bundled/_shared/test-dispatch-lib.sh` — Test 8 passes (5 assertions ✓)
- [x] Static grep: 0 unscoped find calls, 1 issue-scoped find call, stderr key present
- [ ] (Post-merge) Monitor `body_callout_drift_recovery_skipped` in agent logs to confirm Class A routing works

## Post-Deploy Monitoring & Validation

- **Log query:** `grep body_callout_drift_recovery_skipped server.log` — presence confirms the skip path fires when dev-groom drifts without a plan
- **Healthy signal:** Class C drift incidents stop (no more wrong-plan callouts on issue bodies)
- **Failure signal:** `body_callout_drift_recovered` logs pointing at unrelated plan paths — would indicate the fallback was re-introduced
- **Validation window:** Next 3 dev-groom dispatches that encounter drift

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>