### PR TITLE
feat(qa-review): add review depth declaration to verdict output (mika#275)

### DIFF
--- a/crates/mika-agent/src/server/verdict.rs
+++ b/crates/mika-agent/src/server/verdict.rs
@@ -14,6 +14,16 @@ pub(crate) struct PrReviewEvent {
     pub body: String,
 }
 
+/// Review depth parsed from a verdict body (mika#275).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ReviewDepth {
+    CodeLevel,
+    CodeLevelPartial,
+    MetadataOnly,
+    /// DEPTH line was present but had an unrecognized value.
+    Unknown(String),
+}
+
 impl PrReviewEvent {
     /// Construct the PR HTML URL from repo and number.
     pub fn pr_url(&self) -> String {
@@ -37,6 +47,9 @@ static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
 
 static VERDICT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?mi)^VERDICT:\s*(.+)$").expect("verdict regex"));
+
+static DEPTH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?mi)^DEPTH:\s*(.+)$").expect("depth regex"));
 
 static BLOCK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^block\[([^\]]+)\]$").expect("block regex"));
@@ -118,6 +131,20 @@ pub(crate) fn parse_verdict(body: &str) -> Verdict {
     Verdict::Missing {
         truncated: body.contains("[truncated]"),
     }
+}
+
+/// Parse review depth from a verdict body (mika#275).
+///
+/// Returns `None` if no `DEPTH:` line is present (backward compat).
+pub(crate) fn parse_review_depth(body: &str) -> Option<ReviewDepth> {
+    let caps = DEPTH_RE.captures(body)?;
+    let value = caps[1].trim();
+    Some(match value.to_lowercase().as_str() {
+        "code-level" => ReviewDepth::CodeLevel,
+        "code-level (partial)" => ReviewDepth::CodeLevelPartial,
+        "metadata-only" => ReviewDepth::MetadataOnly,
+        _ => ReviewDepth::Unknown(value.to_string()),
+    })
 }
 
 #[cfg(test)]
@@ -244,5 +271,58 @@ Please fix the pipeline issues.";
 
         let text2 = "[GitHub] PR review (approved) on repo#notanumber (title) by @user";
         assert!(parse_pr_review_event(text2).is_none());
