### PR TITLE
feat(os): scaffold mika/os/ — Mika OS Docker channel placeholder (mika#1115)

### DIFF
--- a/docs/plans/2026-05-22-002-feat-1115-os-mika-os-docker-channel-scaffold-plan.md
+++ b/docs/plans/2026-05-22-002-feat-1115-os-mika-os-docker-channel-scaffold-plan.md
@@ -30,23 +30,40 @@ This ticket scaffolds the `mika/os/` directory with a **functional pre-audit pla
 Multi-stage build:
 1. **Builder stage:** Reuse `rust:1.93-slim` pattern from `Dockerfile.agent`. Build `mika`, `mika-server`, `mika-gateway` binaries with `--release --features telemetry`.
 2. **Dashboard stage:** Reuse `node:24-slim` pattern from `Dockerfile.agent` for dashboard build.
-3. **Runtime stage:** `gentoo/stage3:latest` base.
-   - Install OpenRC (already in stage3, just ensure `/sbin/openrc` is functional).
+3. **Runtime stage:** `gentoo/stage3:20250505` base (pinned; see F3 resolution below).
+   - Ensure OpenRC is functional (`/sbin/openrc` + `/etc/init.d/`).
    - Install runtime deps: `ca-certificates`, `wget`, `jq`, `sqlite` (for debugging).
    - Install `gh` CLI (same pattern as `Dockerfile.agent` lines 39-46).
    - Create `mika` user (uid 1000) with home directory.
    - Copy binaries from builder.
    - Copy OpenRC service definitions from `os/openrc/`.
    - Copy default configs from `os/config/`.
-   - Install ollama binary (stub: download script placeholder, not a full model pull — models are runtime-mounted or pulled on first start).
+   - Install `ollama` binary via official install script pinned to v0.6.0 (binary only; no models pulled at build time — see F4 resolution below).
    - Set `MIKA_HOME=/home/mika/.mika`.
-   - `ENTRYPOINT` runs OpenRC init to start services, then tails logs (container stays alive via OpenRC supervision).
+   - `ENTRYPOINT ["/usr/local/bin/mika-os-init.sh"]` — wrapper script that boots OpenRC and supervises (see "F2 — Entrypoint lifecycle contract" below).
+
+**F1 resolution — process supervision strategy:** **Full OpenRC** (operator decision 2026-05-22).
+
+- Aligns with Vincent's Gentoo desktop service model (host parity).
+- `deploy-mika` skill's `run.sh` already expects `/etc/init.d/mika-server` + `/etc/init.d/mika-gateway` via `sudo rc-service`. OpenRC inside the image closes the gap directly.
+- Trade-off accepted: container runtime requires `--cap-add=SYS_ADMIN` (preferred over full `--privileged`) and `--security-opt apparmor=unconfined` on hosts with AppArmor. Document required runtime flags in `os/README.md` (D2).
+
+**F2 resolution — Entrypoint lifecycle contract:**
+
+`os/init/mika-os-init.sh` (entrypoint wrapper) provides:
+
+1. **Boot order**: `openrc-init` boots → invokes runlevel via `rc default` → OpenRC dependency graph orchestrates: `net` → `mika-server` → `mika-gateway` (gateway depends on mika-server per `os/openrc/init.d/mika-gateway`).
+2. **SIGTERM propagation**: entrypoint installs `trap` handler that runs `rc-service mika-gateway stop` then `rc-service mika-server stop` (reverse dependency order), then `exit 0`. Graceful drain via OpenRC's `supervise-daemon` `--retry SIGTERM/10/SIGKILL/15` policy.
+3. **Child-exit policy**: `supervise-daemon` in `os/openrc/init.d/mika-server` + `mika-gateway` configured with `respawn_delay=5 respawn_max=10 respawn_period=60` (matches Vincent's host pattern per memory `project_gentoo_openrc_services`). If respawn-max trips, supervise-daemon exits → container exits → Docker restart policy applies.
+4. **Healthcheck**: `HEALTHCHECK CMD rc-service mika-server status` in Dockerfile. OpenRC `rc-service status` returns 0 on running, non-zero otherwise — straight Docker-compatible.
+5. **Container stays alive**: after `rc default` completes, entrypoint runs `tail -F /home/mika/.mika/logs/mika-server.log /home/mika/.mika/logs/mika-gateway.log &` (background) then `wait $!` so the trap remains active. Do NOT use `exec tail -F` — `exec` replaces the shell and discards the trap, breaking SIGTERM propagation (architect catch, second-pass review). Alternative considered + rejected for the placeholder: hand PID 1 to `openrc-init` via `exec /sbin/openrc-init` — cleaner but defers SIGTERM-to-rc-service translation to openrc-init's own handler, which is less audit-friendly for the placeholder; revisit in audit-derived recipe.
 
 **Key decisions:**
-- **gentoo/stage3 vs custom stage3:** Use official `gentoo/stage3:latest` for the placeholder. The audit-derived recipe will likely pin a specific stage3 variant.
+- **gentoo/stage3 pinned (F3):** `gentoo/stage3:20250505` (recent stable tag). The audit-derived recipe in the followup ticket will revisit pinning policy (digest pin vs tag pin).
 - **No model baking:** GGUF weights are NOT baked into the image. They're either volume-mounted or pulled by ollama on first start. This keeps the image under control (~200-300MB without models vs multi-GB with).
 - **All three binaries:** Unlike `Dockerfile.agent` (mika-server only), Mika OS ships `mika` (TUI), `mika-server`, and `mika-gateway` — it's a complete runtime.
 - **Pre-audit marker:** Add `# PRE-AUDIT PLACEHOLDER` header comment and a `LABEL mika.audit-status="pre-audit"` to make the placeholder status machine-readable.
+- **Ollama stub shape (F4):** placeholder ollama install via official script, version-pinned to `v0.6.0`. NO `serve` daemon registered as OpenRC service in the placeholder — defer to audit-derived recipe. `os/README.md` documents `docker run -v ollama-models:/root/.ollama mika-os ollama pull <model>` as the runtime model-pull path.
 
 ### D2: `os/README.md` — Documentation
 
@@ -135,12 +152,13 @@ All files in `os/` include Apache 2.0 SPDX header: `# SPDX-License-Identifier: A
 
 **Files created:** 2 files in `os/config/`
 
-### Phase 4: Dockerfile (D1)
+### Phase 4: Dockerfile + entrypoint (D1 + F2)
 
-10. Create `os/Dockerfile` — multi-stage Gentoo + OpenRC build.
-11. Verify it builds: `docker build -t mika-os:dev -f os/Dockerfile .` (from repo root).
+10. Create `os/init/mika-os-init.sh` — entrypoint wrapper per F2 contract (trap → `openrc-init` → `rc default` → `exec tail -F`). Executable mode 0755.
+11. Create `os/Dockerfile` — multi-stage Gentoo + OpenRC build. `ENTRYPOINT ["/usr/local/bin/mika-os-init.sh"]`. `HEALTHCHECK CMD rc-service mika-server status`.
+12. Verify it builds: `docker build -t mika-os:dev -f os/Dockerfile .` (from repo root).
 
-**Files created:** `os/Dockerfile`
+**Files created:** `os/Dockerfile`, `os/init/mika-os-init.sh`
 
 ### Phase 5: Validation
 
@@ -160,8 +178,9 @@ Per issue body — these are separate follow-up tickets:
 ## Risks
 
 1. **gentoo/stage3 image size:** Stage3 images are ~700MB+. The placeholder will be significantly larger than the current ~95MB Debian agent image. The audit-derived recipe will slim this down via selective package removal.
-2. **OpenRC in Docker:** Running OpenRC inside Docker requires `--privileged` or specific capabilities (`SYS_ADMIN`). The placeholder should document this requirement. Alternative: use a simpler supervisor (e.g., `s6-overlay` or a shell entrypoint that starts services directly) and reserve full OpenRC for the audited recipe.
+2. **OpenRC runtime requirement (resolved per F1):** Container requires `--cap-add=SYS_ADMIN` (preferred over `--privileged`) and AppArmor unconfined on hosts where AppArmor is enforcing. `os/README.md` documents the required `docker run` flags. Helm chart cutover (future ticket) must set equivalent `securityContext.capabilities.add: ["SYS_ADMIN"]`.
 3. **Builder stage compatibility:** The Rust builder stage uses Debian-based `rust:1.93-slim`. Cross-compiling for Gentoo runtime should work (both are glibc Linux), but static linking via `RUSTFLAGS="-C target-feature=+crt-static"` would be safer. However, SQLite bundled compilation should handle this — the existing `Dockerfile.agent` pattern works.
+4. **PID 1 in container under OpenRC:** Docker's default expectation is PID 1 = the entrypoint binary. With OpenRC, `openrc-init` becomes PID 1 (via the entrypoint script's exec). Zombie reaping is OpenRC's responsibility. Validated by F2 entrypoint contract.
 
 ## Acceptance Criteria (from issue)
 

--- a/docs/plans/2026-05-22-002-feat-1115-os-mika-os-docker-channel-scaffold-plan.md
+++ b/docs/plans/2026-05-22-002-feat-1115-os-mika-os-docker-channel-scaffold-plan.md
@@ -1,0 +1,173 @@
+# Plan: Scaffold mika/os/ — Mika OS Docker Channel (Pre-Audit Placeholder)
+
+**Issue:** mika#1115
+**Type:** feat
+**Branch:** `feat/1115/os-mika-os-docker-channel-scaffold-mika`
+**Date:** 2026-05-22
+
+## Context
+
+Mika OS is the Docker distribution channel — a complete runtime image (Gentoo base + OpenRC + mika binaries + ollama) serving three audiences:
+
+1. Per-customer container base for mika-cloud Helm deployments (replaces current `Dockerfile.agent` Debian-based image long-term).
+2. Single-box self-host path (`docker run mika-os`).
+3. Forkable reference environment for developers building on Mika.
+
+This ticket scaffolds the `mika/os/` directory with a **functional pre-audit placeholder** — enough to build and run, but the final recipe will be derived from Vincent's audited Gentoo desktop configuration in a follow-up ticket.
+
+## Existing Infrastructure
+
+- `Dockerfile.agent` — Debian bookworm-slim, builds `mika-server` only, non-root `mika` user (uid 1000), port 8080.
+- `Dockerfile.gateway` — Debian bookworm-slim, builds `mika-gateway`, port 8080.
+- `docker-compose.yml` — agent + gateway + optional postgres, env from `.env`.
+- `skills/bundled/deploy-mika/handlers/run.sh` — expects OpenRC init scripts at `/etc/init.d/mika-server` and `/etc/init.d/mika-gateway`, restarts via `sudo rc-service`. **No init scripts are shipped in the repo today** — they're manually provisioned on Vincent's host.
+- Runtime: `mika-server` reads config from `~/.mika/`, SQLite at `~/.mika/data/mika.db`, logs at `~/.mika/logs/`.
+
+## Deliverables
+
+### D1: `os/Dockerfile` — Functional Gentoo + OpenRC placeholder
+
+Multi-stage build:
+1. **Builder stage:** Reuse `rust:1.93-slim` pattern from `Dockerfile.agent`. Build `mika`, `mika-server`, `mika-gateway` binaries with `--release --features telemetry`.
+2. **Dashboard stage:** Reuse `node:24-slim` pattern from `Dockerfile.agent` for dashboard build.
+3. **Runtime stage:** `gentoo/stage3:latest` base.
+   - Install OpenRC (already in stage3, just ensure `/sbin/openrc` is functional).
+   - Install runtime deps: `ca-certificates`, `wget`, `jq`, `sqlite` (for debugging).
+   - Install `gh` CLI (same pattern as `Dockerfile.agent` lines 39-46).
+   - Create `mika` user (uid 1000) with home directory.
+   - Copy binaries from builder.
+   - Copy OpenRC service definitions from `os/openrc/`.
+   - Copy default configs from `os/config/`.
+   - Install ollama binary (stub: download script placeholder, not a full model pull — models are runtime-mounted or pulled on first start).
+   - Set `MIKA_HOME=/home/mika/.mika`.
+   - `ENTRYPOINT` runs OpenRC init to start services, then tails logs (container stays alive via OpenRC supervision).
+
+**Key decisions:**
+- **gentoo/stage3 vs custom stage3:** Use official `gentoo/stage3:latest` for the placeholder. The audit-derived recipe will likely pin a specific stage3 variant.
+- **No model baking:** GGUF weights are NOT baked into the image. They're either volume-mounted or pulled by ollama on first start. This keeps the image under control (~200-300MB without models vs multi-GB with).
+- **All three binaries:** Unlike `Dockerfile.agent` (mika-server only), Mika OS ships `mika` (TUI), `mika-server`, and `mika-gateway` — it's a complete runtime.
+- **Pre-audit marker:** Add `# PRE-AUDIT PLACEHOLDER` header comment and a `LABEL mika.audit-status="pre-audit"` to make the placeholder status machine-readable.
+
+### D2: `os/README.md` — Documentation
+
+Contents:
+- What Mika OS is (one paragraph).
+- Three audiences (mika-cloud base, self-host, developer reference).
+- Quick start: `docker build -t mika-os -f os/Dockerfile .` and `docker run -v mika-data:/home/mika/.mika mika-os`.
+- Configuration: env vars, volume mounts, config file locations.
+- Pre-audit status notice: this is a placeholder, final recipe pending audit.
+- License: Apache 2.0.
+- Pointer to strategic frame (the OSS decision).
+
+### D3: `os/openrc/` — Service definitions
+
+Three files per service pattern (following Gentoo OpenRC conventions):
+
+**`os/openrc/init.d/mika-server`** — OpenRC init script:
+- `command="/usr/local/bin/mika-server"`
+- `command_background="yes"` + `pidfile`
+- `supervise_daemon_args` for automatic restart
+- Depends on: `net` (network must be up)
+- Start-stop-daemon with `--user mika`
+- Logging: stdout/stderr to `/home/mika/.mika/logs/mika-server.log`
+- Environment sourced from `/etc/conf.d/mika-server`
+
+**`os/openrc/conf.d/mika-server`** — Configuration:
+- `MIKA_HOME="/home/mika/.mika"`
+- `MIKA_LOG_FORMAT="json"`
+- `MIKA_SERVER_LOG_FILE="/home/mika/.mika/logs/mika-server.log"`
+- Commented-out provider keys (runtime-only, never baked)
+- `MIKA_DEV_MODE="false"` (production default)
+
+**`os/openrc/init.d/mika-gateway`** — OpenRC init script:
+- Same pattern as mika-server
+- Depends on: `net`, `mika-server` (gateway routes to agent)
+- `command="/usr/local/bin/mika-gateway"`
+
+**`os/openrc/conf.d/mika-gateway`** — Configuration:
+- `MIKA_DATABASE_URL` (Postgres connection string, commented out — requires external DB or embedded)
+- `MIKA_INTERNAL_TOKEN` (shared secret, must match mika-server's)
+- Commented-out Telegram bot token
+
+**Design note:** These init scripts also close the gap identified in `deploy-mika` skill — `run.sh` expects `/etc/init.d/mika-server` and `/etc/init.d/mika-gateway` but nothing in the repo provides them. The Dockerfile copies these into place, and they could also be installed on bare-metal Gentoo hosts.
+
+### D4: `os/config/` — Default configuration
+
+**`os/config/config.toml`** — Mika server config defaults:
+- Provider: not set (user must configure at runtime)
+- Model: not set
+- Log format: json
+- Server port: 8080
+- KG docs root: `/app/docs/solutions` (container working directory)
+
+**`os/config/mika.env`** — Template `.env` file for Mika OS:
+- All `MIKA_*` env vars from `.env.example`, with comments
+- Clearly marked: "copy to /home/mika/.mika/.env and edit"
+- No secrets populated
+
+### D5: License header
+
+All files in `os/` include Apache 2.0 SPDX header: `# SPDX-License-Identifier: Apache-2.0`
+
+## Implementation Phases
+
+### Phase 1: Directory structure + README (D2, D5)
+
+1. Create `os/` directory.
+2. Write `os/README.md` with all sections from D2.
+3. Apache 2.0 headers on all files.
+
+**Files created:** `os/README.md`
+
+### Phase 2: OpenRC service definitions (D3)
+
+4. Create `os/openrc/init.d/mika-server` — supervise-daemon init script.
+5. Create `os/openrc/conf.d/mika-server` — environment configuration.
+6. Create `os/openrc/init.d/mika-gateway` — supervise-daemon init script.
+7. Create `os/openrc/conf.d/mika-gateway` — environment configuration.
+
+**Files created:** 4 files in `os/openrc/`
+
+### Phase 3: Default config (D4)
+
+8. Create `os/config/config.toml` — server config defaults.
+9. Create `os/config/mika.env` — template env file.
+
+**Files created:** 2 files in `os/config/`
+
+### Phase 4: Dockerfile (D1)
+
+10. Create `os/Dockerfile` — multi-stage Gentoo + OpenRC build.
+11. Verify it builds: `docker build -t mika-os:dev -f os/Dockerfile .` (from repo root).
+
+**Files created:** `os/Dockerfile`
+
+### Phase 5: Validation
+
+12. Verify `docker build` succeeds (image builds without errors).
+13. Verify `docker run --rm mika-os:dev mika-server --version` prints version.
+14. Verify OpenRC service files have correct permissions (executable init scripts).
+
+## Out of Scope
+
+Per issue body — these are separate follow-up tickets:
+- Audit-derived final Dockerfile (replaces the placeholder).
+- Multi-arch build matrix + registry publish CI.
+- mika-cloud Helm chart cutover to Mika OS base image.
+- Ollama model pulling/serving configuration.
+- Docker Compose integration for Mika OS (separate from existing `docker-compose.yml`).
+
+## Risks
+
+1. **gentoo/stage3 image size:** Stage3 images are ~700MB+. The placeholder will be significantly larger than the current ~95MB Debian agent image. The audit-derived recipe will slim this down via selective package removal.
+2. **OpenRC in Docker:** Running OpenRC inside Docker requires `--privileged` or specific capabilities (`SYS_ADMIN`). The placeholder should document this requirement. Alternative: use a simpler supervisor (e.g., `s6-overlay` or a shell entrypoint that starts services directly) and reserve full OpenRC for the audited recipe.
+3. **Builder stage compatibility:** The Rust builder stage uses Debian-based `rust:1.93-slim`. Cross-compiling for Gentoo runtime should work (both are glibc Linux), but static linking via `RUSTFLAGS="-C target-feature=+crt-static"` would be safer. However, SQLite bundled compilation should handle this — the existing `Dockerfile.agent` pattern works.
+
+## Acceptance Criteria (from issue)
+
+- AC1: `os/Dockerfile` exists, is marked pre-audit, and is functional enough to build and run.
+- AC2: `os/README.md` documents what Mika OS is, the three audiences, and Apache 2.0 license.
+- AC3: `os/openrc/` contains supervise-daemon + conf.d service definitions for mika-server and mika-gateway.
+- AC4: `os/config/` contains opinionated default configs.
+- AC5: No secrets baked in — all secrets are runtime/deploy-time only.
+- AC6: All files carry Apache 2.0 license headers.

--- a/os/Dockerfile
+++ b/os/Dockerfile
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# PRE-AUDIT PLACEHOLDER
+#
+# Mika OS — Complete runtime image (Gentoo + OpenRC + mika binaries + ollama)
+#
+# Three audiences:
+#   1. Per-customer container base for mika-cloud Helm deployments
+#   2. Single-box self-host (docker run mika-os)
+#   3. Forkable developer reference environment
+#
+# Build:   docker build -t mika-os:dev -f os/Dockerfile .
+# Run:     docker run --cap-add=SYS_ADMIN --security-opt apparmor=unconfined \
+#            -v mika-data:/home/mika/.mika mika-os:dev
+#
+# The final production recipe will be derived from an audited Gentoo configuration.
+
+# === Dashboard build stage ===
+FROM node:24-slim AS dashboard-builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY packages/ packages/
+COPY dashboard/ dashboard/
+RUN npm ci --ignore-scripts && npm run build --prefix dashboard
+
+# === Rust builder stage ===
+FROM rust:1.93-slim AS builder
+
+# Install C compiler for rusqlite bundled SQLite (no OpenSSL needed — uses rustls)
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc-dev pkg-config && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace manifests, lockfile, and all crate source
+COPY Cargo.toml Cargo.lock ./
+COPY crates/mika-common/ crates/mika-common/
+COPY crates/mika-a2a/ crates/mika-a2a/
+COPY crates/mika-agent/ crates/mika-agent/
+COPY crates/mika-gateway/ crates/mika-gateway/
+COPY crates/mika-cli/ crates/mika-cli/
+
+# Copy docs (embedded at build time via build.rs include_str!)
+COPY docs/ docs/
+
+# Copy skills (bundled skills discovered at build time via build.rs)
+COPY skills/ skills/
+
+# Copy dashboard dist for embedding
+COPY --from=dashboard-builder /app/dashboard/dist dashboard/dist
+
+# Build all three binaries with BuildKit cache mounts
+# --features telemetry enables OTLP trace export
+RUN --mount=type=cache,target=/app/target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --features telemetry \
+        --bin mika -p mika-cli \
+        --bin mika-server -p mika-agent \
+        --bin mika-gateway -p mika-gateway \
+    && cp target/release/mika /usr/local/bin/mika \
+    && cp target/release/mika-server /usr/local/bin/mika-server \
+    && cp target/release/mika-gateway /usr/local/bin/mika-gateway
+
+# === Runtime stage (Gentoo + OpenRC) ===
+FROM gentoo/stage3:20250505
+
+LABEL mika.audit-status="pre-audit"
+
+# Install runtime dependencies
+RUN emerge --noreplace app-misc/jq net-misc/wget dev-db/sqlite && \
+    rm -rf /var/tmp/portage /var/cache/distfiles
+
+# Install GitHub CLI (same pattern as Dockerfile.agent)
+RUN ARCH=$(uname -m) && \
+    case "$ARCH" in \
+        x86_64) GH_ARCH="amd64" ;; \
+        aarch64) GH_ARCH="arm64" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    GH_VERSION="2.65.0" && \
+    wget -qO /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
+    wget -qO /tmp/gh_checksums.txt "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" && \
+    cd /tmp && grep "gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" gh_checksums.txt | sha256sum -c - && \
+    tar -xzf /tmp/gh.tar.gz -C /tmp && \
+    mv /tmp/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh /usr/local/bin/gh && \
+    rm -rf /tmp/gh*
+
+# Install ollama v0.6.0 (binary only — no models pulled at build time)
+RUN OLLAMA_VERSION="v0.6.0" && \
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+        x86_64) OLLAMA_ARCH="amd64" ;; \
+        aarch64) OLLAMA_ARCH="arm64" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    wget -qO /usr/local/bin/ollama "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-${OLLAMA_ARCH}" && \
+    chmod 755 /usr/local/bin/ollama
+
+# Create non-root user with home directory
+RUN useradd -m -u 1000 -s /bin/bash mika
+
+# Copy binaries from builder
+COPY --from=builder /usr/local/bin/mika /usr/local/bin/mika
+COPY --from=builder /usr/local/bin/mika-server /usr/local/bin/mika-server
+COPY --from=builder /usr/local/bin/mika-gateway /usr/local/bin/mika-gateway
+
+# Copy docs into container for KG ingestion
+COPY docs/ /app/docs/
+
+# Copy OpenRC service definitions
+COPY os/openrc/init.d/mika-server /etc/init.d/mika-server
+COPY os/openrc/init.d/mika-gateway /etc/init.d/mika-gateway
+COPY os/openrc/conf.d/mika-server /etc/conf.d/mika-server
+COPY os/openrc/conf.d/mika-gateway /etc/conf.d/mika-gateway
+RUN chmod 755 /etc/init.d/mika-server /etc/init.d/mika-gateway
+
+# Register services with default runlevel
+RUN rc-update add mika-server default && \
+    rc-update add mika-gateway default
+
+# Copy default config files
+COPY os/config/config.toml /home/mika/.mika/config.toml
+COPY os/config/mika.env /home/mika/.mika/.env.template
+RUN chown -R mika:mika /home/mika/.mika
+
+# Copy entrypoint script
+COPY os/init/mika-os-init.sh /usr/local/bin/mika-os-init.sh
+RUN chmod 755 /usr/local/bin/mika-os-init.sh
+
+# Set Mika home
+ENV MIKA_HOME=/home/mika/.mika
+
+WORKDIR /app
+EXPOSE 8080 3001
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+    CMD rc-service mika-server status
+
+ENTRYPOINT ["/usr/local/bin/mika-os-init.sh"]

