### PR TITLE
obs(kg): instrument resolver no_match rate with 7-day rolling window (#1077)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -10300,6 +10300,94 @@ impl Database {
         Ok((count as u64, example))
     }
 
+    /// Rolling-window outcome stats from `kg_resolutions_log` (#1077).
+    ///
+    /// When `docs_root_hash` is `Some`, scopes to a single corpus via JOIN
+    /// through `kg_subject_entities`. When `None`, returns agent-wide stats
+    /// (no JOIN needed).
+    ///
+    /// The `attempted` denominator excludes structural skips and errors per
+    /// design decision D6 — only outcomes representing genuine resolution
+    /// attempts are counted.
+    pub fn kg_resolution_outcome_stats(
+        &self,
+        agent_id: &str,
+        docs_root_hash: Option<&str>,
+        window_days: u32,
+    ) -> Result<kg_schema::ResolutionOutcomeStats> {
+        let window_param = format!("-{window_days} days");
+
+        if let Some(hash) = docs_root_hash {
+            // Per-corpus: JOIN through kg_subject_entities for docs_root_hash filter.
+            // COALESCE guards against NULL when no rows match (SUM returns NULL on empty set).
+            let sql = r#"
+                SELECT
+                    COUNT(*) as total,
+                    COALESCE(SUM(CASE WHEN rl.outcome IN ('matched_exact','matched_llm','matched_llm_db_fallback','no_match','no_candidate_of_type') THEN 1 ELSE 0 END), 0) as attempted,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'no_match' THEN 1 ELSE 0 END), 0) as no_match,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'no_candidate_of_type' THEN 1 ELSE 0 END), 0) as no_candidate_of_type,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'matched_exact' THEN 1 ELSE 0 END), 0) as matched_exact,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'matched_llm' THEN 1 ELSE 0 END), 0) as matched_llm,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'matched_llm_db_fallback' THEN 1 ELSE 0 END), 0) as matched_llm_db_fallback,
+                    COALESCE(SUM(CASE WHEN rl.outcome IN ('skipped_no_llm','skipped_discovered_type','skipped_discovered_subject') THEN 1 ELSE 0 END), 0) as skipped,
+                    COALESCE(SUM(CASE WHEN rl.outcome = 'error' THEN 1 ELSE 0 END), 0) as errors
+                FROM kg_resolutions_log rl
+                JOIN kg_subject_entities se ON se.id = rl.subject_entity_id
+                WHERE rl.agent_id = ?1
+                  AND se.docs_root_hash = ?2
+                  AND rl.resolved_at >= datetime('now', ?3)
+            "#;
+            self.conn
+                .query_row(sql, params![agent_id, hash, window_param], |row| {
+                    Ok(kg_schema::ResolutionOutcomeStats {
+                        total: row.get::<_, i64>(0)? as u64,
+                        attempted: row.get::<_, i64>(1)? as u64,
+                        no_match: row.get::<_, i64>(2)? as u64,
+                        no_candidate_of_type: row.get::<_, i64>(3)? as u64,
+                        matched_exact: row.get::<_, i64>(4)? as u64,
+                        matched_llm: row.get::<_, i64>(5)? as u64,
+                        matched_llm_db_fallback: row.get::<_, i64>(6)? as u64,
+                        skipped: row.get::<_, i64>(7)? as u64,
+                        errors: row.get::<_, i64>(8)? as u64,
+                    })
+                })
+                .map_err(Into::into)
+        } else {
+            // Agent-wide: no JOIN needed.
+            // COALESCE guards against NULL when no rows match (SUM returns NULL on empty set).
+            let sql = r#"
+                SELECT
+                    COUNT(*) as total,
+                    COALESCE(SUM(CASE WHEN outcome IN ('matched_exact','matched_llm','matched_llm_db_fallback','no_match','no_candidate_of_type') THEN 1 ELSE 0 END), 0) as attempted,
+                    COALESCE(SUM(CASE WHEN outcome = 'no_match' THEN 1 ELSE 0 END), 0) as no_match,
+                    COALESCE(SUM(CASE WHEN outcome = 'no_candidate_of_type' THEN 1 ELSE 0 END), 0) as no_candidate_of_type,
+                    COALESCE(SUM(CASE WHEN outcome = 'matched_exact' THEN 1 ELSE 0 END), 0) as matched_exact,
+                    COALESCE(SUM(CASE WHEN outcome = 'matched_llm' THEN 1 ELSE 0 END), 0) as matched_llm,
+                    COALESCE(SUM(CASE WHEN outcome = 'matched_llm_db_fallback' THEN 1 ELSE 0 END), 0) as matched_llm_db_fallback,
+                    COALESCE(SUM(CASE WHEN outcome IN ('skipped_no_llm','skipped_discovered_type','skipped_discovered_subject') THEN 1 ELSE 0 END), 0) as skipped,
+                    COALESCE(SUM(CASE WHEN outcome = 'error' THEN 1 ELSE 0 END), 0) as errors
+                FROM kg_resolutions_log
+                WHERE agent_id = ?1
+                  AND resolved_at >= datetime('now', ?2)
+            "#;
+            self.conn
+                .query_row(sql, params![agent_id, window_param], |row| {
+                    Ok(kg_schema::ResolutionOutcomeStats {
+                        total: row.get::<_, i64>(0)? as u64,
+                        attempted: row.get::<_, i64>(1)? as u64,
+                        no_match: row.get::<_, i64>(2)? as u64,
+                        no_candidate_of_type: row.get::<_, i64>(3)? as u64,
+                        matched_exact: row.get::<_, i64>(4)? as u64,
+                        matched_llm: row.get::<_, i64>(5)? as u64,
+                        matched_llm_db_fallback: row.get::<_, i64>(6)? as u64,
+                        skipped: row.get::<_, i64>(7)? as u64,
+                        errors: row.get::<_, i64>(8)? as u64,
+                    })
+                })
+                .map_err(Into::into)
+        }
+    }
+
     /// Count kg_chunks rows with NULL source_doc_hash.
     pub fn kg_count_null_hash(&self) -> Result<u64> {
         let count = self.conn.query_row(
@@ -17126,5 +17214,188 @@ mod tests {
         let db = db();
         let result = db.count_agent_state("nonexistent-agent");
         assert!(result.is_err(), "Should fail for nonexistent agent");
+    }
+
+    // --- kg_resolution_outcome_stats integration tests (#1077) ---
+
+    /// Helper: seed a kg_subject_entity row and return its id.
+    fn seed_subject_entity(db: &Database, docs_root_hash: &str, name: &str) -> i64 {
+        let entity_key = format!("concept:{name}");
+        db.conn
+            .execute(
+                "INSERT INTO kg_subject_entities (name, type, entity_key, docs_root_hash, docs_root, confidence, created_at) \
+                 VALUES (?1, 'concept', ?2, ?3, '/test/path', 0.9, datetime('now'))",
+                params![name, entity_key, docs_root_hash],
+            )
+            .unwrap();
+        db.conn.last_insert_rowid()
+    }
+
+    /// Helper: seed a kg_resolutions_log row with a given outcome and age.
+    fn seed_resolution_log(
+        db: &Database,
+        agent_id: &str,
+        subject_entity_id: i64,
+        outcome: &str,
+        days_ago: i32,
+    ) {
+        let resolved_at = if days_ago == 0 {
+            "datetime('now')".to_string()
+        } else {
+            format!("datetime('now', '-{days_ago} days')")
+        };
+        db.conn
+            .execute(
+                &format!(
+                    "INSERT INTO kg_resolutions_log \
+                     (agent_id, subject_entity_id, outcome, resolved_at, source_extraction_trace_id, resolution_trace_id) \
+                     VALUES (?1, ?2, ?3, {resolved_at}, 'trace-test', 'trace-test')"
+                ),
+                params![agent_id, subject_entity_id, outcome],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_kg_outcome_stats_empty_returns_zeros() {
+        let db = db();
+        let stats = db.kg_resolution_outcome_stats("mika", None, 7).unwrap();
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.attempted, 0);
+        assert_eq!(stats.no_match, 0);
+        assert_eq!(stats.no_match_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_kg_outcome_stats_agent_wide() {
+        let db = db();
+        let hash = "testhash1234";
+        let agent = "mika"; // Default agent registered by schema init.
+
+        // Seed entities
+        let e1 = seed_subject_entity(&db, hash, "entity-1");
+        let e2 = seed_subject_entity(&db, hash, "entity-2");
+        let e3 = seed_subject_entity(&db, hash, "entity-3");
+        let e4 = seed_subject_entity(&db, hash, "entity-4");
+        let e5 = seed_subject_entity(&db, hash, "entity-5");
+
+        // Seed outcomes within 7-day window
+        seed_resolution_log(&db, agent, e1, "no_match", 1);
+        seed_resolution_log(&db, agent, e2, "matched_exact", 2);
+        seed_resolution_log(&db, agent, e3, "matched_llm", 3);
+        seed_resolution_log(&db, agent, e4, "skipped_no_llm", 1);
+        seed_resolution_log(&db, agent, e5, "error", 1);
+
+        let stats = db.kg_resolution_outcome_stats(agent, None, 7).unwrap();
+
+        assert_eq!(stats.total, 5);
+        assert_eq!(stats.attempted, 3); // no_match + matched_exact + matched_llm
+        assert_eq!(stats.no_match, 1);
+        assert_eq!(stats.matched_exact, 1);
+        assert_eq!(stats.matched_llm, 1);
+        assert_eq!(stats.skipped, 1);
+        assert_eq!(stats.errors, 1);
+        // no_match_rate = 1/3 ≈ 0.333
+        assert!(
+            (stats.no_match_rate() - 1.0 / 3.0).abs() < 1e-10,
+            "Expected ~0.333, got {}",
+            stats.no_match_rate()
+        );
+    }
+
+    #[test]
+    fn test_kg_outcome_stats_per_corpus() {
+        let db = db();
+        let hash_a = "hash_corpus_a";
+        let hash_b = "hash_corpus_b";
+        let agent = "mika";
+
+        // Corpus A: 2 no_match, 1 matched
+        let a1 = seed_subject_entity(&db, hash_a, "a-entity-1");
+        let a2 = seed_subject_entity(&db, hash_a, "a-entity-2");
+        let a3 = seed_subject_entity(&db, hash_a, "a-entity-3");
+        seed_resolution_log(&db, agent, a1, "no_match", 1);
+        seed_resolution_log(&db, agent, a2, "no_match", 2);
+        seed_resolution_log(&db, agent, a3, "matched_exact", 1);
+
+        // Corpus B: 0 no_match, 2 matched
+        let b1 = seed_subject_entity(&db, hash_b, "b-entity-1");
+        let b2 = seed_subject_entity(&db, hash_b, "b-entity-2");
+        seed_resolution_log(&db, agent, b1, "matched_llm", 1);
+        seed_resolution_log(&db, agent, b2, "matched_exact", 3);
+
+        // Per-corpus A
+        let stats_a = db
+            .kg_resolution_outcome_stats(agent, Some(hash_a), 7)
+            .unwrap();
+        assert_eq!(stats_a.attempted, 3);
+        assert_eq!(stats_a.no_match, 2);
+        assert!((stats_a.no_match_rate() - 2.0 / 3.0).abs() < 1e-10);
+
+        // Per-corpus B
+        let stats_b = db
+            .kg_resolution_outcome_stats(agent, Some(hash_b), 7)
+            .unwrap();
+        assert_eq!(stats_b.attempted, 2);
+        assert_eq!(stats_b.no_match, 0);
+        assert_eq!(stats_b.no_match_rate(), 0.0);
+
+        // Agent-wide includes both corpora
+        let stats_all = db.kg_resolution_outcome_stats(agent, None, 7).unwrap();
+        assert_eq!(stats_all.attempted, 5);
+        assert_eq!(stats_all.no_match, 2);
+    }
+
+    #[test]
+    fn test_kg_outcome_stats_window_excludes_old_rows() {
+        let db = db();
+        let hash = "windowhash";
+        let agent = "mika";
+
+        // 3-day-old row — inside 7-day window
+        let e1 = seed_subject_entity(&db, hash, "recent-entity");
+        seed_resolution_log(&db, agent, e1, "no_match", 3);
+
+        // 8-day-old row — outside 7-day window
+        let e2 = seed_subject_entity(&db, hash, "old-entity");
+        seed_resolution_log(&db, agent, e2, "no_match", 8);
+
+        let stats = db.kg_resolution_outcome_stats(agent, None, 7).unwrap();
+        assert_eq!(stats.total, 1, "8-day-old row should be excluded");
+        assert_eq!(stats.no_match, 1);
+    }
+
+    #[test]
+    fn test_kg_outcome_stats_all_outcome_types() {
+        let db = db();
+        let hash = "alloutcomes";
+
+        let outcomes = [
+            "matched_exact",
+            "matched_llm",
+            "matched_llm_db_fallback",
+            "no_match",
+            "no_candidate_of_type",
+            "skipped_no_llm",
+            "skipped_discovered_type",
+            "skipped_discovered_subject",
+            "error",
+        ];
+        let agent = "mika";
+        for (i, outcome) in outcomes.iter().enumerate() {
+            let eid = seed_subject_entity(&db, hash, &format!("e-{i}"));
+            seed_resolution_log(&db, agent, eid, outcome, 1);
+        }
+
+        let stats = db.kg_resolution_outcome_stats(agent, None, 7).unwrap();
+        assert_eq!(stats.total, 9);
+        assert_eq!(stats.attempted, 5); // matched_exact + matched_llm + matched_llm_db_fallback + no_match + no_candidate_of_type
+        assert_eq!(stats.skipped, 3); // skipped_no_llm + skipped_discovered_type + skipped_discovered_subject
+        assert_eq!(stats.errors, 1);
+        assert_eq!(stats.matched_exact, 1);
+        assert_eq!(stats.matched_llm, 1);
+        assert_eq!(stats.matched_llm_db_fallback, 1);
+        assert_eq!(stats.no_match, 1);
+        assert_eq!(stats.no_candidate_of_type, 1);
     }
 }

--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -223,6 +223,42 @@ pub fn record_invalidated_no_match(
     Ok(total)
 }
 
+/// Rolling-window outcome breakdown from `kg_resolutions_log`.
+///
+/// Used by `mika kg status` (AC1/AC2 of mika#1077) and the resolver tick
+/// alert (AC3). The `attempted` denominator excludes structural skips
+/// (`skipped_no_llm`, `skipped_discovered_type`, `skipped_discovered_subject`)
+/// and `error` — only outcomes that represent a genuine resolution attempt
+/// are counted. See plan design decision D6 for rationale.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct ResolutionOutcomeStats {
+    /// All rows in window (informational — includes skips and errors).
+    pub total: u64,
+    /// Attempted resolution outcomes only (denominator for rate calculation).
+    /// = matched_exact + matched_llm + matched_llm_db_fallback + no_match + no_candidate_of_type
+    pub attempted: u64,
+    pub no_match: u64,
+    pub no_candidate_of_type: u64,
+    pub matched_exact: u64,
+    pub matched_llm: u64,
+    pub matched_llm_db_fallback: u64,
+    /// Structural skips (excluded from rate denominator).
+    pub skipped: u64,
+    /// Infrastructure failures (excluded from rate denominator).
+    pub errors: u64,
+}
+
+impl ResolutionOutcomeStats {
+    /// `no_match / attempted`. Returns 0.0 when no attempted resolutions exist.
+    pub fn no_match_rate(&self) -> f64 {
+        if self.attempted == 0 {
+            0.0
+        } else {
+            self.no_match as f64 / self.attempted as f64
+        }
+    }
+}
+
 /// Remove a single invalidation marker after the entity has been re-resolved.
 /// No-op if the marker does not exist (idempotent).
 ///
@@ -242,6 +278,63 @@ pub fn clear_invalidated_no_match(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- ResolutionOutcomeStats unit tests (#1077) ---
+
+    #[test]
+    fn no_match_rate_zero_attempted_returns_zero() {
+        let stats = ResolutionOutcomeStats::default();
+        assert_eq!(stats.no_match_rate(), 0.0);
+    }
+
+    #[test]
+    fn no_match_rate_normal_calculation() {
+        let stats = ResolutionOutcomeStats {
+            total: 120,
+            attempted: 100,
+            no_match: 82,
+            no_candidate_of_type: 0,
+            matched_exact: 5,
+            matched_llm: 13,
+            matched_llm_db_fallback: 0,
+            skipped: 15,
+            errors: 5,
+        };
+        let rate = stats.no_match_rate();
+        assert!((rate - 0.82).abs() < 1e-10, "Expected 0.82, got {rate}");
+    }
+
+    #[test]
+    fn no_match_rate_all_matched() {
+        let stats = ResolutionOutcomeStats {
+            total: 50,
+            attempted: 50,
+            no_match: 0,
+            no_candidate_of_type: 0,
+            matched_exact: 30,
+            matched_llm: 20,
+            matched_llm_db_fallback: 0,
+            skipped: 0,
+            errors: 0,
+        };
+        assert_eq!(stats.no_match_rate(), 0.0);
+    }
+
+    #[test]
+    fn no_match_rate_all_no_match() {
+        let stats = ResolutionOutcomeStats {
+            total: 100,
+            attempted: 80,
+            no_match: 80,
+            no_candidate_of_type: 0,
+            matched_exact: 0,
+            matched_llm: 0,
+            matched_llm_db_fallback: 0,
+            skipped: 15,
+            errors: 5,
+        };
+        assert_eq!(stats.no_match_rate(), 1.0);
+    }
 
     #[test]
     fn format_entity_key_happy_path() {

--- a/crates/mika-agent/src/kg/resolver_tick.rs
+++ b/crates/mika-agent/src/kg/resolver_tick.rs
@@ -314,6 +314,12 @@ async fn tick_resolution(
                 per_corpus_attempted = %per_corpus_attempted,
                 event = "kg_resolver_tick.complete",
             );
+
+            // --- 7-day no_match rate alert (#1077) ---
+            // After each resolution tick, compute the rolling 7-day no_match
+            // rate. Emit WARN when the agent-wide rate exceeds 60% and the
+            // sample size is sufficient (>= 50 attempted) to avoid false alarms.
+            check_no_match_rate(agent_id, db, docs_root_hashes, trace_id).await;
         }
         Err(e) => {
             warn!(
@@ -380,6 +386,91 @@ async fn tick_coverage(
             event = "kg_extraction_coverage",
         );
     }
+}
+
+/// Minimum attempted resolutions required before the no_match rate alert
+/// fires. Prevents false alarms on cold-start or newly-provisioned agents.
+const NO_MATCH_RATE_MIN_SAMPLE: u64 = 50;
+
+/// Threshold above which the 7-day no_match rate triggers a WARN log.
+const NO_MATCH_RATE_THRESHOLD: f64 = 0.60;
+
+/// Rolling window in days for the no_match rate computation.
+const NO_MATCH_RATE_WINDOW_DAYS: u32 = 7;
+
+/// Check the rolling 7-day no_match rate after each resolution tick (#1077).
+///
+/// Computes the agent-wide rate first. If it exceeds the threshold (>60%)
+/// with a sufficient sample size (>=50 attempted), emits a WARN log with
+/// per-corpus breakdown so operators can identify which corpus is driving
+/// the rate.
+async fn check_no_match_rate(
+    agent_id: &str,
+    db: &AsyncDatabase,
+    docs_root_hashes: &[String],
+    trace_id: &str,
+) {
+    let aid = agent_id.to_string();
+    let agent_wide = db
+        .with_db(move |db| db.kg_resolution_outcome_stats(&aid, None, NO_MATCH_RATE_WINDOW_DAYS))
+        .await;
+
+    let stats = match agent_wide {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                target: "mika::otel",
+                trace_id = %trace_id,
+                agent_id = %agent_id,
+                error = %e,
+                event = "kg_no_match_rate_check.error",
+                "failed to compute 7-day no_match rate"
+            );
+            return;
+        }
+    };
+
+    let rate = stats.no_match_rate();
+    if rate <= NO_MATCH_RATE_THRESHOLD || stats.attempted < NO_MATCH_RATE_MIN_SAMPLE {
+        return;
+    }
+
+    // Agent-wide threshold exceeded — compute per-corpus breakdown for the
+    // WARN log so operators can see which corpus is contributing.
+    let mut per_corpus = serde_json::Map::new();
+    for hash in docs_root_hashes {
+        let aid = agent_id.to_string();
+        let h = hash.clone();
+        let corpus_stats = db
+            .with_db(move |db| {
+                db.kg_resolution_outcome_stats(&aid, Some(&h), NO_MATCH_RATE_WINDOW_DAYS)
+            })
+            .await;
+        if let Ok(cs) = corpus_stats {
+            per_corpus.insert(
+                hash.clone(),
+                serde_json::json!({
+                    "no_match_count": cs.no_match,
+                    "total": cs.attempted,
+                    "rate": (cs.no_match_rate() * 1000.0).round() / 1000.0,
+                }),
+            );
+        }
+    }
+    let per_corpus_json =
+        serde_json::to_string(&serde_json::Value::Object(per_corpus)).unwrap_or_default();
+
+    warn!(
+        target: "mika::otel",
+        trace_id = %trace_id,
+        agent_id = %agent_id,
+        no_match_rate = rate,
+        no_match_count = stats.no_match,
+        attempted_count = stats.attempted,
+        window_days = NO_MATCH_RATE_WINDOW_DAYS,
+        per_corpus = %per_corpus_json,
+        event = "kg_no_match_rate_high",
+    );
 }
 
 #[cfg(test)]

--- a/crates/mika-cli/src/commands/kg.rs
+++ b/crates/mika-cli/src/commands/kg.rs
@@ -84,6 +84,15 @@ struct AgentKgState {
     resolved: u64,
     pending: u64,
     last_extraction: Option<String>,
+    /// Rolling 7-day no_match rate (0.0–1.0). `None` when data unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    no_match_rate_7d: Option<f64>,
+    /// Count of no_match outcomes in the 7-day window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    no_match_count_7d: Option<u64>,
+    /// Total attempted resolutions in the 7-day window (denominator).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_resolutions_7d: Option<u64>,
     drift: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
@@ -241,11 +250,18 @@ fn run_status(global_home: &Path, db_path: &Path, args: &KgStatusArgs) -> Result
 
             // Per-agent detail table
             println!(
-                "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} last_extraction",
-                "Agent", "enabled", "docs_root", "chunks", "subjects", "resolved", "pending",
+                "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} {:>12} last_extraction",
+                "Agent",
+                "enabled",
+                "docs_root",
+                "chunks",
+                "subjects",
+                "resolved",
+                "pending",
+                "7d_no_match",
             );
             println!(
-                "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} {}",
+                "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} {:>12} {}",
                 "-".repeat(20),
                 "-".repeat(8),
                 "-".repeat(36),
@@ -253,6 +269,7 @@ fn run_status(global_home: &Path, db_path: &Path, args: &KgStatusArgs) -> Result
                 "-".repeat(10),
                 "-".repeat(10),
                 "-".repeat(8),
+                "-".repeat(12),
                 "-".repeat(18)
             );
 
@@ -282,8 +299,21 @@ fn run_status(global_home: &Path, db_path: &Path, args: &KgStatusArgs) -> Result
                 // Truncate docs_root for display (char-safe, no byte slicing)
                 let docs_display = truncate_docs_root(docs_root, 34);
 
+                // Format 7-day no_match rate column (#1077).
+                let no_match_display = match (state.no_match_rate_7d, state.total_resolutions_7d) {
+                    (Some(rate), Some(total)) if total > 0 => {
+                        let pct = format!("{:.1}%", rate * 100.0);
+                        if rate > 0.60 {
+                            format!("{} [!]", pct)
+                        } else {
+                            pct
+                        }
+                    }
+                    _ => "N/A".to_string(),
+                };
+
                 println!(
-                    "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} {}{}{}",
+                    "  {:<20} {:<8} {:<36} {:>8} {:>10} {:>10} {:>8} {:>12} {}{}{}",
                     agent_col,
                     enabled_str,
                     docs_display,
@@ -291,6 +321,7 @@ fn run_status(global_home: &Path, db_path: &Path, args: &KgStatusArgs) -> Result
                     format_count(state.subjects),
                     format_count(state.resolved),
                     format_count(state.pending),
+                    no_match_display,
                     last_ext,
                     drift_tag,
                     error_tag,
@@ -332,6 +363,9 @@ fn build_agent_kg_states(
                 resolved: 0,
                 pending: 0,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: Some(format!("config error: {e}")),
             }];
@@ -352,6 +386,9 @@ fn build_agent_kg_states(
                 resolved: 0,
                 pending: 0,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: None,
             }]
@@ -378,6 +415,18 @@ fn build_agent_kg_states(
                     let last_extraction =
                         db.kg_last_extraction(&corpus.docs_root_hash).ok().flatten();
 
+                    // Compute 7-day no_match rate per corpus (#1077).
+                    let (no_match_rate_7d, no_match_count_7d, total_resolutions_7d) = match db
+                        .kg_resolution_outcome_stats(agent_name, Some(&corpus.docs_root_hash), 7)
+                    {
+                        Ok(stats) if stats.attempted > 0 => (
+                            Some(stats.no_match_rate()),
+                            Some(stats.no_match),
+                            Some(stats.attempted),
+                        ),
+                        _ => (None, None, None),
+                    };
+
                     AgentKgState {
                         agent_id: agent_name.to_string(),
                         enabled: true,
@@ -388,6 +437,9 @@ fn build_agent_kg_states(
                         resolved,
                         pending,
                         last_extraction,
+                        no_match_rate_7d,
+                        no_match_count_7d,
+                        total_resolutions_7d,
                         drift: false,
                         error: None,
                     }
@@ -410,6 +462,9 @@ fn build_agent_kg_states(
                 resolved: 0,
                 pending: 0,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: Some(format!("{e}")),
             }]
@@ -1195,6 +1250,9 @@ mod tests {
                 resolved: 8082,
                 pending: 22082,
                 last_extraction: Some("2026-04-29T12:00:00Z".to_string()),
+                no_match_rate_7d: Some(0.82),
+                no_match_count_7d: Some(1000),
+                total_resolutions_7d: Some(1220),
                 drift: false,
                 error: None,
             },
@@ -1208,6 +1266,9 @@ mod tests {
                 resolved: 4,
                 pending: 160,
                 last_extraction: Some("2026-04-29T12:00:00Z".to_string()),
+                no_match_rate_7d: Some(0.50),
+                no_match_count_7d: Some(50),
+                total_resolutions_7d: Some(100),
                 drift: false,
                 error: None,
             },
@@ -1267,6 +1328,9 @@ mod tests {
                 resolved: 10,
                 pending: 40,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: None,
             },
@@ -1280,6 +1344,9 @@ mod tests {
                 resolved: 5,
                 pending: 20,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: None,
             },
@@ -1293,6 +1360,9 @@ mod tests {
                 resolved: 10,
                 pending: 40,
                 last_extraction: None,
+                no_match_rate_7d: None,
+                no_match_count_7d: None,
+                total_resolutions_7d: None,
                 drift: false,
                 error: None,
             },

--- a/docs/plans/2026-05-21-001-obs-kg-resolver-no-match-rate-plan.md
+++ b/docs/plans/2026-05-21-001-obs-kg-resolver-no-match-rate-plan.md
@@ -33,43 +33,64 @@ The resolver tick (`resolver_tick.rs`) already runs every 30 minutes per KG-enab
 
 Extend `AgentKgState` with `no_match_rate_7d: Option<f64>` and `no_match_count_7d: Option<u64>`, `total_resolutions_7d: Option<u64>`. The text table gains a `7d_no_match` column showing the rate as a percentage (e.g., `82.1%`). JSON output includes the raw fields. Per-corpus rows already exist in the status table (#877). This satisfies AC1.
 
-### D5: DB query as a Database method
+### D5: DB query as a reusable Database method
 
-Add `kg_resolution_outcome_stats(agent_id, docs_root_hash_filter, window_days) -> Result<ResolutionOutcomeStats>` to `Database`. Returns `{total, no_match, no_candidate_of_type, matched_exact, matched_llm, matched_llm_db_fallback}` for the window. The method is reusable by both the CLI and the resolver tick alert.
+Add `kg_resolution_outcome_stats(agent_id, docs_root_hash_filter, window_days) -> Result<ResolutionOutcomeStats>` to `Database`. The method is reusable by both the CLI (always computes per-corpus — AC2 requires per-corpus to be "available", not conditional) and the resolver tick alert (per-corpus detail only computed when agent-wide threshold exceeded — optimization for the alert path only).
+
+### D6: Denominator excludes structural skips and errors
+
+The `no_match_rate()` denominator counts only **attempted resolution** outcomes: `matched_exact`, `matched_llm`, `matched_llm_db_fallback`, `no_match`, `no_candidate_of_type`. Structural skips (`skipped_no_llm`, `skipped_discovered_type`, `skipped_discovered_subject`) and `error` are excluded. Rationale: structural skips are entities that never entered the resolution pipeline (no LLM configured, discovered type with no domain counterpart); including them would dilute the rate and mask fragmentation. `error` represents infrastructure failures, not resolution outcomes. The struct carries both `attempted` (denominator) and `total` (all rows in window, informational only) for full transparency.
 
 ## Implementation Steps
 
-### Phase 1: DB query method (mika-agent, `src/db.rs` or `src/db/kg_schema.rs`)
+### Phase 1: DB query method
 
-**Step 1.** Add `ResolutionOutcomeStats` struct:
+**File: `crates/mika-agent/src/db/kg_schema.rs`** — struct definition (centralizes KG types).
+**File: `crates/mika-agent/src/db.rs`** — query method (alongside other `kg_*` methods).
+
+**Step 1.** Add `ResolutionOutcomeStats` struct to `crates/mika-agent/src/db/kg_schema.rs`:
 ```rust
+/// Rolling-window outcome breakdown from `kg_resolutions_log`.
+/// Used by `mika kg status` (AC1/AC2) and the resolver tick alert (AC3).
 pub struct ResolutionOutcomeStats {
+    /// All rows in window (informational — includes skips and errors).
     pub total: u64,
+    /// Attempted resolution outcomes only (denominator for rate calculation).
+    /// = matched_exact + matched_llm + matched_llm_db_fallback + no_match + no_candidate_of_type
+    pub attempted: u64,
     pub no_match: u64,
     pub no_candidate_of_type: u64,
     pub matched_exact: u64,
     pub matched_llm: u64,
     pub matched_llm_db_fallback: u64,
+    /// Structural skips (excluded from rate denominator).
+    pub skipped: u64,
+    /// Infrastructure failures (excluded from rate denominator).
+    pub errors: u64,
 }
 
 impl ResolutionOutcomeStats {
+    /// no_match / attempted. Returns 0.0 when no attempted resolutions exist.
     pub fn no_match_rate(&self) -> f64 {
-        if self.total == 0 { 0.0 } else { self.no_match as f64 / self.total as f64 }
+        if self.attempted == 0 { 0.0 } else { self.no_match as f64 / self.attempted as f64 }
     }
 }
 ```
 
-**Step 2.** Add `Database::kg_resolution_outcome_stats(&self, agent_id: &str, docs_root_hash: Option<&str>, window_days: u32) -> Result<ResolutionOutcomeStats>`.
+**Step 2.** Add `Database::kg_resolution_outcome_stats(&self, agent_id: &str, docs_root_hash: Option<&str>, window_days: u32) -> Result<ResolutionOutcomeStats>` to `crates/mika-agent/src/db.rs`.
 
 SQL (per-corpus variant when `docs_root_hash` is `Some`):
 ```sql
 SELECT
     COUNT(*) as total,
+    SUM(CASE WHEN rl.outcome IN ('matched_exact','matched_llm','matched_llm_db_fallback','no_match','no_candidate_of_type') THEN 1 ELSE 0 END) as attempted,
     SUM(CASE WHEN rl.outcome = 'no_match' THEN 1 ELSE 0 END) as no_match,
     SUM(CASE WHEN rl.outcome = 'no_candidate_of_type' THEN 1 ELSE 0 END) as no_candidate_of_type,
     SUM(CASE WHEN rl.outcome = 'matched_exact' THEN 1 ELSE 0 END) as matched_exact,
     SUM(CASE WHEN rl.outcome = 'matched_llm' THEN 1 ELSE 0 END) as matched_llm,
-    SUM(CASE WHEN rl.outcome = 'matched_llm_db_fallback' THEN 1 ELSE 0 END) as matched_llm_db_fallback
+    SUM(CASE WHEN rl.outcome = 'matched_llm_db_fallback' THEN 1 ELSE 0 END) as matched_llm_db_fallback,
+    SUM(CASE WHEN rl.outcome IN ('skipped_no_llm','skipped_discovered_type','skipped_discovered_subject') THEN 1 ELSE 0 END) as skipped,
+    SUM(CASE WHEN rl.outcome = 'error' THEN 1 ELSE 0 END) as errors
 FROM kg_resolutions_log rl
 JOIN kg_subject_entities se ON se.id = rl.subject_entity_id
 WHERE rl.agent_id = ?1
@@ -79,25 +100,29 @@ WHERE rl.agent_id = ?1
 
 The `?3` parameter is `-N days` string (e.g., `'-7 days'`). When `docs_root_hash` is `None`, drop the JOIN and `se.docs_root_hash` filter for agent-wide stats.
 
-**Step 3.** Add `AsyncDatabase::kg_resolution_outcome_stats(...)` async wrapper (same pattern as other `with_db` wrappers).
+**Step 3.** Add `AsyncDatabase::kg_resolution_outcome_stats(...)` async wrapper to `crates/mika-agent/src/async_db.rs` (same pattern as other `with_db` wrappers).
 
-### Phase 2: Resolver tick alert (mika-agent, `src/kg/resolver_tick.rs`)
+### Phase 2: Resolver tick alert
 
-**Step 4.** After the resolution phase completes in the tick loop, call `db.kg_resolution_outcome_stats(agent_id, None, 7)` for the agent-wide rate. If `stats.no_match_rate() > 0.60 && stats.total >= 50` (minimum sample size to avoid false alarms on cold start), emit:
+**File: `crates/mika-agent/src/kg/resolver_tick.rs`**
+
+**Step 4.** After the resolution phase completes in the tick loop, call `db.kg_resolution_outcome_stats(agent_id, None, 7)` for the agent-wide rate. If `stats.no_match_rate() > 0.60 && stats.attempted >= 50` (minimum sample size to avoid false alarms on cold start), emit:
 ```rust
 warn!(
     agent_id = %agent_id,
     no_match_rate = stats.no_match_rate(),
     no_match_count = stats.no_match,
-    total_count = stats.total,
+    attempted_count = stats.attempted,
     window_days = 7,
     "kg_no_match_rate_high"
 );
 ```
 
-**Step 5.** For per-corpus breakdown in the WARN, iterate `docs_root_hashes` and call `db.kg_resolution_outcome_stats(agent_id, Some(hash), 7)` for each. Serialize as JSON in the log event's `per_corpus` field. Only compute per-corpus breakdown when the agent-wide rate exceeds the threshold (avoids unnecessary queries on healthy agents).
+**Step 5.** Per-corpus breakdown in the WARN (only when agent-wide threshold exceeded — optimization for the alert path; CLI always computes per-corpus per AC2): iterate `docs_root_hashes` and call `db.kg_resolution_outcome_stats(agent_id, Some(hash), 7)` for each. Serialize as JSON in the log event's `per_corpus` field.
 
-### Phase 3: CLI extension (mika-cli, `src/commands/kg.rs`)
+### Phase 3: CLI extension
+
+**File: `crates/mika-cli/src/commands/kg.rs`**
 
 **Step 6.** Extend `AgentKgState` with three new fields:
 ```rust
@@ -132,7 +157,8 @@ total_resolutions_7d: Option<u64>,
 
 | File | Change |
 |------|--------|
-| `crates/mika-agent/src/db.rs` (or `src/db/kg_schema.rs`) | `ResolutionOutcomeStats` struct, `kg_resolution_outcome_stats()` method |
+| `crates/mika-agent/src/db/kg_schema.rs` | `ResolutionOutcomeStats` struct definition |
+| `crates/mika-agent/src/db.rs` | `kg_resolution_outcome_stats()` query method |
 | `crates/mika-agent/src/async_db.rs` | Async wrapper for new DB method |
 | `crates/mika-agent/src/kg/resolver_tick.rs` | 7-day no_match rate check + WARN log after resolution phase |
 | `crates/mika-cli/src/commands/kg.rs` | `AgentKgState` extension, `build_agent_kg_states()` population, text table format update |
@@ -151,4 +177,8 @@ total_resolutions_7d: Option<u64>,
 
 1. **Performance on large `kg_resolutions_log`.** Current mika-arch has ~13K rows. The JOIN through `kg_subject_entities` adds cost, but both tables have indexes on the join columns. For O(100K) rows this is sub-millisecond on SQLite. If it grows to O(1M), a covering index on `(agent_id, resolved_at, outcome)` would help, but that's a premature optimization now.
 
-2. **Minimum sample size.** The 50-resolution minimum in Step 4 prevents false WARN alerts on cold-start or newly-provisioned agents. This is a conservative threshold — a fresh corpus with 50 `no_match` resolutions at >60% is still a meaningful signal.
+2. **Minimum sample size.** The 50-attempted-resolution minimum in Step 4 prevents false WARN alerts on cold-start or newly-provisioned agents. This is a conservative threshold — a fresh corpus with 50 attempted resolutions at >60% `no_match` is still a meaningful signal.
+
+## Architect Review History
+
+- **First-pass (ITERATE):** session `bc7f0fdd-fefe-4102-9412-4ae853157263`. F1: Phase 0 file placement pinned (4 sites). F2: denominator definition — resolved via D6 (exclude structural skips and errors, use `attempted` as denominator). F3: error outcome — excluded from denominator per D6. F4: D5 per-corpus gating vs AC2 — CLI always computes per-corpus; gating only in WARN alert path.

--- a/docs/plans/2026-05-21-001-obs-kg-resolver-no-match-rate-plan.md
+++ b/docs/plans/2026-05-21-001-obs-kg-resolver-no-match-rate-plan.md
@@ -1,0 +1,154 @@
+# Plan: obs(kg) — instrument resolver no_match rate (#1077)
+
+**Issue:** mika#1077
+**Type:** obs (observability enhancement)
+**Branch:** `obs/1077/kg-instrument-resolver-no-match-rate`
+
+## Problem
+
+The KG entity resolver's `no_match` outcome accounts for ~82% of lifetime `kg_resolutions_log` rows (mika-arch, 10,666/13,033). This could indicate graph fragmentation or naturally novel corpus content. There is no rolling-window metric to distinguish the two, detect regressions, or compare across agents/corpora.
+
+## Acceptance Criteria Tie-backs
+
+- **AC1:** `mika kg status` surfaces a rolling 7-day `no_match` rate per agent and per corpus.
+- **AC2:** Per-corpus breakdown available (not just per-agent).
+- **AC3:** Alert mechanism (log WARN) triggers when 7-day rate >60% sustained.
+- **AC4:** Metric persists across restarts (DB-backed, not in-memory).
+
+## Design Decisions
+
+### D1: No new table — query `kg_resolutions_log` directly
+
+The `kg_resolutions_log` table already has `resolved_at TEXT` (ISO 8601) and `outcome TEXT` per row, with an index `idx_kg_res_log_pending ON (agent_id, outcome)`. A rolling 7-day window query is a simple `WHERE resolved_at >= datetime('now', '-7 days')` filter. No materialized metric table is needed — SQLite is fast enough for the expected row counts (<100K per agent). This satisfies AC4 inherently — the source data is already DB-backed.
+
+### D2: Per-corpus breakdown via JOIN through `kg_subject_entities`
+
+`kg_resolutions_log` has `subject_entity_id` FK to `kg_subject_entities`, which carries `docs_root_hash`. A JOIN gives per-corpus breakdown without schema changes. This satisfies AC2.
+
+### D3: Alert via resolver tick structured log
+
+The resolver tick (`resolver_tick.rs`) already runs every 30 minutes per KG-enabled agent. After each resolution batch, compute the 7-day `no_match` rate and emit a WARN log if >60%. This is zero-cost when not firing and reuses the existing periodic execution context. The structured log event name: `kg_no_match_rate_high`. Fields: `agent_id`, `no_match_rate` (f64, 0.0–1.0), `no_match_count` (u64), `total_count` (u64), `window_days` (u64), `per_corpus` (JSON object mapping `docs_root_hash` to `{no_match_count, total, rate}`). This satisfies AC3.
+
+### D4: CLI surface via `mika kg status` extension
+
+Extend `AgentKgState` with `no_match_rate_7d: Option<f64>` and `no_match_count_7d: Option<u64>`, `total_resolutions_7d: Option<u64>`. The text table gains a `7d_no_match` column showing the rate as a percentage (e.g., `82.1%`). JSON output includes the raw fields. Per-corpus rows already exist in the status table (#877). This satisfies AC1.
+
+### D5: DB query as a Database method
+
+Add `kg_resolution_outcome_stats(agent_id, docs_root_hash_filter, window_days) -> Result<ResolutionOutcomeStats>` to `Database`. Returns `{total, no_match, no_candidate_of_type, matched_exact, matched_llm, matched_llm_db_fallback}` for the window. The method is reusable by both the CLI and the resolver tick alert.
+
+## Implementation Steps
+
+### Phase 1: DB query method (mika-agent, `src/db.rs` or `src/db/kg_schema.rs`)
+
+**Step 1.** Add `ResolutionOutcomeStats` struct:
+```rust
+pub struct ResolutionOutcomeStats {
+    pub total: u64,
+    pub no_match: u64,
+    pub no_candidate_of_type: u64,
+    pub matched_exact: u64,
+    pub matched_llm: u64,
+    pub matched_llm_db_fallback: u64,
+}
+
+impl ResolutionOutcomeStats {
+    pub fn no_match_rate(&self) -> f64 {
+        if self.total == 0 { 0.0 } else { self.no_match as f64 / self.total as f64 }
+    }
+}
+```
+
+**Step 2.** Add `Database::kg_resolution_outcome_stats(&self, agent_id: &str, docs_root_hash: Option<&str>, window_days: u32) -> Result<ResolutionOutcomeStats>`.
+
+SQL (per-corpus variant when `docs_root_hash` is `Some`):
+```sql
+SELECT
+    COUNT(*) as total,
+    SUM(CASE WHEN rl.outcome = 'no_match' THEN 1 ELSE 0 END) as no_match,
+    SUM(CASE WHEN rl.outcome = 'no_candidate_of_type' THEN 1 ELSE 0 END) as no_candidate_of_type,
+    SUM(CASE WHEN rl.outcome = 'matched_exact' THEN 1 ELSE 0 END) as matched_exact,
+    SUM(CASE WHEN rl.outcome = 'matched_llm' THEN 1 ELSE 0 END) as matched_llm,
+    SUM(CASE WHEN rl.outcome = 'matched_llm_db_fallback' THEN 1 ELSE 0 END) as matched_llm_db_fallback
+FROM kg_resolutions_log rl
+JOIN kg_subject_entities se ON se.id = rl.subject_entity_id
+WHERE rl.agent_id = ?1
+  AND se.docs_root_hash = ?2
+  AND rl.resolved_at >= datetime('now', ?3)
+```
+
+The `?3` parameter is `-N days` string (e.g., `'-7 days'`). When `docs_root_hash` is `None`, drop the JOIN and `se.docs_root_hash` filter for agent-wide stats.
+
+**Step 3.** Add `AsyncDatabase::kg_resolution_outcome_stats(...)` async wrapper (same pattern as other `with_db` wrappers).
+
+### Phase 2: Resolver tick alert (mika-agent, `src/kg/resolver_tick.rs`)
+
+**Step 4.** After the resolution phase completes in the tick loop, call `db.kg_resolution_outcome_stats(agent_id, None, 7)` for the agent-wide rate. If `stats.no_match_rate() > 0.60 && stats.total >= 50` (minimum sample size to avoid false alarms on cold start), emit:
+```rust
+warn!(
+    agent_id = %agent_id,
+    no_match_rate = stats.no_match_rate(),
+    no_match_count = stats.no_match,
+    total_count = stats.total,
+    window_days = 7,
+    "kg_no_match_rate_high"
+);
+```
+
+**Step 5.** For per-corpus breakdown in the WARN, iterate `docs_root_hashes` and call `db.kg_resolution_outcome_stats(agent_id, Some(hash), 7)` for each. Serialize as JSON in the log event's `per_corpus` field. Only compute per-corpus breakdown when the agent-wide rate exceeds the threshold (avoids unnecessary queries on healthy agents).
+
+### Phase 3: CLI extension (mika-cli, `src/commands/kg.rs`)
+
+**Step 6.** Extend `AgentKgState` with three new fields:
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+no_match_rate_7d: Option<f64>,
+#[serde(skip_serializing_if = "Option::is_none")]
+no_match_count_7d: Option<u64>,
+#[serde(skip_serializing_if = "Option::is_none")]
+total_resolutions_7d: Option<u64>,
+```
+
+**Step 7.** In `build_agent_kg_states()`, after computing `resolved`/`pending`, call `db.kg_resolution_outcome_stats(agent_name, Some(&corpus.docs_root_hash), 7)` and populate the new fields. On error, leave as `None` (fail-open — existing status output is not degraded).
+
+**Step 8.** Update the text table format: add a `7d_no_match` column between `pending` and `last_extraction`. Format as `"82.1%"` when present, `"N/A"` when `None` or `total_resolutions_7d == 0`. Highlight with `[!]` suffix when rate >60%.
+
+**Step 9.** JSON output: the new fields are included automatically via `serde::Serialize`.
+
+### Phase 4: Tests
+
+**Step 10.** Unit test for `ResolutionOutcomeStats::no_match_rate()` — zero total returns 0.0, normal calculation correct.
+
+**Step 11.** Integration test for `Database::kg_resolution_outcome_stats()`:
+- Seed `kg_resolutions_log` with known outcomes and `resolved_at` timestamps spanning >7 days.
+- Seed `kg_subject_entities` with two different `docs_root_hash` values.
+- Assert agent-wide stats match expected counts.
+- Assert per-corpus filter returns correct subset.
+- Assert 8-day-old rows are excluded from 7-day window.
+
+**Step 12.** No eval-harness changes needed — this is pure observability, no agent loop behavior change.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/db.rs` (or `src/db/kg_schema.rs`) | `ResolutionOutcomeStats` struct, `kg_resolution_outcome_stats()` method |
+| `crates/mika-agent/src/async_db.rs` | Async wrapper for new DB method |
+| `crates/mika-agent/src/kg/resolver_tick.rs` | 7-day no_match rate check + WARN log after resolution phase |
+| `crates/mika-cli/src/commands/kg.rs` | `AgentKgState` extension, `build_agent_kg_states()` population, text table format update |
+
+## Scope
+
+**In scope:** Rolling 7-day `no_match` rate metric via DB query, per-agent and per-corpus, CLI surface, structured WARN log alert.
+
+**Out of scope:**
+- Dashboard widget (future — this provides the DB query; the dashboard can consume it later)
+- Deduplication/canonicalization pass (separate concern — this surfaces the signal to decide whether to invest)
+- Configurable threshold (hardcoded 60% per AC3; tunability deferred)
+- Configurable window (hardcoded 7 days per AC1; the DB method takes `window_days` as a parameter for future flexibility)
+
+## Risks
+
+1. **Performance on large `kg_resolutions_log`.** Current mika-arch has ~13K rows. The JOIN through `kg_subject_entities` adds cost, but both tables have indexes on the join columns. For O(100K) rows this is sub-millisecond on SQLite. If it grows to O(1M), a covering index on `(agent_id, resolved_at, outcome)` would help, but that's a premature optimization now.
+
+2. **Minimum sample size.** The 50-resolution minimum in Step 4 prevents false WARN alerts on cold-start or newly-provisioned agents. This is a conservative threshold — a fresh corpus with 50 `no_match` resolutions at >60% is still a meaningful signal.


### PR DESCRIPTION
## Summary

- Add rolling 7-day `no_match` rate observability for the KG entity resolver to detect fragmentation regressions vs natural corpus novelty
- `ResolutionOutcomeStats` struct with denominator that excludes structural skips/errors (design decision D6)
- `Database::kg_resolution_outcome_stats()` query method — agent-wide and per-corpus via `docs_root_hash` JOIN
- Resolver tick WARN alert (`kg_no_match_rate_high`) when 7-day rate >60% with ≥50 attempted resolutions
- CLI `mika kg status` gains `7d_no_match` column with `[!]` suffix when >60%
- 9 new tests (4 unit + 5 integration)

## Acceptance Criteria

- [x] AC1: `mika kg status` surfaces a rolling 7-day `no_match` rate per agent and per corpus
- [x] AC2: Per-corpus breakdown available (not just per-agent)
- [x] AC3: Alert mechanism (log WARN) triggers when 7-day rate >60% sustained
- [x] AC4: Metric persists across restarts (DB-backed, not in-memory)

## Design Decisions

- **D1:** No new table — query `kg_resolutions_log` directly with `datetime('now', '-7 days')` window
- **D5:** Reusable `Database` method used by both CLI and resolver tick
- **D6:** Denominator excludes structural skips and errors — only genuine resolution attempts count

## Test Plan

- [x] Unit tests for `ResolutionOutcomeStats::no_match_rate()` — zero/normal/all-matched/all-no-match
- [x] Integration tests for DB method — empty DB, agent-wide counts, per-corpus filtering, window exclusion, all 9 outcome types
- [x] All 9 new tests pass, all 23 existing CLI KG tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean, pre-commit hooks pass

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)