### PR TITLE
feat(agents): add mika-test built-in agent (mika#963)

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -70,6 +70,24 @@ pub struct WellKnownAgent {
     pub llm_overrides: &'static [LlmOverrideSpec],
 }
 
+/// mika-test agent specification (mika#963).
+///
+/// Minimal test agent with no skills for engine validation and debugging.
+/// Uses identity-driven `[skills].allowlist` with a sentinel value to deny
+/// all skills. KG disabled. Default LLM provider/model from `Settings`.
+pub static MIKA_TEST: WellKnownAgent = WellKnownAgent {
+    name: "mika-test",
+    display_name: "Test",
+    emoji: "🧪",
+    soul: MIKA_TEST_SOUL,
+    // Empty: mika-test uses identity allowlist, not denylist (#815).
+    disabled_skills: &[],
+    config_toml: None,
+    // KG disabled (#963): mika-test is a bare engine exerciser — no KG noise.
+    identity_source: Some(IdentitySource::Static(MIKA_TEST_IDENTITY)),
+    llm_overrides: &[],
+};
+
 /// mika-dev agent specification.
 ///
 /// Uses identity-driven `[skills].allowlist` (D2 cross-cutting, #815).
@@ -383,7 +401,8 @@ allowlist = ["mika-arch-groom-ticket", "mika-arch-groom-milestone", "mika-arch-s
 }
 
 /// All well-known agents.
-pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA, &MIKA_RELAY, &MIKA_ARCH];
+pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] =
+    &[&MIKA_DEV, &MIKA_TEST, &MIKA_QA, &MIKA_RELAY, &MIKA_ARCH];
 
 /// Identity-toml section paths that the reconciler owns from the static spec.
 ///
@@ -1064,6 +1083,35 @@ llm_max_tokens = 1024
 log_level = "info"
 "#;
 
+const MIKA_TEST_SOUL: &str = r#"# Mika Test — Minimal Test Agent
+
+## Role
+You are Mika Test, a minimal test agent for engine validation and debugging.
+You have no skills enabled. Your purpose is to exercise the core agent loop
+(LLM calls, memory, tools) without skill-system interference.
+
+## Communication style
+- Respond directly and helpfully
+- You are a plain conversational agent with no special workflows
+"#;
+
+/// mika-test identity.toml — no skills, KG disabled per mika#963.
+///
+/// The allowlist uses a sentinel value `__mika_test_no_skills__` that matches
+/// no real skill. An empty `allowlist = []` would be treated as a no-op by
+/// `apply_identity_allowlist()` (which early-returns on empty), so we need a
+/// non-empty list with a value that cannot match any bundled or custom skill.
+/// This follows the same pattern as `__fail_closed_no_skills__` in `prompt.rs`.
+const MIKA_TEST_IDENTITY: &str = "\
+name = \"Test\"\n\
+emoji = \"🧪\"\n\
+\n\
+[kg]\n\
+enabled = false\n\
+\n\
+[skills]\n\
+allowlist = [\"__mika_test_no_skills__\"]\n";
+
 const MIKA_ARCH_SOUL: &str = r#"# Mika Architect — Plan Review Agent
 
 ## Role