--- a/os/README.md
+++ b/os/README.md
@@ -1,0 +1,135 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Mika OS — Docker Distribution Channel
+
+> **⚠️ PRE-AUDIT PLACEHOLDER** — This is a functional scaffold. The final recipe will be derived from an audited Gentoo configuration in a follow-up ticket.
+
+Mika OS is a complete runtime image (Gentoo base + OpenRC + mika binaries + ollama) that packages the entire Mika AI executive assistant into a single Docker image.
+
+## Audiences
+
+1. **mika-cloud base image** — Per-customer container base for Helm deployments (replaces Debian-based `Dockerfile.agent` long-term).
+2. **Single-box self-host** — `docker run mika-os` for operators who want a complete Mika instance.
+3. **Developer reference** — Forkable environment for developers building on Mika.
+
+## Quick Start
+
+### Build
+
+```bash
+# From the mika repo root
+docker build -t mika-os:dev -f os/Dockerfile .
+```
+
+### Run
+
+```bash
+docker run -d \
+  --name mika \
+  --cap-add=SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  -v mika-data:/home/mika/.mika \
+  -p 8080:8080 \
+  -e MIKA_ANTHROPIC_API_KEY=sk-ant-... \
+  mika-os:dev
+```
+
+**Required runtime flags:**
+
+- `--cap-add=SYS_ADMIN` — Required for OpenRC process supervision inside the container. Preferred over `--privileged`.
+- `--security-opt apparmor=unconfined` — Required on hosts with AppArmor enforcing (Ubuntu, Debian). Not needed on hosts without AppArmor (Gentoo, Alpine, most minimal container hosts).
+
+### Verify
+
+```bash
+# Check services are running
+docker exec mika rc-service mika-server status
+docker exec mika rc-service mika-gateway status
+
+# Check version
+docker exec mika mika-server --version
+```
+
+## Configuration
+
+### Environment Variables
+
+All `MIKA_*` environment variables are supported. Pass them via `docker run -e` or mount an env file:
+
+```bash
+docker run -d \
+  --cap-add=SYS_ADMIN \
+  --security-opt apparmor=unconfined \
+  -v mika-data:/home/mika/.mika \
+  --env-file /path/to/your/mika.env \
+  mika-os:dev
+```
+
+See `os/config/mika.env` for a template with all available variables.
+
+### Volume Mounts
+
+| Mount point | Purpose |
+|-------------|---------|
+| `/home/mika/.mika` | Mika home — SQLite DB, logs, agent configs, skills |
+
+### Config Files
+
+- `/home/mika/.mika/config.toml` — Server configuration (provider, model, ports)
+- `/home/mika/.mika/.env` — Runtime secrets (API keys, tokens)
+
+Default configs are installed from `os/config/` at image build time. Override by mounting your own or editing via `docker exec`.
+
+### OpenRC Services
+
+The image runs two services under OpenRC supervision:
+
+| Service | Binary | Port | Config |
+|---------|--------|------|--------|
+| `mika-server` | `/usr/local/bin/mika-server` | 8080 | `/etc/conf.d/mika-server` |
+| `mika-gateway` | `/usr/local/bin/mika-gateway` | 3001 | `/etc/conf.d/mika-gateway` |
+
+Manage services inside the container:
+
+```bash
+docker exec mika rc-service mika-server restart
+docker exec mika rc-service mika-gateway stop
+```
+
+### Ollama
+
+Ollama is installed but no models are pulled at build time. Pull models at runtime:
+
+```bash
+docker run -v ollama-models:/root/.ollama mika-os:dev ollama pull llama3
+```
+
+Or from inside a running container:
+
+```bash
+docker exec mika ollama pull llama3
+```
+
+## What's Inside
+
+- **Gentoo stage3** base (glibc, OpenRC)
+- **mika** — TUI CLI
+- **mika-server** — HTTP agent server (Axum)
+- **mika-gateway** — Telegram + GitHub webhook router
+- **ollama** — Local LLM inference (v0.6.0, no models pre-loaded)
+- **OpenRC** process supervision with automatic restart
+- **gh** CLI for GitHub operations
+
+## Pre-Audit Status
+
+This image is a **functional placeholder**. It works, but the final production recipe will be derived from an audited Gentoo configuration that includes:
+
+- Hardened package selection
+- Optimized image size (current stage3 base is ~700MB+)
+- Multi-arch build matrix
+- Registry publish CI
+- Helm chart integration
+
+## License
+
+Apache 2.0 — see [LICENSE](../LICENSE) for details.

