### PR TITLE
fix(ci): gate docker-build job on paths filter (mika#1360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,31 @@ jobs:
           GITHUB_PR_BODY: ${{ github.event.pull_request.body }}
         run: bash scripts/verify-pipeline.sh origin/main
 
+  docker-build-filter:
+    name: Docker Build Filter
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    outputs:
+      docker-relevant: ${{ steps.filter.outputs.docker-relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker-relevant:
+              - 'Dockerfile.agent'
+              - 'Dockerfile.gateway'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**'
+              - '.github/workflows/ci.yml'
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
+    needs: docker-build-filter
+    if: github.event_name == 'pull_request' && needs.docker-build-filter.outputs.docker-relevant == 'true'
     strategy:
       matrix:
         dockerfile: [Dockerfile.agent, Dockerfile.gateway]


### PR DESCRIPTION
## Summary

- Adds a `docker-build-filter` job using `dorny/paths-filter@v3` to detect changes in Docker-relevant paths
- Gates `docker-build` on the filter output — skips when only docs or non-Docker files change
- Trigger paths: `Dockerfile.agent`, `Dockerfile.gateway`, `Cargo.toml`, `Cargo.lock`, `crates/**`, `.github/workflows/ci.yml`

## Why

The `docker-build` job (added in mika#1330) ran on **every** PR including docs-only PRs, wasting minutes of CI time on unnecessary Docker builds. For example, PR#1358 (3 markdown files) triggered both Agent and Gateway docker builds.

Closes #1360

## Test plan

- [ ] Open a docs-only PR → docker-build should be skipped
- [ ] Open a PR touching `crates/` → docker-build should run
- [ ] Open a PR touching a Dockerfile → docker-build should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)