### PR TITLE
fix(skills): dev-groom dependency edge (mika#1173 follow-up)

### DIFF
--- a/crates/mika-agent/src/skills/matcher.rs
+++ b/crates/mika-agent/src/skills/matcher.rs
@@ -424,4 +424,105 @@ mod tests {
         assert_eq!(matched[1].entry.manifest.skill.name, "skill-review");
         assert_eq!(matched[1].reason, MatchReason::Dependency);
     }
+
+    // --- Bundled dispatch-skill loader symmetry (mika#1251) ---
+
+    /// Build a `SkillEntry` from the *real* bundled `skill.toml` shipped in
+    /// `skills/bundled/<name>/`. Reads the source-tree file at test time via
+    /// `CARGO_MANIFEST_DIR` (mirroring `build.rs`, which resolves the same
+    /// `../../skills/bundled` root) so the assertion runs against the manifest
+    /// that actually ships — not a synthetic copy. That is what makes the
+    /// dependent test a regression guard for the self-dev → dev-groom edge: if
+    /// someone deletes the edge from `skill.toml`, this reflects it.
+    fn bundled_entry(name: &str) -> SkillEntry {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../skills/bundled")
+            .join(name)
+            .join("skill.toml");
+        let toml_str = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "failed to read bundled skill.toml at {}: {e}",
+                path.display()
+            )
+        });
+        let manifest: crate::skills::manifest::SkillManifest = toml::from_str(&toml_str)
+            .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()));
+        let keywords_lower = manifest
+            .triggers
+            .keywords
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect();
+        SkillEntry {
+            manifest,
+            dir: PathBuf::from(format!("/skills/{name}")),
+            keywords_lower,
+            prompt_snippet: String::new(),
+            skill_tools: vec![],
+            enabled: true,
+            has_override: false,
+            provider_overrides: std::collections::HashMap::new(),
+            model_prompts: std::collections::HashMap::new(),
+            model_overrides: std::collections::HashMap::new(),
+            generated_model_prompts: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_dev_pilot_and_dev_groom_loader_symmetry_on_ready_label_webhook() {
+        // Regression for mika#1251. The autonomous loop's auto-groom path went
+        // wedged on github-webhook turns: dev-groom (always_on=false, keywords
+        // ["groom", ...]) was unreachable, so its tool `run_claude_pilot_groom`
+        // returned "Unknown tool" on every dispatch. dev-pilot worked on the
+        // same turn only because self-dev (always_on=true) lists it in
+        // `dependencies`. mika#1173 restored dev-groom as a tool-owning skill
+        // but never added the dependency edge from self-dev.
+        //
+        // Both dispatch skills must be loader-symmetric: pulled into the matched
+        // set as `Dependency` (NOT `Keyword` — the webhook prompt carries no
+        // dispatch keyword) so their tools register on the turn.
+        let skills = vec![
+            bundled_entry("self-dev"),
+            bundled_entry("dev-pilot"),
+            bundled_entry("dev-groom"),
+        ];
+
+        // The exact webhook trigger shape. Carries none of the dispatch skills'
+        // keywords, so the only path that can include them is the dependency BFS.
+        let webhook_msg = "[GitHub] Issue labeled ready on senara-solutions/mika#1 — title here";
+
+        // Precondition: confirm no dev-pilot/dev-groom keyword is present in the
+        // prompt. If this ever fails, the test below would pass for the wrong
+        // reason (Keyword match instead of the Dependency edge under test).
+        let lower = webhook_msg.to_lowercase();
+        for entry in &skills[1..] {
+            for kw in &entry.keywords_lower {
+                assert!(
+                    !lower.contains(kw),
+                    "test precondition violated: webhook prompt contains dispatch keyword '{kw}'"
+                );
+            }
+        }
+
+        let matched = match_skills(&skills, webhook_msg);
+        let find = |name: &str| matched.iter().find(|m| m.entry.manifest.skill.name == name);
+
+        let pilot = find("dev-pilot")
+            .expect("dev-pilot must be matched on the webhook turn (dependency of self-dev)");
+        assert_eq!(
+            pilot.reason,
+            MatchReason::Dependency,
+            "dev-pilot must match via the self-dev dependency edge, not a keyword"
+        );
+
+        let groom = find("dev-groom").expect(
+            "dev-groom must be matched on the webhook turn — a missing edge in \
+             self-dev.dependencies wedges run_claude_pilot_groom (mika#1251)",
+        );
+        assert_eq!(
+            groom.reason,
+            MatchReason::Dependency,
+            "dev-groom must match via the self-dev dependency edge, not a keyword"
+        );
+    }
 }

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -831,6 +831,13 @@ EOF
     #   4. Add the skill to the relevant well-known agent allowlist
     #      (well_known_agents.rs MIKA_*_IDENTITY).
     #   5. Update self-dev/system_prompt.md to teach mika-dev when to dispatch.