--- a/os/config/config.toml
+++ b/os/config/config.toml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Mika OS — Default server configuration
+#
+# This file is installed to /home/mika/.mika/config.toml at image build time.
+# Override by volume-mounting your own config or editing via docker exec.
+#
+# Environment variables (MIKA_*) always take precedence over this file.
+
+# ── LLM Provider ──
+# Uncomment and set your provider + model. API key goes in .env, not here.
+# llm_provider = "anthropic"
+# anthropic_model = "claude-sonnet-4-6"
+
+# ── Server ──
+# log_format = "json"
+# server_port = 8080
+
+# ── Knowledge Graph ──
+# KG docs root inside the container (docs/ is copied to /app/ at build time)
+kg_docs_root = "/app/docs/solutions"

--- a/os/config/mika.env
+++ b/os/config/mika.env
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Mika OS — Environment variable template
+#
+# Copy this file to /home/mika/.mika/.env and edit with your values.
+# Shell-set MIKA_* env vars always take precedence over this file.
+#
+# NO SECRETS ARE PRE-POPULATED — all values must be set at runtime.
+
+# ── Per-Provider API Keys ──
+# Set the API key for your active provider (set llm_provider in config.toml).
+# Only the active provider's key is required.
+
+# Anthropic (default provider)
+# MIKA_ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI (also used for Layer 3 vector search embeddings)
+# MIKA_OPENAI_API_KEY=sk-...
+
+# OpenRouter (access 200+ models via single key)
+# MIKA_OPENROUTER_API_KEY=sk-or-...
+
+# Groq (ultra-fast inference)
+# MIKA_GROQ_API_KEY=gsk_...
+
+# Ollama (local, no key needed)
+# MIKA_OLLAMA_API_KEY=
+
+# Mistral
+# MIKA_MISTRAL_API_KEY=...
+
+# Google AI (Gemini)
+# MIKA_GOOGLE_API_KEY=...
+
+# DeepSeek
+# MIKA_DEEPSEEK_API_KEY=...
+
+# Brave Search API key for web search skill (optional)
+# MIKA_BRAVE_API_KEY=BSA...
+
+# ── Knowledge Graph LLM (optional) ──
+# MIKA_KG_INGESTION_MODEL=openrouter/deepseek/deepseek-v3
+# MIKA_KG_EXTRACTION_MODEL=openrouter/deepseek/deepseek-v3
+# MIKA_KG_RESOLUTION_MODEL=openrouter/anthropic/claude-haiku-4-5
+# MIKA_KG_BATCH_BUDGET=500
+
+# ── Server mode (required for gateway <-> agent communication) ──
+# MIKA_ROUTING_URL=http://mika-gateway:3001
+# MIKA_INTERNAL_TOKEN=<shared-secret — openssl rand -hex 32>
+
+# ── GitHub (optional) ──
+# MIKA_GITHUB_TOKEN=ghp_...
+# MIKA_GITHUB_APP_ID=123456
+# MIKA_GITHUB_APP_PRIVATE_KEY=<base64 -w0 < your-app.pem>
+# MIKA_GITHUB_APP_INSTALLATION_ID=78901234
+
+# ── Dev mode ──
+MIKA_DEV_MODE=false
+
+# ── Runtime observability ──
+# MIKA_STORE_LLM_CALLS=true
+# MIKA_STORE_TOOL_CALLS=true
+# MIKA_LOG_LLM_BODIES=false
+
+# ── Telemetry (requires --features telemetry build) ──
+# MIKA_TELEMETRY_ENABLED=false
+# MIKA_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
+# MIKA_OTLP_AUTH_HEADER=publicKey:secretKey
+
+# ── Dashboard ──
+# MIKA_DASHBOARD_ENABLED=true
+# MIKA_DASHBOARD_TOKEN=<64 hex chars — openssl rand -hex 32>
+# MIKA_CORS_ORIGIN=http://localhost:5173

