### PR TITLE
test(skills): static parity assertion for engine-referenced tool names

### DIFF
--- a/crates/mika-agent/src/bundled_skills.rs
+++ b/crates/mika-agent/src/bundled_skills.rs
@@ -1401,6 +1401,148 @@ mod tests {
         }
     }
 
+    /// Engine post-condition guards (agent.rs, engine.rs, executor.rs) reference
+    /// these skill tool names by string literal. The guards fire regardless of
+    /// which skills are loaded — a missing tool means the guard silently no-ops
+    /// or misfires.
+    ///
+    /// **Category A only.** These are tools that appear in `EndTurn` guard
+    /// predicates, intent-precondition checks, and dispatch-class derivation.
+    /// Category B tools (builtin handler dispatch tables, test fixtures) are
+    /// intentionally agent-scoped and NOT listed here — their loader
+    /// unreachability on non-matching agents is by design.
+    ///
+    /// **Maintenance contract:** When adding a new engine post-condition guard
+    /// that references a skill tool name, add the tool name here. If the test
+    /// below fails, add the owning skill to the always-on dependency closure
+    /// (typically via `self-dev.dependencies`).
+    const ENGINE_REFERENCED_SKILL_TOOLS: &[&str] = &[
+        "run_claude_pilot",       // dev-pilot
+        "run_claude_pilot_groom", // dev-groom
+        "deploy_mika",            // deploy-mika
+    ];
+
+    #[test]
+    fn test_engine_referenced_tool_names_are_loader_reachable() {
+        // Static parity assertion (mika#1253, generalizing mika#1251).
+        //
+        // Every skill tool name referenced by engine post-condition guards
+        // must be reachable through the always-on dependency closure of
+        // BUNDLED_SKILL_MANIFESTS. This catches the class of bug where a
+        // tool is known to the engine but unreachable by the skill loader
+        // on keyword-less turns (e.g., GitHub webhook auto-groom).
+        //
+        // The test replicates the match_skills() BFS from matcher.rs but
+        // simplified: no keyword matching, no disabled-skill filtering
+        // (enabled is a runtime DB flag not present in compile-time data).
+        // This mirrors the worst-case reachability on a webhook turn with
+        // no keyword hits — only always_on=true seeds.
+
+        use std::collections::{HashMap, HashSet, VecDeque};
+
+        let all_skills = all_bundled_skills();
+
+        // Parse each skill's manifest and collect tool names
+        let mut skill_manifests: HashMap<String, crate::skills::manifest::SkillManifest> =
+            HashMap::new();
+        let mut skill_tools: HashMap<String, Vec<String>> = HashMap::new();
+
+        for skill in &all_skills {
+            let manifest_file = skill
+                .files
+                .iter()
+                .find(|f| f.path == "skill.toml")
+                .unwrap_or_else(|| panic!("skill '{}' must have skill.toml", skill.name));
+
+            let manifest: crate::skills::manifest::SkillManifest =
+                toml::from_str(manifest_file.content).unwrap_or_else(|e| {
+                    panic!("skill '{}' skill.toml parse error: {e}", skill.name)
+                });
+
+            // Collect tool names from tools.json if present
+            let mut tools = Vec::new();
+            if let Some(tools_file) = skill.files.iter().find(|f| f.path == "tools.json") {
+                let tool_defs: Vec<serde_json::Value> = serde_json::from_str(tools_file.content)
+                    .unwrap_or_else(|e| {
+                        panic!("skill '{}' tools.json parse error: {e}", skill.name)
+                    });
+                for tool_def in &tool_defs {
+                    if let Some(name) = tool_def.get("name").and_then(|n| n.as_str()) {
+                        tools.push(name.to_string());
+                    }
+                }
+            }
+
+            let name_lower = skill.name.to_lowercase();
+            skill_manifests.insert(name_lower.clone(), manifest);
+            skill_tools.insert(name_lower, tools);
+        }
+
+        // BFS: seed with always_on=true skills, walk transitive dependencies
+        let mut closure: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+
+        for (name, manifest) in &skill_manifests {
+            if manifest.skill.always_on {
+                closure.insert(name.clone());
+                queue.push_back(name.clone());
+            }
+        }
+
+        while let Some(current) = queue.pop_front() {
+            if let Some(manifest) = skill_manifests.get(&current) {
+                for dep in &manifest.skill.dependencies {
+                    let dep_lower = dep.to_lowercase();
+                    if skill_manifests.contains_key(&dep_lower) && !closure.contains(&dep_lower) {
+                        closure.insert(dep_lower.clone());
+                        queue.push_back(dep_lower);
+                    }
+                }
+            }
+        }
+
+        // Collect all tool names reachable through the closure
+        let mut reachable_tools: HashSet<String> = HashSet::new();
+        for skill_name in &closure {
+            if let Some(tools) = skill_tools.get(skill_name) {
+                for tool in tools {
+                    reachable_tools.insert(tool.clone());
+                }
+            }
+        }
+
+        // Assert every engine-referenced tool is reachable
+        let mut missing: Vec<(&str, Option<&str>)> = Vec::new();
+        for &tool_name in ENGINE_REFERENCED_SKILL_TOOLS {
+            if !reachable_tools.contains(tool_name) {
+                // Find owning skill for diagnostic message
+                let owner = skill_tools
+                    .iter()
+                    .find(|(_, tools)| tools.iter().any(|t| t == tool_name))
+                    .map(|(name, _)| name.as_str());
+                missing.push((tool_name, owner));
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "Engine-referenced skill tool(s) not reachable through the always-on \
+             dependency closure (mika#1253). Missing tools:\n{}\n\
+             Fix: add the owning skill to an always_on=true skill's dependencies \
+             (typically self-dev/skill.toml).",
+            missing
+                .iter()
+                .map(|(tool, owner)| {
+                    match owner {
+                        Some(skill) => format!("  - {tool} (owned by skill '{skill}')"),
+                        None => format!("  - {tool} (owning skill not found in bundle)"),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
     // Shared fixtures for merge-semantics tests — call `merge_skill_lists`
     // directly so the production merge function is the unit under test.
     // Previously the test re-implemented the merge algorithm locally, which

--- a/docs/plans/2026-05-28-001-test-1253-skills-static-parity-assertion-plan.md
+++ b/docs/plans/2026-05-28-001-test-1253-skills-static-parity-assertion-plan.md
@@ -1,0 +1,126 @@
+---
+title: "test(skills): static parity assertion — engine-referenced tool names must be loader-reachable"
+type: feat
+status: active
+date: 2026-05-28
+issue: mika#1253
+---
+
+# Static Parity Assertion: Engine-Referenced Tool Names Must Be Loader-Reachable
+
+## Overview
+
+Add a compile-time test that asserts every skill tool name referenced by string literal in the engine's Rust code is reachable through the always-on dependency closure of `BUNDLED_SKILL_MANIFESTS`. This catches the class of bug surfaced by mika#1251 — where a tool name is known to the engine but unreachable by the skill loader on keyword-less turns (e.g., GitHub webhook auto-groom).
+
+## Problem Frame
+
+mika#1173 created `dev-groom` as a tool-owning skill but omitted the loader-side dependency edge from `self-dev` (always_on=true). For 6 days, `run_claude_pilot_groom` was engine-referenced but loader-unreachable on every github-webhook auto-groom turn. mika#1251 fixed the specific instance. This test generalizes the defense so any future engine-referenced skill tool name that lacks a loader path is caught at build time.
+
+## Requirements Trace
+
+- R1. Test named `test_engine_referenced_tool_names_are_loader_reachable` exists in `crates/mika-agent/src/skills/`
+- R2. Test reads `BUNDLED_SKILL_MANIFESTS` (build-time constant), not filesystem
+- R3. Test PASSES at current HEAD
+- R4. Test FAILS if `dev-groom` is removed from `self-dev.dependencies`
+
+## Scope Boundaries
+
+- Only skill-owned tools (defined in `tools.json`) are in scope — builtin tools (Rust-defined in `crates/mika-agent/src/tools/`) are always registered by the engine and don't need loader reachability
+- The test validates the worst-case keyword-less turn (only `always_on=true` seeds) — keyword-triggered reachability is a superset and doesn't need separate assertion
+- No runtime or integration test — this is a pure data-structure assertion over compiled-in constants
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/bundled_skills.rs` — `all_bundled_skills()` merges legacy + build-time ENTRIES; existing test `test_self_dev_declares_both_dispatch_siblings_as_dependencies` (line 1365) uses the same data access pattern
+- `crates/mika-agent/src/skills/matcher.rs` — `match_skills()` BFS algorithm for transitive dependency resolution (lines 56-73); the test replicates this walk starting from `always_on=true` seeds only
+- `crates/mika-agent/src/skills/manifest.rs` — `SkillManifest` with `skill.always_on`, `skill.dependencies` fields
+- Skill tool definitions live in `tools.json` files embedded as `SkillFile` entries in each `BundledSkill`
+
+### Engine-Referenced Skill Tool Names (Current HEAD)
+
+Two categories of skill tool names appear in engine Rust code. The distinction determines what belongs in the registry:
+
+**Category A — Engine post-condition guards (production code in agent.rs, engine.rs, executor.rs).** These tool names appear in `EndTurn` guard predicates, intent-precondition checks, and dispatch-class derivation. The guards fire regardless of which skills are loaded — a missing tool means the guard silently no-ops or misfires. These MUST be in the always-on closure:
+
+| Tool Name | Owning Skill | Guard References |
+|-----------|-------------|------------------|
+| `run_claude_pilot` | dev-pilot | agent.rs:1713,5532,5559,5645,5709,5771; engine.rs; executor.rs; dispatcher.rs |
+| `run_claude_pilot_groom` | dev-groom | agent.rs:1465,1476,1713,5532,5559,5645,5709,5771 |
+| `deploy_mika` | deploy-mika | agent.rs:5785; engine.rs; executor.rs |
+
+**Category B — Builtin handler dispatch and test-only code.** These tool names appear in `KNOWN_BUILTINS` handler dispatch tables (`builtin_handlers.rs`) or in test fixtures (`agent.rs` test modules). They're active only when the owning skill is loaded via keyword match or identity allowlist. Loader unreachability is by design (agent-specific scope), not a bug:
+
+| Tool Name | Owning Skill | Reference Type |
+|-----------|-------------|----------------|
+| `gh_read` | mika-arch-groom-ticket/milestone/second-review | builtin handler dispatch + test fixtures |
+| `review_skill` | skill-review | builtin handler dispatch + test fixtures |
+| `qa_pr_view` | qa-review | test fixtures only |
+
+Only Category A tools belong in `ENGINE_REFERENCED_SKILL_TOOLS`. Category B tools are correctly agent-scoped — their unreachability on non-matching agents is intentional.
+
+### Institutional Learnings
+
+- mika#1251 (regression) — the specific instance this test generalizes
+- mika#1173 (origin) — the PR that created the engine/loader asymmetry
+- mika#1244, mika#1248 — sibling structural defenses
+
+## Key Technical Decisions
+
+- **Central const registry over source scanning**: The ticket suggests `EngineReferencedToolNames`. A `const` slice is explicit, searchable, and maintainable. Source-scanning alternatives (regex over `agent.rs` at test time) are fragile and produce false positives. The const requires manual maintenance when adding new engine tool references, but this is a feature — it forces the developer to consciously register the dependency.
+
+- **Test location in `bundled_skills.rs`**: The existing sibling test (`test_self_dev_declares_both_dispatch_siblings_as_dependencies`) lives here and uses the same data access pattern (`all_bundled_skills()`). The ticket says `crates/mika-agent/src/skills/<file>.rs` — `bundled_skills.rs` satisfies this constraint. No new file needed.
+
+- **BFS walk replication**: The test replicates the `match_skills()` BFS from `matcher.rs` but simplified — no keyword matching, no disabled-skill filtering, just pure always-on transitive closure. This mirrors the worst-case reachability (a webhook turn with no keyword hits).
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `ENGINE_REFERENCED_SKILL_TOOLS` const and parity test**
+
+**Goal:** Create the central registry const and the static parity assertion test that validates every entry is reachable through the always-on dependency closure.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/bundled_skills.rs` — add const + test
+
+**Approach:**
+
+1. Add `ENGINE_REFERENCED_SKILL_TOOLS: &[&str]` as a module-level const (inside `#[cfg(test)]` or at module level — prefer module level so it can serve as documentation and future enforcement point). Contains the 3 Category A tool names: `run_claude_pilot`, `run_claude_pilot_groom`, `deploy_mika`. Doc comment explains the Category A/B distinction and the maintenance contract.
+
+2. Add `test_engine_referenced_tool_names_are_loader_reachable` test that:
+   - Calls `all_bundled_skills()` to get all embedded skill manifests
+   - Parses each skill's `skill.toml` to extract `always_on` and `dependencies`
+   - Parses each skill's `tools.json` to extract tool names
+   - Computes the always-on closure via BFS: seed with all `always_on=true` skills, walk transitive `dependencies`
+   - Collects all tool names from closure-member skills' `tools.json`
+   - Asserts every entry in `ENGINE_REFERENCED_SKILL_TOOLS` is in the closure-reachable set
+   - On failure: names the missing tool(s) and which skill owns them, to make the fix obvious
+
+**Patterns to follow:**
+- `test_self_dev_declares_both_dispatch_siblings_as_dependencies` (bundled_skills.rs:1365) — same `all_bundled_skills()` + TOML parse pattern
+- `match_skills()` BFS in `matcher.rs:56-73` — same transitive dependency walk algorithm (simplified: no keyword, no disabled check)
+
+**Test scenarios:**
+- Happy path: test passes at current HEAD — all 3 Category A engine-referenced tools (`run_claude_pilot`, `run_claude_pilot_groom`, `deploy_mika`) are reachable through the always-on closure via self-dev (always_on=true, depends on dev-pilot, dev-groom, deploy-mika)
+- Regression detection: if `dev-groom` were removed from `self-dev.dependencies`, `run_claude_pilot_groom` would not be in the closure and the test would fail (verified by implementer during development, not committed)
+- Error message quality: the assertion message names the unreachable tool and ideally its owning skill, so the developer knows exactly what dependency edge to add
+
+**Verification:**
+- `cargo test -p mika-agent test_engine_referenced_tool_names_are_loader_reachable` passes
+- Temporarily removing `dev-groom` from `skills/bundled/self-dev/skill.toml` dependencies causes the test to fail (restore after verification)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| New engine guard references to skill tools added without updating the const | The const has a doc comment explaining the maintenance contract and the Category A/B distinction; the developer adding the reference must add it to the const |
+| Category B tool mistakenly added to the const | The doc comment on the const explains the distinction; Category B tools (agent-scoped, only active when skill is loaded) would cause test failure since they're intentionally not in the always-on closure |
+
+## Sources & References
+
+- Related issues: mika#1251 (regression), mika#1173 (origin), mika#1244, mika#1248 (siblings)
+- Related code: `crates/mika-agent/src/skills/matcher.rs` (BFS algorithm), `crates/mika-agent/src/bundled_skills.rs` (data access pattern)

--- a/docs/plans/2026-05-28-001-test-1253-skills-static-parity-assertion-plan.md
+++ b/docs/plans/2026-05-28-001-test-1253-skills-static-parity-assertion-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "test(skills): static parity assertion — engine-referenced tool names must be loader-reachable"
 type: feat
-status: active
+status: completed
 date: 2026-05-28
 issue: mika#1253
 ---
@@ -35,8 +35,8 @@ mika#1173 created `dev-groom` as a tool-owning skill but omitted the loader-side
 
 - `crates/mika-agent/src/bundled_skills.rs` — `all_bundled_skills()` merges legacy + build-time ENTRIES; existing test `test_self_dev_declares_both_dispatch_siblings_as_dependencies` (line 1365) uses the same data access pattern
 - `crates/mika-agent/src/skills/matcher.rs` — `match_skills()` BFS algorithm for transitive dependency resolution (lines 56-73); the test replicates this walk starting from `always_on=true` seeds only
-- `crates/mika-agent/src/skills/manifest.rs` — `SkillManifest` with `skill.always_on`, `skill.dependencies` fields
-- Skill tool definitions live in `tools.json` files embedded as `SkillFile` entries in each `BundledSkill`
+- `crates/mika-agent/src/skills/manifest.rs` — `SkillManifest` with `skill.always_on`, `skill.dependencies` fields. **No `enabled` field exists in `SkillManifest` or `skill.toml`** — enabled/disabled is a runtime DB-backed state via `skill_overrides.enabled` (tri-state nullable: NULL=default enabled, 0=disabled, 1=explicitly enabled; schema v24, mika#629). `BUNDLED_SKILL_MANIFESTS` has zero knowledge of enabled/disabled status.
+- Skill tool definitions live in `tools.json` files embedded as `SkillFile` entries in each `BundledSkill`. The `BundledSkill` struct (bundled_skills.rs:44–52) carries `files: &'static [SkillFile]` where each `SkillFile` has `path: &'static str`, `content: &'static str`, `executable: bool`. To extract tool names, filter `files` for `path == "tools.json"`, parse `content` as JSON. **JSON shape:** top-level array of tool objects `[{"name": "...", "description": "...", "input_schema": {...}, "handler": {...}}]`. Tool name is `obj["name"]`. **Not all skills have tools.json** — 10 of 22 bundled skills lack it (e.g., `self-dev`, `permission-policy`, `dev-handsoff`); these must be skipped gracefully during tool-name collection.
 
 ### Engine-Referenced Skill Tool Names (Current HEAD)
 
@@ -72,11 +72,11 @@ Only Category A tools belong in `ENGINE_REFERENCED_SKILL_TOOLS`. Category B tool
 
 - **Test location in `bundled_skills.rs`**: The existing sibling test (`test_self_dev_declares_both_dispatch_siblings_as_dependencies`) lives here and uses the same data access pattern (`all_bundled_skills()`). The ticket says `crates/mika-agent/src/skills/<file>.rs` — `bundled_skills.rs` satisfies this constraint. No new file needed.
 
-- **BFS walk replication**: The test replicates the `match_skills()` BFS from `matcher.rs` but simplified — no keyword matching, no disabled-skill filtering, just pure always-on transitive closure. This mirrors the worst-case reachability (a webhook turn with no keyword hits).
+- **BFS walk replication**: The test replicates the `match_skills()` BFS from `matcher.rs` but simplified — no keyword matching, just pure always-on transitive closure. This mirrors the worst-case reachability (a webhook turn with no keyword hits). **Disabled-skill filtering is intentionally omitted** because `enabled` is a runtime DB flag (`skill_overrides.enabled`, schema v24), not a TOML field — `BUNDLED_SKILL_MANIFESTS` contains no enabled/disabled state, and `build.rs` has zero knowledge of it. The production `match_skills()` BFS disabled-skill gate at matcher.rs:67 is a defensive secondary guard for the runtime registry; the test operates over compile-time data where the concept does not apply. (Citation: matcher.rs:197–199 confirms "disabled skills are evicted from the registry by `apply_overrides()` before `match_skills()` is ever called"; review-guide.md § Orthogonality.)
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add `ENGINE_REFERENCED_SKILL_TOOLS` const and parity test**
+- [x] **Unit 1: Add `ENGINE_REFERENCED_SKILL_TOOLS` const and parity test**
 
 **Goal:** Create the central registry const and the static parity assertion test that validates every entry is reachable through the always-on dependency closure.
 
@@ -89,12 +89,12 @@ Only Category A tools belong in `ENGINE_REFERENCED_SKILL_TOOLS`. Category B tool
 
 **Approach:**
 
-1. Add `ENGINE_REFERENCED_SKILL_TOOLS: &[&str]` as a module-level const (inside `#[cfg(test)]` or at module level — prefer module level so it can serve as documentation and future enforcement point). Contains the 3 Category A tool names: `run_claude_pilot`, `run_claude_pilot_groom`, `deploy_mika`. Doc comment explains the Category A/B distinction and the maintenance contract.
+1. Add `ENGINE_REFERENCED_SKILL_TOOLS: &[&str]` inside the `#[cfg(test)] mod tests` block. The sole consumer is the parity test — no production code path reads this const, so `#[cfg(test)]` is the correct placement per review-guide.md § YAGNI. A well-named test-only const with a doc comment explaining the Category A/B distinction and maintenance contract serves the documentation purpose equally well without adding ~200 bytes to the production binary. Contains the 3 Category A tool names: `run_claude_pilot`, `run_claude_pilot_groom`, `deploy_mika`.
 
 2. Add `test_engine_referenced_tool_names_are_loader_reachable` test that:
    - Calls `all_bundled_skills()` to get all embedded skill manifests
    - Parses each skill's `skill.toml` to extract `always_on` and `dependencies`
-   - Parses each skill's `tools.json` to extract tool names
+   - For each skill, finds the `SkillFile` with `path == "tools.json"` in `files`; skips skills without one (10 of 22 bundled skills lack `tools.json`). Parses the `content` as a JSON array `[{"name": "...", ...}]` and collects each `obj["name"]` as a tool name
    - Computes the always-on closure via BFS: seed with all `always_on=true` skills, walk transitive `dependencies`
    - Collects all tool names from closure-member skills' `tools.json`
    - Asserts every entry in `ENGINE_REFERENCED_SKILL_TOOLS` is in the closure-reachable set
@@ -102,7 +102,7 @@ Only Category A tools belong in `ENGINE_REFERENCED_SKILL_TOOLS`. Category B tool
 
 **Patterns to follow:**
 - `test_self_dev_declares_both_dispatch_siblings_as_dependencies` (bundled_skills.rs:1365) — same `all_bundled_skills()` + TOML parse pattern
-- `match_skills()` BFS in `matcher.rs:56-73` — same transitive dependency walk algorithm (simplified: no keyword, no disabled check)
+- `match_skills()` BFS in `matcher.rs:56-73` — same transitive dependency walk algorithm (simplified: no keyword matching; disabled-skill filtering omitted because `enabled` is a runtime DB flag not present in compile-time `BUNDLED_SKILL_MANIFESTS` — see matcher.rs:197–199)
 
 **Test scenarios:**
 - Happy path: test passes at current HEAD — all 3 Category A engine-referenced tools (`run_claude_pilot`, `run_claude_pilot_groom`, `deploy_mika`) are reachable through the always-on closure via self-dev (always_on=true, depends on dev-pilot, dev-groom, deploy-mika)
@@ -124,3 +124,7 @@ Only Category A tools belong in `ENGINE_REFERENCED_SKILL_TOOLS`. Category B tool
 
 - Related issues: mika#1251 (regression), mika#1173 (origin), mika#1244, mika#1248 (siblings)
 - Related code: `crates/mika-agent/src/skills/matcher.rs` (BFS algorithm), `crates/mika-agent/src/bundled_skills.rs` (data access pattern)
+
+## Revision history
+
+- rev 2 (2026-05-28): addressed F1 by adding Phase 0 pin confirming `enabled` is a runtime DB flag (`skill_overrides.enabled`, schema v24) not present in `skill.toml` or `BUNDLED_SKILL_MANIFESTS` — disabled-skill filtering omission is safe and now documented with justification citing matcher.rs:197–199 and review-guide.md § Orthogonality; addressed F2 by adding Phase 0 pins for `BundledSkill` struct definition (`files: &[SkillFile]` where `path == "tools.json"`), `tools.json` JSON shape (top-level array of `{"name": ..., ...}` objects), and tool-less skill handling (10 of 22 bundled skills lack `tools.json`, must be skipped); addressed F3 by changing `ENGINE_REFERENCED_SKILL_TOOLS` placement from "prefer module level" to `#[cfg(test)]` — sole consumer is the parity test, no production use exists or is planned, per review-guide.md § YAGNI and § KISS.


### PR DESCRIPTION
## Summary

- Add `ENGINE_REFERENCED_SKILL_TOOLS` const (3 Category A tools) and `test_engine_referenced_tool_names_are_loader_reachable` test in `bundled_skills.rs`
- Test computes the always-on dependency closure via BFS over `BUNDLED_SKILL_MANIFESTS` and asserts every engine-referenced skill tool is reachable
- Generalizes the defense from #1251 — catches future engine/loader asymmetries at build time

Closes #1253

## Verification

- ✅ Test passes at current HEAD (all 3 Category A tools reachable via self-dev → dev-pilot/dev-groom/deploy-mika)
- ✅ Temporarily removing `dev-groom` from `self-dev.dependencies` causes the test to fail with actionable message: `run_claude_pilot_groom (owned by skill 'dev-groom')`
- ✅ All 53 bundled_skills tests pass
- ✅ clippy clean, fmt clean, all pre-commit hooks pass

## Test plan

- [x] `cargo test -p mika-agent test_engine_referenced_tool_names` passes
- [x] Regression detection verified: removing dev-groom dependency causes test failure naming the missing tool and owning skill
- [x] Full `cargo test -p mika-agent bundled_skills` suite passes (53 tests)
- [x] `cargo clippy -p mika-agent --tests` clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a compile-time test with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Compound Engineered · Claude Opus 4.6 (1M context) · Claude Code</sub>