### PR TITLE
fix(agent): dispatch-arg-fabrication guard for ready-label webhooks (#1313)

### DIFF
--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1702,8 +1702,7 @@ async fn run_loop(
                         && let Some(expected_location) =
                             parse_ready_label_location(&user_input_text)
                         && let Some(mismatched) = all_tool_summaries.iter().find(|s| {
-                            (s.name == "run_claude_pilot"
-                                || s.name == "run_claude_pilot_groom")
+                            (s.name == "run_claude_pilot" || s.name == "run_claude_pilot_groom")
                                 && !s.input_summary.contains(&expected_location)
                         })
                     {

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1695,15 +1695,23 @@ async fn run_loop(
                     // satisfied predicate needs the user_message (to extract
                     // the expected location) AND the input_summary of each
                     // dispatch call. Single retry with structured re-prompt.
+                    // Match on `#N` only (not full `repo#N`) — the dispatch
+                    // prompt has multiple valid formats: `mika#500`,
+                    // `mika issue#500`, `senara-solutions/mika#500`. The
+                    // structural invariant is: the trigger's ISSUE NUMBER
+                    // must appear in the dispatch arg. Extract `#N` suffix
+                    // from location.
+                    let expected_hash_n: Option<String> =
+                        parse_ready_label_location(&user_input_text)
+                            .and_then(|loc| loc.rfind('#').map(|idx| loc[idx..].to_string()));
                     if !skip_remaining_guards
                         && matches!(response.stop_reason, LlmStopReason::EndTurn)
                         && !intent_guard_retries.contains("dispatch_arg_match")
                         && ready_label_dispatch_trigger(&user_input_text)
-                        && let Some(expected_location) =
-                            parse_ready_label_location(&user_input_text)
+                        && let Some(ref expected_location) = expected_hash_n
                         && let Some(mismatched) = all_tool_summaries.iter().find(|s| {
                             (s.name == "run_claude_pilot" || s.name == "run_claude_pilot_groom")
-                                && !s.input_summary.contains(&expected_location)
+                                && !s.input_summary.contains(expected_location.as_str())
                         })
                     {
                         intent_guard_retries.insert("dispatch_arg_match");

--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -1682,6 +1682,66 @@ async fn run_loop(
                         continue;
                     }
 
+                    // #1313 — Dispatch-arg-fabrication guard. When a ready-label
+                    // webhook fires for repo#N, the LLM must dispatch
+                    // run_claude_pilot / run_claude_pilot_groom with
+                    // prompt="<repo>#<N>" matching the trigger. If the LLM
+                    // emits a dispatch arg that references a DIFFERENT issue
+                    // (drawn from stale conversation context), the dispatch
+                    // succeeds for the wrong issue — burning a full pilot
+                    // session and writing plans into the wrong worktree.
+                    //
+                    // Inline rather than in INTENT_GUARDS because the
+                    // satisfied predicate needs the user_message (to extract
+                    // the expected location) AND the input_summary of each
+                    // dispatch call. Single retry with structured re-prompt.
+                    if !skip_remaining_guards
+                        && matches!(response.stop_reason, LlmStopReason::EndTurn)
+                        && !intent_guard_retries.contains("dispatch_arg_match")
+                        && ready_label_dispatch_trigger(&user_input_text)
+                        && let Some(expected_location) =
+                            parse_ready_label_location(&user_input_text)
+                        && let Some(mismatched) = all_tool_summaries.iter().find(|s| {
+                            (s.name == "run_claude_pilot"
+                                || s.name == "run_claude_pilot_groom")
+                                && !s.input_summary.contains(&expected_location)
+                        })
+                    {
+                        intent_guard_retries.insert("dispatch_arg_match");
+                        warn!(
+                            step,
+                            label = mode.label(),
+                            tool = %mismatched.name,
+                            expected = %expected_location,
+                            input_preview = %mismatched.input_summary,
+                            intent_guard = "dispatch_arg_match",
+                            "Dispatch-arg-fabrication guard fired — re-prompting (#1313)"
+                        );
+                        request.messages.push(LlmMessage {
+                            role: LlmRole::Assistant,
+                            content: LlmContent::Blocks(
+                                mika_common::llm::response_content_to_blocks(&response.content),
+                            ),
+                        });
+                        request.messages.push(LlmMessage {
+                            role: LlmRole::User,
+                            content: LlmContent::Text(format!(
+                                "[mika-engine] The ready-label webhook trigger \
+                                 for this turn was `{expected_location}`, but \
+                                 your `{}` call used a `prompt` argument that \
+                                 does not contain `{expected_location}` \
+                                 (input preview: `{}`). The dispatch arg must \
+                                 match the triggering webhook's `repo#issue` \
+                                 exactly — do NOT compose it from prior \
+                                 conversation context. Re-emit the dispatch \
+                                 call with `prompt=\"{expected_location}\"` \
+                                 (and the same task_id + skill). See mika#1313.",
+                                mismatched.name, mismatched.input_summary,
+                            )),
+                        });
+                        continue;
+                    }
+
                     // Persistence evaluation guard: if the agent is ending a turn
                     // that appears to contain institutional knowledge but no
                     // persistence tool was called, nudge the model to consider

--- a/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_blocked_no_fallback.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_blocked_no_fallback.rs
@@ -36,7 +36,7 @@ fn assert_no_fallback_patterns(text: &str) {
             panic!(
                 "assert_no_fallback_patterns failed:\n  forbidden pattern '{}' found\n  response: {:?}",
                 pattern,
-                &text[..text.len().min(300)]
+                mika_common::text::safe_truncate(text, 300)
             );
         }
     }
@@ -85,7 +85,7 @@ async fn test_merge_gate_blocked_no_fallback() -> anyhow::Result<()> {
     assert!(
         lower.contains("merge_conflict") || lower.contains("rebase") || lower.contains("conflict"),
         "Response should reference merge conflict, rebase, or conflict. Got: {:?}",
-        &text[..text.len().min(300)]
+        mika_common::text::safe_truncate(text, 300)
     );
 
     Ok(())

--- a/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_errored_no_fallback.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/merge_gate_errored_no_fallback.rs
@@ -37,7 +37,7 @@ fn assert_no_fallback_patterns(text: &str) {
             panic!(
                 "assert_no_fallback_patterns failed:\n  forbidden pattern '{}' found\n  response: {:?}",
                 pattern,
-                &text[..text.len().min(300)]
+                mika_common::text::safe_truncate(text, 300)
             );
         }
     }
@@ -90,7 +90,7 @@ async fn test_merge_gate_errored_no_fallback() -> anyhow::Result<()> {
             || lower.contains("escalat")
             || lower.contains("gate_errored"),
         "Response should reference infrastructure failure or escalation. Got: {:?}",
-        &text[..text.len().min(300)]
+        mika_common::text::safe_truncate(text, 300)
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
Inline post-condition guard in `run_loop` (conversation mode) that rejects EndTurn when a ready-label webhook trigger's `<repo>#<N>` doesn't match the `prompt` arg used in `run_claude_pilot` / `run_claude_pilot_groom` calls. Single retry with structured re-prompt naming expected location + actual input preview.

## Why
mika#1313: today's mika#736 dispatch had `input_context: {"prompt":"mika#1311",...}` — the labeled webhook arrived for #736 but mika-dev's LLM emitted #1311 as the dispatch arg. Full pilot session ($1-3) burned for the wrong issue + plans written into the wrong worktree. Same silent-fail class as #1309 + #1310.

Mirrors the asserted-unavailability inline-guard pattern (#862) — needs both user_message + per-tool input_summary, can't thread cleanly through const INTENT_GUARDS array.

## Test plan
- [ ] CI green (cargo check + clippy + fmt locally clean)
- [ ] Manual: simulate ready-label webhook + LLM dispatch with wrong arg → observe guard catches it

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)