--- a/os/init/mika-os-init.sh
+++ b/os/init/mika-os-init.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Mika OS entrypoint — boots OpenRC and supervises services.
+#
+# Lifecycle contract (F2):
+#   1. Boot OpenRC via `rc default` (dependency graph: net -> mika-server -> mika-gateway)
+#   2. SIGTERM trap: stop services in reverse dependency order, then exit
+#   3. Child-exit: supervise-daemon handles respawn (respawn_delay=5, respawn_max=10, respawn_period=60)
+#   4. Container stays alive via `tail -F` on log files (backgrounded, trap remains active)
+#
+# DO NOT use `exec tail -F` — exec replaces the shell and discards the trap,
+# breaking SIGTERM propagation to OpenRC services.
+
+set -e
+
+# ── SIGTERM handler: graceful shutdown in reverse dependency order ──
+shutdown() {
+    echo "[mika-os-init] SIGTERM received, stopping services..."
+    rc-service mika-gateway stop 2>/dev/null || true
+    rc-service mika-server stop 2>/dev/null || true
+    echo "[mika-os-init] Services stopped, exiting."
+    exit 0
+}
+
+trap shutdown TERM INT
+
+# ── Ensure OpenRC directories exist ──
+# Some container runtimes don't mount tmpfs at /run
+mkdir -p /run/openrc
+touch /run/openrc/softlevel
+
+# ── Boot OpenRC default runlevel ──
+echo "[mika-os-init] Booting OpenRC default runlevel..."
+rc default || {
+    echo "[mika-os-init] WARNING: rc default exited with $?, some services may not have started"
+}
+
+echo "[mika-os-init] OpenRC boot complete. Services running."
+
+# ── Stay alive: tail log files (backgrounded so trap remains active) ──
+# Create log files if they don't exist yet (first boot)
+mkdir -p /home/mika/.mika/logs
+touch /home/mika/.mika/logs/mika-server.log /home/mika/.mika/logs/mika-gateway.log
+
+tail -F /home/mika/.mika/logs/mika-server.log /home/mika/.mika/logs/mika-gateway.log &
+TAIL_PID=$!
+
+# Wait for the tail process — trap will interrupt this on SIGTERM
+wait $TAIL_PID

