### PR TITLE
fix(agent): reconcile code-owned identity sections on startup (mika#1220)

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -385,6 +385,217 @@ allowlist = ["mika-arch-groom-ticket", "mika-arch-groom-milestone", "mika-arch-s
 /// All well-known agents.
 pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA, &MIKA_RELAY, &MIKA_ARCH];
 
+/// Identity-toml section paths that the reconciler owns from the static spec.
+///
+/// **Each entry is a dotted path** from the root of `identity.toml`. The reconciler
+/// walks each path in both the expected (spec-rendered) tree and the on-disk tree;
+/// when they differ, the expected subtree replaces the on-disk subtree.
+///
+/// Adding a new code-owned section to `WellKnownAgent`'s identity templates requires
+/// adding an entry here AND adding a unit test below — the
+/// `test_code_owned_sections_have_reconciler_coverage` test iterates this constant
+/// and fails the build if any entry is not exercised by a spec.
+///
+/// Sections NOT listed here are preserved verbatim from the on-disk file (operator-owned:
+/// `name`, `emoji`, `[reflection]`, `[kg]`).
+pub const CODE_OWNED_IDENTITY_SECTIONS: &[&str] =
+    &["skills.allowlist", "tools.disabled", "context.summary"];
+
+/// Walk a dotted path through a `toml::Value` tree.
+///
+/// Returns `None` if any segment is missing or traverses a non-table value.
+fn get_path<'a>(value: &'a toml::Value, dotted: &str) -> Option<&'a toml::Value> {
+    let mut current = value;
+    for segment in dotted.split('.') {
+        current = current.as_table()?.get(segment)?;
+    }
+    Some(current)
+}
+
+/// Set a value at a dotted path, creating intermediate empty tables as needed.
+///
+/// Returns `Err` if a non-table value blocks the path. Existing siblings at any
+/// intermediate level are preserved.
+fn set_path(value: &mut toml::Value, dotted: &str, new: toml::Value) -> Result<(), String> {
+    let segments: Vec<&str> = dotted.split('.').collect();
+    let (last, parents) = segments
+        .split_last()
+        .ok_or_else(|| "empty dotted path".to_string())?;
+    let mut current = value;
+    for segment in parents {
+        let table = current
+            .as_table_mut()
+            .ok_or_else(|| format!("path '{dotted}' traverses non-table at '{segment}'"))?;
+        if !table.contains_key(*segment) {
+            table.insert(
+                (*segment).to_string(),
+                toml::Value::Table(toml::Table::new()),
+            );
+        }
+        current = table
+            .get_mut(*segment)
+            .ok_or_else(|| format!("insertion failed at '{segment}'"))?;
+    }
+    let table = current.as_table_mut().ok_or_else(|| {
+        format!("path '{dotted}' parent is not a table at final segment '{last}'")
+    })?;
+    table.insert((*last).to_string(), new);
+    Ok(())
+}
+
+/// Reconcile the code-owned sections of a well-known agent's on-disk identity.toml
+/// against the static spec.
+///
+/// For each path in [`CODE_OWNED_IDENTITY_SECTIONS`], if the spec defines a value
+/// and the on-disk file differs (or is missing the section), the on-disk subtree
+/// is replaced with the expected subtree. Operator-owned sections (`name`, `emoji`,
+/// `[reflection]`, `[kg]`) are preserved verbatim.
+///
+/// Failure isolation: any error (parse, render, write) logs a `warn!` and skips
+/// THIS agent only. The existing fail-closed parse path in `prompt::load_identity()`
+/// protects the running agent from a malformed file.
+///
+/// Idempotent: when the on-disk file already matches the spec on every code-owned
+/// path, the function emits a single info log and writes nothing.
+///
+/// Atomic write: serialized content is written to `identity.toml.tmp` then renamed
+/// over `identity.toml` so a crash mid-write never leaves a partial file.
+pub fn reconcile_well_known_identity(home_dir: &Path, spec: &WellKnownAgent, settings: &Settings) {
+    let agent_home = mika_common::agent::agent_dir(home_dir, spec.name);
+    let identity_path = agent_home.join("identity.toml");
+
+    let expected_str = match render_identity_content(spec, settings) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                event = "identity_reconcile.skipped",
+                reason = "render_failed",
+                agent = spec.name,
+                error = %e,
+                "identity reconciliation skipped — failed to render expected identity"
+            );
+            return;
+        }
+    };
+
+    let on_disk_str = match std::fs::read_to_string(&identity_path) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                event = "identity_reconcile.skipped",
+                reason = "read_failed",
+                agent = spec.name,
+                error = %e,
+                "identity reconciliation skipped — failed to read on-disk identity.toml"
+            );
+            return;
+        }
+    };
+
+    let expected: toml::Value = match toml::from_str(&expected_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                event = "identity_reconcile.skipped",
+                reason = "expected_parse_failed",
+                agent = spec.name,
+                error = %e,
+                "identity reconciliation skipped — failed to parse expected identity"
+            );
+            return;
+        }
+    };
+
+    let mut on_disk: toml::Value = match toml::from_str(&on_disk_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                event = "identity_reconcile.skipped",
+                reason = "on_disk_parse_failed",
+                agent = spec.name,
+                error = %e,
+                "identity reconciliation skipped — on-disk identity.toml is malformed"
+            );
+            return;
+        }
+    };
+
+    let mut reconciled_paths: Vec<&str> = Vec::new();
+    for path in CODE_OWNED_IDENTITY_SECTIONS {
+        let expected_val = match get_path(&expected, path) {
+            Some(v) => v,
+            None => continue,
+        };
+        if get_path(&on_disk, path) != Some(expected_val) {
+            if let Err(e) = set_path(&mut on_disk, path, expected_val.clone()) {
+                warn!(
+                    event = "identity_reconcile.skipped",
+                    reason = "set_path_failed",
+                    agent = spec.name,
+                    path = %path,
+                    error = %e,
+                    "identity reconciliation failed at path"
+                );
+                return;
+            }
+            reconciled_paths.push(path);
+        }
+    }
+
+    if reconciled_paths.is_empty() {
+        info!(
+            event = "identity_reconcile.in_sync",
+            agent = spec.name,
+            "identity in sync — no reconciliation needed"
+        );
+        return;
+    }
+
+    let merged_str = match toml::to_string(&on_disk) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                event = "identity_reconcile.skipped",
+                reason = "serialize_failed",
+                agent = spec.name,
+                error = %e,
+                "identity reconciliation failed — TOML serialization"
+            );
+            return;
+        }
+    };
+
+    let tmp_path = identity_path.with_extension("toml.tmp");
+    if let Err(e) = std::fs::write(&tmp_path, &merged_str) {
+        warn!(
+            event = "identity_reconcile.skipped",
+            reason = "tmp_write_failed",
+            agent = spec.name,
+            error = %e,
+            "identity reconciliation failed — could not write tmp file"
+        );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp_path, &identity_path) {
+        warn!(
+            event = "identity_reconcile.skipped",
+            reason = "rename_failed",
+            agent = spec.name,
+            error = %e,
+            "identity reconciliation failed — atomic rename"
+        );
+        let _ = std::fs::remove_file(&tmp_path);
+        return;
+    }
+
+    info!(
+        event = "identity_reconcile.complete",
+        agent = spec.name,
+        reconciled_paths = ?reconciled_paths,
+        "reconciled drifted identity sections for well-known agent"
+    );
+}
+
 /// Platform agents that can be dispatched via `mika ask --agent <peer>` without
 /// requiring LLM permission classification. These are intra-platform peers that
 /// claude-pilot and mika-relay should structurally allow.
