### PR TITLE
fix(dispatch): substrate noise cleanup — /ce:plan + REBASE_CONFLICT false positives (#1303, #1301)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -561,11 +561,14 @@ ${RESULT}"
 
 ${RESULT}"
             elif [ "$CE_PLAN_INVOKED" != "1" ] && [ "$CE_PLAN_INVOKED" != "unknown" ]; then
-                # Valid plan file exists but /ce:plan was never invoked — LLM
-                # wrote a plan-shaped file without running the planning skill
-                RESULT="PIPELINE FAILURE: dev-groom produced a plan file but no /ce:plan invocation detected in session log. Plan may not have been generated through the planning skill.
-
-${RESULT}"
+                # Valid plan file exists but /ce:plan was never invoked.
+                # Demoted from PIPELINE FAILURE to advisory note (mika#1303):
+                # pilot Write-tool plan creation is a valid path. The plan
+                # file's existence + size threshold + downstream architect
+                # verdict are the structural contract — the slash-command
+                # invocation is one of multiple valid paths to producing a
+                # plan, not the gate itself.
+                echo "Note: dev-groom produced a plan file ($VALID_PLAN) without explicit /ce:plan invocation. Plan-file existence is the operative gate." >&2
             fi
         fi
 

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -270,6 +270,16 @@ _set_up_worktree() {
         # Rebase-or-abort guard
         BEHIND=$(git -C "$WORKTREE_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
         if [ "$BEHIND" -gt 0 ]; then
+            # Clean dispatch-lib-owned ephemeral files before rebase (mika#1301):
+            # .claude/groom-verdict-trail.log and .iterate/ are written by the
+            # iterate-loop itself; their presence as unstaged changes blocks
+            # rebase with `error: cannot rebase: You have unstaged changes`,
+            # producing a misleading REBASE_CONFLICT with no actual semantic
+            # conflict. dispatch-lib owns these paths, so it can safely reset
+            # them before rebasing.
+            git -C "$WORKTREE_DIR" checkout -- .claude/groom-verdict-trail.log 2>/dev/null || true
+            rm -rf "$WORKTREE_DIR/.iterate" 2>/dev/null || true
+
             if git -C "$WORKTREE_DIR" rebase origin/main 2>/dev/null; then
                 echo "Rebased ${BRANCH} onto origin/main (${BEHIND} commits caught up)." >&2
             else


### PR DESCRIPTION
## Summary
Two paired substrate fixes that together unblock the autonomous loop after today's observed dispatch failures.

**Closes #1303 (commit 1):** Removes the false-positive `PIPELINE FAILURE: dev-groom produced a plan file but no /ce:plan invocation detected` that fired across every dev-groom dispatch today (mika#804, #806, #793, #736, #716). Plan-file existence + size threshold + downstream architect verdict are the structural contract. The `/ce:plan` slash-command invocation is one of multiple valid paths; pilot Write-tool direct creation is equally valid. Demoted to stderr advisory note; plan-file-missing PIPELINE FAILURE branches remain (those catch real executor-mode drift).

**Closes #1301 (commit 2):** Cleans dispatch-lib-owned ephemeral files (`.claude/groom-verdict-trail.log`, `.iterate/`) before the pre-rebase guard runs. Without this, re-grooms on branches behind `origin/main` produce misleading `STATUS=REBASE_CONFLICT` with no actual semantic conflict — git refused to start the rebase due to unstaged dispatch-lib-owned changes. Observed on mika#804 re-groom (task 4d69bba3) after mika#784 (PR #1300) merged mid-groom.

## Why
Today's autonomous loop produced eight stuck grooms across five tickets because of #1303 alone. With both fixes, the GROOMED→ready→impl flow proceeds cleanly when the architect's verdict is the gate, and re-grooms survive sibling-PR merges during in-flight cycles.

## Test plan
- [ ] CI green
- [ ] Deploy + dispatch any open ticket via ready label; observe no spurious PIPELINE FAILURE
- [ ] Re-dispatch on a branch behind main; observe clean rebase (no REBASE_CONFLICT false positive)

Closes #1303
Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)