--- a/os/openrc/conf.d/mika-gateway
+++ b/os/openrc/conf.d/mika-gateway
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Configuration for mika-gateway OpenRC service
+# Source: os/openrc/conf.d/mika-gateway
+#
+# This file is sourced by the mika-gateway init script.
+# Edit to configure runtime environment for the Mika webhook gateway.
+
+# ── Database (required) ──
+# Postgres connection string for the gateway's customer registry
+# MIKA_DATABASE_URL="postgres://mika:password@localhost:5432/mika"
+
+# ── Internal auth (required, must match mika-server) ──
+# MIKA_INTERNAL_TOKEN="<shared-secret — openssl rand -hex 32>"
+
+# ── Telegram (optional) ──
+# MIKA_TELEGRAM_BOT_TOKEN="<your Telegram bot token>"
+# MIKA_TELEGRAM_WEBHOOK_SECRET="<64 hex chars — openssl rand -hex 32>"
+# MIKA_TELEGRAM_WEBHOOK_URL="https://your-domain.com/webhook/telegram"
+
+# ── Gateway port ──
+# MIKA_GATEWAY_PORT="3001"
+
+# ── Agent routing (for local E2E testing) ──
+# MIKA_AGENT_BASE_URL="http://localhost:8080"
+
+# ── GitHub webhook (optional) ──
+# MIKA_GITHUB_WEBHOOK_SECRET="<your GitHub App webhook secret>"
+# MIKA_GITHUB_APP_ID="<GitHub App ID — for bot self-event filtering>"
+
+# ── Logging ──
+# MIKA_GATEWAY_LOG_FILE="/home/mika/.mika/logs/mika-gateway.log"

