### PR TITLE
fix(dispatch): auto-rescue commit silently fails in linked worktrees (.git-as-file scratch path)

### DIFF
--- a/docs/plans/2026-05-30-003-fix-1341-dispatch-rescue-git-as-file-scratch-plan.md
+++ b/docs/plans/2026-05-30-003-fix-1341-dispatch-rescue-git-as-file-scratch-plan.md
@@ -1,0 +1,137 @@
+---
+title: "fix(dispatch): auto-rescue commit silently fails in linked worktrees — .git-as-file scratch path"
+type: fix
+status: active
+date: 2026-05-30
+issue: senara-solutions/mika#1341
+branch: bug/1341/dispatch-auto-rescue-commit-silently
+---
+
+# fix(dispatch): auto-rescue commit silently fails in linked worktrees (.git-as-file scratch path / ENOTDIR)
+
+## Summary
+
+The autonomous loop's dirty-worktree auto-rescue (`skills/bundled/_shared/dispatch-lib.sh`, mika#1282/#1296/#1310) writes its commit-output capture file to `"$WORKTREE_DIR/.git/mika-rescue-commit-err"`. In a **linked git worktree** — which is every autonomous `dev-pilot` run (`.claude/worktrees/<branch>/<repo>`) — `.git` is a **file** (a `gitdir:` pointer), not a directory. The redirect `git commit ... > "$RESCUE_COMMIT_ERR" 2>&1` therefore cannot open its target (`ENOTDIR`), the redirection fails, and per POSIX shell semantics **the `git commit` is never executed and exits non-zero**. The rescue silently produces no commit, no branch push, and no PR.
+
+Fix: one-line change to write the scratch file to a guaranteed-valid path (`mktemp`). Plus a regression test that exercises the rescue path inside a real linked worktree.
+
+This is a **Lightweight** plan: one production-line fix + one regression test. No scope expansion.
+
+---
+
+## Problem Frame
+
+**Observed (cpp#24 → mika#1341):** A fully-groomed ticket re-dispatched through the loop on 2026-05-29 produced `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook (non-rustfmt)` with `Hook output: <rescue capture was empty>`. The pilot's edit (`M Dockerfile.agent`) was present but uncommitted; no PR.
+
+**Root cause (confirmed by live repro):**
+- `dispatch-lib.sh:512` — `RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"`.
+- In a linked worktree, `.git` is a 79-byte file (`gitdir: /…/.git/worktrees/<name>`), not a directory. Live repro: `echo probe > <linked-wt>/.git/mika-rescue-commit-err` → `not a directory` (exit 1).
+- The `> "$RESCUE_COMMIT_ERR" 2>&1` redirect on the `git commit` (`dispatch-lib.sh:522`) fails to open → `git commit` never runs → exits non-zero with no output written.
+
+**Symptom chain (each maps to one observed fact):**
+| Observed | Mechanism |
+|---|---|
+| HEAD unchanged, edit left uncommitted, no PR | `git commit` never executes (redirect open fails) |
+| `rejected by pre-commit hook (non-rustfmt)` | `if git commit` → exit≠0 → elif `grep rustfmt "$RESCUE_COMMIT_ERR"` → file absent → no match → non-rustfmt `else` branch (`dispatch-lib.sh:607`) |
+| `<rescue capture was empty>` | `cat "$RESCUE_COMMIT_ERR"` → file never created → empty → git-status diagnostic fallback (mika#1310) |
+
+**Ruled out (with evidence — do not chase):**
+- *Injected `.claude/commands` pollution*: already excluded by mika#1288 via `git add -A -- ':!.claude/commands/'` (`dispatch-lib.sh:466`/`:516`). Never enters the changeset; appears only in the diagnostic dump. Red herring.
+- *lefthook missing from PATH*: `.git/hooks/pre-commit` falls through to `echo "Can't find lefthook in PATH"` and returns 0 (non-fatal). With only `Dockerfile.agent` staged, no `lefthook.yml` job glob even matches. Never the rejecter.
+
+**Provenance:** introduced by mika#1296 (commit `0eababa7`, 2026-05-26). Latent 3 days because mika#1327's groom brake wedged the loop upstream until 2026-05-29 (this is the "next downstream wedge").
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Change the rescue commit-capture scratch path to a guaranteed-valid location.
+- Add a regression test covering the rescue path under a linked worktree.
+
+**Out of scope (non-goals):**
+- The deeper Layer-1 question of *why the pilot exits 0 without self-committing* (the rescue is a safety net; this fix makes the net work). Tracked separately if it recurs.
+- Refactoring the rescue block's structure, the mika#1310 diagnostic logic, or the lefthook/pre-commit hook.
+
+### Deferred to Follow-Up Work
+- The existing `test_rescue_hook_failure_invariant` (test-dispatch-lib.sh ~line 880) **reimplements** the rescue logic inline rather than sourcing the real function, and uses `2>"$RESCUE_COMMIT_ERR"` (stderr-only) instead of the real `> … 2>&1`. Tightening these tests to exercise the real `dispatch_claude_pilot` function is a larger test-architecture change — not pulled into this fix.
+
+---
+
+## Key Technical Decisions
+
+**KTD-1: Use `mktemp` for the scratch path.**
+`RESCUE_COMMIT_ERR="$(mktemp)"` — out of the working tree (preserves mika#1296's intent of not coupling to `.iterate/`), always a real path regardless of linked vs. non-linked worktree, no git-internals writing. The existing `rm -f "$RESCUE_COMMIT_ERR"` cleanup in every branch works unchanged (a `mktemp` file is a normal file).
+
+*Alternative considered:* `"$(git -C "$WORKTREE_DIR" rev-parse --git-dir)/mika-rescue-commit-err"` resolves to the real per-worktree git dir (`<repo>/.git/worktrees/<name>`, a real directory). Rejected: more complex, writes into git internals, and adds a subprocess; `mktemp` is simpler and strictly safer. No reason found to prefer it.
+
+**KTD-2: Single assignment site.** There is exactly one `RESCUE_COMMIT_ERR=` assignment (`dispatch-lib.sh:512`) feeding all three commit-attempt paths (first commit, cargo-fmt retry, and both failure branches). The one-line change fixes every path; the comment above it (lines 510–512 referencing `.git/`) must be updated to reflect the new rationale.
+
+---
+
+## Implementation Units
+
+### U1. Fix the rescue scratch path
+
+**Goal:** Replace the linked-worktree-invalid `.git/` scratch path with a `mktemp` path so the rescue `git commit` redirect always opens.
+
+**Requirements:** Acceptance criterion 1 (rescue produces a real commit + push + PR in a linked worktree).
+
+**Dependencies:** none.
+
+**Files:**
+- `skills/bundled/_shared/dispatch-lib.sh` (modify — the `RESCUE_COMMIT_ERR=` assignment at line 512 and its preceding comment at lines 510–512)
+
+**Approach:**
+- Change `RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"` → `RESCUE_COMMIT_ERR="$(mktemp)"`.
+- Update the comment to explain the linked-worktree `.git`-is-a-file hazard and cite mika#1341 (so a future reader doesn't "restore" the `.git/` location for orthogonality reasons).
+- Confirm all `rm -f "$RESCUE_COMMIT_ERR"` cleanup sites remain correct (three branches: first-try success, retry success, both failure branches). No new exit path is introduced.
+
+**Patterns to follow:** mika#1296/#1310 comment-citation style already in this block (inline `# mika#NNNN:` rationale comments).
+
+**Test scenarios:** behavior is covered by U2's regression test. No unit-local test beyond U2.
+
+**Verification:** `grep -n 'RESCUE_COMMIT_ERR=' skills/bundled/_shared/dispatch-lib.sh` shows the `mktemp` form and no `.git/` path; `bash -n` parses clean.
+
+### U2. Regression test: rescue path under a linked worktree
+
+**Goal:** Lock in the fix with a test that fails against the `.git/`-scratch code and passes after U1, and that documents the linked-worktree root cause as an executable artifact.
+
+**Requirements:** Acceptance criterion 2.
+
+**Dependencies:** U1 (the structural assertion asserts the fixed shape).
+
+**Files:**
+- `skills/bundled/_shared/test-dispatch-lib.sh` (modify — add a test block mirroring the existing Test A/Test B structure near the mika#1296 rescue tests, ~line 845+)
+
+**Approach (mirror existing A/B convention):**
+- **Test A — structural (coupled to real source):** extract the `RESCUE_COMMIT_ERR=` assignment line from `dispatch-lib.sh` and assert it does **not** contain `.git/mika-rescue-commit-err` and **does** use `mktemp`. This is the assertion that fails on current code and passes after U1.
+- **Test B — live invariant (linked-worktree proof):** in a `mktemp -d` base repo with an initial commit, create a **linked worktree** via `git worktree add`. Assert that `.git` inside the linked worktree is a file (`[ -f "$wt/.git" ]`), that a redirect into `"$wt/.git/scratch"` fails (documents ENOTDIR), and that a `git commit` capturing into a `mktemp` path **succeeds and advances HEAD** with a dirty tracked file staged. Clean up the worktree (`git worktree remove --force`) and temp dirs via `trap … RETURN`.
+
+**Patterns to follow:** existing `test_auto_rescue_empty_index_guard` and `test_rescue_hook_failure_invariant` (function returning `PASS`/`FAIL: …`, wrapped by a `RESULT_X=$(…)` + `assert`-style PASS/FAIL counter increment). Use `git -C` throughout; no `cd` into the harness's own tree.
+
+**Test scenarios:**
+- Covers AC2. Structural: `RESCUE_COMMIT_ERR` assignment uses `mktemp`, not `$WORKTREE_DIR/.git/`. (Fails pre-fix.)
+- Linked worktree: `.git` is a file; redirect into `<wt>/.git/<name>` fails (exit ≠ 0).
+- Linked worktree: rescue commit with a `mktemp` capture path succeeds; `HEAD` advances; staged file is committed; scratch file is cleaned up.
+
+**Verification:** `bash skills/bundled/_shared/test-dispatch-lib.sh` — all assertions pass on the fixed code; the structural assertion fails when temporarily reverting U1.
+
+---
+
+## Risks & Dependencies
+
+- **Low risk.** One-line production change in a well-isolated rescue path; `mktemp` is POSIX-portable and already used throughout the test harness. No schema, API, or interface contract touched.
+- **Deploy note:** `dispatch-lib.sh` is copy-deployed (not in-binary) — the fix is live only after `make deploy` re-seeds bundled skills to `~/.mika`. Per `project_dispatch_lib_deploy_lag_wedge`: diff the `~/.mika` copy against source after merge to confirm the live copy carries the fix before declaring the loop unwedged.
+
+## Acceptance Criteria
+
+1. A pilot that writes files but does not self-commit, running in a linked worktree, is auto-rescued into a real commit + pushed branch + PR — no "non-rustfmt empty-capture" PIPELINE FAILURE.
+2. `test-dispatch-lib.sh` covers the rescue path under a linked worktree and fails against the current `.git/`-scratch code.
+
+## Sources & Research
+
+- Live repro (this session): linked-worktree `.git` is a file; `echo probe > <wt>/.git/<name>` → `not a directory`.
+- `git blame` / `git log -S`: scratch path introduced by mika#1296 (`0eababa7`, 2026-05-26).
+- `dispatch-lib.sh:466`/`:516` (mika#1288 pathspec exclusion); `.git/hooks/pre-commit` + `lefthook.yml` (lefthook non-fatal fallthrough).
+- Originating mis-scoped report: claude-pilot-py#24 (closed, pointing here).

--- a/docs/solutions/dev-loop/dispatch-rescue-git-as-file-linked-worktree.md
+++ b/docs/solutions/dev-loop/dispatch-rescue-git-as-file-linked-worktree.md
@@ -1,0 +1,94 @@
+---
+module: mika-skills
+tags: [dispatch-lib, auto-rescue, linked-worktree, git-worktree, mktemp, enotdir, autonomous-loop, mika-1341, mika-1296]
+problem_type: runtime_error
+category: dev-loop
+date: 2026-05-30
+---
+
+# Dispatch auto-rescue silently fails in linked worktrees (`.git`-as-file scratch path)
+
+## Problem
+
+The autonomous loop's dirty-worktree auto-rescue (`skills/bundled/_shared/dispatch-lib.sh`, mika#1282/#1296/#1310) silently failed to commit in **every linked git worktree** — i.e. every autonomous `dev-pilot` run, which always operates in `.claude/worktrees/<branch>/<repo>`. The pilot wrote the correct edit, but the rescue commit never landed: no branch pushed, no PR. The loop could not land any implementation.
+
+## Symptoms
+
+A groomed ticket dispatched through the loop produced:
+
+```
+PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook (non-rustfmt).
+Hook output: <rescue capture was empty — likely no hook output, falling back to git diagnostic>
+git status:
+ M Dockerfile.agent          <- the edit WAS applied
+ ?? .claude/commands/...      <- injected scaffold (red herring)
+```
+
+Fingerprint: **"non-rustfmt" rejection + empty hook capture + HEAD unchanged + edit left uncommitted.**
+
+## Root cause
+
+`dispatch-lib.sh` wrote its commit-output capture file to:
+
+```sh
+RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"
+```
+
+**In a linked git worktree, `.git` is a FILE — a `gitdir:` pointer — not a directory.** (Only the main checkout has a `.git` directory.) So the redirect on the rescue commit:
+
+```sh
+git -C "$WORKTREE_DIR" commit -m "..." > "$RESCUE_COMMIT_ERR" 2>&1
+```
+
+could not **open** its output target (`ENOTDIR: not a directory`). Per POSIX shell semantics, **a failed output redirection means the command is never executed and exits non-zero, with no output written.** That single failure cascaded through the rescue block's error-classification logic:
+
+1. `git commit` never runs → HEAD unchanged → edit uncommitted → no PR.
+2. `if git commit ...` exits non-zero → falls to `elif grep -q "rustfmt" "$RESCUE_COMMIT_ERR"` → the capture file was never created → no match → falls into the **"non-rustfmt"** `else` branch.
+3. `cat "$RESCUE_COMMIT_ERR"` → file absent → empty → triggers the mika#1310 **"rescue capture was empty"** git-status diagnostic fallback.
+
+Every observed symptom traced to this one line.
+
+## What didn't work (ruled out with evidence)
+
+- **Injected `.claude/commands/*.md` pollution** (the original hypothesis): already excluded from the changeset by mika#1288's `git add -A -- ':!.claude/commands/'`. The files appear only in the *diagnostic dump*, which made them *look* causal. Red herring.
+- **`lefthook` missing from PATH**: `.git/hooks/pre-commit` falls through to `echo "Can't find lefthook in PATH"` and returns **0** (non-fatal). With only `Dockerfile.agent` staged, no `lefthook.yml` job glob even matches. The hook was never the rejecter.
+- **Mis-scoped ticket**: filed as `claude-pilot-py#24`, but the entire fix surface was in `mika`. Triaging by the failure string — the `PIPELINE FAILURE` text originates in `mika/skills/bundled/_shared/dispatch-lib.sh` — located the real repo.
+
+## Solution
+
+One-line change — write the scratch file to a guaranteed-valid path:
+
+```sh
+# Before (ENOTDIR in linked worktrees):
+RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"
+
+# After:
+RESCUE_COMMIT_ERR="$(mktemp "${TMPDIR:-/tmp}/mika-rescue-commit-err.XXXXXX")"
+```
+
+`mktemp` preserves the original mika#1296 intent (keep the scratch off the working tree, away from `.iterate/`) while guaranteeing a real, writable path in both linked and non-linked checkouts. The named template also preserves the literal token `mika-rescue-commit-err`, which several tests use as a `sed` anchor to extract the rescue block.
+
+The existing `rm -f "$RESCUE_COMMIT_ERR"` cleanup in each terminal branch is unchanged (a `mktemp` file is a normal file).
+
+## Why this works
+
+The alternative `mktemp` family resolves a path in `$TMPDIR`/`/tmp` — always a real directory — so the redirect always opens and `git commit` actually runs. The alternative considered (`"$(git -C "$WORKTREE_DIR" rev-parse --git-dir)/..."`, which resolves to the real per-worktree git dir `<repo>/.git/worktrees/<name>`) also works but writes into git internals and adds a subprocess; `mktemp` is simpler and strictly safer.
+
+Edge case: if `mktemp` itself fails (empty result), the subsequent redirect fails the same way — but only when `/tmp` is itself broken, versus the old code's **100% failure in every linked worktree**. Strictly better; no guard needed.
+
+## Prevention
+
+1. **`.git` is a file in linked worktrees.** Any code that builds paths under `"$WORKTREE_DIR/.git/"` (scratch files, hook outputs, config) works in the main checkout but breaks (`ENOTDIR`) in a worktree. The autonomous loop **always** uses linked worktrees, so `.git`-as-directory assumptions are latent landmines. Use `mktemp`, or `git rev-parse --git-dir` when a git-local path is genuinely required.
+2. **Failed redirects fail silently.** `cmd > badpath` exits non-zero *without running `cmd`* and *without output*. Downstream logic that greps/cats the (never-created) capture file then misclassifies the failure. Watch for the "empty capture + unexpected error class" fingerprint.
+3. **Don't trust reimplementation-mirror tests.** This bug shipped because the existing test (`test_rescue_hook_failure_invariant`) reimplemented the rescue logic inline against a `mktemp -d` **non-linked** repo (where `.git` is a directory), so it never exercised the failing environment. The regression test added here has two parts: **Test C** is *source-coupled* — it greps the real `RESCUE_COMMIT_ERR` assignment and asserts it uses `mktemp`, not `.git/` (fails on the buggy code, passes on the fix); **Test D** builds a real linked worktree and proves the `.git`-is-a-file / ENOTDIR mechanics. Prefer source-coupled or real-environment tests over reimplemented mirrors that can diverge from the production environment.
+
+## Related
+
+- mika#1296 (`0eababa7`, 2026-05-26) — introduced the `.git/` scratch path. The intent (keep scratch off the working tree) was right; the location was invalid in worktrees.
+- mika#1310 — the combined stdout+stderr capture this scratch file feeds.
+- mika#1282 — the dirty-worktree rescue mechanism itself.
+- mika#1288 — the `.claude/commands` pathspec exclusion (the red herring in this bug).
+- mika#1327 — the upstream groom brake that wedged the loop until 2026-05-29, keeping this downstream bug latent for 3 days.
+- `docs/solutions/workflow-issues/failed-pilot-worktree-contamination-signature-2026-05-18.md` — sibling worktree-hygiene signature.
+- **Deploy note:** `dispatch-lib.sh` is copy-deployed (seeded to `~/.mika`, not compiled into the binary). Main-merged ≠ live until `make deploy` re-seeds bundled skills. Diff the `~/.mika` copy against source before declaring the loop unwedged.
+- Plan: `docs/plans/2026-05-30-003-fix-1341-dispatch-rescue-git-as-file-scratch-plan.md`.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -507,9 +507,18 @@ ${RESULT}"
                         fi
 
                         # Attempt rescue commit — capture stderr for hook-failure diagnosis (mika#1296).
-                        # Use a worktree-local scratch file under .git/ to avoid coupling with
-                        # .iterate/ (the iterate-loop artifact directory — review-guide.md § Orthogonality).
-                        RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"
+                        # mika#1341: scratch file MUST live outside the worktree tree, NOT under
+                        # "$WORKTREE_DIR/.git/". In a linked worktree (every autonomous dev-pilot run)
+                        # ".git" is a FILE (a `gitdir:` pointer), not a directory — so a redirect into
+                        # "$WORKTREE_DIR/.git/<name>" fails to OPEN (ENOTDIR). A failed output redirect
+                        # means `git commit` never runs and exits non-zero with no captured output,
+                        # producing the "non-rustfmt empty-capture" PIPELINE FAILURE with HEAD unchanged.
+                        # `mktemp` keeps the original intent (off the working tree, away from .iterate/)
+                        # while guaranteeing a real, writable path in both linked and non-linked checkouts.
+                        # Named template preserves the descriptive "mika-rescue-commit-err" scratch name.
+                        # NOTE: the literal token "mika-rescue-commit-err" is also a sed anchor in
+                        # test-dispatch-lib.sh (rescue-block extraction); renaming it breaks those tests.
+                        RESCUE_COMMIT_ERR="$(mktemp "${TMPDIR:-/tmp}/mika-rescue-commit-err.XXXXXX")"
 
                         # mika#1310: capture BOTH stdout and stderr. Lefthook
                         # pre-commit hooks print their summary + failure marks

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -908,7 +908,10 @@ STUB
     local REPO="mika" ISSUE_NUM="1296" SESSION_ID="test-session"
     local RESCUED_DIRTY_WORKTREE=0
     local RESULT=""
-    local RESCUE_COMMIT_ERR="$WORKTREE_DIR/.git/mika-rescue-commit-err"
+    # mika#1341: mirror the production scratch path (mktemp), not the old "$WORKTREE_DIR/.git/"
+    # location. This harness uses a non-linked `git init` repo (where .git is a directory), so
+    # either path would open here — but the mirror should track production shape for fidelity.
+    local RESCUE_COMMIT_ERR="$(mktemp)"
     local CARGO_FMT_ERR="" RESCUE_ERR_CONTENT=""
 
     # First attempt — will fail due to pre-commit hook
@@ -975,26 +978,93 @@ else
     echo "  ✗ Hook failure invariant: $RESULT_HOOK"
 fi
 
-# Test C — structural assertion: scratch file uses .git/ location (not .iterate/)
-SCRATCH_FILE_CHECK=$(grep -c 'mika-rescue-commit-err' "$DISPATCH_LIB" || true)
-if [ "$SCRATCH_FILE_CHECK" -ge 1 ]; then
-    # Verify it uses $WORKTREE_DIR/.git/ prefix
-    SCRATCH_IN_GIT=$(grep 'WORKTREE_DIR/.git/mika-rescue-commit-err' "$DISPATCH_LIB" | grep -v '^\s*#' | head -1)
-    if [ -n "$SCRATCH_IN_GIT" ]; then
-        PASS=$((PASS + 1))
-        echo "  ✓ Scratch file uses \$WORKTREE_DIR/.git/mika-rescue-commit-err (not .iterate/)"
-    else
-        FAIL=$((FAIL + 1))
-        echo "  ✗ Scratch file location does not use \$WORKTREE_DIR/.git/ prefix"
-    fi
+# Test C — structural assertion (mika#1341): the rescue scratch path MUST NOT live
+# under "$WORKTREE_DIR/.git/". In a linked worktree (every autonomous dev-pilot run)
+# ".git" is a FILE, so a redirect into "$WORKTREE_DIR/.git/<name>" fails (ENOTDIR),
+# the rescue `git commit` never runs, and the loop wedges. The active assignment must
+# use mktemp (off the working tree, valid in linked + non-linked checkouts).
+# This assertion FAILS against the pre-mika#1341 ".git/"-scratch code.
+RESCUE_ASSIGN=$(grep 'RESCUE_COMMIT_ERR=' "$DISPATCH_LIB" | grep -v '^\s*#')
+ACTIVE_ASSIGN=$(printf '%s\n' "$RESCUE_ASSIGN" | grep 'mktemp' || true)
+GIT_FILE_ASSIGN=$(printf '%s\n' "$RESCUE_ASSIGN" | grep 'WORKTREE_DIR/.git/mika-rescue-commit-err' || true)
+if [ -n "$ACTIVE_ASSIGN" ] && [ -z "$GIT_FILE_ASSIGN" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ Rescue scratch path uses mktemp, not \$WORKTREE_DIR/.git/ (mika#1341)"
 else
     FAIL=$((FAIL + 1))
-    echo "  ✗ No mika-rescue-commit-err reference found in dispatch-lib.sh"
+    echo "  ✗ Rescue scratch path must use mktemp and must NOT use \$WORKTREE_DIR/.git/ (mika#1341)"
+    echo "    active(mktemp): ${ACTIVE_ASSIGN:-<none>}"
+    echo "    git-file path:  ${GIT_FILE_ASSIGN:-<none>}"
 fi
 
 # Verify no .iterate/rescue-commit-err reference exists (regression guard)
 ITERATE_SCRATCH=$(grep -c '.iterate/rescue-commit-err' "$DISPATCH_LIB" || true)
 assert_eq "No .iterate/rescue-commit-err reference in dispatch-lib.sh" "0" "$ITERATE_SCRATCH"
+
+# Test D — live invariant (mika#1341): the rescue commit must succeed inside a real
+# LINKED worktree. Reproduces the root cause as an executable artifact: in a linked
+# worktree ".git" is a file, a redirect into "<wt>/.git/<name>" fails (ENOTDIR), but
+# a commit capturing into an mktemp path lands and advances HEAD.
+#
+# This is a standalone root-cause PROOF — it reimplements the rescue commit with its own
+# mktemp scratch and does NOT source dispatch-lib.sh, so it passes regardless of the
+# production code. The source-coupled regression guard is Test C above (which asserts the
+# production RESCUE_COMMIT_ERR assignment uses mktemp, not "$WORKTREE_DIR/.git/"). Do not
+# delete Test C assuming Test D covers the regression — Test D would still pass on buggy code.
+test_rescue_linked_worktree_invariant() {
+    local base_dir wt_dir
+    base_dir=$(mktemp -d)
+    wt_dir="${base_dir}-wt"
+    trap "git -C '$base_dir' worktree remove --force '$wt_dir' 2>/dev/null; rm -rf '$base_dir' '$wt_dir'" RETURN
+
+    # Base repo with an initial commit + an identity so commits work in CI.
+    git -C "$base_dir" init -q
+    git -C "$base_dir" config user.email "test@mika.local"
+    git -C "$base_dir" config user.name "mika test"
+    git -C "$base_dir" commit --allow-empty -m "initial" -q
+
+    # Create a LINKED worktree on a new branch.
+    git -C "$base_dir" worktree add -q -b rescue-test "$wt_dir" 2>/dev/null
+
+    local failures=""
+
+    # (1) In a linked worktree, .git is a FILE, not a directory.
+    if [ ! -f "$wt_dir/.git" ]; then
+        failures="${failures}linked worktree .git is not a file; "
+    fi
+
+    # (2) The OLD path construction fails to open (documents the ENOTDIR root cause).
+    if ( echo probe > "$wt_dir/.git/mika-rescue-commit-err" ) 2>/dev/null; then
+        failures="${failures}redirect into <wt>/.git/<name> unexpectedly succeeded; "
+    fi
+
+    # (3) The FIXED approach: capture into an mktemp path; the rescue commit lands.
+    local pre_head post_head scratch
+    pre_head=$(git -C "$wt_dir" rev-parse HEAD)
+    echo "pilot wrote this but never committed" > "$wt_dir/impl.txt"
+    git -C "$wt_dir" add -A -- ':!.claude/commands/' 2>/dev/null
+    scratch="$(mktemp)"
+    if git -C "$wt_dir" commit -m "wip(mika#1341): rescue in linked worktree" > "$scratch" 2>&1; then
+        post_head=$(git -C "$wt_dir" rev-parse HEAD)
+        [ "$pre_head" != "$post_head" ] || failures="${failures}HEAD did not advance after rescue commit; "
+        git -C "$wt_dir" diff --quiet HEAD -- impl.txt || failures="${failures}impl.txt not committed; "
+    else
+        failures="${failures}rescue commit failed with mktemp scratch path; "
+    fi
+    rm -f "$scratch"
+    [ ! -f "$scratch" ] || failures="${failures}scratch not cleaned; "
+
+    if [ -z "$failures" ]; then echo "PASS"; else echo "FAIL: $failures"; fi
+}
+
+RESULT_LWT=$(test_rescue_linked_worktree_invariant 2>/dev/null)
+if [ "$RESULT_LWT" = "PASS" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ Linked-worktree rescue: .git is a file, mktemp scratch lands the commit (mika#1341)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ Linked-worktree rescue invariant: $RESULT_LWT"
+fi
 
 # --- Test 11: Idempotency-bypass-architect fabrication brake retired (mika#1327) ---
 


### PR DESCRIPTION
Closes #1341. Re-scoped from claude-pilot-py#24 (closed — fix surface is entirely in this repo).

## Why

The autonomous loop's dirty-worktree auto-rescue (`skills/bundled/_shared/dispatch-lib.sh`, mika#1282/#1296/#1310) silently failed to commit in **every linked git worktree** — i.e. every autonomous `dev-pilot` run (`.claude/worktrees/<branch>/<repo>`). The pilot wrote the correct edit, but the rescue commit never landed: no branch pushed, no PR. This was the downstream wedge that surfaced after mika#1327 unblocked the groom layer on 2026-05-29.

## Root cause (confirmed by live repro)

`dispatch-lib.sh` wrote its commit-capture scratch file to `"$WORKTREE_DIR/.git/mika-rescue-commit-err"`. **In a linked worktree, `.git` is a FILE (a `gitdir:` pointer), not a directory.** So the redirect:

```sh
git -C "$WORKTREE_DIR" commit -m "..." > "$RESCUE_COMMIT_ERR" 2>&1
```

could not open its output target (`ENOTDIR`). Per POSIX shell semantics, **a failed output redirection means the command is never executed and exits non-zero with no output written.** Every observed symptom traces to this one line:

| Symptom | Mechanism |
|---|---|
| HEAD unchanged, edit uncommitted, no PR | `git commit` never runs (redirect open fails) |
| `rejected by pre-commit hook (non-rustfmt)` | `if git commit` → exit≠0 → `elif grep rustfmt <file>` → file absent → no match → non-rustfmt `else` branch |
| `<rescue capture was empty>` | `cat <file>` → file never created → empty → mika#1310 git-status diagnostic fallback |

**Ruled out (red herrings):** injected `.claude/commands` pollution (already excluded by mika#1288 — appears only in the diagnostic dump); `lefthook` missing from PATH (the hook's fallthrough returns 0; no `lefthook.yml` job matches a lone `Dockerfile.agent` stage).

**Provenance:** introduced by mika#1296 (`0eababa7`, 2026-05-26); latent 3 days because mika#1327's groom brake wedged the loop upstream until 2026-05-29.

## What

- **`dispatch-lib.sh`** — one-line fix: `RESCUE_COMMIT_ERR="$(mktemp "${TMPDIR:-/tmp}/mika-rescue-commit-err.XXXXXX")"`. Valid in linked and non-linked checkouts; preserves the original mika#1296 intent (off the working tree, away from `.iterate/`), the descriptive scratch name, and the literal `mika-rescue-commit-err` token that several tests use as a `sed` anchor. Single assignment feeds all three commit-attempt paths; existing `rm -f` cleanup unchanged.
- **`test-dispatch-lib.sh`** — **Test C** (source-coupled structural assertion: the `RESCUE_COMMIT_ERR` assignment must use `mktemp`, not `.git/` — **fails on the buggy code, passes on the fix**) + **Test D** (linked-worktree live invariant proving the `.git`-is-a-file / ENOTDIR mechanics). Also fixed **Test B**, which masked the bug by reimplementing the rescue logic against a non-linked `mktemp -d` repo.

## Verification

- `bash skills/bundled/_shared/test-dispatch-lib.sh` → **145 passed, 7 failed**. The 7 failures are **pre-existing on `main`** (unrelated self-dev-prompt + case-switch greps), unchanged by this PR.
- **Negative control:** temporarily reverting the production line to the buggy `.git/` path makes **Test C fail** — confirming the test guards the bug (AC2).
- `bash -n` clean on both files; commit landed through the real `lefthook` pre-commit hook.

## Deploy note

`dispatch-lib.sh` is copy-deployed (seeded to `~/.mika`, not compiled into the binary). Main-merged ≠ live until `make deploy` re-seeds bundled skills — diff the `~/.mika` copy against source before declaring the loop unwedged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)