### PR TITLE
fix(docker): make Docker Build green — dashboard UI workspace (#1368) + gateway mika-a2a stub (#1370)

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -4,7 +4,13 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/ packages/
 COPY dashboard/ dashboard/
-RUN npm ci --ignore-scripts && npm run build --prefix dashboard
+# Build the @senara-solutions/ui workspace package BEFORE the dashboard: the
+# dashboard's `tsc -b` resolves `@senara-solutions/ui` to its built dist/types
+# (packages/ui/package.json main/types), and `--ignore-scripts` suppresses any
+# prepare-hook build. Mirrors the root `dev:dashboard` order. (mika#1368)
+RUN npm ci --ignore-scripts \
+ && npm run build --workspace=packages/ui \
+ && npm run build --prefix dashboard
 
 # === Builder stage ===
 FROM rust:1.93-slim AS builder

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -16,8 +16,9 @@ RUN mkdir -p crates/mika-agent/src/bin && echo "fn main() {}" > crates/mika-agen
     && echo "" > crates/mika-agent/src/lib.rs \
     && mkdir -p crates/mika-agent/src && echo "fn main() {}" > crates/mika-agent/src/cli.rs
 
-COPY crates/mika-a2a/Cargo.toml crates/mika-a2a/Cargo.toml
-RUN mkdir -p crates/mika-a2a/src && echo "" > crates/mika-a2a/src/lib.rs
+# mika-gateway depends on mika-a2a's real code (mika_a2a::jsonrpc, A2A proxy),
+# so copy the crate in full — an empty-lib stub breaks the build with E0432 (mika#1370).
+COPY crates/mika-a2a/ crates/mika-a2a/
 
 COPY crates/mika-cli/Cargo.toml crates/mika-cli/Cargo.toml
 RUN mkdir -p crates/mika-cli/src && echo "fn main() {}" > crates/mika-cli/src/main.rs

--- a/docs/solutions/ci-cd/dockerfile-agent-dashboard-ui-workspace-build-2026-06-01.md
+++ b/docs/solutions/ci-cd/dockerfile-agent-dashboard-ui-workspace-build-2026-06-01.md
@@ -1,0 +1,58 @@
+---
+module: ci-cd
+tags: [docker, dashboard, npm-workspace, vite, packages-ui, ci-drift]
+problem_type: build-failure
+category: ci-cd
+---
+
+# Dockerfile.agent dashboard build failed — workspace UI package never built
+
+## Problem
+
+`Dockerfile.agent`'s `dashboard-builder` stage failed: the dashboard's `tsc -b` could not
+resolve `@senara-solutions/ui`, with `TS2307: Cannot find module '@senara-solutions/ui'`
+across ~40 files. The stage ran:
+
+```dockerfile
+RUN npm ci --ignore-scripts && npm run build --prefix dashboard
+```
+
+This was **masked** until mika#1366 (the uppercase Docker-tag bug) was fixed — the invalid-tag
+error aborted the build before this stage ever ran, so nobody saw it.
+
+## Root cause
+
+`@senara-solutions/ui` is a local npm-workspace package (`packages/ui/`). Its `package.json`
+points the import at **built** output (`main: ./dist/index.js`, `types: ./dist/index.d.ts`).
+The dashboard's build is `tsc -b && vite build`, and `tsc -b` needs `packages/ui/dist/` to exist.
+
+The stage built only the dashboard, never `packages/ui` — and `npm ci --ignore-scripts`
+suppresses any lifecycle/`prepare` hook that might have built it. So `packages/ui/dist/` was
+absent → `TS2307`.
+
+The canonical local order already builds it first (root `package.json`):
+```json
+"dev:dashboard": "npm run build --workspace=packages/ui && npm run dev --workspace=dashboard"
+```
+The Dockerfile simply didn't mirror it.
+
+## Fix
+
+Build the UI workspace package before the dashboard:
+
+```dockerfile
+RUN npm ci --ignore-scripts \
+ && npm run build --workspace=packages/ui \
+ && npm run build --prefix dashboard
+```
+
+Verified with a real `docker build -f Dockerfile.agent --target dashboard-builder .`:
+`packages/ui` builds (`dist/index.js`, declaration files), then the dashboard `tsc -b && vite
+build` succeeds and the stage exports cleanly.
+
+## Lesson
+
+When a Docker stage builds a consumer of a local workspace package that resolves to compiled
+output, it must build the producer package first — `npm ci --ignore-scripts` will NOT do it via
+a prepare hook. Mirror the repo's canonical build order (root `package.json` scripts) inside the
+Dockerfile rather than assuming install side-effects produce `dist/`.

--- a/docs/solutions/ci-cd/dockerfile-gateway-mika-a2a-stub-stale-2026-06-01.md
+++ b/docs/solutions/ci-cd/dockerfile-gateway-mika-a2a-stub-stale-2026-06-01.md
@@ -1,0 +1,54 @@
+---
+module: ci-cd
+tags: [docker, mika-gateway, mika-a2a, workspace-stub, ci-drift]
+problem_type: build-failure
+category: ci-cd
+---
+
+# Dockerfile.gateway stubbed mika-a2a empty after gateway started using it
+
+## Problem
+
+`Docker Build (Dockerfile.gateway)` failed compiling the gateway:
+
+```
+error[E0432]: unresolved import `mika_a2a::jsonrpc`
+error: could not compile `mika-gateway` (bin "mika-gateway") due to 1 previous error
+```
+
+Masked until mika#1366 (uppercase tag) was fixed — the tag error aborted before any build ran.
+
+## Root cause
+
+To speed builds, `Dockerfile.gateway` stubs workspace members the gateway "doesn't build" with
+an empty lib:
+
+```dockerfile
+COPY crates/mika-a2a/Cargo.toml crates/mika-a2a/Cargo.toml
+RUN mkdir -p crates/mika-a2a/src && echo "" > crates/mika-a2a/src/lib.rs   # empty stub
+```
+
+That stub was valid only while mika-gateway didn't reference mika-a2a's code. The gateway now
+genuinely depends on `mika_a2a::jsonrpc` (the A2A proxy), so the empty `lib.rs` makes the import
+unresolvable → E0432.
+
+## Fix
+
+Copy the real crate (Dockerfile.agent already does this for mika-a2a):
+
+```dockerfile
+COPY crates/mika-a2a/ crates/mika-a2a/
+```
+
+Verified with a real `docker build -f Dockerfile.gateway .` → mika-gateway compiles and the image
+exports.
+
+## Lesson
+
+A "dummy stub for workspace members not being built" is a standing liability: it silently breaks
+the moment the built crate adds a real dependency on the stubbed one. When a Dockerfile stubs a
+workspace member, that stub must be revisited whenever inter-crate dependencies change. Prefer
+copying the real crate unless the build-time win is measured and the dependency boundary is
+enforced (e.g. a no-`mika-a2a`-import lint on mika-gateway). This was the third masked failure in
+a chain behind the same broken Docker tag (mika#1366 → #1368 → #1370) — a reminder that a
+broken-early CI step hides every failure downstream of it.


### PR DESCRIPTION
## Why

After mika#1366 (the uppercase Docker-tag bug, PR #1367 — merged) was fixed, the Docker Build job finally ran and exposed **two more previously-masked failures**. Both are fixed here. Fail-fast couples the two matrix legs, so neither goes green without both — hence one PR.

This was a cascade: a single broken-early step (the invalid tag) hid every failure downstream of it. Chain: #1366 → #1368 → #1370.

## Fix 1 — Dockerfile.agent: build `@senara-solutions/ui` before the dashboard (closes #1368)

The `dashboard-builder` stage ran `npm ci --ignore-scripts && npm run build --prefix dashboard` but never built the local workspace package `packages/ui`. The dashboard's `tsc -b` resolves `@senara-solutions/ui` to its built output → `TS2307` across ~40 files. Fixed by building the UI workspace first (mirrors root `dev:dashboard`).

## Fix 2 — Dockerfile.gateway: copy real mika-a2a instead of an empty stub (closes #1370)

The gateway Dockerfile stubbed mika-a2a with an empty `lib.rs`, but mika-gateway now imports `mika_a2a::jsonrpc` (the A2A proxy) → `error[E0432]: unresolved import`. Fixed by `COPY crates/mika-a2a/ crates/mika-a2a/` (as Dockerfile.agent already does).

## Verification

- **mika#1368** dashboard fix confirmed green in CI on the prior run (agent leg's dashboard stage: `packages/ui` built → dashboard `✓ 2487 modules transformed`), and the failing-stage local build.
- **Both fixes** confirmed with real **end-to-end local builds** (exit 0):
  - `docker build -f Dockerfile.gateway .` → mika-gateway compiles, image exports.
  - `docker build -f Dockerfile.agent .` → full build through dashboard + Rust stages, image exports.

Each root cause has a compound doc under `docs/solutions/ci-cd/`.

Closes #1368
Closes #1370
Follow-up to #1367 (mika#1366)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