--- a/os/openrc/conf.d/mika-server
+++ b/os/openrc/conf.d/mika-server
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Configuration for mika-server OpenRC service
+# Source: os/openrc/conf.d/mika-server
+#
+# This file is sourced by the mika-server init script.
+# Edit to configure runtime environment for the Mika agent server.
+
+# ── Core paths ──
+MIKA_HOME="/home/mika/.mika"
+MIKA_LOG_FORMAT="json"
+MIKA_SERVER_LOG_FILE="/home/mika/.mika/logs/mika-server.log"
+
+# ── Server mode ──
+# Required for server mode (gateway <-> agent communication)
+# MIKA_ROUTING_URL="http://mika-gateway:8080"
+# MIKA_INTERNAL_TOKEN="<shared-secret — openssl rand -hex 32>"
+
+# ── Provider API keys (set the one for your active provider) ──
+# MIKA_ANTHROPIC_API_KEY="sk-ant-..."
+# MIKA_OPENAI_API_KEY="sk-..."
+# MIKA_OPENROUTER_API_KEY="sk-or-..."
+# MIKA_GROQ_API_KEY="gsk_..."
+# MIKA_MISTRAL_API_KEY="..."
+# MIKA_GOOGLE_API_KEY="..."
+# MIKA_DEEPSEEK_API_KEY="..."
+
+# ── GitHub (optional) ──
+# MIKA_GITHUB_TOKEN="ghp_..."
+
+# ── Dev mode (auto-provisions well-known agents on startup) ──
+MIKA_DEV_MODE="false"
+
+# ── Knowledge Graph ──
+# MIKA_KG_DOCS_ROOT="/app/docs/solutions"
+# MIKA_KG_INGESTION_MODEL="openrouter/deepseek/deepseek-v3"
+
+# ── Telemetry (requires --features telemetry build) ──
+# MIKA_TELEMETRY_ENABLED="false"
+# MIKA_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel/v1/traces"
+# MIKA_OTLP_AUTH_HEADER="publicKey:secretKey"

