### PR TITLE
feat(skill): remove MIKA_DISPATCH_USE_ITERATE_LOOP feature flag (#1271)

### DIFF
--- a/docs/plans/2026-05-25-008-feat-1271-flag-removal-plan.md
+++ b/docs/plans/2026-05-25-008-feat-1271-flag-removal-plan.md
@@ -1,0 +1,95 @@
+# Remove `MIKA_DISPATCH_USE_ITERATE_LOOP` feature flag (mika#1271)
+
+**Ticket:** mika#1271 — Contract refactor: pilot owns content; dispatch-lib owns git workflow + iterate loop.
+**Architect verdict:** `flip` on session `0583a902-cd7a-45ab-89be-59e13c8b09ec`; v1 scope `yes`.
+**Sub-PR sequence:** **Seventh sub-PR of mika#1271 (sub-PR 7a — flag removal only).**
+  - PRs #1273 (`f2bef21`), #1274 (`1eb5a03`), #1275 (`30917d7`), #1276 (`96fd2281`), #1277 (`9c20096e`), #1278 (`f58b5450`).
+  - **This PR (7a)**: remove `MIKA_DISPATCH_USE_ITERATE_LOOP` flag → iterate loop runs unconditionally for `dev-groom`. Class D recovery shim STAYS as defense-in-depth.
+  - **Sub-PR 7b (follow-up)**: retire Class D shim after 7a soaks in production.
+
+## Scope-split rationale
+
+Sub-PR 7 was originally scoped as "remove flag + retire Class D shim" in one PR. Splitting into 7a + 7b for safety:
+
+- **The canonical writer has never been runtime-exercised in production.** The feature flag has been off by default since sub-PR 3. All evidence is from structural tests, not real `gh issue edit` round-trips against the architect.
+- **7a flips the switch to enable production exercise** while keeping Class D as a safety net. If the iterate loop fails to write a callout for any reason (gh API error, idempotency check false-positive, etc.), Class D recovery still catches the drift and surfaces it to the operator.
+- **7b retires Class D after 7a soaks** — once we have evidence the canonical writer covers every case the recovery shim caught, the redundancy can be removed.
+
+Per memory `feedback_loop_stability_beats_loop_speed`: stability beats wall-clock; the 1-PR split is the safer call.
+
+## What changes
+
+### Removed: feature-flag gate
+
+Line 1322-1329 of `dispatch-lib.sh` (call site of `_iterate_groom_loop`) was:
+
+```bash
+if [ "$SKILL" = "dev-groom" ] && [ "${MIKA_DISPATCH_USE_ITERATE_LOOP:-0}" = "1" ]; then
+    _iterate_groom_loop || echo "info: iterate_groom_loop did not converge — falling through to existing path" >&2
+fi
+```
+
+Becomes:
+
+```bash
+if [ "$SKILL" = "dev-groom" ]; then
+    _iterate_groom_loop || echo "info: iterate_groom_loop did not converge — Class D recovery (mika#1123) downstream catches drift" >&2
+fi
+```
+
+### Comment updates
+
+- `_iterate_groom_loop` docstring updated to describe the five terminal states explicitly + the always-on contract.
+- Wiring-point comment in `dispatch_claude_pilot` updated to reflect that the flag is gone and the Class D shim is still active.
+
+### Tests
+
+- Removed: `dispatch_claude_pilot reads MIKA_DISPATCH_USE_ITERATE_LOOP flag` (no longer applicable).
+- Added: `dispatch_claude_pilot no longer references MIKA_DISPATCH_USE_ITERATE_LOOP flag` (via `assert_not_contains`).
+- Added: `dispatch_claude_pilot still gates iterate-loop on dev-groom skill` (regression guard for the remaining gate).
+- Added: `_run_claude_pilot still invokes Class D recovery shim (defense-in-depth)` (records 7a's defense-in-depth contract).
+
+## Acceptance criteria
+
+- [ ] **AC1:** `MIKA_DISPATCH_USE_ITERATE_LOOP` is gone from `dispatch-lib.sh` (`grep -c` returns 0).
+- [ ] **AC2:** `_iterate_groom_loop` is invoked unconditionally for the `dev-groom` skill (no flag check, only `SKILL = "dev-groom"`).
+- [ ] **AC3:** `_verify_and_write_body_callout` Class D recovery shim is STILL present and STILL invoked from `_run_claude_pilot` (sub-PR 7a defense-in-depth).
+- [ ] **AC4:** All prior canonical-writer + escalate-groom invariants from sub-PRs 5 and 6 hold unchanged (call counts: 2 canonical-write, 3 escalate, 2 cleanup).
+- [ ] **AC5:** `bash -n` passes on both `dispatch-lib.sh` and `test-dispatch-lib.sh`.
+- [ ] **AC6:** Pre-existing test failure count (6) unchanged. Net new test count = +1.
+
+## Behavioral contract under 7a
+
+Production behavior after 7a lands:
+
+1. `_run_claude_pilot` runs the dev-groom pilot. Pilot may write its organic callout block on success.
+2. After the pilot exits, `_verify_and_write_body_callout` runs (Class D recovery). If pilot drifted (no callout written), recovery callout is prepended.
+3. `_iterate_groom_loop` runs unconditionally. Invokes architect first-pass + (READY → second-pass) | (ITERATE → revise → second-pass). On GROOMED → `_write_canonical_callout` prepends the canonical block. On ESCALATE → structured PIPELINE FAILURE marker.
+4. `_push_branch` + `_deliver_callback` finalize.
+
+In the GROOMED case, the body may now carry up to three callout blocks (organic, recovery, canonical) — last-written-first. The dispatch gate's `has_verdict` regex matches the canonical block's `second-pass (GROOMED)` marker → gate passes. Operator-visible noise (multiple callout blocks) is the price of 7a's defense-in-depth posture; 7b cleans it up.
+
+## What does NOT ship in this sub-PR (7b scope)
+
+- **`_verify_and_write_body_callout` retirement.** Function definition + call site in `_run_claude_pilot` stay. Sub-PR 7b removes both.
+- **dev-groom pilot prompt changes.** The pilot still invokes its own architect; the iterate loop's architect is redundant in production. Cost optimization, not correctness — addressed when (and only when) the pilot's contract is updated to "content-only."
+- **Guard-failure shape changes.** The four `return 1` guards in `_iterate_groom_loop` (missing WORKTREE_DIR / ISSUE_NUM / REPO / plan file) still WARN+return-1 silently. Once Class D shim is gone (7b), these should produce PIPELINE FAILURE markers — but until then, Class D catches the missing-body-callout case, so the silent return is harmless.
+
+## Test plan
+
+Structural tests in `test-dispatch-lib.sh`:
+
+- `MIKA_DISPATCH_USE_ITERATE_LOOP` absent from `dispatch_claude_pilot` source.
+- `dev-groom` still gates the iterate-loop call.
+- `_verify_and_write_body_callout` still invoked from `_run_claude_pilot` source.
+- All previous canonical/escalate/cleanup call counts unchanged.
+
+No runtime test invokes real `mika ask` or `gh issue edit` — production exercise is the operator's first observation surface for sub-PR 7a, by design.
+
+## Provenance
+
+- mika#1271 parent ticket, milestone#26.
+- Sequence: PRs #1273 → #1274 → #1275 → #1276 → #1277 → #1278 → **this**.
+- Architect contract: session `0583a902-cd7a-45ab-89be-59e13c8b09ec` (`flip` / `(i) Retire` / `yes`).
+- mika#1123 — Class D recovery shim (defense-in-depth retained in 7a).
+- Memory: `feedback_loop_stability_beats_loop_speed` — stability over speed; scope-split rationale.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1024,17 +1024,22 @@ CALLOUT_EOF
 }
 
 _iterate_groom_loop() {
-    # Phase D — the iterate-loop state machine (mika#1271 v1 cut).
+    # Phase D — the iterate-loop state machine (mika#1271).
     #
-    # Invokes mika-arch first-pass on the plan-on-branch, then on Disposition:
-    # READY proceeds to second-pass. On Verdict: GROOMED returns 0 (success).
-    # All other paths return non-zero (caller falls through to existing flow).
+    # Architect-driven groom convergence with five terminal states:
+    #   READY    → second-pass GROOMED → _write_canonical_callout "ready-to-groomed"
+    #   READY    → second-pass *      → _escalate_groom "second-pass-after-ready"
+    #   ITERATE  → revise → second-pass GROOMED → _write_canonical_callout "iterate-to-groomed"
+    #   ITERATE  → revise → second-pass *      → _escalate_groom "second-pass-after-iterate"
+    #   ESCALATE (first-pass)                   → _escalate_groom "first-pass"
     #
-    # v1 scope: READY → second-pass → GROOMED finalize ONLY. ITERATE rounds
-    # and ESCALATE handling are out-of-v1; both emit WARN and return non-zero
-    # so the existing pilot-owns-architect path can still produce the canonical
-    # body callout via the Class D shim. See
-    # docs/plans/2026-05-25-004-feat-1271-iterate-loop-state-machine-wire-plan.md.
+    # GROOMED paths preserve findings in $WORKTREE_DIR/.iterate/ until cleanup
+    # at the end of the success branch. ESCALATE paths PRESERVE findings for
+    # operator forensic access (worktree TTL handles eventual sweep).
+    #
+    # Always-on for the dev-groom skill as of sub-PR 7a. Non-zero return means
+    # the loop did not converge — caller continues to downstream Class D recovery
+    # (mika#1123) until sub-PR 7b retires the shim.
     #
     # Guards: requires WORKTREE_DIR, ISSUE_NUM, REPO; finds the plan file via
     # the same issue-scoped pattern Class D uses. Returns 1 if any guard fails.
@@ -1319,13 +1324,16 @@ EOF
     _handle_dry_run
     _run_claude_pilot "$ENTRY_COMMAND"
 
-    # mika#1271 — iterate-loop state machine (v1 cut, READY → second-pass → GROOMED only).
-    # Gated by MIKA_DISPATCH_USE_ITERATE_LOOP=1. Default unset (existing pilot-owns-architect
-    # path remains authoritative). On success the existing Class D body-callout shim still
-    # writes the canonical callout downstream — the state machine validates the architect
-    # convergence; the callout write retires in a follow-up sub-PR.
-    if [ "$SKILL" = "dev-groom" ] && [ "${MIKA_DISPATCH_USE_ITERATE_LOOP:-0}" = "1" ]; then
-        _iterate_groom_loop || echo "info: iterate_groom_loop did not converge — falling through to existing path" >&2
+    # mika#1271 — iterate-loop state machine (always-on for dev-groom as of sub-PR 7a).
+    # Invokes mika-arch first-pass on the plan-on-branch, then second-pass on READY
+    # or ITERATE-then-revise; on GROOMED writes the canonical body callout via
+    # _write_canonical_callout (idempotent vs. the pilot's organic write); on ESCALATE
+    # appends a structured PIPELINE FAILURE marker to RESULT. Non-zero return means
+    # the loop did NOT converge — the downstream Class D recovery shim (mika#1123)
+    # inside _run_claude_pilot still catches drift cases as defense-in-depth until
+    # sub-PR 7b retires it. See docs/plans/2026-05-25-008-feat-1271-flag-removal-plan.md.
+    if [ "$SKILL" = "dev-groom" ]; then
+        _iterate_groom_loop || echo "info: iterate_groom_loop did not converge — Class D recovery (mika#1123) downstream catches drift" >&2
     fi
 
     _push_branch

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -600,9 +600,15 @@ assert_contains "_iterate_groom_loop threads session_id to second pass" 'mika-ar
 
 # Wiring point inspection on dispatch_claude_pilot
 DISPATCH_FUNC=$(declare -f dispatch_claude_pilot)
-assert_contains "dispatch_claude_pilot reads MIKA_DISPATCH_USE_ITERATE_LOOP flag" "MIKA_DISPATCH_USE_ITERATE_LOOP" "$DISPATCH_FUNC"
-assert_contains "dispatch_claude_pilot guards iterate-loop on dev-groom skill" "dev-groom" "$DISPATCH_FUNC"
+# Sub-PR 7a: MIKA_DISPATCH_USE_ITERATE_LOOP feature flag removed — iterate loop
+# is now unconditional for the dev-groom skill (gated by SKILL check only).
+assert_not_contains "dispatch_claude_pilot no longer references MIKA_DISPATCH_USE_ITERATE_LOOP flag" "MIKA_DISPATCH_USE_ITERATE_LOOP" "$DISPATCH_FUNC"
+assert_contains "dispatch_claude_pilot still gates iterate-loop on dev-groom skill" "dev-groom" "$DISPATCH_FUNC"
 assert_contains "dispatch_claude_pilot calls _iterate_groom_loop" "_iterate_groom_loop" "$DISPATCH_FUNC"
+# Defense-in-depth: Class D recovery shim (mika#1123) still runs in
+# _run_claude_pilot for drift cases until sub-PR 7b retires it.
+RUN_CLAUDE_PILOT_FUNC=$(declare -f _run_claude_pilot)
+assert_contains "_run_claude_pilot still invokes Class D recovery shim (defense-in-depth)" "_verify_and_write_body_callout" "$RUN_CLAUDE_PILOT_FUNC"
 
 # Ordering check: iterate-loop runs AFTER _run_claude_pilot and BEFORE _push_branch.
 # Use grep -n on declare-f output; pick first occurrence of each.


### PR DESCRIPTION
## ⚠ Draft — awaiting operator authorization to merge

This PR removes the `MIKA_DISPATCH_USE_ITERATE_LOOP` feature flag → iterate-loop state machine runs unconditionally for `dev-groom` in production. This is a **production behavior change** — flipping it surfaces the iterate loop on every autonomous and operator groom going forward.

**Why draft.** The state-machine completion work (sub-PRs 5 + 6) shipped via the standing \"keep pushing the state machine\" directive. Flag-flip + Class D shim retirement is a different scope — flips default production behavior on every groom. Holding for explicit operator go before non-draft promotion + merge.

## Summary

Sub-PR 7a of mika#1271 (scope-split from sub-PR 7 for safety). Removes the feature-flag gate so the iterate-loop state machine runs unconditionally for the `dev-groom` skill. **Class D recovery shim (`_verify_and_write_body_callout`, mika#1123) STAYS as defense-in-depth.** Sub-PR 7b retires the shim after 7a soaks.

## Scope-split rationale

The canonical writer has never been runtime-exercised in production (flag has been off by default since sub-PR 3). 7a flips the switch while keeping the recovery shim as a safety net; 7b retires the shim once we have evidence the canonical writer covers every drift case the recovery shim caught. Per memory `feedback_loop_stability_beats_loop_speed` — stability beats wall-clock.

## Production behavior after 7a

1. `_run_claude_pilot` runs the dev-groom pilot. Pilot may write its organic callout block on success.
2. `_verify_and_write_body_callout` runs (Class D recovery). If pilot drifted (no callout), recovery callout is prepended.
3. `_iterate_groom_loop` runs unconditionally. Architect first-pass + (READY → second-pass) | (ITERATE → revise → second-pass). On GROOMED → `_write_canonical_callout` prepends canonical block. On ESCALATE → structured PIPELINE FAILURE marker.
4. `_push_branch` + `_deliver_callback` finalize.

**Operator-visible noise on GROOMED:** body may carry up to three callout blocks (organic + recovery + canonical) — last-written-first. The dispatch gate's `has_verdict` regex matches the canonical block's `second-pass (GROOMED)` marker → gate passes. **Architect cost on groom doubles** (pilot's architect + dispatch-lib's architect). Both are 7a-acceptable; 7b cleans them up.

## What changed

- `dispatch_claude_pilot`: removed `[ "${MIKA_DISPATCH_USE_ITERATE_LOOP:-0}" = \"1\" ]` from the iterate-loop gate. Now only the `SKILL = \"dev-groom\"` check remains.
- `_iterate_groom_loop` docstring updated to document the five terminal states + always-on contract.
- Comment near the call site updated to reflect Class D defense-in-depth retention.

## Tests

- Removed: `dispatch_claude_pilot reads MIKA_DISPATCH_USE_ITERATE_LOOP flag`.
- Added: `dispatch_claude_pilot no longer references MIKA_DISPATCH_USE_ITERATE_LOOP flag` (`assert_not_contains`).
- Added: `dispatch_claude_pilot still gates iterate-loop on dev-groom skill`.
- Added: `_run_claude_pilot still invokes Class D recovery shim (defense-in-depth)`.

Results: **144 passed / 6 pre-existing failures unchanged** (net +1 assertion vs sub-PR 6).

## What does NOT ship in 7a (7b scope)

- `_verify_and_write_body_callout` retirement (function + call site).
- dev-groom pilot prompt changes (pilot still invokes its own architect; redundant in production after 7a).
- Guard-failure shape changes in `_iterate_groom_loop` (silent `return 1` paths — Class D shim catches them in 7a).

## Provenance

- Sequence: PRs #1273 → #1274 → #1275 → #1276 → #1277 → #1278 → **this** (7a) → 7b (terminal).
- Architect contract: session \`0583a902-cd7a-45ab-89be-59e13c8b09ec\` (`flip` / `(i) Retire` / `yes`).
- mika#1123 — Class D recovery (retained as defense-in-depth in 7a).

Part of #1271 (milestone#26).

Pipeline-Exempt: code-only — no UI-visible behavior; plan doc lives at \`docs/plans/2026-05-25-008-feat-1271-flag-removal-plan.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)