### PR TITLE
fix(mika-arch): always_on=true + remove per-skill LLM overrides (mika#949)

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -214,9 +214,8 @@ allowlist = [\n\
 ///
 /// Read-only architect agent for plan-stage review. Uses identity-driven
 /// skill allowlist (`mika-arch-groom-ticket`, `mika-arch-groom-milestone`,
-/// and `mika-arch-second-review` are enabled). Base model is Kimi; per-skill
-/// LLM overrides route to Opus 4.7 (groom-ticket, groom-milestone) and
-/// Sonnet 4.6 (second-review).
+/// and `mika-arch-second-review` are enabled). Skills inherit the agent
+/// default model — no per-skill LLM overrides (mika#949).
 ///
 /// Identity is computed at provision time from `Settings.kg_docs_roots` so
 /// `[kg].docs_roots` contains absolute paths. Without `MIKA_KG_DOCS_ROOTS`
@@ -230,23 +229,7 @@ pub static MIKA_ARCH: WellKnownAgent = WellKnownAgent {
     disabled_skills: &[],
     config_toml: Some(MIKA_ARCH_CONFIG),
     identity_source: Some(IdentitySource::Computed(build_mika_arch_identity)),
-    llm_overrides: &[
-        LlmOverrideSpec {
-            skill_name: "mika-arch-groom-ticket",
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-        },
-        LlmOverrideSpec {
-            skill_name: "mika-arch-groom-milestone",
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-        },
-        LlmOverrideSpec {
-            skill_name: "mika-arch-second-review",
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-        },
-    ],
+    llm_overrides: &[],
 };
 
 /// Tools mika-arch must NOT receive in its LLM tool array.
@@ -810,6 +793,50 @@ pub fn migrate_well_known_to_identity_allowlist(db: &mut Database) {
     );
 }
 
+/// Clean up stale LLM override rows left by a previous spec that had
+/// per-skill LLM overrides, when the current spec has none (mika#949).
+///
+/// Only deletes rows whose sole purpose was the LLM override (i.e.,
+/// `enabled` is `None` — the default). If a row has `enabled = Some(false)`,
+/// that was an operator-set disable and must not be deleted — the LLM
+/// fields are cleared but the row is preserved for the `enabled` state.
+fn cleanup_stale_llm_overrides(db: &mut Database, agent_name: &str) {
+    let overrides = match db.get_skill_overrides(agent_name) {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(
+                agent = agent_name,
+                error = %e,
+                "failed to read skill overrides for stale LLM cleanup"
+            );
+            return;
+        }
+    };
+
+    for ov in &overrides {
+        let has_llm = ov.llm_provider.is_some() || ov.llm_model.is_some();
+        if !has_llm {
+            continue;
+        }
+
+        // Row has an LLM override that needs clearing.
+        if let Err(e) = db.delete_skill_llm_override(agent_name, &ov.skill_name) {
+            warn!(
+                agent = agent_name,
+                skill = %ov.skill_name,
+                error = %e,
+                "failed to clean up stale LLM override"
+            );
+        } else {
+            info!(
+                agent = agent_name,
+                skill = %ov.skill_name,
+                "cleaned up stale LLM override row (spec now has no per-skill overrides)"
+            );
+        }
+    }
+}
+
 /// Seed skill overrides for a well-known agent, with drift reconciliation.
 ///
 /// Seeds skill overrides for a well-known agent. On first creation (no
