### PR TITLE
fix(dispatch): surface gh issue edit + auto-rescue commit failures (#1309 + #1310)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -457,11 +457,18 @@ ${RESULT}"
                         # .iterate/ (the iterate-loop artifact directory — review-guide.md § Orthogonality).
                         RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"
 
+                        # mika#1310: capture BOTH stdout and stderr. Lefthook
+                        # pre-commit hooks print their summary + failure marks
+                        # to stdout (not stderr); a `2>` redirect alone captured
+                        # an empty file and the operator saw "Hook output:"
+                        # blank on every false-positive rejection. Combined
+                        # `>file 2>&1` captures the full lefthook decoration
+                        # block including ⛔ failure lines.
                         if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): impl staged by post-flight recovery (mika#1282)
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection.
-Scaffold paths excluded (mika#1288)." 2>"$RESCUE_COMMIT_ERR"; then
+Scaffold paths excluded (mika#1288)." > "$RESCUE_COMMIT_ERR" 2>&1; then
                             # Commit succeeded on first try — proceed normally
                             rm -f "$RESCUE_COMMIT_ERR"
 
@@ -487,11 +494,12 @@ ${RESULT}"
                             CARGO_FMT_ERR=$( (cd "$WORKTREE_DIR" && cargo fmt --all) 2>&1 ) || true
                             git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' 2>&9
 
+                            # mika#1310: capture both stdout+stderr (see above).
                             if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): impl staged by post-flight recovery (mika#1282)
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection (cargo fmt applied).
-Scaffold paths excluded (mika#1288)." 2>"$RESCUE_COMMIT_ERR"; then
+Scaffold paths excluded (mika#1288)." > "$RESCUE_COMMIT_ERR" 2>&1; then
                                 # Retry succeeded after cargo fmt
                                 rm -f "$RESCUE_COMMIT_ERR"
 
@@ -509,7 +517,17 @@ ${RESULT}"
                                 # Surface the full diagnostic chain: cargo fmt output + retry commit
                                 # hook output, so the operator can diagnose from the message alone
                                 # (mika#1296 acceptance criteria).
-                                RESCUE_ERR_CONTENT=$(cat "$RESCUE_COMMIT_ERR" 2>/dev/null | head -20)
+                                RESCUE_ERR_CONTENT=$(cat "$RESCUE_COMMIT_ERR" 2>/dev/null | head -50)
+                            # mika#1310: if captured output is empty, dump git
+                            # diagnostic state as fallback so PIPELINE FAILURE
+                            # carries SOMETHING the operator can act on.
+                            if [ -z "$(printf '%s' "$RESCUE_ERR_CONTENT" | tr -d '[:space:]')" ]; then
+                                RESCUE_ERR_CONTENT="<rescue capture was empty — likely no hook output, falling back to git diagnostic>
+git status:
+$(git -C "$WORKTREE_DIR" status --short 2>&1 | head -10)
+git diff --cached --name-only:
+$(git -C "$WORKTREE_DIR" diff --cached --name-only 2>&1 | head -10)"
+                            fi
                                 RESULT="PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook after cargo-fmt retry.
 cargo fmt stderr: ${CARGO_FMT_ERR:-<empty>}
 Hook output: ${RESCUE_ERR_CONTENT}
@@ -521,7 +539,17 @@ ${RESULT}"
                             fi
                         else
                             # Unknown hook failure — abort rescue, leave dirty
-                            RESCUE_ERR_CONTENT=$(cat "$RESCUE_COMMIT_ERR" 2>/dev/null | head -20)
+                            RESCUE_ERR_CONTENT=$(cat "$RESCUE_COMMIT_ERR" 2>/dev/null | head -50)
+                            # mika#1310: if captured output is empty, dump git
+                            # diagnostic state as fallback so PIPELINE FAILURE
+                            # carries SOMETHING the operator can act on.
+                            if [ -z "$(printf '%s' "$RESCUE_ERR_CONTENT" | tr -d '[:space:]')" ]; then
+                                RESCUE_ERR_CONTENT="<rescue capture was empty — likely no hook output, falling back to git diagnostic>
+git status:
+$(git -C "$WORKTREE_DIR" status --short 2>&1 | head -10)
+git diff --cached --name-only:
+$(git -C "$WORKTREE_DIR" diff --cached --name-only 2>&1 | head -10)"
+                            fi
                             RESULT="PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook (non-rustfmt).
 Hook output: ${RESCUE_ERR_CONTENT}
 Worktree left dirty for operator inspection: ${WORKTREE_DIR}

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1193,13 +1193,22 @@ CALLOUT_EOF
     tmpfile=$(mktemp /tmp/canonical-callout-XXXXXX.md)
     printf '%s' "$new_body" > "$tmpfile"
 
-    if gh issue edit "$ISSUE_NUM" --repo "senara-solutions/$REPO" \
-        --body-file "$tmpfile" 2>/dev/null; then
+    # mika#1309: capture stderr from gh issue edit so failure cause is visible.
+    # The previous `2>/dev/null` silently dropped permission/rate-limit/network
+    # errors, leaving the dispatch-gate signals missing without operator-visible
+    # cause. We also redirect stdout to /dev/null (gh prints URL on success)
+    # and route stderr to a captured variable so it can be surfaced in the WARN
+    # line on failure.
+    local gh_stderr gh_exit
+    gh_stderr=$(gh issue edit "$ISSUE_NUM" --repo "senara-solutions/$REPO" \
+        --body-file "$tmpfile" 2>&1 >/dev/null)
+    gh_exit=$?
+    if [ "$gh_exit" -eq 0 ]; then
         echo "write_canonical_callout: wrote canonical callout to $REPO#$ISSUE_NUM (stage=$stage, session=$session_id)" >&2
         rm -f "$tmpfile"
         return 0
     else
-        echo "WARN: write_canonical_callout: gh issue edit failed for $REPO#$ISSUE_NUM" >&2
+        echo "WARN: write_canonical_callout: gh issue edit failed for $REPO#$ISSUE_NUM (exit=$gh_exit): ${gh_stderr:-<empty>}" >&2
         rm -f "$tmpfile"
         return 1
     fi
@@ -1278,7 +1287,7 @@ _iterate_groom_loop() {
                 GROOMED)
                     echo "iterate_groom_loop: converged on GROOMED for $REPO#$ISSUE_NUM (session $session_id)" >&2
                     _write_canonical_callout "ready-to-groomed" "$session_id" || \
-                        echo "info: canonical callout write non-fatal failure — pilot's organic write in dev-groom skill prompt remains as fallback until prompt-update follow-up ships" >&2
+                        echo "WARN: canonical_callout_failed — dispatch gate will reject next ready unless pilot organic write or operator-direct rescue fills the body callout" >&2
                     _cleanup_iterate_findings
                     return 0
                     ;;
@@ -1329,7 +1338,7 @@ _iterate_groom_loop() {
                 GROOMED)
                     echo "iterate_groom_loop: revised plan converged on GROOMED for $REPO#$ISSUE_NUM (session $session_id)" >&2
                     _write_canonical_callout "iterate-to-groomed" "$session_id" || \
-                        echo "info: canonical callout write non-fatal failure — pilot's organic write in dev-groom skill prompt remains as fallback until prompt-update follow-up ships" >&2
+                        echo "WARN: canonical_callout_failed — dispatch gate will reject next ready unless pilot organic write or operator-direct rescue fills the body callout" >&2
                     _cleanup_iterate_findings
                     return 0
                     ;;


### PR DESCRIPTION
## Summary

Two paired observability fixes that restore diagnostic surface lost to silent stream redirects. Both close p1 substrate gaps blocking the autonomous loop.

**Closes #1309 (commit 1):** `_write_canonical_callout` redirected `gh issue edit` stderr to `/dev/null`. When the dispatch-gate signals didn't land in the body, the WARN line carried no cause. Capture stderr + exit code, surface in the WARN. Upgrade two iterate-loop callsites from `info:` to `WARN: canonical_callout_failed` so the failure shows up in operator log scans.

**Closes #1310 (commit 2):** Auto-rescue commit captured only stderr (`2>FILE`). Lefthook v2 writes hook output + ⛔ failure markers to STDOUT — empty captures on every false-positive rejection, `Hook output:` blank on every PIPELINE FAILURE. Combined-stream capture (`>FILE 2>&1`) + empty-capture fallback that dumps `git status --short` + staged file list so the marker always carries actionable state.

## Why
Today's autonomous loop:
- 5+ tickets ground through GROOMED verdicts in `.claude/groom-verdict-trail.log` without ever landing a body callout → operator-direct rescue every time. No way to diagnose with current logging.
- Every dev-pilot with real work hit the false hook-rejection class; operator-direct `git commit` on identical staged set passed all hooks cleanly. The dispatch-lib couldn't tell us what git commit actually said because the capture stream was wrong.

These are pure observability fixes — root-cause comes after we can SEE the failure. No behavior change beyond log content.

## Test plan
- [ ] CI green
- [ ] Deploy + dispatch any ticket: if `gh issue edit` fails, WARN line carries actual error
- [ ] Deploy + force a pre-commit hook failure: PIPELINE FAILURE carries lefthook decoration block

Closes #1309
Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)