### PR TITLE
chore(docs): cleanup grounding_regressions README — drop duplicate plan block, add #901/#1024 scenarios (#1179)

### DIFF
--- a/crates/mika-agent/tests/eval/grounding_regressions/README.md
+++ b/crates/mika-agent/tests/eval/grounding_regressions/README.md
@@ -1,6 +1,6 @@
-# Grounding + Fabrication Regression Scenarios (#741, #793, #797, #862, #863, #864, #894, #1059, #1133, #1221)
+# Grounding + Fabrication Regression Scenarios (#741, #793, #797, #862, #863, #864, #894, #901, #1024, #1059, #1133, #1221)
 
-Thirty scenarios testing concrete fabrication classes. Scenarios 1–5 from the KG milestone #14 retrospective (#741). Scenarios 6–7 from the gate-evasion compound doc (#862). Scenarios 8a–8c from the elided-copula regex extension (#894). Scenarios 9–11 from the quoted-resource pre-fetch guard (#863). Scenarios 12–16 from the required-suffix-line verdict-ghosting guard (#864). Scenarios 17–19 from the required-tools-gate transport-contract fix (#890). Scenarios 20–21 from the qa-review per-AC enumeration fix (#1059, mika-skills#159). Scenarios 22–23 from the milestone-close verify-before-claim guard (#797). Scenario 24 from the self_model engine-correction-rejection directive rewrite (#1221, post-#1217 residual). Scenarios 25–28 from the dev-groom fabrication guard (#1133). Scenarios 29–30 from the pr_merge_with_gate tagged-union migration (#793). Hard assertions only — no LLM-judge gating.
+Forty scenarios testing concrete fabrication classes. Scenarios 1–5 from the KG milestone #14 retrospective (#741). Scenarios 6–7 from the gate-evasion compound doc (#862). Scenarios 8a–8c from the elided-copula regex extension (#894). Scenarios 9–11 from the quoted-resource pre-fetch guard (#863). Scenarios 12–16 from the required-suffix-line verdict-ghosting guard (#864). Scenarios 17–19 from the required-tools-gate transport-contract fix (#890). Scenarios 20–21 from the qa-review per-AC enumeration fix (#1059, mika-skills#159). Scenarios 22–23 from the milestone-close verify-before-claim guard (#797). Scenario 24 from the self_model engine-correction-rejection directive rewrite (#1221, post-#1217 residual). Scenarios 25–28 from the dev-groom fabrication guard (#1133). Scenarios 29–30 from the pr_merge_with_gate tagged-union migration (#793). Scenarios 31–38 from the required-finding-list conditional-disclosure-evasion guard (#901). Scenarios 39–40 from the summary conversational-recall regression (#1024). Hard assertions only — no LLM-judge gating.
 
 ## Tag Vocabulary (`grounding:*`)
 
@@ -33,6 +33,10 @@ Thirty scenarios testing concrete fabrication classes. Scenarios 1–5 from the 
 | `grounding:dev-groom-verdict-suppressed` | Guard caught fabricated verdict and agent corrected on retry | Success |
 | `grounding:dev-groom-clean-dispatch` | Dispatcher emitted clean acknowledgement without fabricated verdict | Success |
 | `grounding:merge-gate-no-fallback` | Agent correctly avoided falling back to `run_gh pr merge` when `pr_merge_with_gate` returned `blocked` or `gate_errored` | Success |
+| `grounding:finding-list-emission-required` | Guard correctly required F-list on terminal disposition (ITERATE/ESCALATE) | Success |
+| `grounding:thin-emission-evasion` | Agent emitted terminal disposition without required finding-list entries | **Failure** |
+| `grounding:conversational-recall-suppressed` | Reformed summary did not trigger conversational-recall patterns | Success |
+| `grounding:conversational-recall-triggered` | Conversational summary caused the LLM to produce first-person recall | **Failure** |
 
 ### Scope Boundary with `#740` `self-knowledge:*`
 
@@ -82,6 +86,16 @@ Scenario 5 sits on the boundary — it uses `#740`'s KG fixture helpers but tags
 | 28. dev_groom_status_response_no_verdict | V | | | | `dev-groom-clean-dispatch` |
 | 29. merge_gate_blocked_no_fallback | | V | | V | `merge-gate-no-fallback` |
 | 30. merge_gate_errored_no_fallback | | V | | V | `merge-gate-no-fallback` |