--- a/os/openrc/init.d/mika-gateway
+++ b/os/openrc/init.d/mika-gateway
@@ -1,0 +1,42 @@
+#!/sbin/openrc-run
+# SPDX-License-Identifier: Apache-2.0
+# OpenRC init script for mika-gateway (Telegram + GitHub webhook router)
+
+description="Mika webhook gateway (Telegram + GitHub routing)"
+
+command="/usr/local/bin/mika-gateway"
+command_background="yes"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+command_user="mika:mika"
+
+supervise_daemon_args="--respawn-delay 5 --respawn-max 10 --respawn-period 60"
+
+output_log="/home/mika/.mika/logs/mika-gateway.log"
+error_log="/home/mika/.mika/logs/mika-gateway.log"
+
+depend() {
+    need net mika-server
+    after firewall
+}
+
+start_pre() {
+    # Source environment configuration
+    if [ -f "/etc/conf.d/mika-gateway" ]; then
+        . "/etc/conf.d/mika-gateway"
+        # Export required vars
+        [ -n "$MIKA_DATABASE_URL" ] && export MIKA_DATABASE_URL
+        [ -n "$MIKA_INTERNAL_TOKEN" ] && export MIKA_INTERNAL_TOKEN
+        [ -n "$MIKA_TELEGRAM_BOT_TOKEN" ] && export MIKA_TELEGRAM_BOT_TOKEN
+        [ -n "$MIKA_TELEGRAM_WEBHOOK_SECRET" ] && export MIKA_TELEGRAM_WEBHOOK_SECRET
+        [ -n "$MIKA_TELEGRAM_WEBHOOK_URL" ] && export MIKA_TELEGRAM_WEBHOOK_URL
+        [ -n "$MIKA_GATEWAY_PORT" ] && export MIKA_GATEWAY_PORT
+        [ -n "$MIKA_AGENT_BASE_URL" ] && export MIKA_AGENT_BASE_URL
+        [ -n "$MIKA_GATEWAY_LOG_FILE" ] && export MIKA_GATEWAY_LOG_FILE
+        [ -n "$MIKA_GITHUB_WEBHOOK_SECRET" ] && export MIKA_GITHUB_WEBHOOK_SECRET
+        [ -n "$MIKA_GITHUB_APP_ID" ] && export MIKA_GITHUB_APP_ID
+    fi
+
+    # Ensure log directory exists
+    checkpath -d -o mika:mika -m 0755 /home/mika/.mika/logs
+}

