### PR TITLE
fix(skill): _arch_ask delivers plan content via stdin (#1283)

### DIFF
--- a/docs/plans/2026-05-26-001-fix-1283-arch-ask-deliver-content-via-stdin-plan.md
+++ b/docs/plans/2026-05-26-001-fix-1283-arch-ask-deliver-content-via-stdin-plan.md
@@ -1,0 +1,68 @@
+# `_arch_ask` delivers plan content via stdin (mika#1283)
+
+**Ticket:** mika#1283 — p0-critical, milestone#26. Surfaced by mika#1282's groom dispatch which hit ESCALATE on second-pass-after-iterate because the architect could not read the plan file at the worktree path.
+
+## Goal
+
+Fix the substrate-foundation bug where `_arch_ask` passes `"@${plan_path}"` as the message argument to `mika ask`, expecting the CLI to expand `@<path>` to file content. **`mika ask` does NOT support `@<path>` expansion** — the literal string is passed to mika-arch, which can't read worktree paths via its scoped `read_agent_file` tool. The architect has been reviewing whatever issue-body context was in session memory, NOT plan content.
+
+## What changes
+
+### Single function change in `dispatch-lib.sh`
+
+`_arch_ask` switches from `args+=( "@${plan_path}" ); mika "${args[@]}"` to `args+=( - ); mika "${args[@]}" < "$plan_path"`. The `-` marker tells `mika ask` to read the message from stdin per `mika ask --help` (`The message to send (use "-" to read from stdin)`).
+
+Tests updated:
+- Removed: `_arch_ask passes @-file body` (asserted the broken behavior).
+- Added: `_arch_ask uses stdin marker (mika#1283)` (`|-|` in argv).
+- Added: `_arch_ask no longer passes @-path (mika#1283)` (`assert_not_contains` regression guard).
+- Added: `_arch_ask delivers plan content via stdin (mika#1283)` — uses a stub that echoes its stdin to verify content flows through.
+
+Net delta: +3 assertions (130 passed vs 127 pre-fix; 6 pre-existing failures unchanged).
+
+## Why this wasn't caught by sub-PRs 5–8 tests
+
+sub-PRs 5–8 covered structural plumbing (state machine, ESCALATE markers, canonical writer, content-only pilot routing). The actual architect-call delivery surface was assumed to work because `/mika-ask-arch` (operator-facing slash command) uses `@<path>` syntax and that works inside Claude Code sessions (where Claude expands `@<path>` itself before invoking `mika ask`). dispatch-lib's bash subprocess does NOT have that expansion — the literal `@<path>` string is sent.
+
+The sub-PR 7a first-test on mika#1267 produced a "GROOMED" verdict that we attributed to canonical-writer behavior. In retrospect, the architect was approving on session-memory + issue-body context, not on actual plan content. mika#1282's groom surfaced the bug because mika#1282 was a fresh ticket with no prior session-memory context — the architect was strict and complained loudly.
+
+## Verification
+
+Direct probe before fix (verified 2026-05-25 ~21:55Z):
+
+```
+$ mika ask --agent mika-arch --format json --verbose "@/tmp/nonexistent-path-test-12345.md"
+```
+
+mika-arch response (verbatim): *"The `@` prefix doesn't cause the file content to be inlined into my context. I only see the literal path string, and `read_agent_file` rejects anything outside my home directory."*
+
+Session: `aff2d0fe-5733-4d7e-bcba-ae231a1b7a0f`.
+
+## Acceptance criteria
+
+- [ ] `_arch_ask` source contains `args+=( - )` (stdin marker) and `mika "${args[@]}" < "$plan_path"` (file redirect).
+- [ ] `_arch_ask` source does NOT contain `"@${plan_path}"` or `"@$plan_path"`.
+- [ ] `bash -n` exit 0 on `dispatch-lib.sh` and `test-dispatch-lib.sh`.
+- [ ] Test suite: 130 passed, 6 pre-existing failures unchanged (net +3 vs sub-PR 8's 127).
+- [ ] Post-merge + deploy: re-grooming mika#1282 produces architect findings that reference actual plan content (file paths, AC text, citations from the plan), not "I cannot read that path."
+
+## Verification plan post-merge
+
+1. Merge PR + run `make deploy` to install new substrate.
+2. Re-dispatch mika#1282 grooming (clean up existing worktree first; the architect findings file from the prior groom is preserved as forensic evidence).
+3. Watch the architect's first-pass response — it should reference actual content from the plan file (the worktree has `docs/plans/2026-05-25-011-bug-1282-dev-pilot-wrote-but-no-commit-plan.md` from the prior failed groom).
+4. Expected outcome: architect produces a real review (READY/ITERATE/ESCALATE based on plan merit), not a tool-scope complaint.
+
+## What does NOT ship in this PR
+
+- **Re-grooming of prior tickets** with suspect verdicts (mika#1267, others). Their canonical-callout markers stand for now; if specific tickets need re-verification, they can be re-dispatched once the substrate is honest.
+- **mika ask CLI `@<path>` expansion support.** The bigger fix would make `mika ask` symmetric with Claude Code's `@<path>` syntax. Out of scope; sub-issue-able if desired.
+- **mika#1282 implementation.** Once #1282's grooming completes under the fixed substrate, that ships separately.
+
+## Provenance
+
+- Surfaced by mika#1282 grooming dispatch task `55e79ca5-d651-4603-ab28-ee98ad261c7b` on 2026-05-25 ~21:42–21:54Z.
+- Architect findings preserved at `.iterate/escalate-second-pass-after-iterate.md` in the `bug/1282/skill-dev-pilot-wrote-but-no-commit-on` worktree (sub-PR 5's ESCALATE flow working as designed).
+- Verification session: `aff2d0fe-5733-4d7e-bcba-ae231a1b7a0f` (direct probe confirming `mika ask` doesn't expand `@<path>`).
+- Related solution doc: `mika/docs/solutions/architecture-patterns/pilot-vs-substrate-contract-split-2026-05-25.md` (which documented the contract refactor without catching this content-delivery gap).
+- Operator-direct authorization for the substrate fix: 2026-05-25 evening; chicken-egg condition where the substrate's `_arch_ask` gap prevents grooming the very fix that closes it.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -592,12 +592,23 @@ Push: FAILED — commits remain local-only on $BRANCH"
 
 _arch_ask() {
     # Phase A — architect-call helper. Invokes mika-arch via the CLI with the
-    # given skill and plan file. Returns the full JSON envelope on stdout for
-    # the caller to parse `.content` and `.metadata.session_id`.
+    # given skill, delivering plan content via stdin. Returns the full JSON
+    # envelope on stdout for the caller to parse `.content` and
+    # `.metadata.session_id`.
+    #
+    # mika#1283: previously passed "@${plan_path}" as the message argument,
+    # expecting `mika ask` to expand it to file content. `mika ask` does NOT
+    # support `@<path>` expansion (verified 2026-05-25 via direct probe — the
+    # literal path string was sent, and mika-arch's `read_agent_file` is
+    # scoped to /home/samidarko/.mika/agents/mika-arch/ so worktree paths
+    # like /data/workspace/.../docs/plans/...md are unreadable). The
+    # architect was reviewing whatever issue-body context was already in
+    # session memory, not the plan content. Fix: pipe content via stdin
+    # (mika ask "-" reads the message from stdin per `mika ask --help`).
     #
     # Args:
     #   $1: skill name (mika-arch-groom-ticket | mika-arch-second-review)
-    #   $2: absolute path to plan file (passed as @-file body)
+    #   $2: absolute path to plan file (content piped via stdin)
     #   $3: optional session_id to continue an existing architect session
     local skill="$1" plan_path="$2" session_id="${3:-}"
 
@@ -606,9 +617,9 @@ _arch_ask() {
 
     local args=( ask --agent mika-arch --format json --verbose --enable-skill "$skill" )
     [ -n "$session_id" ] && args+=( --session-id "$session_id" )
-    args+=( "@${plan_path}" )
+    args+=( - )
 
-    mika "${args[@]}"
+    mika "${args[@]}" < "$plan_path"
 }
 
 _parse_disposition() {

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -443,6 +443,11 @@ assert_eq "_arch_ask rejects unreadable plan_path" "2" \
 # This catches the --skill vs --enable-skill flag-name bug that was in PR#1274.
 # Argv is joined with `|` so we can grep substrings; needles are prefixed with
 # `|` to avoid grep treating `--`-leading strings as flags.
+#
+# mika#1283: _arch_ask passes plan content via stdin (mika ask "-" reads stdin),
+# NOT as @-file argument (mika ask doesn't expand @<path>). The argv should
+# contain a literal "-" marker and the stub should receive the plan content
+# on stdin when invoked.
 ARCH_PLAN_TMP=$(mktemp /tmp/arch-plan-XXXXXX.md)
 printf 'plan content for arch ask test\n' > "$ARCH_PLAN_TMP"
 mika() { printf '|%s' "$@"; printf '|'; }  # leading | so first arg also has separator
@@ -452,14 +457,24 @@ assert_contains "_arch_ask threads skill name after enable-skill" "|--enable-ski
 assert_contains "_arch_ask sets agent mika-arch" "|--agent|mika-arch|" "$ARCH_ARGV"
 assert_contains "_arch_ask sets format json" "|--format|json|" "$ARCH_ARGV"
 assert_contains "_arch_ask sets verbose flag" "|--verbose|" "$ARCH_ARGV"
-assert_contains "_arch_ask passes @-file body" "|@${ARCH_PLAN_TMP}|" "$ARCH_ARGV"
+# mika#1283: stdin-marker, not @-file
+assert_contains "_arch_ask uses stdin marker (mika#1283)" "|-|" "$ARCH_ARGV"
+assert_not_contains "_arch_ask no longer passes @-path (mika#1283)" "|@${ARCH_PLAN_TMP}|" "$ARCH_ARGV"
 assert_not_contains "_arch_ask omits session-id when not given" "|--session-id|" "$ARCH_ARGV"
 
 ARCH_ARGV_WITH_SESSION=$(_arch_ask "mika-arch-second-review" "$ARCH_PLAN_TMP" "session-xyz")
 assert_contains "_arch_ask threads session-id when given" "|--session-id|session-xyz|" "$ARCH_ARGV_WITH_SESSION"
-assert_contains "_arch_ask passes @-file with session-id" "|@${ARCH_PLAN_TMP}|" "$ARCH_ARGV_WITH_SESSION"
+assert_contains "_arch_ask uses stdin marker with session-id (mika#1283)" "|-|" "$ARCH_ARGV_WITH_SESSION"
+assert_not_contains "_arch_ask no longer passes @-path with session-id (mika#1283)" "|@${ARCH_PLAN_TMP}|" "$ARCH_ARGV_WITH_SESSION"
 
-unset -f mika
+# mika#1283: verify plan content arrives on stdin, not as argv. Use a stub that
+# echoes the stdin it receives so we can grep for the plan content.
+mika_stdin_capture() { cat; }  # echo whatever arrives on stdin
+mika() { mika_stdin_capture; }
+ARCH_STDIN_RECEIVED=$(_arch_ask "mika-arch-groom-ticket" "$ARCH_PLAN_TMP")
+assert_contains "_arch_ask delivers plan content via stdin (mika#1283)" "plan content for arch ask test" "$ARCH_STDIN_RECEIVED"
+
+unset -f mika mika_stdin_capture
 rm -f "$ARCH_PLAN_TMP"
 
 # _iterate_groom_loop — guard rejects missing worktree/issue


### PR DESCRIPTION
## Summary

Substrate-foundation fix for the p0-critical gap surfaced by mika#1271's structural ESCALATE flow during mika#1282 grooming.

`_arch_ask` was passing the plan as `"@${plan_path}"` to `mika ask`, expecting the CLI to expand `@<path>` to file content. **`mika ask` does NOT support `@<path>` expansion** — the literal path string was sent to mika-arch, which can't read worktree paths via its scoped `read_agent_file` (limited to `/home/samidarko/.mika/agents/mika-arch/`).

**All today's grooming verdicts from the new substrate were architect approvals on session-memory + issue-body context, not on plan content.** The sub-PR 5 structured ESCALATE flow worked exactly as designed — it surfaced this deeper substrate gap when mika#1282 (a fresh ticket with no prior session context) hit architect-strict mode.

## Verification before fix

```
$ mika ask --agent mika-arch --format json --verbose "@/tmp/nonexistent-path-test-12345.md"
```

mika-arch response verbatim:
> *"The `@` prefix doesn't cause the file content to be inlined into my context. I only see the literal path string, and `read_agent_file` rejects anything outside my home directory."*

Session: `aff2d0fe-5733-4d7e-bcba-ae231a1b7a0f`.

## The fix

Single function change in `_arch_ask`:

```diff
- args+=( "@${plan_path}" )
- mika "${args[@]}"
+ args+=( - )
+ mika "${args[@]}" < "$plan_path"
```

The `-` marker tells `mika ask` to read the message from stdin (`mika ask --help`: *"The message to send (use \`-\` to read from stdin)"*).

## Tests

- Removed: `_arch_ask passes @-file body` (asserted the broken behavior).
- Added: `_arch_ask uses stdin marker (mika#1283)` — `|-|` in argv.
- Added: `_arch_ask no longer passes @-path (mika#1283)` — `assert_not_contains` regression guard.
- Added: `_arch_ask delivers plan content via stdin (mika#1283)` — stub echoes stdin, grep for content.

Net +3 assertions: **130 passed / 6 pre-existing failures unchanged**.

## Post-merge verification plan

1. Merge + `make deploy`.
2. Clean up the existing `bug/1282` worktree (preserve `.iterate/escalate-second-pass-after-iterate.md` as forensic evidence first).
3. Re-dispatch mika#1282 grooming.
4. **Expected:** architect's first-pass response references actual plan content (file paths, AC text, citations from the plan), not a tool-scope complaint. READY/ITERATE/ESCALATE based on plan merit.

## What does NOT ship here

- Re-grooming of prior tickets (mika#1267, etc.) with suspect verdicts. Can be re-dispatched once substrate is honest.
- `mika ask` CLI `@<path>` expansion (the symmetric API fix). Out of scope; sub-issue-able.
- mika#1282 implementation. Ships separately after its grooming completes under the fixed substrate.

## Provenance

- Surfaced by: mika#1282 grooming dispatch task \`55e79ca5-d651-4603-ab28-ee98ad261c7b\` (2026-05-25 ~21:42-21:54Z).
- Architect findings: \`.iterate/escalate-second-pass-after-iterate.md\` in bug/1282 worktree.
- Verification probe: session \`aff2d0fe-5733-4d7e-bcba-ae231a1b7a0f\`.
- Operator-direct authorization for the substrate fix (2026-05-25 evening): chicken-egg condition — the substrate's gap prevents grooming the very fix that closes it.

Closes #1283.

Part of milestone#26.

Pipeline-Exempt: code-only foundation fix + plan doc — no UI-visible behavior; plan doc at \`docs/plans/2026-05-26-001-fix-1283-arch-ask-deliver-content-via-stdin-plan.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)