### PR TITLE
chore(skill): rename _post_flight_push to _push_branch (#1271)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -699,10 +699,12 @@ ${STDERR_TAIL}"
     RESULT=$(printf '%s' "$RESULT" | head -c 92000)
 }
 
-_post_flight_push() {
-    # Unconditional push finalizer (mika#1268): after _run_claude_pilot completes,
-    # push any local-ahead commits to origin regardless of pilot exit code.
-    # Handles both first-push (no origin/$BRANCH) and existing-remote cases.
+_push_branch() {
+    # Canonical push step in dispatch-lib's git workflow (mika#1271 contract
+    # refactor; introduced as _post_flight_push in mika#1268). After
+    # _run_claude_pilot completes, push any local-ahead commits to origin
+    # regardless of pilot exit code. Handles both first-push (no origin/$BRANCH)
+    # and existing-remote cases.
 
     # Guard: repo#number mode only — free-text mode has no branch to push.
     [ -n "$REPO" ] && [ -n "$WORKTREE_DIR" ] && [ -n "$BRANCH" ] || return 0
@@ -710,7 +712,7 @@ _post_flight_push() {
     # Fetch fresh remote state. No-ops if origin/$BRANCH doesn't exist (first-push).
     git -C "$WORKTREE_DIR" fetch origin "$BRANCH" 2>/dev/null || true
 
-    # Branch on remote-ref existence (F1 fix from architect review):
+    # Branch on remote-ref existence (F1 fix from architect review on mika#1268):
     if git -C "$WORKTREE_DIR" rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
         # Existing-remote case — push only if HEAD is ahead.
         local ahead
@@ -723,16 +725,16 @@ _post_flight_push() {
 
     # Push with upstream tracking (-u sets upstream on first push).
     local push_err
-    push_err=$(mktemp /tmp/post-flight-push-err-XXXXXX)
+    push_err=$(mktemp /tmp/push-branch-err-XXXXXX)
     if git -C "$WORKTREE_DIR" push -u origin "$BRANCH" 2>"$push_err"; then
-        echo "post_flight_push: pushed $BRANCH to origin" >&2
+        echo "push_branch: pushed $BRANCH to origin" >&2
         RESULT="${RESULT}
-Post-flight push: pushed to origin/$BRANCH"
+Push: pushed to origin/$BRANCH"
     else
-        echo "WARN: post_flight_push_failed for $BRANCH — commits remain local-only" >&2
+        echo "WARN: push_branch_failed for $BRANCH — commits remain local-only" >&2
         cat "$push_err" >&2
         RESULT="${RESULT}
-Post-flight push: FAILED — commits remain local-only on $BRANCH"
+Push: FAILED — commits remain local-only on $BRANCH"
     fi
     rm -f "$push_err"
 }
@@ -901,6 +903,6 @@ EOF
     _detect_plan_on_branch
     _handle_dry_run
     _run_claude_pilot "$ENTRY_COMMAND"
-    _post_flight_push
+    _push_branch
     _deliver_callback
 }


### PR DESCRIPTION
## Summary

First sub-PR of the mika#1271 contract refactor. Renames `_post_flight_push` → `_push_branch` in `skills/bundled/_shared/dispatch-lib.sh`. Behavior unchanged.

Under the new contract (architect `flip` verdict on session `0583a902-cd7a-45ab-89be-59e13c8b09ec`), this function is the **canonical push step** in dispatch-lib's git workflow, not a post-hoc recovery layer. The rename clarifies that role without changing behavior.

## Why this ships standalone

Per the mika#1271 ticket body, the rename is named explicitly as a standalone clarity-only PR — a visible deliverable for the 2026-06-18 evaluation checkpoint, independent of the iterate-loop state machine work that follows. It's the smallest valid sub-deliverable of the refactor.

## What changes

- Function definition: `_post_flight_push()` → `_push_branch()`
- Call site in `dispatch_claude_pilot()`: `_post_flight_push` → `_push_branch`
- Stderr log markers: `post_flight_push:` → `push_branch:`; `post_flight_push_failed` → `push_branch_failed`
- RESULT status line: `Post-flight push:` → `Push:`
- Tmp file template: `/tmp/post-flight-push-err-XXXXXX` → `/tmp/push-branch-err-XXXXXX`
- Docstring updated to reflect canonical-push role + reference mika#1271

## Provenance preserved

The function's docstring retains the `introduced as _post_flight_push in mika#1268` line so the git-blame trail stays readable for future debuggers.

## What doesn't change

- All control flow + side effects identical
- F1 / F2 / F3 fixes from mika#1268's architect review remain in place
- Class D body-callout shim untouched (retires in a later sub-PR per mika#1271 sequencing)
- No external callers existed (verified via grep across mika/, mika-skills/, mika-cloud/, claude-pilot-py/)

## Test plan

- [x] Diff review against mika#1271 v1 scope
- [x] `bash -n` syntax check passes
- [x] Zero stale references in source (only provenance comment retains the old name)
- [ ] CI green

Part of mika#1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)