### PR TITLE
fix(ci): use static lowercase tag for Docker Build matrix (#1366)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3
       - name: Build ${{ matrix.dockerfile }}
-        run: docker buildx build -f ${{ matrix.dockerfile }} --platform linux/amd64 --load -t test-${{ matrix.dockerfile }} .
+        # Static lowercase tag: matrix legs run on isolated runners (no collision), and Docker
+        # rejects uppercase tags — `test-${{ matrix.dockerfile }}` produced `test-Dockerfile.agent`
+        # which failed every PR's load-only build (mika#1366).
+        run: docker buildx build -f ${{ matrix.dockerfile }} --platform linux/amd64 --load -t test-image .
 
   security:
     name: Security

--- a/docs/solutions/ci-cd/docker-build-matrix-uppercase-tag-2026-06-01.md
+++ b/docs/solutions/ci-cd/docker-build-matrix-uppercase-tag-2026-06-01.md
@@ -1,0 +1,41 @@
+---
+module: ci-cd
+tags: [github-actions, docker, buildx, matrix, ci-drift]
+problem_type: ci-failure
+category: ci-cd
+---
+
+# Docker Build matrix produced an uppercase (invalid) image tag
+
+## Problem
+
+`ci.yml`'s `docker-build` job runs a matrix over `dockerfile: [Dockerfile.agent, Dockerfile.gateway]`
+and tagged the load-only test build with `-t test-${{ matrix.dockerfile }}`. That interpolates to
+`test-Dockerfile.agent` / `test-Dockerfile.gateway` — **invalid**, because Docker repository names
+must be lowercase. Every PR that triggered the Docker Build matrix failed in ~10s with:
+
+```
+ERROR: failed to build: invalid tag "test-Dockerfile.agent": repository name must be lowercase
+```
+
+Introduced by `29db043e` (mika#1353, 2026-05-31). It broke **every** mika PR's Docker Build job
+until mika#1366 — the paths-filter work in #1360/#1361 was orthogonal (the filter passed; the build
+itself was broken).
+
+## Fix
+
+Use a static lowercase tag — the build is `--load` only (never pushed), the tag is never referenced
+by any downstream step, and matrix legs run on isolated runners (separate VMs), so a shared tag
+cannot collide:
+
+```yaml
+run: docker buildx build -f ${{ matrix.dockerfile }} --platform linux/amd64 --load -t test-image .
+```
+
+## Lesson
+
+When a CI tag/name is derived from a value that is **not guaranteed lowercase** (matrix keys,
+filenames, branch names, env values), either hardcode a known-valid token or pipe through
+`tr '[:upper:]' '[:lower:]'`. Docker tag-validity failures surface only at build time, never at
+workflow-parse time — so a green YAML lint says nothing about tag legality. Prefer a static tag for
+load-only builds that are never pushed or re-referenced.


### PR DESCRIPTION
## Why

`ci.yml`'s `docker-build` job tagged its load-only test build with `-t test-${{ matrix.dockerfile }}`, which interpolates to `test-Dockerfile.agent` / `test-Dockerfile.gateway` — **invalid**, because Docker repository names must be lowercase. The build failed in ~10s on **every** PR since `29db043e` (mika#1353, 2026-05-31):

```
ERROR: failed to build: invalid tag "test-Dockerfile.agent": repository name must be lowercase
```

This is a P0 — it blocked the Docker Build job on every open mika PR (PR#1365, #1358, #1355, …). The paths-filter work in #1360/#1361 was orthogonal (the filter passed; the build itself was broken).

## What

Use a static lowercase tag `test-image`:

```diff
- run: docker buildx build -f ${{ matrix.dockerfile }} --platform linux/amd64 --load -t test-${{ matrix.dockerfile }} .
+ run: docker buildx build -f ${{ matrix.dockerfile }} --platform linux/amd64 --load -t test-image .
```

Safe because the build is `--load` only (never pushed), the tag is never referenced by any downstream step, and matrix legs run on isolated runners (separate VMs) — a shared static tag cannot collide.

Also adds `docs/solutions/ci-cd/docker-build-matrix-uppercase-tag-2026-06-01.md` capturing the CI-drift class.

## ⚠️ This unblocks the tag error but does NOT make Docker Build green on its own

Fixing the tag lets the build actually run — which surfaces a **second, previously-masked failure**: `Dockerfile.agent`'s `dashboard-builder` stage fails because `@senara-solutions/ui` (the local `packages/ui` workspace package) is never built before the dashboard's `tsc -b` (`TS2307` across ~40 files). That defect was hidden because the invalid-tag error aborted the build before it started.

That is a distinct root cause in a different file, tracked separately in **mika#1368** (not folded into this PR, per scope discipline). The gateway leg here is `fail-fast`-canceled by the agent leg, not independently broken.

So: this PR's own `Docker Build` checks remain **red** until mika#1368 lands. AC#2 below is met only after both ship.

## Acceptance criteria

- [x] `ci.yml` Docker Build step uses a lowercase-valid tag
- [ ] Docker Build green — **gated on mika#1368** (dashboard/packages-ui build fix)

Closes #1366
Related: mika#1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)