### PR TITLE
fix(os): gws install sha256sum filename mismatch

### DIFF
--- a/docs/plans/2026-05-23-1249-fix-os-gws-sha256sum-plan.md
+++ b/docs/plans/2026-05-23-1249-fix-os-gws-sha256sum-plan.md
@@ -1,0 +1,63 @@
+# Plan: fix(os) — gws install sha256sum filename mismatch
+
+- **Issue:** mika#1249
+- **Type:** fix
+- **Priority:** p0-critical
+- **Branch:** `fix/1249/os-gws-install-sha256sum-filename`
+
+## Problem
+
+`docker build --target mika-runtime -f os/Dockerfile .` fails at the gws (Google Workspace CLI) install step. The `sha256sum -c -` invocation receives a malformed three-token line because the `.sha256` file from GitHub releases already contains the archive's full name (`<hash>  gws-x86_64-unknown-linux-gnu.tar.gz`), and the Dockerfile wraps it with `echo "$(cat .sha256)  gws.tar.gz"`, producing `<hash>  gws-x86_64-unknown-linux-gnu.tar.gz  gws.tar.gz` — sha256sum interprets everything after the hash as a single filename with an embedded space.
+
+This is the 5th instance of the same bug class (download-rename + sha256sum filename mismatch) in 4 days, after mika#1240, mika#1242, mika#1243.
+
+## Fix
+
+Two changes to the gws install block (lines 107-120 of `os/Dockerfile`):
+
+### Change 1: Download under canonical archive name
+
+Replace `wget -qO /tmp/gws.tar.gz` with `wget -qO "/tmp/gws-${GWS_ARCH}.tar.gz"` so the downloaded file's name matches what the `.sha256` file references. Same for the `.sha256` file itself.
+
+### Change 2: Use grep-based checksum verification
+
+Replace:
+```sh
+echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -
+```
+
+With:
+```sh
+grep "gws-${GWS_ARCH}.tar.gz" "gws-${GWS_ARCH}.tar.gz.sha256" | sha256sum -c -
+```
+
+This matches the canonical pattern already working at line 100 (gh CLI install).
+
+### sha256sum audit (AC4)
+
+All three `sha256sum` invocations in `os/Dockerfile` after this fix:
+
+| Line | Binary | Pattern | Status |
+|------|--------|---------|--------|
+| 100 | gh CLI | `grep "<name>" checksums.txt \| sha256sum -c -` | ✅ Correct (fixed in mika#1243) |
+| 117 | gws | `grep "<name>" "<name>.sha256" \| sha256sum -c -` | ✅ Fixed by this PR |
+| 136 | ollama | `awk '{print $1}' + echo "$HASH  <name>" \| sha256sum -c -` | ✅ Correct (hash-only extract, filename matches downloaded name) |
+
+**Note:** `Dockerfile.agent` line 58 still uses the broken `echo "$(cat .sha256)  gws.tar.gz"` pattern — same bug class but out of scope for this issue (separate file, separate image). Should be tracked as a follow-up.
+
+## Acceptance Criteria Mapping
+
+- **AC1.** `docker build --target mika-os -f os/Dockerfile .` succeeds — verified by the fix ensuring sha256sum passes.
+- **AC2.** `docker build --target mika-runtime -f os/Dockerfile .` succeeds — mika-runtime inherits from mika-os, so fixing the mika-os stage fixes both.
+- **AC3.** Uses the same `grep <name> <checksums> | sha256sum -c -` recipe as the gh install on line 100.
+- **AC4.** Full audit of all sha256sum invocations in os/Dockerfile completed — see table above. All three are correct after this fix.
+
+## Test Plan
+
+- [ ] `docker build --target mika-os -f os/Dockerfile .` completes successfully
+- [ ] `docker build --target mika-runtime -f os/Dockerfile .` completes successfully
+- [ ] Verify gws binary is functional: `docker run --rm mika-os:dev gws --version`
+
+## Risk
+
+Minimal — single-file, 4-line change following an established pattern. No behavioral change beyond fixing the broken checksum verification.

--- a/os/Dockerfile
+++ b/os/Dockerfile
@@ -110,12 +110,12 @@ RUN ARCH=$(uname -m) && \
         aarch64) GWS_ARCH="aarch64-unknown-linux-gnu" ;; \
         *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    wget -qO /tmp/gws.tar.gz \
+    wget -qO "/tmp/gws-${GWS_ARCH}.tar.gz" \
         "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/gws-${GWS_ARCH}.tar.gz" && \