+    #   6. Update skills/bundled/self-dev/skill.toml `dependencies` array to
+    #      include the new skill. self-dev is always_on; non-always-on dispatch
+    #      skills only register their tool on a turn when self-dev pulls them in
+    #      via the dependency BFS. Webhook prompts (`[GitHub] Issue labeled ready
+    #      on …`) carry no dispatch keyword, so without this edge the tool returns
+    #      "Unknown tool" on every auto-dispatch turn (mika#1251 — dev-groom was
+    #      tool-restored in mika#1173 but this edge was missed).
     # Threshold for refactor: if N>5 dispatch skills, consider engine-side
     # routing helpers. Until then, the case switch is the contract.
     local ENTRY_COMMAND

--- a/skills/bundled/self-dev/skill.toml
+++ b/skills/bundled/self-dev/skill.toml
@@ -9,6 +9,7 @@ dependencies = [
     "build-mika",
     "deploy-mika",
     "dev-pilot",
+    "dev-groom",
     "browser-control",
     "resolve-pr-conflicts",
 ]


### PR DESCRIPTION
## Summary

`run_claude_pilot_groom` returned **"Unknown tool"** on every GitHub-webhook auto-groom turn because `dev-groom` was unreachable in the skill matcher. The fix adds `"dev-groom"` to `self-dev`'s `dependencies` array (one line) — mirroring the existing `dev-pilot` edge — so the always-on `self-dev` orchestrator pulls `dev-groom` in via the dependency BFS on every turn, registering its tool.

This is a mika#1173 follow-up: that PR restored `dev-groom` as a tool-owning skill but never added the loader-side dependency edge, leaving `dev-pilot` and `dev-groom` tool-symmetric but **loader-asymmetric**. The asymmetry was exactly the failure surface.

## Reproduction

`dev-groom` is `always_on = false` and its keywords (`groom`, `groom ticket`, …) don't appear in the webhook prompt `[GitHub] Issue labeled ready on …`. With no keyword hit and no dependency edge from the always-on `self-dev`, the matcher (`crates/mika-agent/src/skills/matcher.rs`) never marks `dev-groom` matched, so `build_skill_tool_map()` excludes `run_claude_pilot_groom` and the dispatcher falls through to "Unknown tool".

Ground-truth failure row (full investigation at `/tmp/groom-tool-wedge-investigation-2026-05-23.md`):

- `tool_calls.id = 5a31ac38-…`, agent `mika-dev`, session `c51f7a4b-…` (channel `github`)
- `error_message = "Unknown tool: run_claude_pilot_groom"`
- input `{"prompt":"mika#1249","skill":"dev-groom","task_id":"3b846d46-…"}`
- ts `2026-05-23T10:21:06Z`

The `cli` channel kept working because operator dispatches (`mika ask --agent mika-dev "groom mika#…"`) contain the keyword `groom`, activating `dev-groom` via the Keyword path. Channel→outcome correlation in the evidence sample was 100% (`github` → fail, `cli` → ok).

## Verification

New regression test loads the **real** bundled `skill.toml` files, builds the matcher's `SkillEntry` set, and asserts both dispatch skills are pulled in as `MatchReason::Dependency` (not Keyword) on the literal webhook prompt. It fails without the `skill.toml` edge and passes with it.

```
$ cargo test --package mika-agent --lib \
    test_dev_pilot_and_dev_groom_loader_symmetry_on_ready_label_webhook -- --nocapture

running 1 test
test skills::matcher::tests::test_dev_pilot_and_dev_groom_loader_symmetry_on_ready_label_webhook ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2925 filtered out; finished in 0.00s
```

Failure-direction check (temporarily reverting only the `skill.toml` edge):

```
thread '…test_dev_pilot_and_dev_groom_loader_symmetry_on_ready_label_webhook' panicked at
crates/mika-agent/src/skills/matcher.rs:515:39:
dev-groom must be matched on the webhook turn — a missing edge in self-dev.dependencies
wedges run_claude_pilot_groom (mika#1251)
test result: FAILED. 0 passed; 1 failed; …
```

Full suite + lints clean:

```
cargo test --package mika-agent --lib   →  2924 passed; 0 failed; 2 ignored
cargo clippy --workspace --all-targets -- -D warnings   →  clean
cargo fmt --check   →  clean
```

## Scope

- `skills/bundled/self-dev/skill.toml` — add `"dev-groom"` to `dependencies` (1 line)
- `crates/mika-agent/src/skills/matcher.rs` — loader-symmetry regression test
- `skills/bundled/_shared/dispatch-lib.sh` — add step 6 (update `self-dev.dependencies`) to the "adding a new dispatch sibling" checklist that mika#1173 left incomplete

## Closes #1251