@@ -446,10 +657,10 @@ pub fn provision_well_known_agents(home_dir: &Path, settings: &Settings, disable
 
     for spec in WELL_KNOWN_AGENTS {
         if mika_common::agent::agent_exists(home_dir, spec.name) {
-            info!(
-                agent = spec.name,
-                "well-known agent already exists, skipping"
-            );
+            // Existing agent: reconcile code-owned identity sections so static-spec
+            // changes (e.g., new bundled skill added to MIKA_DEV_IDENTITY) propagate
+            // to on-disk identity.toml. See mika#1220.
+            reconcile_well_known_identity(home_dir, spec, settings);
             continue;
         }
 
@@ -1994,5 +2205,419 @@ mod tests {
             !DISPATCH_TRIGGER_ALLOWLIST.is_empty(),
             "dispatch trigger allowlist must not be empty"
         );
+    }
+
+    // -- Identity reconciliation tests (mika#1220) --
+
+    /// Pre-seed an agent on disk with a custom identity.toml content,
+    /// bypassing the spec-driven provisioner.
+    fn pre_seed_identity(home: &Path, agent_name: &str, content: &str) {
+        mika_common::home::bootstrap_agent(home, agent_name).unwrap();
+        let agent_dir = mika_common::agent::agent_dir(home, agent_name);
+        fs::write(agent_dir.join("identity.toml"), content).unwrap();
+    }
+
+    fn read_identity(home: &Path, agent_name: &str) -> String {
+        let agent_dir = mika_common::agent::agent_dir(home, agent_name);
+        fs::read_to_string(agent_dir.join("identity.toml")).unwrap()
+    }
+
+    #[test]
+    fn test_reconcile_adds_missing_allowlist_for_mika_dev() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Pre-#815 shape: no [skills] block on disk.
+        pre_seed_identity(
+            home,
+            "mika-dev",
+            "name = \"Dev\"\nemoji = \"🛠\"\n\n[kg]\nenabled = false\n",
+        );
+
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+
+        let after = read_identity(home, "mika-dev");
+        let identity: crate::prompt::Identity = toml::from_str(&after).unwrap();
+        let allowlist = identity
+            .skills
+            .allowlist
+            .expect("reconciler must add [skills].allowlist");
+        assert_eq!(
+            allowlist.len(),
+            26,
+            "mika-dev reconciled allowlist must contain all 26 spec skills"
+        );
+        assert!(allowlist.contains(&"self-dev".to_string()));
+        assert!(allowlist.contains(&"dev-pilot".to_string()));
+        assert!(allowlist.contains(&"dev-groom".to_string()));
+    }
+
+    #[test]
+    fn test_reconcile_preserves_operator_kg_and_reflection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Operator-customized identity: distinct name + emoji + [kg] + [reflection].
+        // Name and emoji must NOT equal spec defaults so a regression that rewrote
+        // them from the spec would be detected (operator-owned per the plan, AC3).
+        pre_seed_identity(
+            home,
+            "mika-dev",
+            "name = \"OperatorCustomDev\"\n\
+             emoji = \"⚙\"\n\
+             \n\
+             [kg]\n\
+             enabled = true\n\
+             docs_root = \"/operator/docs\"\n\
+             \n\
+             [reflection]\n\
+             enabled = true\n\
+             time = \"21:30\"\n",
+        );
+
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+
+        let after = read_identity(home, "mika-dev");
+        let value: toml::Value = toml::from_str(&after).unwrap();
+        // Operator-owned: preserved verbatim
+        assert_eq!(
+            value["name"].as_str(),
+            Some("OperatorCustomDev"),
+            "operator name must be preserved"
+        );
+        assert_eq!(
+            value["emoji"].as_str(),
+            Some("⚙"),
+            "operator emoji must be preserved"
+        );
+        assert_eq!(
+            value["kg"]["enabled"].as_bool(),
+            Some(true),
+            "operator [kg].enabled must be preserved"
+        );
+        assert_eq!(
+            value["kg"]["docs_root"].as_str(),
+            Some("/operator/docs"),
+            "operator [kg].docs_root must be preserved"
+        );
+        assert_eq!(
+            value["reflection"]["time"].as_str(),
+            Some("21:30"),
+            "operator [reflection].time must be preserved"
+        );
+        // Code-owned: added by reconciler
+        let allowlist = value["skills"]["allowlist"].as_array().unwrap();
+        assert!(!allowlist.is_empty(), "[skills].allowlist must be added");
+    }
+
+    #[test]
+    fn test_reconcile_overwrites_drifted_allowlist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Operator weakened the allowlist; reconciler must restore the spec.
+        pre_seed_identity(
+            home,
+            "mika-dev",
+            "name = \"Dev\"\n\
+             emoji = \"🛠\"\n\
+             \n\
+             [skills]\n\
+             allowlist = [\"only-self-dev\"]\n",
+        );
+
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+
+        let after = read_identity(home, "mika-dev");
+        let identity: crate::prompt::Identity = toml::from_str(&after).unwrap();
+        let allowlist = identity.skills.allowlist.unwrap();
+        assert!(
+            allowlist.contains(&"dev-pilot".to_string()),
+            "drifted allowlist must be reset to spec — dev-pilot must be present"
+        );
+        assert!(
+            !allowlist.contains(&"only-self-dev".to_string()),
+            "operator-weakened allowlist must be overwritten"
+        );
+        assert_eq!(allowlist.len(), 26);
+    }
+
+    #[test]
+    fn test_reconcile_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        pre_seed_identity(home, "mika-dev", "name = \"Dev\"\nemoji = \"🛠\"\n");
+
+        // First reconcile: writes the [skills] block.
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+        let after_first = read_identity(home, "mika-dev");
+
+        // Second reconcile: should be a no-op (file content unchanged).
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+        let after_second = read_identity(home, "mika-dev");
+
+        assert_eq!(
+            after_first, after_second,
+            "second reconcile must not modify the file"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_adds_mika_arch_missing_groom_milestone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Pre-seed mika-arch with an allowlist missing mika-arch-groom-milestone.
+        pre_seed_identity(
+            home,
+            "mika-arch",
+            "name = \"Architect\"\n\
+             emoji = \"🏛\"\n\
+             \n\
+             [kg]\n\
+             enabled = true\n\
+             docs_roots = [\"/tmp/test-kg-corpus-a\"]\n\
+             \n\
+             [context.summary]\n\
+             inject = false\n\
+             \n\
+             [skills]\n\
+             allowlist = [\"mika-arch-groom-ticket\", \"mika-arch-second-review\"]\n\
+             \n\
+             [tools]\n\
+             disabled = []\n",
+        );
+
+        reconcile_well_known_identity(home, &MIKA_ARCH, &test_settings_with_kg_roots());
+
+        let after = read_identity(home, "mika-arch");
+        let identity: crate::prompt::Identity = toml::from_str(&after).unwrap();
+        let allowlist = identity.skills.allowlist.unwrap();
+        assert!(
+            allowlist.contains(&"mika-arch-groom-milestone".to_string()),
+            "reconciler must add missing mika-arch-groom-milestone to allowlist"
+        );
+        assert_eq!(allowlist.len(), 3);
+    }
+
+    #[test]
+    fn test_reconcile_adds_mika_arch_missing_context_summary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Pre-seed mika-arch without [context.summary].
+        pre_seed_identity(
+            home,
+            "mika-arch",
+            "name = \"Architect\"\n\
+             emoji = \"🏛\"\n\
+             \n\
+             [kg]\n\
+             enabled = true\n\
+             docs_roots = [\"/tmp/test-kg-corpus-a\"]\n\
+             \n\
+             [skills]\n\
+             allowlist = [\"mika-arch-groom-ticket\", \"mika-arch-groom-milestone\", \"mika-arch-second-review\"]\n\
+             \n\
+             [tools]\n\
+             disabled = []\n",
+        );
+
+        reconcile_well_known_identity(home, &MIKA_ARCH, &test_settings_with_kg_roots());
+
+        let after = read_identity(home, "mika-arch");
+        let identity: crate::prompt::Identity = toml::from_str(&after).unwrap();
+        assert!(
+            !identity.context.summary.inject,
+            "reconciler must set [context.summary].inject = false (mika#1009 leak protection)"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_only_touches_specified_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Pre-seed a well-known target.
+        pre_seed_identity(home, "mika-dev", "name = \"Dev\"\nemoji = \"🛠\"\n");
+        // Pre-seed a user-defined agent with custom content the reconciler must not touch.
+        let custom_identity =
+            "name = \"Custom\"\nemoji = \"👤\"\n\n[skills]\nallowlist = [\"custom-only\"]\n";
+        pre_seed_identity(home, "operator-custom-agent", custom_identity);
+
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+
+        let after_custom = read_identity(home, "operator-custom-agent");
+        assert_eq!(
+            after_custom, custom_identity,
+            "reconciler must not modify a non-target agent's identity.toml"
+        );
+    }
+
+    #[test]
+    fn test_provision_disabled_skips_reconciliation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Pre-seed mika-dev with drifted (no [skills]) identity.
+        let pre_content = "name = \"Dev\"\nemoji = \"🛠\"\n";
+        pre_seed_identity(home, "mika-dev", pre_content);
+
+        // disabled=true must skip the entire provisioning loop, including reconciliation.
+        provision_well_known_agents(home, &test_settings_with_kg_roots(), true);
+
+        let after = read_identity(home, "mika-dev");
+        assert_eq!(
+            after, pre_content,
+            "disabled provisioning must not invoke the reconciler"
+        );
+    }
+
+    #[test]
+    fn test_provision_isolates_one_malformed_agent_from_others() {
+        // Plan's central failure-isolation claim: a malformed identity for one
+        // well-known agent must not block reconciliation for the others.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // mika-dev gets garbage that fails TOML parse; mika-qa is left with the
+        // default bootstrap identity (no [skills] block, so it needs reconciling).
+        pre_seed_identity(home, "mika-dev", "this is = = not :: toml }}}");
+        pre_seed_identity(home, "mika-qa", "name = \"QA\"\nemoji = \"🔍\"\n");
+
+        provision_well_known_agents(home, &test_settings_with_kg_roots(), false);
+
+        // mika-dev's malformed file is preserved as-is (the existing fail-closed
+        // parse path in prompt::load_identity protects the running agent).
+        let dev_after = read_identity(home, "mika-dev");
+        assert_eq!(
+            dev_after, "this is = = not :: toml }}}",
+            "malformed mika-dev identity must not be overwritten"
+        );
+
+        // mika-qa was reconciled despite mika-dev's failure — the plan's
+        // failure-isolation claim holds at the loop level.
+        let qa_after = read_identity(home, "mika-qa");
+        let qa_identity: crate::prompt::Identity = toml::from_str(&qa_after).unwrap();
+        assert!(
+            qa_identity.skills.allowlist.is_some(),
+            "mika-qa must be reconciled even though mika-dev failed parse"
+        );
+    }
+
+    #[test]
+    fn test_reconcile_handles_malformed_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // Write garbage that fails toml::from_str.
+        let garbage = "this is = = not :: toml }}}";
+        pre_seed_identity(home, "mika-dev", garbage);
+
+        // Must not panic.
+        reconcile_well_known_identity(home, &MIKA_DEV, &test_settings_with_kg_roots());
+
+        // File is left as-is when on-disk parse fails (existing fail-closed parse
+        // path in prompt::load_identity protects the running agent).
+        let after = read_identity(home, "mika-dev");
+        assert_eq!(
+            after, garbage,
+            "malformed identity must not be overwritten by the reconciler"
+        );
+    }
+
+    #[test]
+    fn test_code_owned_sections_have_reconciler_coverage() {
+        // For every dotted path in CODE_OWNED_IDENTITY_SECTIONS, at least one
+        // WELL_KNOWN_AGENTS spec's rendered identity must produce a non-None value
+        // at that path. Catches typos like "skils.allowlist" landing in the const.
+        let settings = test_settings_with_kg_roots();
+        for path in CODE_OWNED_IDENTITY_SECTIONS {
+            let mut covered = false;
+            for spec in WELL_KNOWN_AGENTS {
+                let content = match render_identity_content(spec, &settings) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                let value: toml::Value = match toml::from_str(&content) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if get_path(&value, path).is_some() {
+                    covered = true;
+                    break;
+                }
+            }
+            assert!(
+                covered,
+                "CODE_OWNED_IDENTITY_SECTIONS entry '{path}' is not emitted by any \
+                 WELL_KNOWN_AGENTS spec — likely a typo or stale entry"
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_code_owned_drift_outside_constant() {
+        // Inverse direction: for every dotted path emitted by a WELL_KNOWN_AGENTS
+        // spec at depth ≤ 2 that is NOT under an operator-owned root, assert it
+        // is exactly listed in CODE_OWNED_IDENTITY_SECTIONS or is a child of an
+        // entry there. Catches the silent-regression case where a new section
+        // is added to a spec but forgotten in the constant.
+        let settings = test_settings_with_kg_roots();
+
+        // Operator-owned root namespaces — paths starting with these are user-controlled.
+        fn is_operator_owned(path: &str) -> bool {
+            path == "name"
+                || path == "emoji"
+                || path == "reflection"
+                || path.starts_with("reflection.")
+                || path == "kg"
+                || path.starts_with("kg.")
+        }
+
+        // A path is "covered" by the constant if it equals an entry or is a
+        // descendant of one (so context.summary covers context.summary.inject).
+        fn is_under_code_owned(path: &str) -> bool {
+            for owned in CODE_OWNED_IDENTITY_SECTIONS {
+                if path == *owned || path.starts_with(&format!("{owned}.")) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // Enumerate leaf-ish paths at depth ≤ 2. Depth-1 scalars and depth-2
+        // entries (whether scalar or table) count as leaves. Deeper nesting is
+        // governed by the depth-2 entry's coverage.
+        fn enumerate_paths(value: &toml::Value) -> Vec<String> {
+            let mut paths = Vec::new();
+            if let Some(table) = value.as_table() {
+                for (k, v) in table {
+                    if let Some(sub) = v.as_table() {
+                        for (k2, _) in sub {
+                            paths.push(format!("{k}.{k2}"));
+                        }
+                    } else {
+                        paths.push(k.clone());
+                    }
+                }
+            }
+            paths
+        }
+
+        for spec in WELL_KNOWN_AGENTS {
+            let content = match render_identity_content(spec, &settings) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let value: toml::Value = match toml::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            for path in enumerate_paths(&value) {
+                if is_operator_owned(&path) {
+                    continue;
+                }
+                assert!(
+                    is_under_code_owned(&path),
+                    "agent '{}' identity emits path '{path}' which is neither \
+                     operator-owned (name/emoji/reflection/kg) nor covered by \
+                     CODE_OWNED_IDENTITY_SECTIONS — add it to the constant or \
+                     justify exclusion in the operator-owned helper",
+                    spec.name
+                );
+            }
+        }
     }
 }

--- a/crates/mika-agent/tests/eval/test_qa_review_run_gh_scope_validator.rs
+++ b/crates/mika-agent/tests/eval/test_qa_review_run_gh_scope_validator.rs
@@ -17,11 +17,13 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+use mika_agent::prompt::Identity;
 use mika_agent::skills::SkillRegistry;
 use mika_agent::skills::builtin_handlers;
 use mika_agent::skills::index::SkillEntry;
 use mika_agent::skills::manifest::{Constraints, SkillInfo, SkillManifest, Triggers};
 use mika_agent::tools::{Tool, ToolContext, ToolOutput, ToolRegistry, default_tools};
+use mika_agent::well_known_agents::{IdentitySource, MIKA_DEV};
 use mika_common::claude::ToolDefinition;
 use mika_common::llm::mock::*;
 use serde_json::json;
@@ -209,5 +211,91 @@ async fn qa_review_not_active_accepts_issue_edit() {
         !output.contains("qa-review's scope"),
         "qa-review scope validator should NOT fire when qa-review is not active, \
          but got output: {output}"
+    );
+}
+
+/// Scenario 3: post-reconciliation, mika-dev's allowlist excludes qa-review,
+/// so the scope validator does not fire on `gh issue edit` (mika#1220).
+///
+/// Wires together the identity reconciler with the scope validator:
+/// 1. Seed a registry that contains qa-review (mirroring the pre-fix on-disk shape).
+/// 2. Apply `MIKA_DEV_IDENTITY`'s `[skills].allowlist` via `apply_identity_allowlist`.
+/// 3. Verify qa-review is evicted from the registry — qa-review is not in mika-dev's
+///    allowlist (mika-dev's 26-skill allowlist contains the dev-pilot family, not
+///    qa-review which is mika-qa's territory).
+/// 4. Run `gh issue edit … --remove-label ready` through `BuiltinRunGhTool` and
+///    assert no scope rejection — the post-reconciliation happy path.
+#[tokio::test]
+async fn qa_review_evicted_by_mika_dev_allowlist_after_reconcile() {
+    let mut harness = EvalHarness::builder()
+        .responses(vec![
+            tool_call_response(
+                "run_gh",
+                json!({"command": ["issue", "edit", "1205", "--remove-label", "ready"]}),
+            ),
+            text_response("Label removed successfully (post-reconciliation)."),
+        ])
+        .tools(tools_with_builtin_run_gh())
+        .build()
+        .await
+        .unwrap();
+
+    // Seed a qa-review skill into the registry, mirroring the pre-fix on-disk state
+    // where qa-review was bundled and always_on=true.
+    let skill_dir = harness.home_dir.path().join("skills/qa-review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("system_prompt.md"),
+        "You are the QA review agent. Review PRs.",
+    )
+    .unwrap();
+    harness.skills = SkillRegistry::from_test_entries(vec![make_qa_review_skill(skill_dir)]);
+
+    // Apply mika-dev's identity allowlist — qa-review is NOT in it, so the registry
+    // must evict qa-review. This is the post-reconciliation steady state. Parse from
+    // MIKA_DEV's actual identity_source so the test stays in lockstep with the spec.
+    let dev_identity_str = match MIKA_DEV
+        .identity_source
+        .as_ref()
+        .expect("mika-dev must declare identity_source")
+    {
+        IdentitySource::Static(s) => *s,
+        IdentitySource::Computed(_) => panic!("mika-dev identity_source must be Static"),
+    };
+    let dev_identity: Identity =
+        toml::from_str(dev_identity_str).expect("MIKA_DEV identity must parse");
+    let dev_allowlist = dev_identity
+        .skills
+        .allowlist
+        .expect("MIKA_DEV identity must declare [skills].allowlist");
+    harness.skills.apply_identity_allowlist(&dev_allowlist);
+
+    assert!(
+        !harness
+            .skills
+            .skills()
+            .iter()
+            .any(|s| s.manifest.skill.name == "qa-review"),
+        "qa-review must be evicted from mika-dev's post-reconciliation registry"
+    );
+
+    // Use a keyword that does NOT match any mika-dev allowlist skill, so the user
+    // message does not trigger keyword-based skill activation.
+    let trace = harness
+        .run("Remove the ready label from issue 1205")
+        .await
+        .unwrap();
+
+    assert_tools_include(&trace, &["run_gh"]);
+    let calls = trace.calls_for_tool("run_gh");
+    let output = calls[0].output.as_deref().unwrap_or("");
+    assert!(
+        !output.contains("qa-review's scope"),
+        "post-reconciliation: qa-review scope validator must NOT fire for mika-dev's \
+         gh issue edit call, but got output: {output}"
+    );
+    assert!(
+        !output.contains("mika#1196"),
+        "post-reconciliation: scope-rejection citation must not appear, but got: {output}"
     );
 }

--- a/docs/plans/2026-05-20-002-bug-1220-mika-dev-qa-review-always-on-loaded-plan.md
+++ b/docs/plans/2026-05-20-002-bug-1220-mika-dev-qa-review-always-on-loaded-plan.md
@@ -15,6 +15,27 @@ mika-dev's `run_gh` calls are being blocked by `validate_qa_review_gh_scope`, sc
 
 The ticket's initial framing (qa-review in `MIKA_DEV_IDENTITY` allowlist) is **wrong by inspection** — the static const at `crates/mika-agent/src/well_known_agents.rs:108-143` does NOT contain `qa-review`. The actual root cause is one layer deeper.
 
+## Phase 0 Pin — load-bearing sites
+
+Concrete anchors the implementer must read before writing any code. All paths are relative to the mika repo root.
+
+| # | Site | What it does | Why it matters |
+|---|------|--------------|----------------|
+| 1 | `crates/mika-agent/src/well_known_agents.rs:437-522` (`provision_well_known_agents`) | Iterates `WELL_KNOWN_AGENTS`; for each, calls `agent_exists` and `continue`s on hit (line 448-453) | This is where the bug lives — the `continue` short-circuits drift propagation. Reconciliation replaces this `continue`. |
+| 2 | `crates/mika-agent/src/well_known_agents.rs:108-143` (`MIKA_DEV_IDENTITY`) | Static const template for mika-dev identity.toml — contains `[skills].allowlist` with 26 entries | Source of truth for mika-dev's allowlist. Reconciler reads it via `render_identity_content` (line 410-422). |
+| 3 | `crates/mika-agent/src/well_known_agents.rs:168-194` (`MIKA_QA_IDENTITY`) | Same shape for mika-qa — 17-entry allowlist | Same role as #2. |
+| 4 | `crates/mika-agent/src/well_known_agents.rs:220-227` (`MIKA_RELAY_IDENTITY`) | mika-relay — 1-entry allowlist (`permission-policy`) | Same role as #2. |
+| 5 | `crates/mika-agent/src/well_known_agents.rs:333-383` (`build_mika_arch_identity`) | Computed identity for mika-arch — runtime-resolved `[kg].docs_roots` + `[skills].allowlist` + `[tools].disabled` + `[context.summary] inject = false` | mika-arch's expected identity is COMPUTED, not static. Reconciler invokes `render_identity_content(spec, settings)` (which dispatches to this function) rather than reading a const directly. |
+| 6 | `crates/mika-agent/src/well_known_agents.rs:295-325` (`MIKA_ARCH_DISABLED_TOOLS`) | The `[tools].disabled` array for mika-arch — 22 platform-mutational tools | Reconciler must overwrite the on-disk `[tools].disabled` to match this const. |
+| 7 | `crates/mika-agent/src/well_known_agents.rs:410-422` (`render_identity_content`) | Resolves the spec's `identity_source` to a string (Static / Computed / default) | Existing function the reconciler calls to get the canonical expected content per agent. |
+| 8 | `crates/mika-agent/src/skills/mod.rs:390-426` (`apply_identity_allowlist`) | Phase -1 of the skill registry filter — evicts non-allowlisted skills when `allowlist` is non-empty | The wedge: when on-disk identity has no `[skills]` block, `identity.skills.allowlist` is `None` and this function is never called (per `if let Some(...)` in callers). |
+| 9 | `crates/mika-agent/src/server/mod.rs:374-410` (`init_agent` skill setup) | Loads identity, conditionally applies allowlist, applies DB overrides | The downstream consumer that depends on the reconciler having run first. |
+| 10 | `crates/mika-agent/src/server/mod.rs:579-597` (`run_server` entry) | Calls `provision_well_known_agents` on dev_mode startup | Where reconciliation lifecycle starts. Reconciliation is internal to #1, so no new call site here. |
+| 11 | `crates/mika-agent/src/skills/builtin_handlers.rs:1806-1833` (`validate_qa_review_gh_scope`) | The validator that fires on `run_gh` when qa-review is in `active_skill_paths` | The observable wedge. Post-fix, qa-review is evicted from mika-dev's registry → never reaches `active_skill_paths` → validator no-ops. Direct correctness signal. |
+| 12 | `crates/mika-agent/src/well_known_agents.rs:618-786` (`seed_well_known_skill_overrides`) | The DB-side reconciler for `disabled_skills` and `llm_overrides` drift (mika#1041) | **Pattern precedent.** New identity reconciler mirrors this shape (idempotent, reconcile-on-restart, info-log on changes). |
+| 13 | `skills/bundled/qa-review/skill.toml` (`always_on = true`) | Marks qa-review as always-on for matching | Confirmed: this is why qa-review fires without keyword match. No change here — fix is in identity allowlist enforcement. |
+| 14 | `~/.mika/agents/<name>/identity.toml` (on host) | Empirical state of the four well-known agents | Verified: mika-dev/qa/relay missing `[skills]`; mika-arch missing `mika-arch-groom-milestone` + `[context.summary]`. |
+
 ## Root cause
 
 `provision_well_known_agents()` (line 437 of `well_known_agents.rs`) short-circuits on `mika_common::agent::agent_exists(home_dir, spec.name)` and skips the agent entirely (line 448-453: `continue`). Once a well-known agent has been provisioned on this host, its on-disk `identity.toml` is **frozen** — subsequent changes to the static `MIKA_*_IDENTITY` templates (e.g., the addition of `[skills].allowlist` in #815) never reach the file.
@@ -42,15 +63,46 @@ Add a reconciliation step that runs on every server startup (same gate as `provi
 
 ### Reconciled sections (code-owned)
 
-| Section | Why code-owned |
-|---------|----------------|
-| `[skills].allowlist` | Security contract — `crates/mika-agent/CLAUDE.md` "Adding a New Bundled Skill" step 4 names the static const as the source of truth; operators add skills via PR, not by editing identity.toml |
-| `[tools].disabled` | Same — defense-in-depth for read-only agent invariant (mika-arch); operators do not edit |
-| `[context.summary]` (`inject` + `max_tokens`) | mika#1009 leak protection; code-owned per mika-arch's spec |
+| Section path | Why code-owned |
+|--------------|----------------|
+| `skills.allowlist` | Security contract — `crates/mika-agent/CLAUDE.md` "Adding a New Bundled Skill" step 4 names the static const as the source of truth; operators add skills via PR, not by editing identity.toml |
+| `tools.disabled` | Same — defense-in-depth for read-only agent invariant (mika-arch); operators do not edit |
+| `context.summary` (both `inject` and `max_tokens` fields) | mika#1009 leak protection; code-owned per mika-arch's spec |
 
 ### Preserved sections (operator-owned)
 
 `name`, `emoji`, `[reflection]`, `[kg]`. Operators legitimately customize these per host (e.g., mika-dev sets `[kg].enabled = true` on this host where the spec defaults to `false`; mika-dev has `name = "Mika Dev"` with the Sparkles emoji where the spec says `name = "Dev"`, `emoji = "🛠"`).
+
+### Structural enforcement of the boundary (`const CODE_OWNED_IDENTITY_SECTIONS`)
+
+To prevent prose-only drift on what's code-owned, the reconciler is driven by a single explicit constant in `well_known_agents.rs`:
+
+```rust
+/// Identity-toml section paths that the reconciler owns from the static spec.
+///
+/// **Each entry is a dotted path** from the root of `identity.toml`. The reconciler
+/// walks each path in both the expected (spec-rendered) tree and the on-disk tree;
+/// when they differ, the expected subtree replaces the on-disk subtree.
+///
+/// Adding a new code-owned section to `WellKnownAgent`'s identity templates requires
+/// adding an entry here AND adding a unit test in `tests` below — the
+/// `test_code_owned_sections_have_reconciler_coverage` test iterates this constant
+/// and fails the build if any entry is not exercised by a test.
+///
+/// Sections NOT listed here are preserved verbatim from the on-disk file (operator-owned:
+/// `name`, `emoji`, `[reflection]`, `[kg]`).
+pub const CODE_OWNED_IDENTITY_SECTIONS: &[&str] = &[
+    "skills.allowlist",
+    "tools.disabled",
+    "context.summary",
+];
+```
+
+The reconciler iterates this constant rather than open-coding the three paths. Adding a future code-owned section is a one-line append (plus a test) — no logic change needed.
+
+A complementary build-time invariant test (in the same module's `tests` block) asserts that each path in `CODE_OWNED_IDENTITY_SECTIONS` corresponds to a section that at least one well-known agent's rendered identity actually emits — catches typos in the constant. Specifically: for each path `P`, walk the rendered identity of every `WELL_KNOWN_AGENTS` entry; assert that at least one produces a non-empty value at `P`. This catches the case where someone adds `"foo.bar"` to the constant but no spec ever emits `[foo].bar`.
+
+A second test asserts the negative direction: for every dotted path the rendered specs emit beyond `name`/`emoji`/`reflection`/`kg`, the path is present in `CODE_OWNED_IDENTITY_SECTIONS`. This catches the dual case where someone adds `[security]` to `MIKA_ARCH_DISABLED_TOOLS`-shape spec but forgets to add `"security"` to the constant — silent drift returns. Both tests together close the loop. (See "Test plan" below for exact test names.)
 
 ### Algorithm
 
@@ -59,12 +111,16 @@ For each agent in `WELL_KNOWN_AGENTS` where `agent_exists(home_dir, spec.name)`:
 1. Render the **expected** identity content via `render_identity_content(spec, settings)` (already exists).
 2. Parse the **on-disk** identity content via `toml::from_str::<toml::Value>`.
 3. Parse the expected content the same way.
-4. For each reconciled section above:
-   - If expected has the section AND on-disk differs (missing OR not equal):
-     - Replace the on-disk section with the expected one in the parsed `toml::Value` tree
-     - Mark `changed = true`
-5. If `changed`, serialize the merged value with `toml::to_string` and write to identity.toml.
-6. Emit `info!` per agent with the list of reconciled sections and `warn!` per skipped agent (parse failure, write failure).
+4. **For each dotted path in `CODE_OWNED_IDENTITY_SECTIONS`:**
+   - Resolve the path in the expected tree (`get_path(&expected, "skills.allowlist")`)
+   - Resolve the path in the on-disk tree
+   - If expected exists AND (on-disk missing OR on-disk != expected):
+     - Set the path in the on-disk tree to the expected value (`set_path(&mut on_disk, "skills.allowlist", value.clone())`)
+     - Record the path in a `reconciled_paths: Vec<&str>` for logging
+5. If `reconciled_paths` is non-empty, serialize the merged on-disk tree with `toml::to_string` and atomic-write to identity.toml (`.tmp` + rename).
+6. Emit one `info!` per agent: `agent=<name> reconciled_paths=[skills.allowlist, ...]` (empty array → in-sync log). Emit `warn!` on parse failure / write failure / spec render failure, skipping THAT agent only.
+
+Helper: `get_path(value: &toml::Value, dotted_path: &str) -> Option<&toml::Value>` and `set_path(value: &mut toml::Value, dotted_path: &str, new: toml::Value)`. Path syntax is dot-separated table keys; e.g., `"context.summary"` resolves `value["context"]["summary"]`. No array indexing needed — none of the code-owned sections are arrays at the top level (they may CONTAIN arrays, but the path itself targets a table or scalar). `set_path` creates intermediate empty tables when the parent doesn't exist on-disk (the missing-section case).
 
 ### Failure isolation
 
@@ -107,7 +163,7 @@ The new function lives in the same module (`well_known_agents.rs`).
 
 ### Unit tests in `well_known_agents.rs`
 
-Add tests in the existing `#[cfg(test)] mod tests` block:
+Add 11 tests in the existing `#[cfg(test)] mod tests` block (9 reconciliation tests + 2 constant-coverage invariant tests):
 
 1. `test_reconcile_adds_missing_allowlist_for_mika_dev` — provision an agent with a pre-#815-shape identity.toml (no `[skills]` block), run the reconciler, assert the file now contains `[skills].allowlist` matching the static const.
 
@@ -126,6 +182,10 @@ Add tests in the existing `#[cfg(test)] mod tests` block:
 8. `test_reconcile_disabled_via_env` — set `disable_agent_provisioning = true`, run reconciler, assert no writes (matches `provision_well_known_agents()` behavior).
 
 9. `test_reconcile_handles_malformed_identity` — write garbage to identity.toml, run reconciler, assert it logs warn and continues (no panic, no partial write).
+
+10. `test_code_owned_sections_have_reconciler_coverage` — for each path in `CODE_OWNED_IDENTITY_SECTIONS`, assert at least one `WELL_KNOWN_AGENTS` entry's rendered identity (via `render_identity_content` with `test_settings_with_kg_roots`) has a non-None value at that path. Catches typos like adding `"skils.allowlist"` to the constant.
+
+11. `test_no_code_owned_drift_outside_constant` — for each `WELL_KNOWN_AGENTS` entry's rendered identity, walk every dotted path at depth ≤ 2 (top-level tables and one level of nesting). For any path that is NOT one of the operator-owned roots (`name`, `emoji`, `reflection.*`, `kg.*`), assert the path appears in `CODE_OWNED_IDENTITY_SECTIONS` (or has a prefix that does, e.g., `skills.allowlist` covers `skills.allowlist` exactly; `tools.disabled` covers `tools.disabled` exactly; `context.summary` covers both `context.summary.inject` and `context.summary.max_tokens`). Catches the silent-regression case where someone adds `[security]` to a future spec but forgets to add it to the constant. Implementation: a small recursive helper that produces a flat list of dotted paths from a `toml::Value::Table`, then `paths.iter().filter(|p| !is_operator_owned(p)).for_each(|p| assert!(is_under_code_owned(p)))`.
 
 ### Integration test
 
@@ -158,14 +218,16 @@ After the binary lands on the host:
 
 Single PR, single commit (or a small commit chain — reconciler + tests + compound doc).
 
-1. Add `reconcile_well_known_identity()` function in `well_known_agents.rs`
-2. Wire into the existing `agent_exists` branch of `provision_well_known_agents()`
-3. Add the 9 unit tests
-4. Add the integration test in `tests/eval/test_qa_review_run_gh_scope_validator.rs`
-5. `cargo test -p mika-agent` and `cargo clippy` pass
-6. `make deploy` → cat the identity files → confirm reconciliation took effect
-7. Trigger a real webhook on a test issue and confirm `gh issue edit` succeeds
-8. Compound doc in `docs/solutions/best-practices/identity-toml-drift-from-static-spec-2026-05-20.md`
+1. Add `CODE_OWNED_IDENTITY_SECTIONS` constant in `well_known_agents.rs`
+2. Add `get_path` / `set_path` helpers (private)
+3. Add `reconcile_well_known_identity(home_dir, spec, settings)` function in `well_known_agents.rs`
+4. Wire into the existing `agent_exists` branch of `provision_well_known_agents()`
+5. Add the 11 unit tests (9 reconciliation tests + 2 constant-coverage invariant tests)
+6. Add the integration test in `tests/eval/test_qa_review_run_gh_scope_validator.rs`
+7. `cargo test -p mika-agent` and `cargo clippy` pass
+8. `make deploy` → cat the identity files → confirm reconciliation took effect
+9. Trigger a real webhook on a test issue and confirm `gh issue edit` succeeds
+10. Compound doc in `docs/solutions/best-practices/identity-toml-drift-from-static-spec-2026-05-20.md`
 
 ## Compound notes
 
@@ -176,7 +238,7 @@ This is the **second** time identity-drift has bitten the autonomous loop:
 
 The compound pattern is: **any code-owned configuration of a long-lived per-agent artifact requires explicit reconciliation, not just first-creation seeding.** The `agent_exists` short-circuit is structurally hostile to evolving the static spec. Future identity-template changes (next year's #815-class restructure) will hit the same shape unless reconciler keeps pace.
 
-Out of scope for this PR but worth filing as a follow-up: a startup-time invariant test that **fails the build** if the spec contains a section that the reconciler doesn't cover. Today the reconciler covers `[skills]`, `[tools]`, `[context.summary]` — if a future spec adds `[security]` and reconciler isn't updated, drift returns silently. A test that iterates over the spec's section names and asserts each is either reconciled or whitelisted-as-operator-owned would catch this at CI time.
+The structural mechanism added in this PR (`CODE_OWNED_IDENTITY_SECTIONS` + the two coverage-invariant tests `test_code_owned_sections_have_reconciler_coverage` and `test_no_code_owned_drift_outside_constant`) closes the loop: any future spec change that adds a code-owned section either (a) gets added to the constant and reconciled, or (b) trips the negative-direction test at CI time. Operator-owned roots (`name`, `emoji`, `reflection.*`, `kg.*`) stay explicitly excluded — extending the operator-owned set is an explicit code change in the test helper, also visible at review time.
 
 ## Cross-repo impact
 

--- a/docs/plans/2026-05-20-002-bug-1220-mika-dev-qa-review-always-on-loaded-plan.md
+++ b/docs/plans/2026-05-20-002-bug-1220-mika-dev-qa-review-always-on-loaded-plan.md
@@ -1,0 +1,196 @@
+---
+ticket: mika#1220
+type: bug
+status: draft
+created: 2026-05-20
+branch: bug/1220/mika-dev-qa-review-skill-loaded-as
+priority: p0-critical
+---
+
+# mika#1220 — qa-review skill loaded as always_on on mika-dev (and likely mika-qa/mika-relay)
+
+## Summary
+
+mika-dev's `run_gh` calls are being blocked by `validate_qa_review_gh_scope`, scoping the tool to qa-review's narrow allowlist (`pr review`, `pr diff`, `pr list`, `issue view`). This breaks every autonomous-loop step that needs `gh issue edit`, `gh pr create`, `gh pr merge`, `gh issue list`, etc. — the loop is structurally broken.
+
+The ticket's initial framing (qa-review in `MIKA_DEV_IDENTITY` allowlist) is **wrong by inspection** — the static const at `crates/mika-agent/src/well_known_agents.rs:108-143` does NOT contain `qa-review`. The actual root cause is one layer deeper.
+
+## Root cause
+
+`provision_well_known_agents()` (line 437 of `well_known_agents.rs`) short-circuits on `mika_common::agent::agent_exists(home_dir, spec.name)` and skips the agent entirely (line 448-453: `continue`). Once a well-known agent has been provisioned on this host, its on-disk `identity.toml` is **frozen** — subsequent changes to the static `MIKA_*_IDENTITY` templates (e.g., the addition of `[skills].allowlist` in #815) never reach the file.
+
+Empirical state on the affected host (verified via `cat ~/.mika/agents/<name>/identity.toml`):
+
+| Agent | On-disk `[skills].allowlist` | Spec wants it? |
+|-------|------------------------------|----------------|
+| mika-dev | **missing** | YES (26-skill allowlist) |
+| mika-qa | **missing** | YES (17-skill allowlist) |
+| mika-relay | **missing** | YES (1-skill allowlist: `permission-policy`) |
+| mika-arch | present (but missing `mika-arch-groom-milestone` + `[context.summary] inject = false`) | YES |
+
+Consequence: in `server/mod.rs:402`, `if let Some(ref allowlist) = identity.skills.allowlist` evaluates to `None` for mika-dev → `apply_identity_allowlist()` is **not called** → the full bundled-skill set stays in the registry → `qa-review.skill.toml` has `always_on = true` → it matches every conversation-mode turn (including webhook events that arrive via `/message`) → `active_skill_paths` includes `qa-review` → `validate_qa_review_gh_scope` fires on every `run_gh` call.
+
+The session in the ticket evidence (`6afe7739-6783-4a12-8fcb-e2aea32dfaf2`) is exactly this shape: `[GitHub] Issue labeled ready on senara-solutions/mika#1205` arrives via webhook, mika-dev's conversation turn runs with `qa-review` keyword/always-on matched, the engine tries `gh issue edit 1205 --remove-label ready`, scope check rejects.
+
+The same wedge silently affects mika-qa and mika-relay — they happen not to need rejected subcommands, so it hides until an autonomous-loop dispatch tries one.
+
+This is a **drift class**: anything code-owned in the identity template (`[skills].allowlist`, `[tools].disabled`, `[context.summary]`) does not propagate to existing well-known agents. Same shape as the disabled-skills drift that mika#1041 fixed for DB-backed `skill_overrides`.
+
+## Fix design
+
+Add a reconciliation step that runs on every server startup (same gate as `provision_well_known_agents`) and writes the security-critical sections of each well-known agent's identity.toml to match the static spec.
+
+### Reconciled sections (code-owned)
+
+| Section | Why code-owned |
+|---------|----------------|
+| `[skills].allowlist` | Security contract — `crates/mika-agent/CLAUDE.md` "Adding a New Bundled Skill" step 4 names the static const as the source of truth; operators add skills via PR, not by editing identity.toml |
+| `[tools].disabled` | Same — defense-in-depth for read-only agent invariant (mika-arch); operators do not edit |
+| `[context.summary]` (`inject` + `max_tokens`) | mika#1009 leak protection; code-owned per mika-arch's spec |
+
+### Preserved sections (operator-owned)
+
+`name`, `emoji`, `[reflection]`, `[kg]`. Operators legitimately customize these per host (e.g., mika-dev sets `[kg].enabled = true` on this host where the spec defaults to `false`; mika-dev has `name = "Mika Dev"` with the Sparkles emoji where the spec says `name = "Dev"`, `emoji = "🛠"`).
+
+### Algorithm
+
+For each agent in `WELL_KNOWN_AGENTS` where `agent_exists(home_dir, spec.name)`:
+
+1. Render the **expected** identity content via `render_identity_content(spec, settings)` (already exists).
+2. Parse the **on-disk** identity content via `toml::from_str::<toml::Value>`.
+3. Parse the expected content the same way.
+4. For each reconciled section above:
+   - If expected has the section AND on-disk differs (missing OR not equal):
+     - Replace the on-disk section with the expected one in the parsed `toml::Value` tree
+     - Mark `changed = true`
+5. If `changed`, serialize the merged value with `toml::to_string` and write to identity.toml.
+6. Emit `info!` per agent with the list of reconciled sections and `warn!` per skipped agent (parse failure, write failure).
+
+### Failure isolation
+
+- Parse failure (on-disk file is malformed): log `warn!`, skip THIS agent, continue with the others. The existing fail-closed parse path in `prompt::load_identity()` (#811) protects the running agent from a malformed file.
+- Render failure on the spec side (e.g., mika-arch when `MIKA_KG_DOCS_ROOTS` is unset): log `warn!`, skip THIS agent, continue. Same shape as `provision_well_known_agents()`.
+- Write failure: log `warn!`, leave the file as-is, continue. The agent will start with stale identity but the existing #815 + #811 protections (fail-closed parse, identity allowlist no-op when None) prevent worse-than-current-state outcomes.
+
+### Disable gate
+
+Same `MIKA_DISABLE_AGENT_PROVISIONING` env var. When set, reconciliation is skipped with a `warn!` log — operators iterating on identity files locally retain control.
+
+## Placement
+
+Insert reconciliation **into** `provision_well_known_agents()` at the existing `agent_exists` branch (line 448-453). The "skip" branch becomes a "reconcile" branch. Single function, single call site, lifecycle stays obvious.
+
+```rust
+if mika_common::agent::agent_exists(home_dir, spec.name) {
+    reconcile_well_known_identity(home_dir, spec, settings);  // NEW
+    continue;
+}
+```
+
+The new function lives in the same module (`well_known_agents.rs`).
+
+## Acceptance criteria
+
+**AC1.** After a server restart on the affected host, `cat ~/.mika/agents/mika-dev/identity.toml` shows a `[skills]` block with an `allowlist` array containing `self-dev`, `dev-pilot`, `dev-groom`, `run_gh`-using skills, etc. — matching `MIKA_DEV_IDENTITY` line-for-line on the `[skills]` section. Same for `mika-qa` and `mika-relay`.
+
+**AC2.** On the running server, `validate_qa_review_gh_scope` returns `Ok(())` on mika-dev turns (verified by sending a webhook `ready`-label event and observing `gh issue edit` succeed — or, equivalent, by a unit test that builds a `SkillRegistry` post-reconciliation and asserts `qa-review` is NOT in the registry's `skills` vec for the mika-dev agent_id).
+
+**AC3.** Operator-customized sections (`name`, `emoji`, `[reflection]`, `[kg]`) on the existing on-disk identity files are **preserved verbatim** after reconciliation — verified by diffing before/after the first reconciler run.
+
+**AC4.** mika-arch's identity is reconciled to include `mika-arch-groom-milestone` in the allowlist AND `[context.summary] inject = false` (currently missing on this host).
+
+**AC5.** Second startup after deploy is a no-op (idempotency): the reconciler sees no drift, writes nothing, logs a single info line per agent ("identity in sync").
+
+**AC6.** Regression test: `tests/eval/test_qa_review_run_gh_scope_validator.rs` covers the existing positive case (validator fires when qa-review IS active). A new test verifies the validator does NOT fire when mika-dev's reconciled identity allowlist excludes qa-review (i.e., the post-fix happy path).
+
+## Test plan
+
+### Unit tests in `well_known_agents.rs`
+
+Add tests in the existing `#[cfg(test)] mod tests` block:
+
+1. `test_reconcile_adds_missing_allowlist_for_mika_dev` — provision an agent with a pre-#815-shape identity.toml (no `[skills]` block), run the reconciler, assert the file now contains `[skills].allowlist` matching the static const.
+
+2. `test_reconcile_preserves_operator_kg_and_reflection` — pre-seed identity.toml with operator-customized `[kg].docs_root` and `[reflection]` blocks plus the missing `[skills]` block, run the reconciler, assert `[kg]`/`[reflection]` are byte-identical to pre-state AND `[skills]` is now present.
+
+3. `test_reconcile_overwrites_drifted_allowlist` — pre-seed with `[skills].allowlist = ["only-self-dev"]`, run reconciler, assert the allowlist matches the static const (drift in code-owned section is reset; operator does not get to weaken security via identity edit).
+
+4. `test_reconcile_idempotent` — run reconciler twice in a row, assert second call writes nothing (check via file mtime or via a `changed: bool` return value).
+
+5. `test_reconcile_adds_mika_arch_missing_groom_milestone` — pre-seed mika-arch identity missing `mika-arch-groom-milestone` from allowlist, run reconciler, assert it's added.
+
+6. `test_reconcile_adds_mika_arch_missing_context_summary` — pre-seed mika-arch identity without `[context.summary]`, run reconciler, assert `inject = false` is now present.
+
+7. `test_reconcile_skips_user_defined_agent` — provision a non-well-known agent name (e.g., "operator-custom-agent"), run reconciler against the global home, assert that agent's identity.toml is not touched (the reconciler only iterates `WELL_KNOWN_AGENTS`).
+
+8. `test_reconcile_disabled_via_env` — set `disable_agent_provisioning = true`, run reconciler, assert no writes (matches `provision_well_known_agents()` behavior).
+
+9. `test_reconcile_handles_malformed_identity` — write garbage to identity.toml, run reconciler, assert it logs warn and continues (no panic, no partial write).
+
+### Integration test
+
+In `tests/eval/test_qa_review_run_gh_scope_validator.rs`, add a new scenario `test_validator_skipped_when_mika_dev_post_reconcile`:
+- Construct a `SkillRegistry` from the bundled skills directory
+- Apply `MIKA_DEV_IDENTITY`'s allowlist via `apply_identity_allowlist`
+- Build a `ToolContext` with `active_skill_paths` derived from the post-allowlist registry
+- Call `validate_qa_review_gh_scope` with `["issue", "edit", "1205"]`
+- Assert it returns `Ok(())` (qa-review is not in the post-reconciliation active set)
+
+### Deploy-side smoke test
+
+After the binary lands on the host:
+1. `cat ~/.mika/agents/mika-dev/identity.toml` → expect `[skills].allowlist` present
+2. Trigger a webhook event (`gh issue edit <test-ticket> --add-label ready`) and watch mika-dev process it
+3. Confirm the previously-blocked `gh issue edit ... --remove-label ready` call now succeeds in the agent loop
+4. `grep validate_qa_review_gh_scope $MIKA_SERVER_LOG_FILE` returns no rejection events for mika-dev sessions post-deploy
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Reconciler corrupts identity.toml mid-write, leaving a partial file | Write to `identity.toml.tmp` then `std::fs::rename` (atomic on Linux). Use `mika_common::fs::write_atomic` if it exists; else inline the pattern. |
+| Operator was relying on the broken-allowlist behavior (e.g., had silently disabled mika-dev's restrictive scope) | Mitigated by changelog note + the existing `MIKA_DISABLE_AGENT_PROVISIONING` env var. Operator can opt out. The "fix" returns mika-dev to its documented behavior (#815) — staying broken is not an option since the autonomous loop is wedged. |
+| TOML serialization drops comments | Identity templates contain no comments today (verified via `cat`). Add a static-string comment-preservation note in the function docstring; if templates gain comments later, switch to `toml_edit` (currently overkill). |
+| Reconciler runs in `dev_mode = true` only (gated by the surrounding `if settings.dev_mode { }` block in `run_server`) | Production hosts run `dev_mode = false` and rely on operator-curated identity files. That's the right scoping — same as `provision_well_known_agents()` itself. No change needed. |
+| Drift reconciliation triggers a `skills_dirty` flush mid-turn | Reconciler runs in `run_server` BEFORE per-agent init / skill loading. No mid-turn concern. |
+
+## Sequencing
+
+Single PR, single commit (or a small commit chain — reconciler + tests + compound doc).
+
+1. Add `reconcile_well_known_identity()` function in `well_known_agents.rs`
+2. Wire into the existing `agent_exists` branch of `provision_well_known_agents()`
+3. Add the 9 unit tests
+4. Add the integration test in `tests/eval/test_qa_review_run_gh_scope_validator.rs`
+5. `cargo test -p mika-agent` and `cargo clippy` pass
+6. `make deploy` → cat the identity files → confirm reconciliation took effect
+7. Trigger a real webhook on a test issue and confirm `gh issue edit` succeeds
+8. Compound doc in `docs/solutions/best-practices/identity-toml-drift-from-static-spec-2026-05-20.md`
+
+## Compound notes
+
+This is the **second** time identity-drift has bitten the autonomous loop:
+
+1. mika#1041 — `disabled_skills` drift in DB-backed `skill_overrides` (fixed by reconciler in `seed_well_known_skill_overrides`)
+2. mika#1220 (this ticket) — `[skills].allowlist` drift in on-disk identity.toml (this fix)
+
+The compound pattern is: **any code-owned configuration of a long-lived per-agent artifact requires explicit reconciliation, not just first-creation seeding.** The `agent_exists` short-circuit is structurally hostile to evolving the static spec. Future identity-template changes (next year's #815-class restructure) will hit the same shape unless reconciler keeps pace.
+
+Out of scope for this PR but worth filing as a follow-up: a startup-time invariant test that **fails the build** if the spec contains a section that the reconciler doesn't cover. Today the reconciler covers `[skills]`, `[tools]`, `[context.summary]` — if a future spec adds `[security]` and reconciler isn't updated, drift returns silently. A test that iterates over the spec's section names and asserts each is either reconciled or whitelisted-as-operator-owned would catch this at CI time.
+
+## Cross-repo impact
+
+None. mika core only. No mika-cloud, mika-skills, or claude-pilot changes needed. The fix is bounded to `crates/mika-agent/src/well_known_agents.rs` + tests.
+
+## Reference
+
+- Static spec: `crates/mika-agent/src/well_known_agents.rs:78-227` (MIKA_DEV, MIKA_DEV_IDENTITY, MIKA_QA, MIKA_QA_IDENTITY, MIKA_RELAY, MIKA_RELAY_IDENTITY)
+- Allowlist application: `crates/mika-agent/src/skills/mod.rs:390-426` (apply_identity_allowlist)
+- Loader: `crates/mika-agent/src/server/mod.rs:374-410` (load_identity → apply_identity_allowlist → apply_overrides)
+- Validator that fires: `crates/mika-agent/src/skills/builtin_handlers.rs:1806-1833` (validate_qa_review_gh_scope)
+- Related precedents:
+  - mika#815 — identity-driven skill allowlist introduced
+  - mika#811 — fail-closed identity parse for well-known agents
+  - mika#1009 — `[context.summary] inject = false` introduced for mika-arch
+  - mika#1041 — disabled_skills drift reconciler in `seed_well_known_skill_overrides`
+  - mika#1196 — `validate_qa_review_gh_scope` introduced


### PR DESCRIPTION
## Summary

`provision_well_known_agents()` short-circuited on `agent_exists`, freezing on-disk `identity.toml` for already-provisioned well-known agents. The `[skills].allowlist` added in #815 never reached disk, so mika-dev/qa/relay ran without it — qa-review (always_on=true) matched every conversation turn, and `validate_qa_review_gh_scope` rejected every `gh issue edit`, `gh pr merge`, etc., structurally breaking the autonomous loop.

This PR adds `reconcile_well_known_identity()` driven by `CODE_OWNED_IDENTITY_SECTIONS = ["skills.allowlist", "tools.disabled", "context.summary"]`. The reconciler runs in the existing `agent_exists` branch and overwrites only the code-owned subtrees when they differ. Operator-owned sections (`name`, `emoji`, `[reflection]`, `[kg]`) are preserved verbatim.

## What changed

- **`crates/mika-agent/src/well_known_agents.rs`**
  - `CODE_OWNED_IDENTITY_SECTIONS` const (dotted paths driving the reconciler)
  - `get_path` / `set_path` TOML traversal helpers (private)
  - `reconcile_well_known_identity()` — read on-disk, diff against rendered spec, atomic write via `.tmp` + `std::fs::rename` only when drift exists
  - Wired into `provision_well_known_agents()` at the existing `agent_exists` branch
  - 12 unit tests + 2 coverage-invariant tests on `CODE_OWNED_IDENTITY_SECTIONS` that fail loud on either-direction silent regression
- **`crates/mika-agent/tests/eval/test_qa_review_run_gh_scope_validator.rs`**
  - New integration test `qa_review_evicted_by_mika_dev_allowlist_after_reconcile` parses `MIKA_DEV.identity_source` to stay in lockstep with the spec, applies the allowlist via `apply_identity_allowlist`, and asserts the scope validator no longer fires on `gh issue edit`

Failure isolation per-agent — parse, render, or write failures emit `warn! event=identity_reconcile.skipped reason=<phase>` and skip THAT agent so the rest of the loop continues. `MIKA_DISABLE_AGENT_PROVISIONING=true` still short-circuits the whole loop. Idempotent: when the on-disk file already matches the spec on every code-owned path, the function emits `info! event=identity_reconcile.in_sync` and writes nothing.

## Structural counterpart

This is the second time identity-drift has wedged the autonomous loop:
- mika#1041 — DB-backed `skill_overrides` drift (fixed by reconciler in `seed_well_known_skill_overrides`)
- mika#1220 (this PR) — on-disk `identity.toml` drift (fixed here)

Compound pattern: any code-owned configuration of a long-lived per-agent artifact requires explicit reconciliation, not just first-creation seeding. The `CODE_OWNED_IDENTITY_SECTIONS` constant + bidirectional coverage tests structurally enforce the code-owned vs operator-owned boundary so a future spec change either gets added to the constant and reconciled, or trips the negative-direction test at CI time.

## Test plan

- [x] `cargo test -p mika-agent --lib well_known_agents::` — 58 pass (12 new reconciler tests + pre-existing)
- [x] `cargo test -p mika-agent --test eval test_qa_review_run_gh_scope` — 3 pass (existing 2 + new post-reconcile test)
- [x] `cargo test -p mika-agent` — 2884 lib + 380 eval tests pass, 0 failures
- [x] `cargo clippy -p mika-agent --tests --all-features` — clean
- [ ] Deploy-side smoke test (post-merge): `cat ~/.mika/agents/mika-dev/identity.toml` shows `[skills].allowlist`; `grep identity_reconcile $MIKA_SERVER_LOG_FILE` shows `.complete` on first restart and `.in_sync` thereafter; trigger a webhook `ready` label and confirm `gh issue edit ... --remove-label ready` succeeds

Closes mika#1220