-    wget -qO /tmp/gws.tar.gz.sha256 \
+    wget -qO "/tmp/gws-${GWS_ARCH}.tar.gz.sha256" \
         "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/gws-${GWS_ARCH}.tar.gz.sha256" && \
-    cd /tmp && echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c - && \
-    tar -xzf /tmp/gws.tar.gz -C /tmp && \
+    cd /tmp && grep "gws-${GWS_ARCH}.tar.gz" "gws-${GWS_ARCH}.tar.gz.sha256" | sha256sum -c - && \
+    tar -xzf "/tmp/gws-${GWS_ARCH}.tar.gz" -C /tmp && \
     find /tmp -name gws -type f -executable -exec install -m 755 {} /usr/local/bin/gws \; && \
     rm -rf /tmp/gws*
 


### PR DESCRIPTION
## Summary

Fixes the `sha256sum -c` filename-mismatch bug in the gws (Google Workspace CLI) install step of `os/Dockerfile`, and audits all other sha256-verified binary installs for the same bug class (AC4).

- **gws install (`os/Dockerfile` lines 113–118) — FIXED.** The old `cd /tmp && echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -` produced a malformed three-token line: the `.sha256` file from GitHub already carries the archname (`<hash> *gws-x86_64-unknown-linux-gnu.tar.gz`), so appending `  gws.tar.gz` made `sha256sum -c` treat `gws-...tar.gz  gws.tar.gz` as a single filename with an embedded space → `No such file or directory`. Switched to the canonical `grep "gws-${GWS_ARCH}.tar.gz" "gws-${GWS_ARCH}.tar.gz.sha256" | sha256sum -c -` pattern (matching the working `gh` install at line 100) and renamed the download to its canonical `gws-${GWS_ARCH}.tar.gz` name so the checksum line resolves on disk.
- **gh install (line 100) — already correct.** Canonical `grep <name> <checksums> | sha256sum -c -`. No change. This is the reference pattern.
- **ollama install (lines 124–138) — audited, sound, no change.** It extracts only the hash with `EXPECTED=$(cat "...sha256" | awk '{print $1}')` and pairs it with the actual on-disk filename `ollama-linux-${OLLAMA_ARCH}`. This is robust to both `.sha256` formats (hash-only or `hash filename`) and is not in the bug class.

## Verification

The full `docker build --target mika-runtime` could **not** be run to completion because the build fails at an **unrelated, upstream** step (see Follow-up below) before reaching the gws step (line 117). Instead, the exact fixed command was verified against the **real** GitHub release artifact (`gws v0.13.3`, `x86_64-unknown-linux-gnu`):

Real `.sha256` file contents (note the embedded archname that causes the bug):
```
81e35ebb2db634beff6606dd15518af81549d3bcad1ef88c13316fb94b5e2160 *gws-x86_64-unknown-linux-gnu.tar.gz
```

OLD (broken) command — reproduces the reported failure:
```
$ echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -
sha256sum: 'gws-x86_64-unknown-linux-gnu.tar.gz  gws.tar.gz': No such file or directory
gws-x86_64-unknown-linux-gnu.tar.gz  gws.tar.gz: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
OLD rc=1
```

NEW (fixed) command — passes:
```
$ grep "gws-${GWS_ARCH}.tar.gz" "gws-${GWS_ARCH}.tar.gz.sha256" | sha256sum -c -
gws-x86_64-unknown-linux-gnu.tar.gz: OK
NEW rc=0
```

## Follow-up needed (separate bug, NOT in this PR's scope)

`docker build --target mika-runtime -f os/Dockerfile .` fails at **line 61** — `RUN npm ci --ignore-scripts && npm run build --prefix dashboard` — on a clean (cache-busted) build with:
```
src/pages/Timeline.tsx(5,187): error TS2307: Cannot find module '@senara-solutions/ui' or its corresponding type declarations.
... (many more)
ERROR: process "/bin/sh -c npm ci --ignore-scripts && npm run build --prefix dashboard" did not complete successfully: exit code: 2
```
The dashboard build cannot resolve the local `@senara-solutions/ui` workspace package — `npm ci --ignore-scripts` skips the lifecycle script that builds `packages/ui`, so its dist/type declarations are missing. This is a distinct bug class (workspace build ordering), not a sha256 mismatch, so per the hot-patch scope it is **not** addressed here. It surfaced because the previously-cached dashboard layer was rebuilt fresh. A follow-up ticket should make the Dockerfile build `packages/ui` before the dashboard (or drop `--ignore-scripts` for the workspace build).

This class of recurrence is exactly what **mika#1248** (Dockerfile sha256 CI smoke test) is meant to catch.

## Closes #1249