### PR TITLE
fix(dockerfile-agent): extract bare hash from gws .sha256 asset before checksum verification

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -55,7 +55,7 @@ RUN ARCH_MAP="amd64:x86_64-unknown-linux-gnu arm64:aarch64-unknown-linux-gnu" &&
     GWS_VERSION="0.13.3" && \
     wget -qO /tmp/gws.tar.gz "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/gws-${GWS_ARCH}.tar.gz" && \
     wget -qO /tmp/gws.tar.gz.sha256 "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/gws-${GWS_ARCH}.tar.gz.sha256" && \
-    cd /tmp && echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c - && \
+    cd /tmp && echo "$(cut -d' ' -f1 gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c - && \
     tar -xzf /tmp/gws.tar.gz -C /tmp && \
     find /tmp -name gws -type f -executable -exec mv {} /usr/local/bin/gws \; && \
     rm -rf /tmp/gws*

--- a/docs/plans/2026-05-28-002-fix-1329-dockerfile-agent-gws-install-sha256-plan.md
+++ b/docs/plans/2026-05-28-002-fix-1329-dockerfile-agent-gws-install-sha256-plan.md
@@ -1,0 +1,45 @@
+# Plan: fix(dockerfile-agent): gws install sha256 verification fails — checksum asset already contains filename
+
+**Ticket:** mika issue#1329
+**Type:** Bug fix
+**Scope:** `Dockerfile.agent` line 58
+
+## Problem
+
+The `gws` (Google Workspace CLI) install step in `Dockerfile.agent` fails during checksum verification. The upstream `.sha256` asset contains the format `<hash> *<original-filename>` (e.g., `81e35ebb...2160 *gws-x86_64-unknown-linux-gnu.tar.gz`), but line 58 appends a second filename:
+
+```sh
+echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -
+# Expands to:
+echo "81e35ebb...2160 *gws-x86_64-unknown-linux-gnu.tar.gz  gws.tar.gz" | sha256sum -c -
+```
+
+`sha256sum -c` parses the filename as `gws-x86_64-unknown-linux-gnu.tar.gz  gws.tar.gz` (concatenated), which doesn't exist → `FAILED` → exit 1.
+
+This blocks the mika-cloud deploy: the agent image cannot be built from a clean `main`.
+
+## Fix
+
+**Single-line change** in `Dockerfile.agent` line 58. Extract only the bare hash from the checksum file before appending the local filename:
+
+```diff
+-    cd /tmp && echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c - && \
++    cd /tmp && echo "$(cut -d' ' -f1 gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c - && \
+```
+
+`cut -d' ' -f1` takes the first space-delimited field (the bare hash), discarding the `*<original-filename>` suffix. This matches the pattern used by `gh` install on line 46 (which works because `gh_checksums.txt` uses `<hash>  <filename>` format matching the local filename).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Dockerfile.agent` | Line 58: `cat` → `cut -d' ' -f1` to extract bare hash |
+
+## Verification
+
+1. `docker build -f Dockerfile.agent --platform linux/amd64 -t mika-agent-test .` completes successfully
+2. `docker run --rm mika-agent-test gws --version` confirms the binary is present and executable
+
+## Risk Assessment
+
+**Minimal.** Single-line change in a `RUN` step. The fix is idempotent — if upstream ever changes the `.sha256` format to bare hash, `cut -d' ' -f1` still returns the correct value. No runtime behavior change; only affects image build.


### PR DESCRIPTION
## Summary

Fixes mika#1329.

The `gws.tar.gz.sha256` checksum file from the GitHub release asset contains `<hash> *<original-filename>`, not just the bare hash. Passing this directly to `sha256sum -c` with a custom filename appended produces a malformed check string, causing installation to silently fail or error.

## Change

Line 58 of `Dockerfile.agent`:

```diff
-echo "$(cat gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -
+echo "$(cut -d' ' -f1 gws.tar.gz.sha256)  gws.tar.gz" | sha256sum -c -
```

`cut -d' ' -f1` extracts only the bare hex hash, which is then paired with the local filename in the format `sha256sum -c` expects. This matches the pattern already used for `gh` checksum verification earlier in the same Dockerfile.

## Testing

Build-time only — verified by successful Docker image build.

## Checklist
- [x] Single-line Dockerfile fix
- [x] Matches existing pattern (gh checksum line)
- [x] No runtime code changes
- [x] No tests required (Dockerfile RUN step)