@@ -1140,6 +1188,11 @@ mod tests {
     fn test_find_well_known_agent_found() {
         assert!(find_well_known_agent("mika-dev").is_some());
         assert_eq!(find_well_known_agent("mika-dev").unwrap().name, "mika-dev");
+        assert!(find_well_known_agent("mika-test").is_some());
+        assert_eq!(
+            find_well_known_agent("mika-test").unwrap().name,
+            "mika-test"
+        );
         assert!(find_well_known_agent("mika-qa").is_some());
         assert_eq!(find_well_known_agent("mika-qa").unwrap().name, "mika-qa");
         assert!(find_well_known_agent("mika-relay").is_some());
@@ -1975,6 +2028,35 @@ mod tests {
         }
     }
 
+    // -- mika-test tests --
+
+    #[test]
+    fn test_find_well_known_agent_mika_test() {
+        let agent = find_well_known_agent("mika-test").unwrap();
+        assert_eq!(agent.name, "mika-test");
+        assert_eq!(agent.display_name, "Test");
+        assert_eq!(agent.emoji, "🧪");
+        assert!(agent.disabled_skills.is_empty());
+        assert!(agent.config_toml.is_none());
+        assert!(agent.llm_overrides.is_empty());
+    }
+
+    #[test]
+    fn test_mika_test_identity_valid_toml() {
+        let identity: crate::prompt::Identity =
+            toml::from_str(MIKA_TEST_IDENTITY).expect("MIKA_TEST_IDENTITY should be valid TOML");
+        assert_eq!(identity.name, "Test");
+        assert_eq!(identity.emoji, "🧪");
+        assert!(!identity.kg.enabled, "mika-test should have KG disabled");
+        let allowlist = identity.skills.allowlist.as_ref().unwrap();
+        assert_eq!(
+            allowlist.len(),
+            1,
+            "mika-test should have sentinel-only allowlist"
+        );
+        assert_eq!(allowlist[0], "__mika_test_no_skills__");
+    }
+
     // -- mika-arch tests --
 
     #[test]
@@ -2184,7 +2266,7 @@ mod tests {
 
     #[test]
     fn test_well_known_agents_includes_mika_arch() {
-        assert_eq!(WELL_KNOWN_AGENTS.len(), 4);
+        assert_eq!(WELL_KNOWN_AGENTS.len(), 5);
         assert!(
             WELL_KNOWN_AGENTS.iter().any(|a| a.name == "mika-arch"),
             "WELL_KNOWN_AGENTS should include mika-arch"

--- a/docs/plans/2026-05-20-004-feat-963-agents-add-mika-test-built-in-agent-plan.md
+++ b/docs/plans/2026-05-20-004-feat-963-agents-add-mika-test-built-in-agent-plan.md
@@ -1,0 +1,186 @@
+# Plan: Add mika-test Built-In Agent (#963)
+
+**Type:** feat
+**Issue:** mika#963
+**Date:** 2026-05-20
+**Base SHA:** `0c2bbcf9` (feat(agent): webhook_milestone_advance inline guard mika#1218)
+
+## Summary
+
+Add `mika-test` as the fifth well-known agent — a minimal, no-skills agent for testing/debugging the engine without skill-system noise. Single-file change in `well_known_agents.rs`.
+
+## Motivation
+
+The four existing well-known agents (mika-dev, mika-qa, mika-relay, mika-arch) are all skill-rich. There's no plain agent to compare against when debugging skill-vs-engine behaviors. mika-test fills this gap: a bare-bones agent that exercises the core engine loop with zero skills, no KG, and default LLM settings.
+
+**Note on issue description counting:** The issue body says "five existing well-known agents (mika, mika-dev, mika-qa, mika-relay, mika-arch)" and refers to mika-test as the "6th member." In reality, `WELL_KNOWN_AGENTS` at base SHA has 4 entries (mika-dev, mika-qa, mika-relay, mika-arch) — the default `mika` agent is not a well-known agent and is not in the array. After this change, the array will have 5 entries. The issue body's count is cosmetically inaccurate but does not affect scope or implementation.
+
+## Base SHA Pin
+
+At `0c2bbcf9`, `crates/mika-agent/src/well_known_agents.rs` (2623 lines):
+
+- **`WELL_KNOWN_AGENTS` (line 386):**
+  ```rust
+  pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_QA, &MIKA_RELAY, &MIKA_ARCH];
+  ```
+
+- **`WellKnownAgent` struct (lines 48–71):** 9 fields — `name`, `display_name`, `emoji`, `soul`, `disabled_skills`, `config_toml`, `identity_source`, `llm_overrides`. `#[non_exhaustive]`.
+
+- **`CODE_OWNED_IDENTITY_SECTIONS` (lines 401–402):**
+  ```rust
+  pub const CODE_OWNED_IDENTITY_SECTIONS: &[&str] =
+      &["skills.allowlist", "tools.disabled", "context.summary"];
+  ```
+  mika-test's identity declares `[skills].allowlist` and `[kg].enabled` — of these, only `skills.allowlist` is in `CODE_OWNED_IDENTITY_SECTIONS`. The `[kg]` section is operator-owned (see line 400: "Sections NOT listed here are preserved verbatim from the on-disk file (operator-owned: `name`, `emoji`, `[reflection]`, `[kg]`)"). No change to `CODE_OWNED_IDENTITY_SECTIONS` required.
+
+- **Hardcoded count assertion (line 2187):**
+  ```rust
+  assert_eq!(WELL_KNOWN_AGENTS.len(), 4);
+  ```
+  Must be updated to `5`.
+
+- **`DISPATCH_TRIGGER_ALLOWLIST` (line 104):** `["samidarko", "mika-platform-dev"]` — unchanged.
+- **`INTRA_PLATFORM_DISPATCH_PEERS` (line 608):** `["mika-arch", "mika-dev", "mika-qa"]` — unchanged.
+
+- **Array position semantics:** `provision_well_known_agents()` (line 658) iterates `WELL_KNOWN_AGENTS` sequentially. Position determines provisioning order only — no code indexes by position. `find_well_known_agent()` (line 611) uses `.iter().find()` by name. Position is cosmetic.
+
+## Deliverables
+
+### Phase 1: Add mika-test to well_known_agents.rs
+
+All changes are in `crates/mika-agent/src/well_known_agents.rs`.
+
+**Step 1: Add `MIKA_TEST_SOUL` constant** (after `MIKA_RELAY_CONFIG` at line ~1065)
+
+```rust
+const MIKA_TEST_SOUL: &str = r#"# Mika Test — Minimal Test Agent
+
+## Role
+You are Mika Test, a minimal test agent for engine validation and debugging.
+You have no skills enabled. Your purpose is to exercise the core agent loop
+(LLM calls, memory, tools) without skill-system interference.
+
+## Communication style
+- Respond directly and helpfully
+- You are a plain conversational agent with no special workflows
+"#;
+```
+
+**Step 2: Add `MIKA_TEST_IDENTITY` constant** (after the soul)
+
+```rust
+const MIKA_TEST_IDENTITY: &str = "\
+name = \"Test\"\n\
+emoji = \"🧪\"\n\
+\n\
+[kg]\n\
+enabled = false\n\
+\n\
+[skills]\n\
+allowlist = []\n";
+```
+
+Key design choices:
+- `[skills].allowlist = []` — empty allowlist means all skills are denied at Phase -1 (`apply_identity_allowlist` evicts everything not in the list). This is the same mechanism used by mika-relay (with 1 skill), just with zero entries. `apply_identity_allowlist()` at `prompt.rs` calls `retain()` on the registry — an empty allowlist retains nothing.
+- `[kg].enabled = false` — no extraction, no resolution, no corpus tracking. Eliminates KG noise for a test agent. Consistent with mika-dev and mika-qa topology (#800).
+- No `[tools].disabled` — mika-test gets the full default tool set, unlike mika-arch which has `MIKA_ARCH_DISABLED_TOOLS`. For a test agent, having all tools available is desirable.
+- No `[context.summary]` override — uses default (`inject = true`). This means `CODE_OWNED_IDENTITY_SECTIONS` reconciliation for `context.summary` will be a no-op (path not present in identity → `get_path` returns `None` → `continue`).
+
+**Reconciliation behavior:** `reconcile_well_known_identity()` iterates `CODE_OWNED_IDENTITY_SECTIONS` (`skills.allowlist`, `tools.disabled`, `context.summary`). For mika-test:
+- `skills.allowlist`: present in identity, will be reconciled (enforces empty array on disk).
+- `tools.disabled`: absent in identity → `get_path` returns `None` → skipped.
+- `context.summary`: absent in identity → `get_path` returns `None` → skipped.
+
+**Step 3: Add `MIKA_TEST` static** (after `MIKA_DEV` at line 78, before `MIKA_QA` at line 145)
+
+```rust
+/// mika-test agent specification.
+///
+/// Minimal test agent with no skills for engine validation and debugging.
+/// Uses identity-driven `[skills].allowlist = []` to deny all skills.
+/// KG disabled. Default LLM provider/model from `Settings`.
+pub static MIKA_TEST: WellKnownAgent = WellKnownAgent {
+    name: "mika-test",
+    display_name: "Test",
+    emoji: "🧪",
+    soul: MIKA_TEST_SOUL,
+    disabled_skills: &[],
+    config_toml: None,
+    identity_source: Some(IdentitySource::Static(MIKA_TEST_IDENTITY)),
+    llm_overrides: &[],
+};
+```
+
+**Step 4: Add to `WELL_KNOWN_AGENTS` array** (line 386)
+
+```rust
+pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_TEST, &MIKA_QA, &MIKA_RELAY, &MIKA_ARCH];
+```
+
+Position after `MIKA_DEV` per issue spec. Position is cosmetic (find_well_known_agent uses name-based lookup, provisioning order has no semantic dependency).
+
+**Step 5: Update tests**
+
+5a. `test_find_well_known_agent_found` (line ~1140): Add assertions for mika-test:
+```rust
+assert!(find_well_known_agent("mika-test").is_some());
+assert_eq!(find_well_known_agent("mika-test").unwrap().name, "mika-test");
+```
+
+5b. Add a dedicated test (following the `test_find_well_known_agent_mika_arch` pattern at line 1981):
+```rust
+#[test]
+fn test_find_well_known_agent_mika_test() {
+    let agent = find_well_known_agent("mika-test").unwrap();
+    assert_eq!(agent.name, "mika-test");
+    assert_eq!(agent.display_name, "Test");
+    assert_eq!(agent.emoji, "🧪");
+    assert!(agent.disabled_skills.is_empty());
+    assert!(agent.config_toml.is_none());
+    assert!(agent.llm_overrides.is_empty());
+}
+```
+
+5c. Add identity parsing test (following `test_mika_arch_config_valid_toml` pattern at line 2013):
+```rust
+#[test]
+fn test_mika_test_identity_valid_toml() {
+    let identity: toml::Value =
+        toml::from_str(MIKA_TEST_IDENTITY).expect("MIKA_TEST_IDENTITY should be valid TOML");
+    assert_eq!(identity["name"].as_str(), Some("Test"));
+    assert_eq!(identity["emoji"].as_str(), Some("🧪"));
+    assert_eq!(identity["kg"]["enabled"].as_bool(), Some(false));
+    let allowlist = identity["skills"]["allowlist"].as_array().unwrap();
+    assert!(allowlist.is_empty(), "mika-test should have empty skill allowlist");
+}
+```
+
+5d. **Update hardcoded count** at line 2187:
+```rust
+// Before:
+assert_eq!(WELL_KNOWN_AGENTS.len(), 4);
+// After:
+assert_eq!(WELL_KNOWN_AGENTS.len(), 5);
+```
+
+## What does NOT change
+
+- No new files outside `well_known_agents.rs`.
+- No changes to `DISPATCH_TRIGGER_ALLOWLIST` (line 104) — mika-test does not trigger autonomous dispatch.
+- No changes to `INTRA_PLATFORM_DISPATCH_PEERS` (line 608) — mika-test is not part of the dev/qa/arch coordination peer group.
+- No changes to `CODE_OWNED_IDENTITY_SECTIONS` (line 401) — mika-test's identity uses `skills.allowlist` which is already in the set; the other two paths (`tools.disabled`, `context.summary`) are absent in the identity and skipped by the reconciler.
+- No `config_toml` override — mika-test uses whatever LLM provider the operator has configured in `Settings`.
+- No schema changes.
+
+## Verification
+
+Per issue ACs:
+1. `MIKA_DEV_MODE=true` startup auto-provisions `~/.mika/agents/mika-test/` ✓ (inherits from `provision_well_known_agents` loop at line 658)
+2. `mika ask --agent mika-test "hello"` returns a response ✓ (default LLM, no skills interference)
+3. `mika skills --agent mika-test list` shows zero active skills ✓ (empty allowlist evicts all at Phase -1)
+4. `mika kg status --agent mika-test` reports KG disabled ✓ (`[kg].enabled = false` → `KgAgentConfig::Disabled`)
+5. `find_well_known_agent("mika-test")` returns `Some(&MIKA_TEST)` ✓ (covered by test 5b)
+
+## Risk assessment
+
+**Low risk.** This is additive — a new array entry and constants. No existing behavior changes. The agent follows established patterns (static identity, no config override, no LLM overrides). The empty allowlist pattern is well-tested (mika-relay has a 1-element allowlist; `apply_identity_allowlist` handles empty the same way — `retain()` with empty set retains nothing).

--- a/docs/solutions/best-practices/well-known-agent-empty-allowlist-sentinel-2026-05-21.md
+++ b/docs/solutions/best-practices/well-known-agent-empty-allowlist-sentinel-2026-05-21.md
@@ -1,0 +1,109 @@
+---
+module: well-known-agents
+date: 2026-05-21
+problem_type: best_practice
+component: tooling
+severity: high
+tags:
+  - well-known-agents
+  - identity-allowlist
+  - skill-registry
+  - empty-allowlist
+  - sentinel-pattern
+applies_when:
+  - Adding a new well-known agent that should have zero skills
+  - Configuring identity.toml with an empty skill allowlist
+  - Debugging why a well-known agent unexpectedly loads all skills
+---
+
+# Well-Known Agent Empty Allowlist Requires Sentinel Value
+
+## Context
+
+When adding a new well-known agent (`mika-test`, mika#963) that should have zero
+skills, the natural approach is to set `allowlist = []` in the identity TOML.
+This appears semantically correct — an empty allowlist should deny everything.
+
+However, `SkillRegistry::apply_identity_allowlist()` in `crates/mika-agent/src/skills/mod.rs`
+treats an empty slice as a no-op:
+
+```rust
+pub fn apply_identity_allowlist(&mut self, allowlist: &[String]) {
+    if allowlist.is_empty() {
+        return;  // <-- empty list = no filtering = ALL skills active
+    }
+    // ... retain() logic that evicts non-listed skills
+}
+```
+
+This means `allowlist = []` results in the agent loading ALL bundled skills —
+the exact opposite of the intended behavior.
+
+## Guidance
+
+Use a sentinel value that matches no real skill name. The codebase already has
+a precedent in `prompt.rs` for the fail-closed identity path:
+
+```rust
+// Fail-closed sentinel (prompt.rs:349)
+allowlist: Some(vec!["__fail_closed_no_skills__".to_string()]),
+```
+
+For `mika-test`, the identity uses:
+
+```toml
+[skills]
+allowlist = ["__mika_test_no_skills__"]
+```
+
+The sentinel passes the `!allowlist.is_empty()` check, so `retain()` runs.
+Since no skill matches `__mika_test_no_skills__`, all skills are evicted.
+
+## Why This Matters
+
+The empty-allowlist no-op is intentional design — it distinguishes "no allowlist
+configured" (user-defined agents) from "allowlist configured but empty" at the
+`Option<Vec<String>>` level. The `if let Some(ref allowlist)` guard at callsites
+handles `None` (skip filtering), and the `is_empty()` guard inside the method
+handles `Some(vec![])` as equivalent to "no constraint."
+
+For well-known agents that genuinely want zero skills, this design means the
+sentinel pattern is the only correct approach. The alternative — removing the
+`is_empty()` guard — would change behavior for any future caller that passes
+`&[]` expecting a no-op.
+
+## When to Apply
+
+- Adding a new well-known agent with `disabled_skills: &[]` and
+  `identity_source: Some(IdentitySource::Static(...))` that should have no skills
+- Any identity TOML where `[skills].allowlist` must deny all skills
+- Testing the fail-closed identity path in `prompt.rs`
+
+## Examples
+
+**Wrong — agent gets all skills:**
+
+```toml
+[skills]
+allowlist = []
+```
+
+**Correct — agent gets zero skills:**
+
+```toml
+[skills]
+allowlist = ["__mika_test_no_skills__"]
+```
+
+**Verify in tests using typed deserialization:**
+
+```rust
+#[test]
+fn test_mika_test_identity_valid_toml() {
+    let identity: crate::prompt::Identity =
+        toml::from_str(MIKA_TEST_IDENTITY).expect("should be valid TOML");
+    let allowlist = identity.skills.allowlist.as_ref().unwrap();
+    assert_eq!(allowlist.len(), 1);
+    assert_eq!(allowlist[0], "__mika_test_no_skills__");
+}
+```


### PR DESCRIPTION
## Summary

- Add `mika-test` as the 5th well-known agent — a minimal, no-skills agent for engine testing/debugging without skill-system noise
- Uses sentinel allowlist value (`__mika_test_no_skills__`) to deny all skills, since `apply_identity_allowlist()` treats empty `[]` as a no-op
- KG disabled, default LLM provider/model from Settings, auto-provisioned by `MIKA_DEV_MODE=true`

## Key design decision

The groomed plan specified `allowlist = []` to deny all skills, but code review caught that `apply_identity_allowlist()` early-returns on empty slices (line 391 in `skills/mod.rs`). An empty allowlist is a no-op, not "deny all." Fixed by using the sentinel pattern already established by the fail-closed identity path (`__fail_closed_no_skills__` in `prompt.rs`).

Compound doc: `docs/solutions/best-practices/well-known-agent-empty-allowlist-sentinel-2026-05-21.md`

## Test plan

- [x] `cargo test -p mika-agent --lib well_known_agents` — 60 tests pass
- [x] `cargo clippy -p mika-agent -- -D warnings` — clean
- [ ] `MIKA_DEV_MODE=true` startup provisions `~/.mika/agents/mika-test/`
- [ ] `mika ask --agent mika-test "hello"` returns a response
- [ ] `mika skills --agent mika-test list` shows zero active skills

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)