### PR TITLE
fix(eval): replace unsafe byte-slice patterns in merge gate tests

### DIFF
--- a/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_blocked_no_fallback.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_blocked_no_fallback.rs
@@ -36,7 +36,7 @@ fn assert_no_fallback_patterns(text: &str) {
             panic!(
                 "assert_no_fallback_patterns failed:\n  forbidden pattern '{}' found\n  response: {:?}",
                 pattern,
-                &text[..text.len().min(300)]
+                mika_common::text::safe_truncate(text, 300)
             );
         }
     }
@@ -85,7 +85,7 @@ async fn test_merge_gate_blocked_no_fallback() -> anyhow::Result<()> {
     assert!(
         lower.contains("merge_conflict") || lower.contains("rebase") || lower.contains("conflict"),
         "Response should reference merge conflict, rebase, or conflict. Got: {:?}",
-        &text[..text.len().min(300)]
+        mika_common::text::safe_truncate(text, 300)
     );
 
     Ok(())

--- a/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_errored_no_fallback.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_errored_no_fallback.rs
@@ -37,7 +37,7 @@ fn assert_no_fallback_patterns(text: &str) {
             panic!(
                 "assert_no_fallback_patterns failed:\n  forbidden pattern '{}' found\n  response: {:?}",
                 pattern,
-                &text[..text.len().min(300)]
+                mika_common::text::safe_truncate(text, 300)
             );
         }
     }
@@ -90,7 +90,7 @@ async fn test_merge_gate_errored_no_fallback() -> anyhow::Result<()> {
             || lower.contains("escalat")
             || lower.contains("gate_errored"),
         "Response should reference infrastructure failure or escalation. Got: {:?}",
-        &text[..text.len().min(300)]
+        mika_common::text::safe_truncate(text, 300)
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Replace 4 `&text[..text.len().min(300)]` patterns (Pattern A) with `mika_common::text::safe_truncate(text, 300)` in 2 eval test files introduced by #1306
- Fixes byte-slice-lint CI failure on main — these patterns panic on multi-byte UTF-8 (#764)

**Files changed:**
- `crates/mika-agent/tests/eval/grounding_regressions/merge_gate_errored_no_fallback.rs` (lines 40, 93)
- `crates/mika-agent/tests/eval/grounding_regressions/merge_gate_blocked_no_fallback.rs` (lines 39, 88)

## Test plan

- [x] `scripts/check-byte-slices.sh` passes (0 violations)
- [x] All 4 merge gate eval tests pass
- [x] Pre-commit hooks pass (fmt, clippy, no-secrets, no-large-files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)