+    }
+
+    // --- Review depth parsing tests (mika#275) ---
+
+    #[test]
+    fn parse_depth_code_level() {
+        let body = "VERDICT: pass\nDEPTH: code-level\nREASON: all good";
+        assert_eq!(parse_review_depth(body), Some(ReviewDepth::CodeLevel));
+    }
+
+    #[test]
+    fn parse_depth_code_level_partial() {
+        let body = "VERDICT: pass\nDEPTH: code-level (partial)\nREASON: truncated diff";
+        assert_eq!(
+            parse_review_depth(body),
+            Some(ReviewDepth::CodeLevelPartial)
+        );
+    }
+
+    #[test]
+    fn parse_depth_metadata_only() {
+        let body = "VERDICT: hold[review]\nDEPTH: metadata-only\nREASON: diff unavailable";
+        assert_eq!(parse_review_depth(body), Some(ReviewDepth::MetadataOnly));
+    }
+
+    #[test]
+    fn parse_depth_missing_returns_none() {
+        let body = "VERDICT: pass\nREASON: all good";
+        assert_eq!(parse_review_depth(body), None);
+    }
+
+    #[test]
+    fn parse_depth_case_insensitive() {
+        let body = "DEPTH: Code-Level";
+        assert_eq!(parse_review_depth(body), Some(ReviewDepth::CodeLevel));
+
+        let body2 = "DEPTH: METADATA-ONLY";
+        assert_eq!(parse_review_depth(body2), Some(ReviewDepth::MetadataOnly));
+    }
+
+    #[test]
+    fn parse_depth_unknown_value() {
+        let body = "DEPTH: something-else";
+        assert_eq!(
+            parse_review_depth(body),
+            Some(ReviewDepth::Unknown("something-else".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_depth_first_match_wins() {
+        let body = "DEPTH: code-level\nDEPTH: metadata-only";
+        assert_eq!(parse_review_depth(body), Some(ReviewDepth::CodeLevel));
     }
 }

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -31,7 +31,9 @@ use crate::tools::pr_merge_with_gate::{
     CheckClassification, classify_checks, run_gh_checks, run_gh_merge,
 };
 
-use super::verdict::{PrReviewEvent, Verdict, parse_pr_review_event, parse_verdict};
+use super::verdict::{
+    PrReviewEvent, Verdict, parse_pr_review_event, parse_review_depth, parse_verdict,
+};
 use super::webhook_queue::has_active_callback_child;
 
 /// Maximum block[ac] retries before escalation.
@@ -76,6 +78,16 @@ pub async fn try_handle_pr_review_verdict(
 
     // 2. Parse the verdict — authoritative regardless of GH review.state (#889)
     let verdict = parse_verdict(&event.body);
+
+    // 2b. Parse and log review depth (mika#275) — informational metadata
+    let review_depth = parse_review_depth(&event.body);
+    info!(
+        event = "verdict_review_depth",
+        pr_number = event.pr_number,
+        repo = %event.repo,
+        review_depth = ?review_depth,
+        "parsed review depth from verdict body"
+    );
 
     match verdict {
         Verdict::Pass => {

--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -1806,6 +1806,33 @@ pub fn validate_tool_arg_suffixes(
     Ok(())
 }
 
+/// Known valid DEPTH values for review depth declaration (mika#275).
+const VALID_DEPTH_VALUES: &[&str] = &["code-level", "code-level (partial)", "metadata-only"];
+
+/// Validate that a `pr review --body` contains a `DEPTH:` line (mika#275).
+///
+/// Called in `run_gh` BEFORE subprocess spawn, only when `required_tool_arg_suffixes`
+/// is active (qa-review skill loaded). Returns a corrective error if missing.
+pub fn validate_review_depth_present(body: &str) -> Result<(), ToolOutput> {
+    let has_depth = body.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("DEPTH:")
+    });
+
+    if !has_depth {
+        return Err(ToolOutput::error(format!(
+            "{{\"error\": \"review_depth_missing\", \"message\": \
+             \"The --body argument of this `pr review` call is missing a DEPTH: line. \
+             Every review verdict must declare review depth between VERDICT: and REASON:. \
+             Valid values: {}. \
+             Re-emit the tool call with DEPTH: <value> after the VERDICT: line.\"}}",
+            VALID_DEPTH_VALUES.join(", ")
+        )));
+    }
+
+    Ok(())
+}
+
 /// Validated `run_gh` input — command args and optional repo.
 #[derive(Debug)]
 struct GhArgs {
@@ -2071,6 +2098,16 @@ async fn run_gh(input: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolOutput 
                 .store(true, std::sync::atomic::Ordering::Release);
             return err;
         }
+    }
+
+    // Review depth declaration validation (mika#275): check that --body of
+    // `pr review` contains a DEPTH: line. Runs only when required_tool_arg_suffixes
+    // is non-empty (i.e., qa-review skill is active — same gating).
+    if !ctx.required_tool_arg_suffixes.is_empty()
+        && let Some(body) = extract_pr_review_body(&gh_args.args)
+        && let Err(err) = validate_review_depth_present(&body)
+    {
+        return err;
     }
 
     // Audit event for `gh api` invocations — structural observability for the
@@ -6428,6 +6465,40 @@ mod tests {
     #[test]
     fn test_extractor_for_unknown_key() {
         assert!(extractor_for_key("nonexistent_key").is_none());
+    }
+
+    // -- validate_review_depth_present tests (mika#275) --
+
+    #[test]
+    fn test_depth_present_passes() {
+        let body = "VERDICT: pass\nDEPTH: code-level\nREASON: all good";
+        assert!(validate_review_depth_present(body).is_ok());
+    }
+
+    #[test]
+    fn test_depth_present_partial_passes() {
+        let body = "VERDICT: pass\nDEPTH: code-level (partial)\nREASON: truncated";
+        assert!(validate_review_depth_present(body).is_ok());
+    }
+
+    #[test]
+    fn test_depth_present_metadata_only_passes() {
+        let body = "VERDICT: hold[review]\nDEPTH: metadata-only\nREASON: diff unavailable";
+        assert!(validate_review_depth_present(body).is_ok());
+    }
+
+    #[test]
+    fn test_depth_missing_fails() {
+        let body = "VERDICT: pass\nREASON: all good\n\nDIFF ANALYSIS:\nFiles: 3";
+        let result = validate_review_depth_present(body);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.content.contains("review_depth_missing"));
+    }
+
+    #[test]
+    fn test_depth_empty_body_fails() {
+        assert!(validate_review_depth_present("").is_err());
     }
 
     // -- validate_qa_review_gh_scope tests (mika#1196) --

--- a/crates/mika-agent/src/skills/context.rs
+++ b/crates/mika-agent/src/skills/context.rs
@@ -31,12 +31,62 @@ static CONTEXT_CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("failed to build context HTTP client")
 });
 
+/// Status of a resolved context block, derived from resolution outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextStatus {
+    /// Full content was available and injected.
+    Full,
+    /// Content was truncated due to budget constraints.
+    Truncated,
+    /// Context resolution failed; sentinel text was injected.
+    Unavailable,
+}
+
+impl ContextStatus {
+    /// Label used in the `<!-- context_meta: ... -->` annotation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContextStatus::Full => "full",
+            ContextStatus::Truncated => "truncated",
+            ContextStatus::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// Sentinel prefix for unavailable context blocks.
+const UNAVAILABLE_SENTINEL_PREFIX: &str = "(Context unavailable:";
+
 /// Resolved context block ready for template injection.
 #[derive(Debug, Clone)]
 pub struct ContextBlock {
     pub name: String,
     pub content: String,
     pub truncated: bool,
+    /// The context type from the skill manifest (e.g., "gh_pr_diff").
+    pub context_type: String,
+}
+
+impl ContextBlock {
+    /// Derive the context status from the block's state.
+    pub fn status(&self) -> ContextStatus {
+        if self.content.starts_with(UNAVAILABLE_SENTINEL_PREFIX) {
+            ContextStatus::Unavailable
+        } else if self.truncated {
+            ContextStatus::Truncated
+        } else {
+            ContextStatus::Full
+        }
+    }
+
+    /// Build the metadata annotation comment line for this context block.
+    pub fn metadata_annotation(&self) -> String {
+        format!(
+            "<!-- context_meta: type={}, status={}, chars={} -->",
+            self.context_type,
+            self.status().as_str(),
+            self.content.len(),
+        )
+    }
 }
 
 /// Resolve context requirements for matched skills.
@@ -147,6 +197,7 @@ pub async fn resolve_contexts(
                                 context_type
                             ),
                             truncated: false,
+                            context_type: context_type.clone(),
                         },
                     );
                 }