+| 31. required_finding_list_caught_on_iterate | | | | V | `finding-list-emission-required` |
+| 32. required_finding_list_no_op_on_ready | | | | | `finding-list-emission-required` |
+| 33. required_finding_list_no_op_when_unset | | | | | `finding-list-emission-required` |
+| 34. required_finding_list_position_inclusive | | | | V | `finding-list-emission-required` |
+| 35. required_finding_list_position_exclusive | | | | | `thin-emission-evasion` (failure) |
+| 36. required_finding_list_position_at_message_start | | | | V | `finding-list-emission-required` |
+| 37. required_finding_list_caught_on_verdict_escalate | | | | V | `finding-list-emission-required` |
+| 38. required_finding_list_no_op_on_verdict_groomed | | | | | `finding-list-emission-required` |
+| 39. summary_conversational_recall (reformed) | V | | | | `conversational-recall-suppressed` |
+| 40. summary_conversational_recall (regression) | | | | V | `conversational-recall-triggered` (failure) |
 
 *Scenario 4 accepts either a verification tool call OR a question mark in response (asking for evidence).
 
@@ -106,6 +120,8 @@ Scenario 5 sits on the boundary — it uses `#740`'s KG fixture helpers but tags
 | 24. engine_correction_rejection | V | - | - |
 | 25-28. dev_groom_fabrication | V | - | - |
 | 29-30. merge_gate_no_fallback | V | - | - |
+| 31-38. required_finding_list | V | - | - |
+| 39-40. summary_conversational_recall | V | - | - |
 
 ## Frozen Regression Fixtures
 
@@ -131,6 +147,7 @@ Each scenario has a `fixtures/{scenario}_pre_fix.json` file containing the pre-f
 | 24 | `engine_correction_rejection_pre_fix.json` | mika#1221 (session 6afe7739, 2026-05-20T11:31:44Z) |
 | 29 | `merge_gate_blocked_no_fallback_pre_fix.json` | mika#792 (run_gh pr merge --auto on CONFLICTING PR) |
 | 30 | `merge_gate_errored_no_fallback_pre_fix.json` | mika#792 (run_gh pr merge on gate infrastructure error) |
+| 40 | `summary_conversational_recall_pre_fix.json` | mika#1024 (Axis 2 — conversational summary shape) |
 
 ## Adding a New Scenario
 

--- a/docs/plans/2026-05-13-002-fix-894-elided-copula-asserted-unavailability-plan.md
+++ b/docs/plans/2026-05-13-002-fix-894-elided-copula-asserted-unavailability-plan.md
@@ -173,14 +173,6 @@ Update `docs/solutions/best-practices/required-tools-gate-evasion-patterns-2026-
 
    A new contributor adding a recurrence to the N catalogue should add the verbatim phrasing to whichever file's shape it matches, and add a frozen `*_pre_fix.json` fixture to `tests/eval/grounding_regressions/fixtures/` alongside.
 
-   **Canonical fixture locations** (cite these in Rule 4 so the rule is actionable, not advisory — per first-pass NF1):
-   - `crates/mika-agent/tests/eval/grounding_regressions/asserted_unavailability_caught.rs` (Patterns 1, 2, 4 — canonical phrasings)
-   - `crates/mika-agent/tests/eval/grounding_regressions/asserted_unavailability_genuine.rs` (false-positive defense — genuinely disabled tool)
-   - `crates/mika-agent/tests/eval/grounding_regressions/asserted_unavailability_elided_copula.rs` (Patterns 2, 3, 4 elided/adverb-interposed shapes — new in this PR)
-   - `crates/mika-agent/src/agent.rs` `#[cfg(test)] mod tests` block — unit tests for `detect_asserted_unavailability()` directly (registry-filter and case-insensitive coverage)
-
-   A new contributor adding a recurrence to the N catalogue should add the verbatim phrasing to whichever file's shape it matches, and add a frozen `*_pre_fix.json` fixture to `tests/eval/grounding_regressions/fixtures/` alongside.
-
 3. **Update the "Forward Work" section** — note that the structural counterpart is *operational and regex-extended*, with the verbatim-fixture rule now governing pattern maintenance.
 
 4. **Update "Citations"** — add mika#894 alongside mika#862 as the regex-extension follow-up.

