### PR TITLE
fix(dispatch): reset docs/plans/ before rebase (mika#1311 follow-up)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -300,6 +300,15 @@ _set_up_worktree() {
             # them before rebasing.
             git -C "$WORKTREE_DIR" checkout -- .claude/groom-verdict-trail.log 2>/dev/null || true
             rm -rf "$WORKTREE_DIR/.iterate" 2>/dev/null || true
+            # mika#1311 follow-up: reused worktrees can carry uncommitted/
+            # staged docs/plans/ edits from a prior failed dispatch (groom
+            # session crashed before commit, or a commit step was hook-
+            # rejected without retry). The committed plan on origin/$BRANCH
+            # is the canonical source of truth; any leftover unstaged or
+            # staged plan-doc edits are abandoned state. Reset tracked
+            # plan files to HEAD so rebase can proceed. (Untracked plan
+            # files are not affected — only tracked-but-modified ones.)
+            git -C "$WORKTREE_DIR" checkout HEAD -- docs/plans/ 2>/dev/null || true
 
             if git -C "$WORKTREE_DIR" rebase origin/main 2>/dev/null; then
                 echo "Rebased ${BRANCH} onto origin/main (${BEHIND} commits caught up)." >&2


### PR DESCRIPTION
## Summary
Extends mika#1301's pre-rebase cleanup pattern to also reset `docs/plans/*.md` tracked-but-modified files. The committed plan on `origin/\$BRANCH` is canonical; leftover staged-or-unstaged plan-doc edits from a prior failed groom block the rebase with `cannot rebase: You have unstaged changes`, producing a misleading REBASE_CONFLICT.

## Why
Post-mika#1311 deploy (PR #1315), mika#716 re-dispatch produced REBASE_CONFLICT despite worktree being correctly based on `origin/$BRANCH`. Diagnosis: single staged-not-committed plan file (`M docs/plans/2026-05-27-001-fix-716-callback-error-state-verification-plan.md`) from prior groom that crashed before commit. Manual `git checkout HEAD -- docs/plans/` unblocked locally; this codifies that cleanup.

Same pattern class as mika#1301's `.claude/groom-verdict-trail.log` + `.iterate/` cleanup — dispatch-lib-owned ephemeral state that blocks rebase when leftover.

## Test plan
- [ ] CI green (bash -n local pass)
- [ ] Re-dispatch mika#716 / #806 / #736 — REBASE_CONFLICT no longer fires on tracked plan-doc leftovers

Pipeline-Exempt: code-only — substrate hot-patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)