@@ -180,7 +231,7 @@ pub fn apply_context_replacements(prompt: &str, context: &HashMap<String, Contex
             let key = &caps[1];
             context
                 .get(key)
-                .map(|b| b.content.clone())
+                .map(|b| format!("{}\n{}", b.metadata_annotation(), b.content))
                 .unwrap_or_else(|| caps[0].to_string())
         })
         .into_owned()
@@ -214,6 +265,7 @@ async fn resolve_gh_pr_diff(message: &str, github_token: Option<&str>) -> Result
             name: "pr_diff".to_string(),
             content: "(No file changes in this pull request.)".to_string(),
             truncated: false,
+            context_type: "gh_pr_diff".to_string(),
         });
     }
 
@@ -226,6 +278,7 @@ async fn resolve_gh_pr_diff(message: &str, github_token: Option<&str>) -> Result
             name: "pr_diff".to_string(),
             content: diff,
             truncated: false,
+            context_type: "gh_pr_diff".to_string(),
         })
     }
 }
@@ -363,6 +416,7 @@ pub fn truncate_diff(raw_diff: &str, char_budget: usize) -> ContextBlock {
             name: "pr_diff".to_string(),
             content: raw_diff[..raw_diff.floor_char_boundary(char_budget)].to_string(),
             truncated: true,
+            context_type: "gh_pr_diff".to_string(),
         };
     }
 
@@ -424,6 +478,7 @@ pub fn truncate_diff(raw_diff: &str, char_budget: usize) -> ContextBlock {
         name: "pr_diff".to_string(),
         content: result,
         truncated: true,
+        context_type: "gh_pr_diff".to_string(),
     }
 }
 
@@ -464,19 +519,27 @@ mod tests {
         assert_eq!(number, 1);
     }
 
+    /// Helper to build a test ContextBlock with default context_type.
+    fn test_block(name: &str, content: &str, truncated: bool) -> ContextBlock {
+        ContextBlock {
+            name: name.to_string(),
+            content: content.to_string(),
+            truncated,
+            context_type: "test_type".to_string(),
+        }
+    }
+
     #[test]
     fn test_apply_context_replacements_basic() {
         let mut ctx = HashMap::new();
         ctx.insert(
             "pr_diff".to_string(),
-            ContextBlock {
-                name: "pr_diff".to_string(),
-                content: "the diff content".to_string(),
-                truncated: false,
-            },
+            test_block("pr_diff", "the diff content", false),
         );
         let result = apply_context_replacements("Review this: {{pr_diff}} end", &ctx);
-        assert_eq!(result, "Review this: the diff content end");
+        assert!(result.contains("<!-- context_meta: type=test_type, status=full, chars=16 -->"));
+        assert!(result.contains("the diff content"));
+        assert!(result.ends_with(" end"));
     }
 
     #[test]