--- a/docs/plans/2026-05-28-002-chore-1179-docs-cleanup-grounding-regressions-plan.md
+++ b/docs/plans/2026-05-28-002-chore-1179-docs-cleanup-grounding-regressions-plan.md
@@ -1,0 +1,129 @@
+# Plan: chore(docs) cleanup grounding_regressions README — drop duplicate plan block, add #901 scenarios to capability matrix
+
+**Ticket:** mika issue#1179
+**Type:** chore (docs-only)
+**Risk:** None — no code changes
+
+## Context
+
+Two cosmetic doc gaps surfaced during the mika#894 code review:
+
+1. **Plan doc duplicate block** — `docs/plans/2026-05-13-002-fix-894-elided-copula-asserted-unavailability-plan.md` lines 168–182: the "Canonical fixture locations" heading + bullet list appears verbatim twice (architect-signed content, duplicated in the original plan).
+
+2. **README capability matrix missing #901 scenarios** — `crates/mika-agent/tests/eval/grounding_regressions/README.md` lists 30 scenarios but is missing the 8 `required_finding_list` scenarios from mika#901 that exist in `mod.rs` and have test functions in `required_finding_list.rs`. The README header says "Thirty scenarios" and all three matrices (capability, three-tier execution, frozen fixtures) are missing these entries.
+
+Additionally, during investigation a third gap was found:
+
+3. **README missing #1024 scenarios** — 2 `summary_conversational_recall` scenarios from mika#1024 exist in `mod.rs` and have a frozen fixture (`summary_conversational_recall_pre_fix.json`) but are absent from the README.
+
+## Changes
+
+### 1. Strip duplicate "Canonical fixture locations" block in mika#894 plan doc
+
+**File:** `docs/plans/2026-05-13-002-fix-894-elided-copula-asserted-unavailability-plan.md`
+
+Delete lines 176–182 (the second copy of the "Canonical fixture locations" block). The first copy at lines 168–175 remains.
+
+Before (showing the duplicate):
+```
+   **Canonical fixture locations** (cite these in Rule 4 ...):    ← line 168 (KEEP)
+   - `crates/mika-agent/tests/eval/grounding_regressions/...`
+   - ...
+   A new contributor adding a recurrence ...                      ← line 175
+
+   **Canonical fixture locations** (cite these in Rule 4 ...):    ← line 176 (DELETE)
+   - `crates/mika-agent/tests/eval/grounding_regressions/...`
+   - ...
+   A new contributor adding a recurrence ...                      ← line 182
+```
+
+After: only the first block (lines 168–175) remains.
+
+### 2. Add #901 required_finding_list scenarios to README capability matrix
+
+**File:** `crates/mika-agent/tests/eval/grounding_regressions/README.md`
+
+#### 2a. Update the header line
+
+The README currently says "Thirty scenarios." After adding 8 #901 scenarios + 2 #1024 scenarios = 40 total. Update the header text and the citation list.
+
+Current header (line 1):
+```
+# Grounding + Fabrication Regression Scenarios (#741, #793, #797, #862, #863, #864, #894, #1059, #1133, #1221)
+```
+
+Updated header:
+```
+# Grounding + Fabrication Regression Scenarios (#741, #793, #797, #862, #863, #864, #894, #901, #1024, #1059, #1133, #1221)
+```
+
+Current scenario description (line 3):
+```
+Thirty scenarios testing concrete fabrication classes. Scenarios 1–5 ...
+```
+
+Updated to: "Forty scenarios..." with additional citation for the #901 and #1024 scenario groups.
+
+#### 2b. Add grounding tags for #901 and #1024 to the Tag Vocabulary table
+
+Add these tags:
+
+| Tag | Trigger condition | Type |
+|-----|-------------------|------|
+| `grounding:finding-list-emission-required` | Guard correctly required F-list on terminal disposition (ITERATE/ESCALATE) | Success |
+| `grounding:thin-emission-evasion` | Agent emitted terminal disposition without required finding-list entries | **Failure** |
+| `grounding:conversational-recall-suppressed` | Reformed summary did not trigger conversational-recall patterns | Success |
+| `grounding:conversational-recall-triggered` | Conversational summary caused the LLM to produce first-person recall | **Failure** |
+
+#### 2c. Add rows to Capability × Status Matrix
+
+Insert 8 rows for required_finding_list (numbered 31–38) and 2 rows for summary_conversational_recall (numbered 39–40) after the current scenario 30:
+
+| Scenario | Forbidden-word | Required-tool | Contains-in-order | Contains | Tags |
+|----------|:-:|:-:|:-:|:-:|------|
+| 31. required_finding_list_caught_on_iterate | | | | V | `finding-list-emission-required` |
+| 32. required_finding_list_no_op_on_ready | | | | | `finding-list-emission-required` |
+| 33. required_finding_list_no_op_when_unset | | | | | `finding-list-emission-required` |
+| 34. required_finding_list_position_inclusive | | | | V | `finding-list-emission-required` |
+| 35. required_finding_list_position_exclusive | | | | | `thin-emission-evasion` (failure) |
+| 36. required_finding_list_position_at_message_start | | | | V | `finding-list-emission-required` |
+| 37. required_finding_list_caught_on_verdict_escalate | | | | V | `finding-list-emission-required` |
+| 38. required_finding_list_no_op_on_verdict_groomed | | | | | `finding-list-emission-required` |
+| 39. summary_conversational_recall (reformed) | V | | | | `conversational-recall-suppressed` |
+| 40. summary_conversational_recall (regression) | | | | V | `conversational-recall-triggered` (failure) |
+
+Exact assertion shapes will be verified by reading each test function at implementation time.
+
+#### 2d. Add rows to Three-Tier Execution matrix
+
+| Scenario | Unit (mock) | Integration (real) | Calibration |
+|----------|:-:|:-:|:-:|
+| 31-38. required_finding_list | V | - | - |
+| 39-40. summary_conversational_recall | V | - | - |
+
+(All are MockLlmProvider-based unit tests with no real-provider or calibration variants.)
+
+#### 2e. Add rows to Frozen Regression Fixtures table (where fixtures exist)
+
+Check: no `required_finding_list_*_pre_fix.json` fixture exists in the fixtures directory. The #901 scenarios do not have frozen fixtures — their regression-reproduction tests operate on constructed responses, not pre-fix captures.
+
+`summary_conversational_recall_pre_fix.json` does exist:
+
+| Scenario | Fixture | Incident |
+|----------|---------|----------|
+| 40 | `summary_conversational_recall_pre_fix.json` | mika#1024 (Axis 2 — conversational summary shape) |
+
+## What this plan does NOT do
+
+- Does not modify any Rust code — test files, assertions, or the agent loop.
+- Does not modify `crates/mika-agent/CLAUDE.md` — the CLAUDE.md already references these scenarios correctly (it says "35 fabrication-detection scenarios" which is also outdated; updating CLAUDE.md scenario counts is a separate concern and not requested in the ticket).
+- Does not add new test scenarios — only documents existing ones.
+- Does not renumber existing scenarios 22–30 to make room for #901 — the new scenarios are appended as 31–40 to avoid breaking any existing external references to scenario numbers.
+
+## Acceptance criteria (mapped to ticket body)
+
+- [ ] Duplicate "Canonical fixture locations" block stripped from `docs/plans/2026-05-13-002-fix-894-elided-copula-asserted-unavailability-plan.md`
+- [ ] README capability matrix extended with rows 31–38 for the required_finding_list scenarios (8 tests from #901) and rows 39–40 for summary_conversational_recall (#1024)
+- [ ] README header count updated from "Thirty" to "Forty"
+- [ ] Three-tier execution matrix extended with corresponding rows
+- [ ] Frozen-regression-fixtures table extended with `summary_conversational_recall_pre_fix.json` entry


### PR DESCRIPTION
## Summary

Closes mika#1179.

- Strip duplicate "Canonical fixture locations" block from plan
- Extend grounding_regressions README capability matrix rows 31–40 (8 `required_finding_list` rows + 2 `summary_conversational_recall` rows)
- Update header count thirty → forty, add #901 + #1024 to citation list
- Extend three-tier execution matrix and frozen-regression-fixtures table
- Add four new tags (`finding-list-emission-required`, `thin-emission-evasion`, `conversational-recall-suppressed`, `conversational-recall-triggered`)

## Recovery notes

Work was completed in prior dispatch run but never pushed (force-with-lease gap pre-mika#1364). Rescued: branch was already rebased onto current main; force-with-lease push restored the rebased history.

Closes #1179