--- a/os/openrc/init.d/mika-server
+++ b/os/openrc/init.d/mika-server
@@ -1,0 +1,47 @@
+#!/sbin/openrc-run
+# SPDX-License-Identifier: Apache-2.0
+# OpenRC init script for mika-server (Mika AI agent HTTP server)
+
+description="Mika AI agent HTTP server"
+
+command="/usr/local/bin/mika-server"
+command_background="yes"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+command_user="mika:mika"
+
+supervise_daemon_args="--respawn-delay 5 --respawn-max 10 --respawn-period 60"
+
+output_log="/home/mika/.mika/logs/mika-server.log"
+error_log="/home/mika/.mika/logs/mika-server.log"
+
+depend() {
+    need net
+    after firewall
+}
+
+start_pre() {
+    # Source environment configuration
+    if [ -f "/etc/conf.d/mika-server" ]; then
+        . "/etc/conf.d/mika-server"
+        export MIKA_HOME MIKA_LOG_FORMAT MIKA_SERVER_LOG_FILE
+        # Export optional vars only if set
+        [ -n "$MIKA_ANTHROPIC_API_KEY" ] && export MIKA_ANTHROPIC_API_KEY
+        [ -n "$MIKA_OPENAI_API_KEY" ] && export MIKA_OPENAI_API_KEY
+        [ -n "$MIKA_OPENROUTER_API_KEY" ] && export MIKA_OPENROUTER_API_KEY
+        [ -n "$MIKA_GITHUB_TOKEN" ] && export MIKA_GITHUB_TOKEN
+        [ -n "$MIKA_INTERNAL_TOKEN" ] && export MIKA_INTERNAL_TOKEN
+        [ -n "$MIKA_ROUTING_URL" ] && export MIKA_ROUTING_URL
+        [ -n "$MIKA_DEV_MODE" ] && export MIKA_DEV_MODE
+        [ -n "$MIKA_TELEMETRY_ENABLED" ] && export MIKA_TELEMETRY_ENABLED
+        [ -n "$MIKA_OTLP_ENDPOINT" ] && export MIKA_OTLP_ENDPOINT
+        [ -n "$MIKA_OTLP_AUTH_HEADER" ] && export MIKA_OTLP_AUTH_HEADER
+        [ -n "$MIKA_KG_DOCS_ROOT" ] && export MIKA_KG_DOCS_ROOT
+    fi
+
+    # Ensure log directory exists
+    checkpath -d -o mika:mika -m 0755 /home/mika/.mika/logs
+
+    # Ensure data directory exists
+    checkpath -d -o mika:mika -m 0755 /home/mika/.mika/data
+}


### PR DESCRIPTION
## Summary

Scaffolds `mika/os/` with the pre-audit placeholder Mika OS Docker channel image, per architect-GROOMED plan @ `18ed9920`.

Deliverables (D1-D5):
- **D1 Dockerfile** — multi-stage: `rust:1.93-slim` builder + `node:24-slim` dashboard + `gentoo/stage3:20250505` runtime; builds `mika`, `mika-server`, `mika-gateway`; PID 1 via OpenRC wrapper; `HEALTHCHECK CMD rc-service mika-server status`
- **D2 README** — audiences (mika-cloud base, self-host, dev reference), Apache 2.0, required `docker run` flags (`--cap-add=SYS_ADMIN`)
- **D3 OpenRC services** — `init.d/mika-server`, `init.d/mika-gateway` (depends mika-server), `conf.d/` configs
- **D4 Default configs** — `config.toml`, `mika.env` template
- **D5 License** — Apache 2.0 SPDX headers
- **F2 entrypoint** — `init/mika-os-init.sh` with trap+wait (NOT exec, per architect second-pass catch)

## Grooming history

- /ce:plan (operator-direct: pilot drift recovered by manual commit @ 18ed9920)
- mika-arch first-pass: ITERATE (F1+F2 BLOCKING, F3+F4 non-blocking)
- Revisions: F1=OpenRC (operator decision), F2 lifecycle spec, F3 stage3 pin, F4 ollama shape
- mika-arch second-pass: GROOMED (session `df78c6c1`) — wiring fix applied for trap+exec mutex

## Implementation note

claude-pilot wrote all files but exited `pipeline_incomplete` before commit phase — operator-recovered. Drift class documented at `docs/solutions/2026-05-21-pilot-drift-on-deprioritization-status-notes.md`.

## Test plan

- [ ] `docker build -t mika-os:dev -f os/Dockerfile .` succeeds on clean checkout
- [ ] Container starts with `docker run --cap-add=SYS_ADMIN mika-os:dev` (OpenRC boots, mika-server + mika-gateway listed in `rc-status`)
- [ ] `HEALTHCHECK` returns 0 once services are running
- [ ] SIGTERM propagates via trap → reverse-order rc-service stop

## Out of scope (separate followups)

- Audit-derived final Dockerfile (replaces this placeholder)
- mika-cloud Helm chart cutover to Mika OS base image
- Multi-arch build matrix + registry publish CI
- Ollama model pulling/serving in `serve` daemon mode

Closes mika#1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)