### PR TITLE
fix(dispatch): base worktree on origin/$BRANCH when it exists (#1311)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -262,8 +262,29 @@ _set_up_worktree() {
             git -C "$WORKTREE_DIR" checkout "$BRANCH" 2>/dev/null || true
         else
             git -C "$SUB_REPO_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
-            if ! git -C "$SUB_REPO_DIR" worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main 2>/dev/null; then
-                git -C "$SUB_REPO_DIR" worktree add "$WORKTREE_DIR" "$BRANCH"
+            # mika#1311: when origin/$BRANCH already exists from a prior
+            # successful dispatch, base the worktree on it (preserves prior
+            # history) rather than creating a fresh local branch from
+            # origin/main. Without this, re-dispatches after origin/main
+            # advances past the prior groom diverge silently — the new
+            # local branch has one commit on new main, the remote has the
+            # prior groom on older main, and the post-flight push fails
+            # with `branch is behind its remote counterpart`. The LLM
+            # then correctly escalates to operator (status=blocked) but
+            # the queue stays wedged. The downstream BEHIND-block rebases
+            # onto origin/main and mika#784's _check_duplicate_commits
+            # handles cherry-mark dedup of any merged-but-still-present
+            # commits — so basing on origin/$BRANCH first and rebasing
+            # afterward composes cleanly with the existing flow.
+            if git -C "$SUB_REPO_DIR" ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+                git -C "$SUB_REPO_DIR" fetch origin "$BRANCH" 2>/dev/null || true
+                if ! git -C "$SUB_REPO_DIR" worktree add -b "$BRANCH" "$WORKTREE_DIR" "origin/$BRANCH" 2>/dev/null; then
+                    git -C "$SUB_REPO_DIR" worktree add "$WORKTREE_DIR" "$BRANCH"
+                fi
+            else
+                if ! git -C "$SUB_REPO_DIR" worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main 2>/dev/null; then
+                    git -C "$SUB_REPO_DIR" worktree add "$WORKTREE_DIR" "$BRANCH"
+                fi
             fi
         fi
 


### PR DESCRIPTION
## Summary
- `_set_up_worktree` in `skills/bundled/_shared/dispatch-lib.sh` now probes `origin/$BRANCH` via `ls-remote --exit-code` before worktree-add.
- When the remote branch exists (re-dispatch case), fetch it and base the worktree on `origin/$BRANCH`. The downstream BEHIND-block rebases onto `origin/main`; mika#784's `_check_duplicate_commits` handles cherry-mark dedup.
- When the remote branch does NOT exist (first dispatch), preserve existing behavior (`worktree add -b $BRANCH ... origin/main`).

## Why
mika#1311: re-dispatches after `origin/main` advances past the prior groom diverged silently. New local branch had one commit on new main; remote had prior groom on older main. Push rejected with `branch is behind its remote counterpart`. LLM correctly escalated via `update_task_status(status='blocked', note='PLAN_GROOMED but push failed…')` — queue wedged.

Today's load-bearing wedge: three of three queued tickets (mika#806, #736, #716) reached `blocked` via this path. Manual SQL cancel of blocked parents was the only recovery — which per `feedback_manual_rescue_is_contract_evidence_not_throughput` is contract disconfirmation.

Peer-Claude diagnosis (2026-05-27) correctly flagged the earlier "extend mika#871 reaper" framing as wrong shape — it would have inverted a structural enforcer into a garbage collector and hidden the actual cause. The honest fix is in `_set_up_worktree`, not the engine.

## Diagnosis trace
mika#806 parent `132759db` reached blocked via callback session `callback-5e026b64`:
- LLM step 0: `update_task_status({"status":"blocked","note":"PLAN_GROOMED but push failed — commits remain local-only on test/806/integration-test-covering-documented..."})`
- LLM step 1: `send_message` to operator
- LLM step 2: EndTurn

Branch divergence at push-time:
- Local: `36e64ac9 (new groom)` → `8932cf67 (main with #1314)`
- Remote: `18bb2e0b (#1314 merge on branch)` → `09b630ea (prior groom)` → `018671b8 (older main)`

Same shape on mika#736 and mika#716.

## Test plan
- [ ] CI green (bash -n passes locally; no Rust changes)
- [ ] Deploy + re-dispatch one of the three queued tickets (#806/#716/#736) — should now base worktree on the existing remote branch, rebase onto main, push succeed
- [ ] Verify first-dispatch case still works (no `origin/$BRANCH` exists → branches from main)

Closes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)