@@ -489,14 +552,7 @@ mod tests {
     #[test]
     fn test_apply_context_replacements_no_placeholders() {
         let mut ctx = HashMap::new();
-        ctx.insert(
-            "key".to_string(),
-            ContextBlock {
-                name: "key".to_string(),
-                content: "value".to_string(),
-                truncated: false,
-            },
-        );
+        ctx.insert("key".to_string(), test_block("key", "value", false));
         let result = apply_context_replacements("no placeholders", &ctx);
         assert_eq!(result, "no placeholders");
     }
@@ -507,23 +563,15 @@ mod tests {
         let mut ctx = HashMap::new();
         ctx.insert(
             "pr_diff".to_string(),
-            ContextBlock {
-                name: "pr_diff".to_string(),
-                content: "contains {{other_key}} text".to_string(),
-                truncated: false,
-            },
+            test_block("pr_diff", "contains {{other_key}} text", false),
         );
         ctx.insert(
             "other_key".to_string(),
-            ContextBlock {
-                name: "other_key".to_string(),
-                content: "SHOULD NOT APPEAR".to_string(),
-                truncated: false,
-            },
+            test_block("other_key", "SHOULD NOT APPEAR", false),
         );
         let result = apply_context_replacements("{{pr_diff}}", &ctx);
         // The {{other_key}} inside pr_diff's content should NOT be replaced
-        assert_eq!(result, "contains {{other_key}} text");
+        assert!(result.contains("contains {{other_key}} text"));
     }
 
     #[test]
@@ -592,23 +640,104 @@ mod tests {
     #[test]
     fn test_apply_context_replacements_multiple_keys() {
         let mut ctx = HashMap::new();
-        ctx.insert(
-            "key_a".to_string(),
-            ContextBlock {
-                name: "key_a".to_string(),
-                content: "AAA".to_string(),
-                truncated: false,
-            },
-        );
-        ctx.insert(
-            "key_b".to_string(),
-            ContextBlock {
-                name: "key_b".to_string(),
-                content: "BBB".to_string(),
-                truncated: false,
-            },
-        );
+        ctx.insert("key_a".to_string(), test_block("key_a", "AAA", false));
+        ctx.insert("key_b".to_string(), test_block("key_b", "BBB", false));
         let result = apply_context_replacements("start {{key_a}} middle {{key_b}} end", &ctx);
-        assert_eq!(result, "start AAA middle BBB end");
+        assert!(result.contains("AAA"));
+        assert!(result.contains("BBB"));
+    }
+
+    // --- Step 1 tests: context metadata annotation ---
+
+    #[test]
+    fn test_context_status_full() {
+        let block = test_block("pr_diff", "diff content", false);
+        assert_eq!(block.status(), ContextStatus::Full);
+    }
+
+    #[test]
+    fn test_context_status_truncated() {
+        let block = test_block("pr_diff", "partial diff...", true);
+        assert_eq!(block.status(), ContextStatus::Truncated);
+    }
+
+    #[test]
+    fn test_context_status_unavailable() {
+        let block = test_block(
+            "pr_diff",
+            "(Context unavailable: gh_pr_diff resolution failed)",
+            false,
+        );
+        assert_eq!(block.status(), ContextStatus::Unavailable);
+    }
+
+    #[test]
+    fn test_metadata_annotation_full() {
+        let block = ContextBlock {
+            name: "pr_diff".to_string(),
+            content: "some diff".to_string(),
+            truncated: false,
+            context_type: "gh_pr_diff".to_string(),
+        };
+        assert_eq!(
+            block.metadata_annotation(),
+            "<!-- context_meta: type=gh_pr_diff, status=full, chars=9 -->"
+        );
+    }
+
+    #[test]
+    fn test_metadata_annotation_truncated() {
+        let block = ContextBlock {
+            name: "pr_diff".to_string(),
+            content: "partial...".to_string(),
+            truncated: true,
+            context_type: "gh_pr_diff".to_string(),
+        };
+        assert_eq!(
+            block.metadata_annotation(),
+            "<!-- context_meta: type=gh_pr_diff, status=truncated, chars=10 -->"
+        );
+    }
+
+    #[test]
+    fn test_metadata_annotation_unavailable() {
+        let block = ContextBlock {
+            name: "pr_diff".to_string(),
+            content: "(Context unavailable: gh_pr_diff resolution failed)".to_string(),
+            truncated: false,
+            context_type: "gh_pr_diff".to_string(),
+        };
+        assert_eq!(
+            block.metadata_annotation(),
+            "<!-- context_meta: type=gh_pr_diff, status=unavailable, chars=51 -->"
+        );
+    }
+
+    #[test]
+    fn test_apply_context_replacements_prepends_metadata() {
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "pr_diff".to_string(),
+            ContextBlock {
+                name: "pr_diff".to_string(),
+                content: "the diff".to_string(),
+                truncated: false,
+                context_type: "gh_pr_diff".to_string(),
+            },
+        );
+        let result = apply_context_replacements("BEGIN {{pr_diff}} END", &ctx);
+        assert!(result.contains("<!-- context_meta: type=gh_pr_diff, status=full, chars=8 -->"));
+        assert!(result.contains("the diff"));
+        // Metadata annotation should come before the content
+        let meta_pos = result.find("<!-- context_meta:").unwrap();
+        let content_pos = result.find("the diff").unwrap();
+        assert!(meta_pos < content_pos);
+    }
+
+    #[test]
+    fn test_truncate_diff_includes_context_type() {
+        let diff = "diff --git a/file.rs b/file.rs\n+line\n";
+        let result = truncate_diff(diff, 100);
+        assert_eq!(result.context_type, "gh_pr_diff");
     }
 }

