### PR TITLE
fix(dockerfile-agent): gh CLI install checksum verification fails — wget filename mismatch

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -38,10 +38,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 # Install GitHub CLI (for github builtin skill) with checksum verification
 RUN ARCH=$(dpkg --print-architecture) && \
     GH_VERSION="2.65.0" && \
-    wget -qO /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
+    wget -qO "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
     wget -qO /tmp/gh_checksums.txt "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt" && \
     cd /tmp && grep "gh_${GH_VERSION}_linux_${ARCH}.tar.gz" gh_checksums.txt | sha256sum -c - && \
-    tar -xzf /tmp/gh.tar.gz -C /tmp && \
+    tar -xzf "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" -C /tmp && \
     mv /tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh /usr/local/bin/gh && \
     rm -rf /tmp/gh*
 

--- a/docs/plans/2026-05-22-003-fix-1240-dockerfile-agent-gh-cli-checksum-plan.md
+++ b/docs/plans/2026-05-22-003-fix-1240-dockerfile-agent-gh-cli-checksum-plan.md
@@ -1,0 +1,73 @@
+# Plan: Fix Dockerfile.agent gh CLI install checksum verification (mika#1240)
+
+## Metadata
+
+- **Issue:** mika#1240
+- **Type:** fix
+- **Branch:** `fix/1240/dockerfile-agent-gh-cli-install-checksum`
+- **Priority:** p1-important (second blocker on agent image build)
+- **Date:** 2026-05-22
+
+## Problem
+
+`Dockerfile.agent` lines 38-46 install the GitHub CLI with checksum verification, but the download
+filename doesn't match what the checksum file references:
+
+1. `wget -qO /tmp/gh.tar.gz` saves the tarball as `/tmp/gh.tar.gz` (renamed)
+2. The checksums file contains lines like `<hash>  gh_2.65.0_linux_amd64.tar.gz`
+3. `sha256sum -c -` parses the checksum line and looks for `gh_2.65.0_linux_amd64.tar.gz` on disk
+4. File not found -> build fails
+
+This is the second Dockerfile.agent build blocker (after mika#1237 which removed broken COPY lines).
+
+## Root cause
+
+The `wget -qO` flag renames the downloaded file, but `sha256sum -c` resolves filenames from the
+checksum file content. The filename on disk must match the filename in the checksum line.
+
+## Fix
+
+Two-line change in `Dockerfile.agent` lines 41 and 44:
+
+### Step 1: Download to original filename
+
+**File:** `Dockerfile.agent` line 41
+
+```diff
+-    wget -qO /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
++    wget -qO "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
+```
+
+### Step 2: Extract from original filename
+
+**File:** `Dockerfile.agent` line 44
+
+```diff
+-    tar -xzf /tmp/gh.tar.gz -C /tmp && \
++    tar -xzf "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" -C /tmp && \
+```
+
+### Verification
+
+The cleanup line 46 (`rm -rf /tmp/gh*`) already covers the new filename pattern — no change needed.
+
+Line 45 (`mv /tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh /usr/local/bin/gh`) references the
+extracted directory name (from the tarball's internal structure), not the tarball filename — no
+change needed.
+
+## AC tie-back
+
+- **AC1 (implicit):** `sha256sum -c -` succeeds during `docker build -f Dockerfile.agent` because
+  the file on disk matches the filename in the checksum line.
+
+## Out of scope
+
+- CI `docker build` smoke test (mentioned as follow-up in the issue — separate ticket)
+- Google Workspace CLI install (lines 48-58 — uses a different pattern that already works: downloads
+  as `gws.tar.gz` and constructs the checksum line manually with `echo "$(cat gws.tar.gz.sha256)  gws.tar.gz"`)
+
+## Risk
+
+Minimal. Two-line change, both within the same `RUN` instruction. The fix aligns the filename on
+disk with the filename the checksum file expects — identical to how the gh CLI install was likely
+intended to work originally.

--- a/docs/solutions/build-errors/dockerfile-agent-gh-cli-checksum-wget-filename-mismatch-2026-05-22.md
+++ b/docs/solutions/build-errors/dockerfile-agent-gh-cli-checksum-wget-filename-mismatch-2026-05-22.md
@@ -1,0 +1,82 @@
+---
+title: Dockerfile.agent gh CLI checksum verification fails due to wget filename mismatch
+date: 2026-05-22
+category: build-errors
+module: Dockerfile.agent
+problem_type: build_error
+component: tooling
+symptoms:
+  - "sha256sum: gh_2.65.0_linux_amd64.tar.gz: No such file or directory"
+  - "sha256sum: WARNING: 1 listed file could not be read"
+  - "docker build -f Dockerfile.agent fails at gh CLI install step with exit code 1"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags:
+  - dockerfile
+  - docker-build
+  - checksum
+  - sha256sum
+  - wget
+  - gh-cli
+  - filename-mismatch
+  - cloud-deploy
+---
+
+# Dockerfile.agent gh CLI checksum verification fails due to wget filename mismatch
+
+## Problem
+
+`docker build -f Dockerfile.agent` fails during the gh CLI installation step. The `sha256sum -c` checksum verification cannot find the downloaded tarball because `wget -qO` renamed it to a generic filename that doesn't match the filename referenced in the checksums file.
+
+This was the second Dockerfile.agent build blocker discovered during the cloud-deploy readiness audit (after mika#1237, which removed broken COPY directives).
+
+## Symptoms
+
+- `sha256sum: gh_2.65.0_linux_amd64.tar.gz: No such file or directory`
+- `sha256sum: WARNING: 1 listed file could not be read`
+- Docker build exits with code 1 at the gh CLI install RUN instruction
+
+## What Didn't Work
+
+This bug was latent — the Dockerfile had never been built end-to-end from a clean checkout. There was no CI `docker build` smoke test to catch it. The issue was discovered only when attempting the first cloud deploy.
+
+## Solution
+
+Download the tarball using its original filename instead of renaming it, so `sha256sum -c` can resolve the filename from the checksums file.
+
+**Before:**
+```dockerfile
+wget -qO /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
+...
+tar -xzf /tmp/gh.tar.gz -C /tmp && \
+```
+
+**After:**
+```dockerfile
+wget -qO "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
+...
+tar -xzf "/tmp/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" -C /tmp && \
+```
+
+Two-line change. The cleanup glob `rm -rf /tmp/gh*` already covers the new filename pattern.
+
+## Why This Works
+
+`sha256sum -c` reads checksum lines in the format `<hash>  <filename>` and verifies by opening `<filename>` relative to the current directory. The gh CLI checksums file contains entries like `abc123  gh_2.65.0_linux_amd64.tar.gz`. When `wget -qO` renames the file to `gh.tar.gz`, `sha256sum` looks for `gh_2.65.0_linux_amd64.tar.gz` and fails with "No such file or directory."
+
+By downloading to the original filename, the file on disk matches the filename in the checksum line, and verification succeeds.
+
+## Prevention
+
+- **Add a CI `docker build` smoke test** to `.github/workflows/ci.yml` — both this issue and mika#1237 would have been caught immediately. Currently tracked as a separate follow-up ticket.
+- **When using `sha256sum -c` with upstream checksums files, always preserve the original filename.** The checksums file references the upstream release filename, so the local copy must match. Alternative: construct the checksum line manually (as the Google Workspace CLI install in the same Dockerfile does with `echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -`).
+- **Contrast the two patterns in Dockerfile.agent:**
+  - gh CLI: uses upstream checksums file with `grep | sha256sum -c` — filename must match
+  - Google Workspace CLI: downloads checksum separately, constructs the line manually — filename can be anything
+
+## Related Issues
+
+- [mika#1240](https://github.com/senara-solutions/mika/issues/1240) — this fix
+- [mika#1237](https://github.com/senara-solutions/mika/issues/1237) — prior Dockerfile.agent fix (broken COPY directives)
+- [docs/solutions/build-errors/dockerfile-agent-broken-copy-nonexistent-paths-2026-05-22.md](dockerfile-agent-broken-copy-nonexistent-paths-2026-05-22.md) — companion doc from the same cloud-deploy audit


### PR DESCRIPTION
## Summary

- Fix `sha256sum -c` failure during `docker build -f Dockerfile.agent` by downloading the gh CLI tarball with its original filename instead of renaming it to `gh.tar.gz`
- The checksums file references `gh_2.65.0_linux_amd64.tar.gz` but the file on disk was `gh.tar.gz` — `sha256sum -c` couldn't find it
- Two-line change in `Dockerfile.agent` (lines 41 and 44)

## Why

Second blocker on the mika-agent Docker image build, after #1237 (broken COPY directives). Discovered during cloud-deploy readiness audit — the Dockerfile had never been built end-to-end from a clean checkout. Mika OS still doesn't build, blocking cloud deploy.

## Test plan

- [ ] `docker build -f Dockerfile.agent -t mika-agent:dev .` completes successfully (checksum verification passes)
- [ ] Verify `gh --version` works inside the built container

Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)