@@ -817,11 +844,16 @@ pub fn migrate_well_known_to_identity_allowlist(db: &mut Database) {
 /// and seeds LLM overrides. On subsequent runs, reconciles both disabled
 /// skills and LLM overrides that have drifted from the source spec.
 ///
+/// **Stale LLM cleanup (mika#949):** when the spec's `llm_overrides` is
+/// empty, any existing DB rows with LLM override columns are cleaned up
+/// before the fast-path exit. This handles the transition from a spec
+/// that had per-skill overrides to one that doesn't.
+///
 /// **Fast-path exit:** agents with empty `disabled_skills` AND empty
 /// `llm_overrides` return immediately — nothing to seed or reconcile.
 /// Post-#815, this applies to mika-dev and mika-qa (both
-/// use identity allowlist). mika-arch still enters for LLM override
-/// reconciliation.
+/// use identity allowlist). Post-#949, mika-arch also hits this path
+/// after stale cleanup runs.
 ///
 /// Disabled-skills reconciliation (mika#1041): when a new skill is added
 /// to the well-known denylist after the agent was first provisioned, the
@@ -833,6 +865,13 @@ pub fn seed_well_known_skill_overrides(db: &mut Database, agent_name: &str) {
         Some(s) => s,
         None => return,
     };
+
+    // Clean up stale LLM override rows when the spec no longer has any
+    // per-skill overrides (mika#949). Must run BEFORE the fast-path exit
+    // so leftover rows from a previous spec are removed.
+    if spec.llm_overrides.is_empty() {
+        cleanup_stale_llm_overrides(db, agent_name);
+    }
 
     // Fast-path exit: agents with identity-driven allowlist and no LLM
     // overrides have nothing to seed or reconcile (#815).
@@ -1090,8 +1129,7 @@ Cite these when relevant in reviews. They are the durable artifacts behind the p
 "#;
 
 const MIKA_ARCH_CONFIG: &str = r#"# Mika Architect — advisory plan review agent.
-# Base model is Kimi for orchestration shell.
-# Per-skill LLM overrides route to Opus 4.7 (groom-ticket) and Sonnet 4.6 (second-review).
+# Base model is Kimi; skills inherit the agent default model (mika#949).
 
 llm_provider = "openrouter"
 openrouter_model = "moonshotai/kimi-k2.5"
@@ -1857,26 +1895,12 @@ mod tests {
     }
 
     #[test]
-    fn test_mika_arch_has_llm_overrides() {
-        assert_eq!(MIKA_ARCH.llm_overrides.len(), 3);
-        assert_eq!(
-            MIKA_ARCH.llm_overrides[0].skill_name,
-            "mika-arch-groom-ticket"
+    fn test_mika_arch_has_no_llm_overrides() {
+        // mika#949: skills inherit the agent default model.
+        assert!(
+            MIKA_ARCH.llm_overrides.is_empty(),
+            "mika-arch should have no per-skill LLM overrides"
         );
-        assert_eq!(MIKA_ARCH.llm_overrides[0].provider, "anthropic");
-        assert_eq!(MIKA_ARCH.llm_overrides[0].model, "claude-sonnet-4-6");
-        assert_eq!(
-            MIKA_ARCH.llm_overrides[1].skill_name,
-            "mika-arch-groom-milestone"
-        );
-        assert_eq!(MIKA_ARCH.llm_overrides[1].provider, "anthropic");
-        assert_eq!(MIKA_ARCH.llm_overrides[1].model, "claude-sonnet-4-6");
-        assert_eq!(
-            MIKA_ARCH.llm_overrides[2].skill_name,
-            "mika-arch-second-review"
-        );
-        assert_eq!(MIKA_ARCH.llm_overrides[2].provider, "anthropic");
-        assert_eq!(MIKA_ARCH.llm_overrides[2].model, "claude-sonnet-4-6");
     }
 
     #[test]
@@ -1953,83 +1977,48 @@ mod tests {
         seed_well_known_skill_overrides(&mut db, "mika-arch");
 
         let overrides = db.get_skill_overrides("mika-arch").unwrap();
-        // Should have 3 LLM overrides (no disabled_skills for mika-arch)
-        assert_eq!(overrides.len(), 3);
-
-        let groom = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-groom-ticket")
-            .expect("groom-ticket override should exist");
-        assert_eq!(groom.llm_provider.as_deref(), Some("anthropic"));
-        assert_eq!(groom.llm_model.as_deref(), Some("claude-sonnet-4-6"));
-
-        let milestone = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-groom-milestone")
-            .expect("groom-milestone override should exist");
-        assert_eq!(milestone.llm_provider.as_deref(), Some("anthropic"));
-        assert_eq!(milestone.llm_model.as_deref(), Some("claude-sonnet-4-6"));
-
-        let review = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-second-review")
-            .expect("second-review override should exist");
-        assert_eq!(review.llm_provider.as_deref(), Some("anthropic"));
-        assert_eq!(review.llm_model.as_deref(), Some("claude-sonnet-4-6"));
+        // mika#949: no disabled_skills and no llm_overrides — fast-path exit,
+        // 0 rows seeded.
+        assert_eq!(overrides.len(), 0);
     }
 
     #[test]
-    fn test_seed_skill_overrides_reconciles_drifted_llm_override() {
+    fn test_seed_skill_overrides_cleans_stale_llm_overrides() {
         let mut db = Database::open_in_memory().unwrap();
         db.register_agent("mika-arch", "Architect", "🏛").unwrap();
 
-        // Simulate a stale DB state: all three skills on opus (the pre-fix drift)
+        // Simulate stale DB state: 3 LLM override rows from previous spec
         db.set_skill_llm_override(
             "mika-arch",
             "mika-arch-groom-ticket",
             "anthropic",
-            "claude-opus-4-7",
+            "claude-sonnet-4-6",
         )
         .unwrap();
         db.set_skill_llm_override(
             "mika-arch",
             "mika-arch-groom-milestone",
             "anthropic",
-            "claude-opus-4-7",
+            "claude-sonnet-4-6",
         )
         .unwrap();
         db.set_skill_llm_override(
             "mika-arch",
             "mika-arch-second-review",
             "anthropic",
-            "claude-opus-4-7",
+            "claude-sonnet-4-6",
         )
         .unwrap();
 
-        // Overrides exist, so this hits the reconciliation path
+        // Verify pre-condition: 3 rows exist
+        assert_eq!(db.get_skill_overrides("mika-arch").unwrap().len(), 3);
+
+        // Seed with the new spec (empty llm_overrides) — should clean up
         seed_well_known_skill_overrides(&mut db, "mika-arch");
 
+        // All 3 stale rows should be removed (LLM-only rows with no enabled flag)
         let overrides = db.get_skill_overrides("mika-arch").unwrap();
-        assert_eq!(overrides.len(), 3);
-
-        // All three should now match the source spec (sonnet for all)
-        let groom = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-groom-ticket")
-            .unwrap();
-        assert_eq!(groom.llm_model.as_deref(), Some("claude-sonnet-4-6"));
-
-        let milestone = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-groom-milestone")
-            .unwrap();
-        assert_eq!(milestone.llm_model.as_deref(), Some("claude-sonnet-4-6"));
-
-        let review = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-second-review")
-            .unwrap();
-        assert_eq!(review.llm_model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(overrides.len(), 0);
     }
 
     #[test]
@@ -2037,20 +2026,60 @@ mod tests {
         let mut db = Database::open_in_memory().unwrap();
         db.register_agent("mika-arch", "Architect", "🏛").unwrap();
 
-        // First seed — fresh
+        // First seed — fresh, 0 rows (empty spec)
         seed_well_known_skill_overrides(&mut db, "mika-arch");
+        assert_eq!(db.get_skill_overrides("mika-arch").unwrap().len(), 0);
 
-        // Second seed — should be a no-op (overrides match source)
+        // Second seed — still 0 rows, no-op
+        seed_well_known_skill_overrides(&mut db, "mika-arch");
+        assert_eq!(db.get_skill_overrides("mika-arch").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_cleanup_preserves_operator_disabled_rows() {
+        let mut db = Database::open_in_memory().unwrap();
+        db.register_agent("mika-arch", "Architect", "🏛").unwrap();
+
+        // Simulate a row that has both an LLM override AND an operator-set
+        // enabled=false. The LLM override came from the old spec; the disable
+        // was set by the operator via `mika skills disable`.
+        db.set_skill_llm_override(
+            "mika-arch",
+            "mika-arch-groom-ticket",
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+        .unwrap();
+        db.set_skill_enabled("mika-arch", "mika-arch-groom-ticket", false)
+            .unwrap();
+
+        // Also add a pure LLM-only row (no enabled flag) for a sibling skill
+        db.set_skill_llm_override(
+            "mika-arch",
+            "mika-arch-second-review",
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+        .unwrap();
+
+        // Pre-condition: 2 rows
+        assert_eq!(db.get_skill_overrides("mika-arch").unwrap().len(), 2);
+
         seed_well_known_skill_overrides(&mut db, "mika-arch");
 
         let overrides = db.get_skill_overrides("mika-arch").unwrap();
-        assert_eq!(overrides.len(), 3);
 
-        let groom = overrides
-            .iter()
-            .find(|o| o.skill_name == "mika-arch-groom-ticket")
-            .unwrap();
-        assert_eq!(groom.llm_model.as_deref(), Some("claude-sonnet-4-6"));
+        // The pure LLM-only row (second-review) should be deleted entirely.
+        // The operator-disabled row (groom-ticket) should survive with LLM
+        // fields cleared but enabled=false preserved.
+        assert_eq!(overrides.len(), 1);
+
+        let preserved = &overrides[0];
+        assert_eq!(preserved.skill_name, "mika-arch-groom-ticket");
+        assert_eq!(preserved.enabled, Some(false));
+        // LLM fields should be cleared
+        assert_eq!(preserved.llm_provider, None);
+        assert_eq!(preserved.llm_model, None);
     }
 
     #[test]

--- a/docs/plans/2026-05-29-001-fix-mika-arch-always-on-remove-overrides-plan.md
+++ b/docs/plans/2026-05-29-001-fix-mika-arch-always-on-remove-overrides-plan.md
@@ -1,0 +1,230 @@
+---
+title: "fix: mika-arch always_on=true + remove per-skill LLM overrides"
+type: fix
+status: active
+date: 2026-05-29
+---
+
+# fix: mika-arch always_on=true + remove per-skill LLM overrides
+
+## Overview
+
+Remove the three per-skill `LlmOverrideSpec` entries from `MIKA_ARCH` and flip all three mika-arch skills to `always_on = true`. After this change, mika-arch skills inherit the agent default model (Opus 4.7, operator-set in `~/.mika/agents/mika-arch/config.toml`) instead of being demoted to Sonnet 4.6. The `always_on = true` flag eliminates keyword-trigger fragility that caused disposition-keyword ghosting in prior dogfooding (documented in `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`).
+
+## Problem Frame
+
+Post-mika#939 merge, mika-arch is in a contradictory three-way state:
+
+1. **Agent default**: Opus 4.7 (operator-set in `config.toml`)
+2. **Per-skill LLM overrides** (source in `well_known_agents.rs`): all three skills route to Sonnet 4.6
+3. **Skill `always_on`** (in `skill.toml`): all three are `false` (keyword-triggered)
+
+Combined effect: the overrides DEMOTE every skill call from Opus to Sonnet (opposite of operator intent). The `always_on=false` creates a fragility surface where keyword-trigger sometimes fires late or partially, causing the architect to skip the `Disposition:` suffix line.
+
+mika-arch is single-purpose — every skill is review-specific. Keyword-trigger gating exists for general-purpose agents that might do non-skill work; it is a fragility surface here, not a value-add.
+
+## Requirements Trace
+
+- R1. Per-skill LLM override entries removed from source — skills inherit agent default model
+- R2. All three mika-arch skills set to `always_on = true` in their `skill.toml`
+- R3. Stale `skill_overrides` DB rows cleaned up on deploy (auto-migration, not manual operator action)
+- R4. Tests updated to reflect the new configuration
+- R5. Post-deploy: `SELECT * FROM skill_overrides WHERE agent_id='mika-arch'` returns 0 rows
+
+## Scope Boundaries
+
+- Other agents' overrides or `always_on` flags are out of scope
+- mika-arch's persistence-meta hallucination (mika#947) is orthogonal
+- The `seed_well_known_skill_overrides` reconciliation loop's general architecture is not being refactored — only adding a clear-on-empty-source cleanup path
+- The `AlwaysOn + DB-override carve-out` (mika#1011) is unaffected — it fires on `from_db_override = true` rows, which will no longer exist for mika-arch
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `crates/mika-agent/src/well_known_agents.rs:258-284` — `MIKA_ARCH` static with the three `LlmOverrideSpec` entries to remove
+- `crates/mika-agent/src/well_known_agents.rs:866-1000` — `seed_well_known_skill_overrides()` — the seeding/reconciliation function. Currently takes a fast-path exit when both `disabled_skills` and `llm_overrides` are empty (line 874). Post-fix, mika-arch will hit this fast path, but pre-existing DB rows will persist unless cleaned up
+- `crates/mika-agent/src/well_known_agents.rs:1155-1163` — `MIKA_ARCH_CONFIG` const with stale comment about per-skill overrides
+- `skills/bundled/mika-arch-groom-ticket/skill.toml`, `skills/bundled/mika-arch-groom-milestone/skill.toml`, `skills/bundled/mika-arch-second-review/skill.toml` — the three skill manifests with `always_on = false`
+- Post-#815 migration pattern: `migrate_well_known_to_identity_allowlist()` uses `schema_meta` marker `well_known_d2_migration_v1` for one-shot cleanup — same pattern applies here
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/well-known-agent-disabled-skills-seeding-drift-2026-05-09.md` — Documents the "seeding-once drift" failure class and one-directional reconciliation design. Key insight: removing an override from spec does NOT auto-delete the DB row. A cleanup migration is required.
+- `docs/solutions/architecture-patterns/well-known-agent-identity-allowlist-migration-2026-05-15.md` — Confirms mika-arch is the only well-known agent still entering `seed_well_known_skill_overrides()` (for LLM override reconciliation). Post-fix, all four agents take the fast-path exit.
+
+## Key Technical Decisions
+
+- **Auto-cleanup via one-shot migration, not manual operator action**: The ticket suggests a post-deploy `DELETE FROM skill_overrides WHERE agent_id='mika-arch'`. Instead, add a one-shot cleanup inside `seed_well_known_skill_overrides()` that detects when the source spec has no overrides but the DB still has LLM override rows, and deletes them. This follows the existing `schema_meta` marker pattern from `migrate_well_known_to_identity_allowlist()` but is simpler — when the source is empty and DB rows exist, the rows are stale by definition. Guard with a `schema_meta` marker `mika_arch_llm_override_cleanup_v1` for idempotency.
+- **`always_on = true` effect on post-condition guards**: With `always_on = true`, `collect_required_suffix_lines()` and `collect_required_finding_list_prefixes()` will union these skills' output constraints on every turn (not just keyword-matched turns). This is the intended fix — the `Disposition:` / `Verdict:` suffix line enforcement becomes unconditional.
+- **`required_tools` constraint (`gh_read`) unchanged**: Per match-reason conditioning (#463), `required_tools` is only enforced on `Keyword` matches. With `always_on = true`, the `gh_read` constraint fires only when keywords also match. This is acceptable — the skill prompt instructs `gh_read` usage, and mika-arch messages always contain review-related keywords.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Does the fast-path exit in `seed_well_known_skill_overrides` need a new code path?** Yes — currently when both arrays are empty, the function returns immediately. Pre-existing DB rows from the old spec persist forever. Adding a cleanup path guarded by a `schema_meta` marker handles the transition cleanly without touching the general reconciliation architecture.
+- **Q: Does `always_on = true` affect the `AlwaysOn + DB-override carve-out` (mika#1011)?** No. That carve-out fires on `from_db_override = true` rows (set by `apply_overrides()` when reading `skill_overrides` DB rows). After cleanup, mika-arch has zero `skill_overrides` rows, so no DB-override is applied, and the carve-out is never triggered.
+
+### Deferred to Implementation
+
+- **Q: Exact `schema_meta` marker key name** — will be finalized during implementation (proposed: `mika_arch_llm_override_cleanup_v1`).
+
+## Implementation Units
+
+- [ ] **Unit 1: Remove LLM overrides from MIKA_ARCH static and update config comment**
+
+**Goal:** Remove the three `LlmOverrideSpec` entries and update all associated comments/doc strings.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `crates/mika-agent/src/well_known_agents.rs`
+
+**Approach:**
+- Change `llm_overrides: &[LlmOverrideSpec { ... }, ...]` to `llm_overrides: &[]` on the `MIKA_ARCH` static (lines 267-283)
+- Update the doc comment (lines 249-253) to state skills inherit the agent default model
+- Update `MIKA_ARCH_CONFIG` comment (line 1157) to remove mention of per-skill LLM overrides
+
+**Patterns to follow:**
+- `MIKA_DEV`, `MIKA_QA`, `MIKA_RELAY` all use `llm_overrides: &[]` — mika-arch now matches
+
+**Test scenarios:**
+- Happy path: `MIKA_ARCH.llm_overrides` is empty (len == 0)
+- Happy path: `MIKA_ARCH_CONFIG` parses as valid TOML with `llm_provider = "openrouter"` and `openrouter_model = "moonshotai/kimi-k2.5"` (base model unchanged)
+
+**Verification:**
+- `MIKA_ARCH.llm_overrides.is_empty()` asserts true
+- Existing `test_mika_arch_config_toml_is_valid_toml` continues to pass
+
+---
+
+- [ ] **Unit 2: Flip always_on to true in all three mika-arch skill.toml files**
+
+**Goal:** Change `always_on = false` to `always_on = true` in all three mika-arch skill manifests.
+
+**Requirements:** R2
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `skills/bundled/mika-arch-groom-ticket/skill.toml`
+- Modify: `skills/bundled/mika-arch-groom-milestone/skill.toml`
+- Modify: `skills/bundled/mika-arch-second-review/skill.toml`
+
+**Approach:**
+- Single-line change in each file: `always_on = false` -> `always_on = true`
+- The `[triggers] keywords` section remains — keywords still contribute to `MatchReason::Keyword` for `required_tools` enforcement, but the skill loads unconditionally via `AlwaysOn`
+
+**Patterns to follow:**
+- Other always-on skills in the codebase (e.g., community bundled skills) for the manifest pattern
+
+**Test scenarios:**
+- Happy path: build-time discovery (`build.rs`) picks up the updated manifests and `BUNDLED_SKILL_MANIFESTS` reflects `always_on = true` for all three skills
+
+**Verification:**
+- `cargo build` succeeds (build.rs re-discovers skills)
+- The three skills appear as `always_on = true` in the compiled `BUNDLED_SKILL_MANIFESTS`
+
+---
+
+- [ ] **Unit 3: Addone-shot DB cleanup for stale mika-arch LLM override rows**
+
+**Goal:** Ensure pre-existing `skill_overrides` rows for mika-arch are cleaned up on the first deploy after this change, so R5 is met without manual operator intervention.
+
+**Requirements:** R3, R5
+
+**Dependencies:** Unit 1 (the source spec must be empty for the cleanup logic to be correct)
+
+**Files:**
+- Modify: `crates/mika-agent/src/well_known_agents.rs`
+
+**Approach:**
+- Add a one-shot cleanup function (e.g., `migrate_mika_arch_llm_override_cleanup()`) that:
+  1. Checks `schema_meta` for marker `mika_arch_llm_override_cleanup_v1` — if present, return (idempotent)
+  2. Deletes all `skill_overrides` rows where `agent_id = 'mika-arch'` and `llm_provider IS NOT NULL` (targets only LLM override rows, not hypothetical `enabled` rows)
+  3. Writes the `schema_meta` marker
+  4. Logs at INFO level with count of deleted rows
+- Call this function from the same site that calls `seed_well_known_skill_overrides()` during agent init — either inside `seed_well_known_skill_overrides` itself (before the fast-path exit) or as a sibling call at the init callsite
+- The cleanup is agent-scoped to `mika-arch` — no other agents' rows are touched
+
+**Patterns to follow:**
+- `migrate_well_known_to_identity_allowlist()` in the same file — uses `schema_meta` marker `well_known_d2_migration_v1`, one-shot execution, idempotent guard, INFO-level logging
+
+**Test scenarios:**
+- Happy path: DB has 3 mika-arch LLM override rows -> cleanup deletes all 3 -> `schema_meta` marker written -> subsequent calls are no-ops
+- Edge case: DB has zero mika-arch rows -> cleanup writes marker, deletes nothing
+- Edge case: DB has mika-arch rows with `enabled` column set (hypothetical operator disable) -> cleanup only deletes rows with `llm_provider IS NOT NULL`, preserving `enabled`-only rows
+- Idempotency: calling cleanup twice produces the same result (marker prevents re-execution)
+
+**Verification:**
+- `SELECT * FROM skill_overrides WHERE agent_id='mika-arch'` returns 0 rows after cleanup
+- `schema_meta` contains the marker key
+
+---
+
+- [ ] **Unit 4: Update tests to reflect the new configuration**
+
+**Goal:** Update all mika-arch-related tests in `well_known_agents.rs` to match the new state (empty overrides, cleanup migration).
+
+**Requirements:** R4
+
+**Dependencies:** Units 1, 2, 3
+
+**Files:**
+- Modify: `crates/mika-agent/src/well_known_agents.rs` (test module)
+
+**Approach:**
+
+Tests to rewrite:
+- `test_mika_arch_has_llm_overrides` → rename to `test_mika_arch_has_no_llm_overrides` — assert `MIKA_ARCH.llm_overrides.is_empty()`
+- `test_seed_skill_overrides_mika_arch` → rewrite to assert that seeding produces 0 rows (mika-arch now takes the fast-path exit)
+- `test_seed_skill_overrides_reconciles_drifted_llm_override` → remove entirely (no overrides to reconcile)
+- `test_seed_skill_overrides_reconciliation_is_idempotent` → if mika-arch-specific assertions exist, remove them; if the test is mika-arch-only, remove entirely
+
+Tests to update:
+- `test_d2_migration_preserves_mika_arch_rows` → update to reflect that mika-arch no longer has LLM override rows post-cleanup. The test should verify that the D2 migration + the new cleanup migration together leave mika-arch with 0 rows
+
+Tests to add:
+- `test_mika_arch_llm_override_cleanup_migration` — verifies the one-shot cleanup (happy path, idempotency, no-op when no rows exist)
+
+**Patterns to follow:**
+- Existing test structure in the `#[cfg(test)] mod tests` block — `Database::open_in_memory()`, `register_agent()`, `set_skill_llm_override()`, `get_skill_overrides()`
+
+**Test scenarios:**
+- Happy path: new `test_mika_arch_has_no_llm_overrides` asserts empty overrides on the static
+- Happy path: `test_seed_skill_overrides_mika_arch` asserts 0 rows after seeding (fast-path exit)
+- Happy path: cleanup migration deletes pre-existing LLM override rows
+- Idempotency: cleanup migration is a no-op on second call
+- Edge case: cleanup with no pre-existing rows writes marker without error
+
+**Verification:**
+- `cargo test -p mika-agent -- well_known` passes with all tests green
+- No test references the removed `LlmOverrideSpec` entries
+
+## System-Wide Impact
+
+- **Skill matching behavior**: With `always_on = true`, the three mika-arch skills are matched on every turn regardless of keyword presence. `required_suffix_lines` and `required_finding_list_prefixes` from `[output]` are now enforced unconditionally (they already union `AlwaysOn` matches). `required_tools` from `[constraints]` remains keyword-gated per #463 — no change.
+- **LLM provider resolution**: Without DB override rows, `resolve_skill_llm_override()` returns `None` for all three skills. The agent-level provider (Kimi via OpenRouter, per `MIKA_ARCH_CONFIG`) is used for the orchestration shell; the operator's `config.toml` override (Opus 4.7) applies at runtime. Skills inherit whichever model the agent resolves to.
+- **`seed_well_known_skill_overrides` fast path**: Post-fix, all four well-known agents take the fast-path exit (empty `disabled_skills` + empty `llm_overrides`). The function body past line 874 becomes dead code for well-known agents but remains correct for future agents that might use overrides.
+- **Unchanged invariants**: mika-arch's identity allowlist (`[skills].allowlist`), tool denylist (`[tools].disabled`), KG configuration (`[kg]`), soul prompt, and config.toml base model are all unchanged. The fail-closed identity behavior on parse failure is unaffected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Stale DB rows persist if cleanup migration doesn't run | `schema_meta` marker pattern is proven (D2 migration). Cleanup runs in the same init path as `seed_well_known_skill_overrides`. Acceptance criterion R5 verifies. |
+| `always_on = true` changes post-condition guard behavior unexpectedly | Only `required_suffix_lines` and `required_finding_list_prefixes` change from conditional to unconditional — both are the intended fix. `required_tools` stays keyword-gated. |
+| Operator had manually set LLM overrides via `mika skills llm set` | The cleanup targets `llm_provider IS NOT NULL` rows — if an operator manually set a different override, it would also be deleted. Acceptable: the ticket's direction is to remove ALL per-skill overrides for mika-arch, and the operator can re-set if needed. |
+
+## Sources & References
+
+- Related issue: mika#949
+- Predecessor: mika#939 / PR #941 — established the Sonnet 4.6 routing now being reverted
+- Source: `crates/mika-agent/src/well_known_agents.rs` (MIKA_ARCH static, seed function, tests)
+- Source: `skills/bundled/mika-arch-{groom-ticket,groom-milestone,second-review}/skill.toml`
+- Dogfood doc: `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`
+- Learning: `docs/solutions/runtime-errors/well-known-agent-disabled-skills-seeding-drift-2026-05-09.md`
+- Learning: `docs/solutions/architecture-patterns/well-known-agent-identity-allowlist-migration-2026-05-15.md`

--- a/docs/plans/2026-05-30-005-fix-mika-arch-always-on-remove-llm-overrides-plan.md
+++ b/docs/plans/2026-05-30-005-fix-mika-arch-always-on-remove-llm-overrides-plan.md
@@ -1,0 +1,117 @@
+# Plan: fix(mika-arch): always_on=true + remove per-skill LLM overrides
+
+**Ticket:** mika issue#949
+**Type:** bug fix
+**Scope:** `crates/mika-agent/src/well_known_agents.rs`, `skills/bundled/mika-arch-*/skill.toml`
+
+## Problem
+
+mika-arch's skill configuration is in three contradictory states:
+
+1. **Agent default model** is Opus 4.7 (operator set in `~/.mika/agents/mika-arch/config.toml`).
+2. **Per-skill LLM overrides** in source code route all three skills to Sonnet 4.6, effectively *demoting* every skill call below the agent default — opposite of operator intent.
+3. **`always_on = false`** on all three skills creates keyword-trigger fragility. mika-arch is single-purpose (all skills are review work), so keyword gating adds a fragility surface with no value.
+
+## Changes
+
+### 1. Remove LLM overrides from `MIKA_ARCH` static — `well_known_agents.rs:267-283`
+
+**Current:**
+```rust
+llm_overrides: &[
+    LlmOverrideSpec { skill_name: "mika-arch-groom-ticket", provider: "anthropic", model: "claude-sonnet-4-6" },
+    LlmOverrideSpec { skill_name: "mika-arch-groom-milestone", provider: "anthropic", model: "claude-sonnet-4-6" },
+    LlmOverrideSpec { skill_name: "mika-arch-second-review", provider: "anthropic", model: "claude-sonnet-4-6" },
+],
+```
+
+**After:**
+```rust
+llm_overrides: &[],
+```
+
+**Effect:** `seed_well_known_skill_overrides` will hit the fast-path exit at line 874 (`disabled_skills.is_empty() && llm_overrides.is_empty()`) and not seed or reconcile any override rows. Existing DB rows remain until cleanup (step 5 below).
+
+### 2. Update doc comment on `MIKA_ARCH` — `well_known_agents.rs:247-253`
+
+Remove the sentence about per-skill LLM overrides routing to Opus/Sonnet. Update to reflect that skills inherit the agent default model.
+
+### 3. Set `always_on = true` in skill manifests
+
+Edit three files:
+- `skills/bundled/mika-arch-groom-ticket/skill.toml` — `always_on = false` → `always_on = true`
+- `skills/bundled/mika-arch-groom-milestone/skill.toml` — `always_on = false` → `always_on = true`
+- `skills/bundled/mika-arch-second-review/skill.toml` — `always_on = false` → `always_on = true`
+
+**Rationale:** mika-arch is single-purpose. Every skill is review-specific. `always_on = true` eliminates keyword-trigger fragility (disposition-keyword drift documented in `mika-arch-first-dogfood-2026-04-25.md`). The identity-driven `[skills].allowlist` already restricts which skills load — `always_on` just controls whether a loaded skill requires keyword activation or is active on every turn.
+
+**Impact on post-condition guards:** `collect_required_suffix_lines()` and `collect_required_finding_list_prefixes()` already collect from both `Keyword` AND `AlwaysOn` matched skills (documented in CLAUDE.md). So the required-suffix-line guard (#864) and required-finding-list guard (#901) will continue to fire correctly. The `required_tools` gate (guard #3) only enforces on `Keyword`-matched skills per #463 — switching to `AlwaysOn` means required_tools constraints will NOT be enforced. This is acceptable: the `gh_read` required_tools constraint was defense-in-depth for keyword-trigger mode; with `always_on = true`, the skill prompt is always present and the LLM reliably calls `gh_read` without the gate. The `required_fetches_for_quoted_resources` constraint is also keyword-only and follows the same reasoning.
+
+### 4. Add DB cleanup on startup — `well_known_agents.rs::seed_well_known_skill_overrides`
+
+The current fast-path exit (line 874) short-circuits when both `disabled_skills` and `llm_overrides` are empty. After this change, mika-arch will hit that fast-path, but stale LLM override rows will remain in `skill_overrides`. These stale rows will continue to override the agent default model until cleaned up.
+
+**Add a cleanup path:** Before the fast-path exit, when `spec.llm_overrides.is_empty()` but existing DB rows have non-NULL `llm_provider`/`llm_model`, delete those stale LLM override rows. This is the "clear-on-empty-source semantic" the ticket's Out of Scope section flagged for investigation.
+
+Implementation approach:
+1. Move the fast-path exit after a new check: if `spec.llm_overrides.is_empty()` AND `spec.disabled_skills.is_empty()`, check for existing override rows with LLM fields set.
+2. For any such rows, call `db.delete_skill_override(agent_name, &row.skill_name)` to remove them.
+3. Log the cleanup at `info!` level for operator visibility.
+4. Then return (fast-path).
+
+This handles both fresh deploys (no rows to clean) and upgrades from pre-#949 (stale Sonnet rows removed).
+
+**Scoping guard:** Only clean up rows that were plausibly seeded by the well-known agent provisioner — rows where `llm_provider` and `llm_model` are both non-NULL and `enabled` is NULL (pure LLM-override rows, not operator-disabled rows). Rows with `enabled = Some(false)` or `enabled = Some(true)` are operator intent and must not be touched.
+
+### 5. Update tests — `well_known_agents.rs`
+
+#### 5a. `test_mika_arch_has_llm_overrides` (line 2070-2091)
+
+**Remove entirely** or rename to `test_mika_arch_has_no_llm_overrides` and assert `MIKA_ARCH.llm_overrides.is_empty()`.
+
+#### 5b. `test_seed_skill_overrides_mika_arch` (line 2159-2190)
+
+Update to assert that after seeding, `get_skill_overrides("mika-arch")` returns 0 rows (not 3).
+
+#### 5c. `test_seed_skill_overrides_reconciles_drifted_llm_override` (line 2192-2244)
+
+**Repurpose:** Pre-seed DB with stale LLM override rows (simulating pre-#949 state), then call `seed_well_known_skill_overrides`. Assert all three rows are deleted (cleanup path from step 4).
+
+#### 5d. `test_seed_skill_overrides_reconciliation_is_idempotent` (line 2246-2262)
+
+Update to verify that repeated calls with empty overrides are no-ops (no rows to clean on second call).
+
+#### 5e. `test_d2_migration_preserves_mika_arch_rows` (line 1933-1965)
+
+This test pre-seeds an LLM override row for mika-arch and asserts the D2 migration preserves it. After #949, the migration still preserves it (unchanged behavior), but `seed_well_known_skill_overrides` would clean it up on the next call. The test is about migration behavior, not seeding — keep it as-is since the D2 migration path is independent.
+
+### 6. Post-deploy verification (no code change — operator action)
+
+After deploy + restart:
+1. `sqlite3 ~/.mika/data/mika.db "SELECT * FROM skill_overrides WHERE agent_id='mika-arch'"` → 0 rows.
+2. `mika skills --agent mika-arch list` → all three skills loaded with `always_on=true`, no `[llm: ...]` annotation.
+3. Check server logs for `kg_resolver_tick` or any mika-arch LLM call → model should be the agent default (Opus 4.7 from config.toml).
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/well_known_agents.rs` | Remove 3 `LlmOverrideSpec` entries, update doc comment, add stale-override cleanup in seeding, update 4 tests |
+| `skills/bundled/mika-arch-groom-ticket/skill.toml` | `always_on = false` → `always_on = true` |
+| `skills/bundled/mika-arch-groom-milestone/skill.toml` | `always_on = false` → `always_on = true` |
+| `skills/bundled/mika-arch-second-review/skill.toml` | `always_on = false` → `always_on = true` |
+
+## Risk Assessment
+
+**Low risk.** All changes are in the mika-arch agent's configuration surface:
+- Removing LLM overrides makes skills inherit the agent default — strictly simpler.
+- `always_on = true` eliminates a fragility surface (keyword-trigger miss) with no functional cost since mika-arch is single-purpose.
+- The stale-row cleanup is guarded to only touch pure LLM-override rows (not operator-set enabled/disabled state).
+- No schema migration needed — cleanup uses existing `delete_skill_override` API.
+- The `required_tools` gate change (no longer enforced on AlwaysOn) is acceptable because `gh_read` is reliably called without the gate when the skill prompt is present.
+
+## Out of Scope
+
+- mika-arch's persistence-meta hallucination (mika#947).
+- Other agents' overrides or always_on flags.
+- The `seed_well_known_skill_overrides` reconciliation loop's general architecture — only the mika-arch-specific cleanup is addressed.

--- a/docs/plans/2026-06-01-003-fix-949-mika-arch-always-on-remove-overrides-plan.md
+++ b/docs/plans/2026-06-01-003-fix-949-mika-arch-always-on-remove-overrides-plan.md
@@ -1,0 +1,100 @@
+# Plan: fix(mika-arch): always_on=true + remove per-skill LLM overrides
+
+**Ticket:** mika issue#949
+**Type:** bug fix
+**Scope:** `crates/mika-agent/src/well_known_agents.rs`, `skills/bundled/mika-arch-*/skill.toml`
+
+## Problem
+
+mika-arch's skill configuration is in three contradictory states:
+
+1. Agent default model is Opus 4.7 (operator-set in `config.toml`).
+2. Per-skill LLM overrides in `well_known_agents.rs` route all three skills to Sonnet 4.6 — demoting them below the agent default.
+3. All three skills are `always_on = false` (keyword-triggered), creating fragility where the architect may skip the `Disposition:` suffix when keyword-trigger fires late or partially.
+
+## Solution
+
+Remove the per-skill LLM overrides so skills inherit the agent default (Opus 4.7). Set `always_on = true` on all three skills since mika-arch is single-purpose (every invocation is review work). Add a cleanup path for stale DB rows.
+
+## Changes
+
+### 1. Remove LLM overrides from `MIKA_ARCH` static (`well_known_agents.rs`)
+
+**File:** `crates/mika-agent/src/well_known_agents.rs`
+
+Change `MIKA_ARCH.llm_overrides` from the current 3-element array to `&[]` (empty).
+
+```rust
+// Before:
+llm_overrides: &[
+    LlmOverrideSpec { skill_name: "mika-arch-groom-ticket", provider: "anthropic", model: "claude-sonnet-4-6" },
+    LlmOverrideSpec { skill_name: "mika-arch-groom-milestone", provider: "anthropic", model: "claude-sonnet-4-6" },
+    LlmOverrideSpec { skill_name: "mika-arch-second-review", provider: "anthropic", model: "claude-sonnet-4-6" },
+],
+
+// After:
+llm_overrides: &[],
+```
+
+Update the docstring on `MIKA_ARCH` to remove the mention of per-skill LLM overrides routing to Opus/Sonnet. The new doc should state that skills inherit the agent default model.
+
+### 2. Add stale-override cleanup to `seed_well_known_skill_overrides` (`well_known_agents.rs`)
+
+**Problem:** The current `seed_well_known_skill_overrides` function has a fast-path exit when both `disabled_skills` and `llm_overrides` are empty (line 839). After this change, mika-arch hits that fast path — but stale DB rows from the previous 3-override spec remain in `skill_overrides`. The reconciliation loop (lines 888–933) only updates drifted values; it never deletes rows that no longer appear in the spec.
+
+**Solution:** Add a cleanup step that runs when `spec.llm_overrides` is empty but the DB still has LLM override rows for this agent. This must run BEFORE the fast-path exit.
+
+In `seed_well_known_skill_overrides`, after the `find_well_known_agent` lookup and before the fast-path exit:
+
+1. Query `db.get_skill_overrides(agent_name)`.
+2. If `spec.llm_overrides.is_empty()` and existing overrides contain rows with non-None `llm_provider` or `llm_model`, delete those rows via `db.delete_skill_override(agent_name, skill_name)`.
+3. Log each deletion at INFO level for operator visibility.
+
+This is idempotent: on subsequent runs, no LLM override rows exist, so the cleanup is a no-op.
+
+**Important:** Only delete rows whose sole purpose was the LLM override (i.e., `enabled` is `None` — the default). If a row has `enabled = Some(false)`, that was an operator-set disable and must not be deleted. If a row has both an LLM override and an `enabled` flag, clear the LLM fields but keep the row for the `enabled` state.
+
+The cleanup should be structured as a new helper function `cleanup_stale_llm_overrides(db, agent_name, spec)` called from `seed_well_known_skill_overrides` to keep the main function's control flow clean.
+
+### 3. Set `always_on = true` in skill manifests
+
+**Files:**
+- `skills/bundled/mika-arch-groom-ticket/skill.toml`
+- `skills/bundled/mika-arch-groom-milestone/skill.toml`
+- `skills/bundled/mika-arch-second-review/skill.toml`
+
+Change `always_on = false` to `always_on = true` in all three files.
+
+**Note on `[triggers] keywords`:** Keep the keywords section. While `always_on = true` means the skill is always matched, the keywords section is still used by `collect_required_tools()` which only fires on keyword-matched skills (#463). However, since `always_on` skills' `required_suffix_lines` and `required_finding_list_prefixes` are collected from both `Keyword` and `AlwaysOn` match reasons (per `collect_required_suffix_lines` and `collect_required_finding_list_prefixes` in the crate CLAUDE.md), the output contracts continue to be enforced. The keywords section is retained for documentation/grep-ability.
+
+### 4. Update tests (`well_known_agents.rs`)
+
+**a. `test_mika_arch_has_llm_overrides` (line 1860):**
+Replace with a test asserting `MIKA_ARCH.llm_overrides.is_empty()`. Rename to `test_mika_arch_has_no_llm_overrides`.
+
+**b. `test_seed_skill_overrides_mika_arch` (line 1948):**
+Update to assert 0 override rows after seeding (since both `disabled_skills` and `llm_overrides` are now empty, the fast-path exit fires).
+
+**c. `test_seed_skill_overrides_reconciles_drifted_llm_override` (line 1981):**
+Repurpose as `test_seed_skill_overrides_cleans_stale_llm_overrides`. Pre-seed 3 LLM override rows, call `seed_well_known_skill_overrides`, assert 0 rows remain.
+
+**d. `test_seed_skill_overrides_reconciliation_is_idempotent` (line 2035):**
+Update to verify that calling seed twice on a clean DB is a no-op (0 rows both times).
+
+**e. Add new test: `test_cleanup_preserves_operator_disabled_rows`:**
+Pre-seed an LLM override row that also has `enabled = Some(false)`. Call `seed_well_known_skill_overrides`. Assert the row still exists with `enabled = Some(false)` and the LLM fields cleared.
+
+## Verification
+
+1. `cargo test -p mika-agent -- well_known_agents` — all tests pass.
+2. `cargo clippy -p mika-agent` — no warnings.
+3. After deploy + restart:
+   - `sqlite3 ~/.mika/data/mika.db "SELECT * FROM skill_overrides WHERE agent_id='mika-arch'"` returns 0 rows.
+   - `mika skills --agent mika-arch list` shows all three skills with `always_on=true` and no `[llm: ...]` annotation.
+   - LLM call telemetry for mika-arch review work shows the agent default model (Opus 4.7).
+
+## Risks
+
+- **Low:** Removing overrides means mika-arch review quality depends on the agent default model (Opus 4.7, which is higher-quality than the Sonnet 4.6 overrides being removed). This is the operator's intent.
+- **Low:** The `always_on` change means all three skills are always matched on every mika-arch turn. Since mika-arch is single-purpose (only does review), this is correct — every turn should have the review skill active.
+- **Medium:** The stale-override cleanup in `seed_well_known_skill_overrides` must not delete operator-set `enabled=false` rows. The plan addresses this with an explicit `enabled` field check.

--- a/skills/bundled/mika-arch-groom-milestone/skill.toml
+++ b/skills/bundled/mika-arch-groom-milestone/skill.toml
@@ -2,7 +2,7 @@
 name = "mika-arch-groom-milestone"
 description = "Milestone-level plan review — reviews all sub-issue plans for cross-cutting concerns, sequencing, and produces an aggregate READY / ITERATE / ESCALATE disposition."
 version = "0.1.0"
-always_on = false
+always_on = true
 timeout_secs = 180
 
 [triggers]

--- a/skills/bundled/mika-arch-groom-ticket/skill.toml
+++ b/skills/bundled/mika-arch-groom-ticket/skill.toml
@@ -2,7 +2,7 @@
 name = "mika-arch-groom-ticket"
 description = "First-pass principle-grounded plan review — produces READY / ITERATE / ESCALATE disposition with annotated plan content."
 version = "0.1.0"
-always_on = false
+always_on = true
 timeout_secs = 120
 
 [triggers]

--- a/skills/bundled/mika-arch-second-review/skill.toml
+++ b/skills/bundled/mika-arch-second-review/skill.toml
@@ -2,7 +2,7 @@
 name = "mika-arch-second-review"
 description = "Iteration-pass plan review after a first-pass ITERATE verdict — produces GROOMED or ESCALATE. Never ITERATE again."
 version = "0.1.0"
-always_on = false
+always_on = true
 timeout_secs = 120
 
 [triggers]


### PR DESCRIPTION
## Rescued implementation (dispatch-lib content/workflow split)

This PR was created by dispatch-lib's git-workflow recovery (mika#1282).

The dev-pilot session wrote file changes but never completed the git workflow
(no `git commit` or `gh pr create`). Per the mika#1271 content/workflow split
contract, dispatch-lib took ownership of the git layer: staged, committed with
`wip()` prefix, pushed, and opened this draft PR to preserve the content.

**This is a draft PR requiring human review.** The content has NOT passed
`/ce:review` and may contain partially-coherent multi-file changes.

### Recovery metadata
- Pilot session: `a4d19c07-af63-4db1-8837-7f04dff6238e`
- Turns: 48
- Cost: $3.6982962500000003

Closes #949