--- a/docs/plans/2026-05-28-001-feat-qa-review-depth-declaration-plan.md
+++ b/docs/plans/2026-05-28-001-feat-qa-review-depth-declaration-plan.md
@@ -1,0 +1,188 @@
+# Plan: mika-qa review comments should declare review depth
+
+**Issue:** mika#275
+**Type:** feat
+**Date:** 2026-05-28
+
+## Problem
+
+When mika-qa posts a PR review comment, there is no indication of whether the review was based on actual code analysis or just PR metadata. A review that only checked file names and CI status looks identical to one that read every line of the diff. This creates false confidence in review thoroughness.
+
+## Analysis
+
+### Current state
+
+The qa-review skill's review process works as follows:
+
+1. **Diff injection is engine-owned:** The engine pre-fetches the PR diff via `resolve_contexts()` in `skills/context.rs` before the LLM turn. The diff is injected as a `{{pr_diff}}` template variable into the skill's system prompt. The context declaration in `skill.toml` is `[context.pr_diff]` with `type = "gh_pr_diff"` and `required = false`.
+
+2. **Three diff availability outcomes:**
+   - **Full diff available:** `ContextBlock { content: <diff>, truncated: false }` — the LLM receives the complete diff.
+   - **Truncated diff:** `ContextBlock { content: <partial>, truncated: true }` — the diff exceeded the 200K char budget. The injected content includes truncation markers like `--- Diff truncated at ~200K chars ---` with a list of omitted files.
+   - **Context resolution failed:** Sentinel text `(Context unavailable: gh_pr_diff resolution failed)` replaces `{{pr_diff}}`. Since `required = false`, the skill still runs but has no diff content.
+
+3. **Current review output format:** The verdict body includes a `DIFF ANALYSIS:` section with files reviewed count and key changes. But there is no declaration of whether the diff was actually available, truncated, or completely missing.
+
+4. **Engine verdict validation:** The `required_tool_arg_suffixes` in `skill.toml` validates that the `--body` arg of `run_gh pr review` contains one of the known `VERDICT:` lines. This validation runs BEFORE subprocess spawn.
+
+### Design approach
+
+The review-depth declaration must be:
+- **Accurate:** Reflect the actual diff availability, not a guess.
+- **Engine-assisted where possible:** The engine knows the `ContextBlock.truncated` flag and whether resolution failed. Surfacing this metadata to the skill prompt removes reliance on the LLM self-reporting.
+- **Enforced:** The declaration must appear in every verdict body, not just when the LLM remembers.
+
+### Three-layer approach
+
+1. **Engine layer:** Surface diff availability metadata alongside the injected content so the LLM has ground truth about what it received.
+2. **Prompt layer:** Require the review-depth declaration in the verdict output format.
+3. **Guard layer:** Add a structural guard (or extend existing `required_tool_arg_suffixes`) to enforce the declaration's presence before the review posts.
+
+## Implementation
+
+### Step 1: Surface context metadata in skill prompts
+
+**File:** `crates/mika-agent/src/skills/context.rs`
+
+Add a metadata annotation to the injected context content. When `apply_context_replacements()` replaces `{{pr_diff}}`, prepend a machine-readable metadata line that the LLM can reference:
+
+```
+<!-- context_meta: type=gh_pr_diff, status=full|truncated|unavailable, chars=N -->
+```
+
+This is injected by the engine (not the LLM), so it's ground truth.
+
+**Changes:**
+- Add a `ContextStatus` enum: `Full`, `Truncated`, `Unavailable`.
+- Derive status from `ContextBlock`: `truncated=true` → `Truncated`; sentinel content → `Unavailable`; else → `Full`.
+- In `apply_context_replacements()`, when replacing a `{{key}}` placeholder with a context block, prepend the metadata comment line.
+
+**File:** `crates/mika-agent/src/agent.rs`
+
+No changes needed — `apply_context_replacements()` is already called on skill prompts, so the metadata annotation flows through automatically.
+
+### Step 2: Add review-depth declaration to the skill prompt
+
+**File:** `skills/bundled/qa-review/system_prompt.md`
+
+**2a. Define the depth taxonomy** (add after the Step Budget section):
+
+Add a `### Review Depth Declaration` section that defines the three depth levels and their mapping to context status:
+
+| Depth | Meaning | Context status |
+|-------|---------|----------------|
+| `code-level` | Full diff was available and reviewed | `status=full` |
+| `code-level (partial)` | Diff was truncated; review covers included files only | `status=truncated` |
+| `metadata-only` | Diff was unavailable; review is based on file list and PR metadata only | `status=unavailable` |
+
+Instruct the LLM to read the `<!-- context_meta: ... -->` annotation from the injected `{{pr_diff}}` block to determine the depth. If the annotation is missing (pre-upgrade edge case), infer from content: presence of actual diff hunks → `code-level`; sentinel text → `metadata-only`.
+
+**2b. Add the declaration to the verdict output format** (modify Step 5 and the Verdict Output section):
+
+The verdict body must begin with:
+
+```
+VERDICT: <class>
+DEPTH: <code-level|code-level (partial)|metadata-only>
+REASON: <one-line summary>
+```
+
+The `DEPTH:` line goes between `VERDICT:` and `REASON:` — this matches the existing pattern of structured metadata at the top of the verdict body.
+
+**2c. Add data integrity rule** for degraded depth:
+
+When `DEPTH: metadata-only`, the maximum verdict is `hold[review]` — the agent must not approve a PR it couldn't read the code for. This reinforces the existing rule: "If any step was skipped due to a tool failure, the maximum verdict is `hold[review]`."
+
+When `DEPTH: code-level (partial)`, the DIFF ANALYSIS must list which files were included vs omitted. The agent may still approve if the reviewed files cover all meaningful changes.
+
+**2d. Update all verdict examples** in the system prompt to include the `DEPTH:` line.
+
+### Step 3: Add engine-side guard for depth declaration
+
+**File:** `skills/bundled/qa-review/skill.toml`
+
+Extend the `[[output.required_tool_arg_suffixes]]` section. The existing guard validates `VERDICT:` lines. We cannot use the same mechanism for `DEPTH:` because `required_tool_arg_suffixes` checks for lines matching any entry in `required_lines` as a suffix — but `DEPTH:` has variable values.
+
+Instead, use the existing `required_suffix_lines` mechanism on skill.toml's `[output]` section — but this also won't work because the depth line is not a suffix, it's in the middle of the body.
+
+**Better approach:** Add a new manifest-level `[output]` field: `required_body_lines`. This is a list of regex patterns that must appear somewhere in the verdict body (not just suffix). The engine validates these against the `--body` argument of `run_gh pr review` before subprocess spawn, just like `required_tool_arg_suffixes`.
+
+**However**, this adds a new engine feature for a single use case. A simpler approach that stays within existing mechanisms:
+
+**Simplest approach — prompt-only enforcement with DIFF ANALYSIS guard:**
+
+The existing Data Integrity Rule already states: "Your verdict output MUST include a `DIFF ANALYSIS` section." The DIFF ANALYSIS section already requires file counts and key changes. We add the `DEPTH:` line to the verdict format and rely on:
+
+1. The prompt discipline (mika-qa has strong prompt compliance — 22 steps of structured process).
+2. The existing `DIFF ANALYSIS` section requirement (if the LLM emits DIFF ANALYSIS, it's already parsing context to determine what it reviewed).
+3. A lightweight post-condition check: scan the `--body` arg of `run_gh pr review` for `DEPTH:` presence. If missing, reject with a corrective error (same pattern as the existing verdict-trailer guard).
+
+**File:** `crates/mika-agent/src/skills/builtin_handlers.rs` (or wherever `run_gh` validates `pr_review_body`)
+
+Add a `DEPTH:` line presence check to the existing `pr_review_body` validation path. The check is simple string containment (`body.contains("\nDEPTH: ")`), not regex. If missing, return a structured validation error with a corrective message.
+
+### Step 4: Parse and surface depth in verdict handler
+
+**File:** `crates/mika-agent/src/server/verdict.rs`
+
+Add a `review_depth` field to the `PrReviewEvent` or `Verdict` struct. Parse it from the `DEPTH:` line in the verdict body using a simple regex: `^DEPTH:\s*(.+)$`. This makes review depth available for:
+- Structured logging (operator observability).
+- Future dashboard display.
+- Task metadata (via `try_extract_callback_metadata`).
+
+**File:** `crates/mika-agent/src/server/verdict_handler.rs`
+
+Log the parsed `review_depth` in the existing verdict-handling structured log events. No behavioral changes to verdict routing — depth is informational metadata, not a routing signal.
+
+### Step 5: Tests
+
+**5a. Unit test for context metadata injection:**
+- `context.rs`: Test that `apply_context_replacements()` prepends the `<!-- context_meta: ... -->` annotation.
+- Test all three statuses: full, truncated, unavailable (sentinel content).
+
+**5b. Unit test for depth line validation:**
+- Test that the `run_gh pr review` validator rejects bodies missing `DEPTH:`.
+- Test that bodies with valid `DEPTH:` lines pass validation.
+
+**5c. Unit test for verdict parsing:**
+- `verdict.rs`: Test that `DEPTH:` line is parsed correctly from verdict bodies.
+- Test missing depth (backward compat — should default to `None`, not error).
+
+**5d. Grounding regression test (optional, recommended):**
+- Add a scenario to `tests/eval/grounding_regressions/` that verifies the qa-review skill emits a `DEPTH:` line when given a diff context with known status.
+
+## Scope boundaries
+
+### In scope
+- Engine-side context metadata annotation (Step 1)
+- Skill prompt depth declaration requirement (Step 2)
+- Lightweight engine-side `DEPTH:` presence validation on `pr review --body` (Step 3)
+- Verdict parser extension for depth field (Step 4)
+- Unit tests (Step 5)
+
+### Out of scope
+- Dashboard UI display of review depth (future: surface via task metadata or LLM call detail)
+- Retroactive depth classification of past reviews
+- Per-file depth tracking (file-level granularity beyond the truncation omitted-files list)
+- New `[output]` manifest mechanism for body-line validation (rejected: too heavy for this use case)
+
+## Risk assessment
+
+**Low risk.** Changes are additive:
+- Context metadata annotation is invisible to the LLM (HTML comment) and backward-compatible.
+- Prompt changes add requirements but don't change existing behavior.
+- The `DEPTH:` validation in `run_gh` is a pre-spawn check — same pattern as the existing verdict-trailer guard. Failure returns a corrective error, not a hard block.
+- Verdict parser extension is additive (new optional field).
+
+**Migration:** No schema changes. No breaking API changes. The `DEPTH:` line in verdict bodies is new — existing review comments won't have it, but the parser handles `None` gracefully.
+
+## Acceptance criteria
+
+- [ ] Every mika-qa review comment includes a `DEPTH:` line in the verdict body (between `VERDICT:` and `REASON:`)
+- [ ] The depth value accurately reflects the diff availability: `code-level` when full diff was injected, `code-level (partial)` when truncated, `metadata-only` when unavailable
+- [ ] Engine injects `<!-- context_meta: ... -->` annotation into context-replaced skill prompts so the LLM has ground truth about context status
+- [ ] `run_gh pr review` body validation rejects verdict bodies missing the `DEPTH:` line with a corrective error
+- [ ] `metadata-only` depth caps the maximum verdict at `hold[review]` (prompt-enforced)
+- [ ] Verdict parser (`verdict.rs`) extracts the `DEPTH:` value into a structured field for logging
+- [ ] Unit tests cover context metadata injection (3 statuses), depth validation (present/absent), and verdict parsing (with/without depth)
+- [ ] No test regressions (`cargo test`)

--- a/skills/bundled/qa-review/system_prompt.md
+++ b/skills/bundled/qa-review/system_prompt.md
@@ -47,6 +47,22 @@ These rules override everything else in this prompt:
 - A qa-review turn is ONLY complete when a successful `run_gh("pr review …")` call appears in this turn's tool history. Emitting verdict text without calling `pr review` is a **protocol violation** — the `pull_request_review.submitted` webhook never fires, mika-dev never receives the verdict, and the dev↔qa contract is broken end-to-end. If you have composed verdict text but have not yet called `run_gh pr review`, you are not done — call it before ending the turn. The posted GitHub review is the source of truth; the verdict text in your response is only a mirror for logging.
 - When your verdict body asserts a quantitative claim about PR content (counts, percentages, presence/absence of sections), you MUST have a tool-result citation for that claim. If you cannot cite a specific line from a tool result, downgrade the claim to "could not verify" rather than asserting it as fact.
 
+### Review Depth Declaration
+
+Every verdict MUST include a `DEPTH:` line that honestly declares the level of code analysis performed. The depth is determined by the engine-injected diff availability — read the `<!-- context_meta: ... -->` annotation prepended to the `{{pr_diff}}` block below.
+
+| Depth | Meaning | Context status |
+|-------|---------|----------------|
+| `code-level` | Full diff was available and reviewed | `status=full` |
+| `code-level (partial)` | Diff was truncated; review covers included files only | `status=truncated` |
+| `metadata-only` | Diff was unavailable; review is based on file list and PR metadata only | `status=unavailable` |
+
+**Rules:**
+- Read the `<!-- context_meta: type=gh_pr_diff, status=..., chars=... -->` annotation to determine the status. If no annotation is present (pre-upgrade edge case), infer from content: presence of actual diff hunks → `code-level`; sentinel text `(Context unavailable: ...)` → `metadata-only`.
+- When `DEPTH: metadata-only`, the maximum verdict is `hold[review]` — you MUST NOT approve a PR whose code you could not read. State the reason (e.g., "diff exceeded context limit", "diff resolution failed").
+- When `DEPTH: code-level (partial)`, the DIFF ANALYSIS must list which files were included vs omitted. You may still approve if the reviewed files cover all meaningful changes.
+- The `DEPTH:` line goes between `VERDICT:` and `REASON:` in the verdict block.
+
 ### Review Process
 
 Execute these steps in order. Stop at the first hard block.
@@ -437,11 +453,11 @@ Post your verdict as a GitHub pull request review using `run_gh`. The review typ
 | `block[ac]` | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 | `block` (other sub-types) | Comment | `run_gh("pr review <NUMBER> --comment --body '<verdict_body>'")` |
 
-The `<verdict_body>` is your full verdict output, structured **VERDICT-FIRST** so the routing token survives any transport-layer truncation: `VERDICT: <class>[<detail>]` as line 1, `REASON: <one-line summary>` as line 2, blank line, then DIFF ANALYSIS + PLAN-AC VERIFICATION (always when Step 2.5 ran) + BUILD VERIFICATION (when Step 3e ran) + FINDINGS (if any) + (when `block[ac]`) Plan amendment required:. The closing `VERDICT:` + `REASON:` block at the bottom of the body remains as a human-readable conclusion echo — both occurrences must agree (the engine's regex captures the first match per `crates/mika-agent/src/server/verdict.rs:97`). Mika#909 / mika#898 incident (2026-04-30): gateway truncates review.body at 16k chars; placing VERDICT at the top guarantees survival even on edge-case body sizes that exceed the cap. See `docs/solutions/workflow-issues/qa-verdict-truncation-2026-04-30.md` if compounded.
+The `<verdict_body>` is your full verdict output, structured **VERDICT-FIRST** so the routing token survives any transport-layer truncation: `VERDICT: <class>[<detail>]` as line 1, `DEPTH: <code-level|code-level (partial)|metadata-only>` as line 2, `REASON: <one-line summary>` as line 3, blank line, then DIFF ANALYSIS + PLAN-AC VERIFICATION (always when Step 2.5 ran) + BUILD VERIFICATION (when Step 3e ran) + FINDINGS (if any) + (when `block[ac]`) Plan amendment required:. The closing `VERDICT:` + `DEPTH:` + `REASON:` block at the bottom of the body remains as a human-readable conclusion echo — both occurrences must agree (the engine's regex captures the first match per `crates/mika-agent/src/server/verdict.rs:97`). Mika#909 / mika#898 incident (2026-04-30): gateway truncates review.body at 16k chars; placing VERDICT at the top guarantees survival even on edge-case body sizes that exceed the cap. See `docs/solutions/workflow-issues/qa-verdict-truncation-2026-04-30.md` if compounded.
 
 **Tool call format:** `run_gh` takes a JSON object with `command` (array of strings) and `repo` (string). Example for a pass verdict:
 ```json
-{"command": ["pr", "review", "455", "--approve", "--body", "VERDICT: pass\nREASON: Pipeline artifacts present, diff review clean."], "repo": "senara-solutions/mika"}
+{"command": ["pr", "review", "455", "--approve", "--body", "VERDICT: pass\nDEPTH: code-level\nREASON: Pipeline artifacts present, diff review clean."], "repo": "senara-solutions/mika"}
 ```
 Each argument is a separate element in the `command` array. The `--body` value is a single string element containing the full verdict text. Do NOT stringify the entire object — pass it as a JSON object directly.
 
@@ -457,6 +473,7 @@ After completing all checks — **including the successful `run_gh pr review` ca
 
 ```
 VERDICT: pass
+DEPTH: code-level
 REASON: Pipeline artifacts present, diff review clean, all plan ACs satisfied
 
 DIFF ANALYSIS:
@@ -480,6 +497,7 @@ Build: pass
 ACs tested: 0 (no Behavioral ACs in plan)
 
 VERDICT: pass
+DEPTH: code-level
 REASON: Pipeline artifacts present, diff review clean, all plan ACs satisfied
 ```
 
@@ -491,6 +509,7 @@ BUILD VERIFICATION: skipped (no Behavioral ACs in plan)
 When `pipeline-exempt` label was honored (docs-only PR with the label):
 ```
 VERDICT: pass
+DEPTH: code-level
 REASON: Docs-only PR; pipeline-exempt label honored — diff review clean.
 
 DIFF ANALYSIS:
@@ -504,12 +523,14 @@ PLAN-AC VERIFICATION: skipped (pipeline-exempt label)
 BUILD VERIFICATION: skipped (pipeline-exempt label — no source changes)
 
 VERDICT: pass
+DEPTH: code-level
 REASON: Docs-only PR; pipeline-exempt label honored — diff review clean.
 ```
 
 When `Pipeline-Exempt: docs-only — <reason>` trailer was honored (docs-only PR with the trailer):
 ```
 VERDICT: pass
+DEPTH: code-level
 REASON: Docs-only PR; Pipeline-Exempt trailer honored — diff review clean.
 
 DIFF ANALYSIS:
@@ -523,12 +544,14 @@ PLAN-AC VERIFICATION: skipped (pipeline-exempt — docs-only trailer)
 BUILD VERIFICATION: skipped (pipeline-exempt — docs-only trailer)
 
 VERDICT: pass
+DEPTH: code-level
 REASON: Docs-only PR; Pipeline-Exempt trailer honored — diff review clean.
 ```
 
 When `Pipeline-Exempt: code-only — <reason>` trailer was honored (code-only PR with the trailer):
 ```
 VERDICT: pass
+DEPTH: code-level
 REASON: Code-only PR; Pipeline-Exempt trailer honored — diff review clean.
 
 DIFF ANALYSIS:
@@ -542,12 +565,14 @@ PLAN-AC VERIFICATION: skipped (pipeline-exempt — code-only trailer)
 BUILD VERIFICATION: skipped (pipeline-exempt — code-only trailer)
 
 VERDICT: pass
+DEPTH: code-level
 REASON: Code-only PR; Pipeline-Exempt trailer honored — diff review clean.
 ```
 
 Or for a `block[ac]` verdict (one or more plan ACs unsatisfied):
 ```
 VERDICT: block[ac]
+DEPTH: code-level
 REASON: Plan AC for v1 metadata block unsatisfied — 10 of 11 fields missing; JSON --verbose silently ignored.
 
 DIFF ANALYSIS:
@@ -574,6 +599,7 @@ ACs tested: 1
 - `mika ask --verbose --format json "ping"`: fail — output contains no metadata object
 
 VERDICT: block[ac]
+DEPTH: code-level
 REASON: Plan AC for v1 metadata block unsatisfied — 10 of 11 fields missing; JSON --verbose silently ignored.
 
 Plan amendment required:
@@ -585,6 +611,7 @@ Or with security findings (severity determines the verdict line):
 
 ```
 VERDICT: block[security]
+DEPTH: code-level
 REASON: Security issues — hardcoded credentials and SQL injection vector
 
 DIFF ANALYSIS:
@@ -603,6 +630,7 @@ FINDINGS:
 - SQL injection vector in src/db.rs line 87
 
 VERDICT: block[security]
+DEPTH: code-level
 REASON: Security issues — hardcoded credentials and SQL injection vector
 ```
 


### PR DESCRIPTION
## Summary

Implements mika#275 per plan in docs/plans/. Adds review depth declaration to mika-qa verdict output so consumers can tell whether review was full/spot-check/skipped.

## Impl

Commit `494af2d7` — written by dev-pilot session, manually pushed by orchestrator (pilot's gh push hit policy:deny in worktree context).

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)