### PR TITLE
docs(retro): schema migrations as integration-test events (#767)

### DIFF
--- a/crates/mika-agent/src/db/kg_schema.rs
+++ b/crates/mika-agent/src/db/kg_schema.rs
@@ -4,6 +4,12 @@
 //! convention constants. All migration code and row mappers import from here
 //! instead of using inline strings or `SELECT *`.
 //!
+//! ## Schema migration pre-ship checklist
+//!
+//! Before shipping any migration that changes what "pending work" queries return,
+//! consult `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md`
+//! for the operational checklist (mika#767).
+//!
 //! ## Write Contract (for `kg_chunks` consumers)
 //!
 //! The `kg_chunks` table stores chunk structural metadata (entity link, seq_id,

--- a/docs/plans/2026-06-02-001-docs-767-retro-schema-migrations-as-integration-plan.md
+++ b/docs/plans/2026-06-02-001-docs-767-retro-schema-migrations-as-integration-plan.md
@@ -9,7 +9,7 @@ Write a compound doc at `docs/solutions/best-practices/schema-migrations-as-inte
 Two existing docs already cover the individual incidents in detail:
 
 - `docs/solutions/best-practices/first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md` — deep dive on #757 (cost spike, budget guards, idempotency, fan-out)
-- `docs/solutions/runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md` — deep dive on the UTF-8 panic (14 sites, `safe_truncate`, CI lint gate)
+- `docs/solutions/runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md` — deep dive on the UTF-8 panic (14 resolver/extractor sites per that doc; #767 body scope is 10 — see §2 Incident 2)
 
 This new doc is the **synthesis layer** — it abstracts the shared pattern from both incidents rather than repeating their details. The two incident docs are evidence; this doc is the lesson. Sections should reference (not duplicate) incident-specific metrics and fixes.
 
@@ -53,7 +53,7 @@ related_issues: [757, 767]
 
 2. **Two concrete incidents** — Brief summaries with metrics, linking to the detailed incident docs:
    - **Incident 1: #757 cost spike** — 11 agents × 283 docs → 30,400 LLM calls → ~$40–60, Anthropic credit exhausted. Fix: budget guard + hash idempotency. Detail: see `first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md`.
-   - **Incident 2: KG UTF-8 panic** — v26 migration invalidated markers → full re-extraction → resolver scheduled ~5K subjects/agent → first multi-byte char panicked 14 `&s[..N]` sites → 27 panics across 11 agents, KG resolution fully broken. Fix: `safe_truncate` + CI byte-slice lint. Detail: see `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`.
+   - **Incident 2: KG UTF-8 panic** — v26 migration invalidated markers → full re-extraction → resolver scheduled ~5K subjects/agent → first multi-byte char (em-dash, byte 2000) panicked tokio-spawn'd resolver tasks → KG resolution fully broken. Site count: #767 body cites "5 resolver/extractor + 5 workspace-wide" (10 total scope); the resolver/extractor-internal site replacement was **14** per `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`, which also reports **27 panic events across 11 agents** in server.log. Fix: `safe_truncate` (`floor_char_boundary`) + CI byte-slice lint + spawn-site panic logging. Detail: see `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`.
 
 3. **Why migration tests don't catch this** — The schema migration is correct in isolation. The failure is a second-order effect: changing what the pending-work query returns changes the *volume* and *distribution* of inputs to downstream consumers. Migration tests validate DDL + data transformation; they don't exercise the consumer pipeline at the new scale or against the new input distribution.
 
@@ -75,6 +75,7 @@ related_issues: [757, 767]
    - `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`
    - `kg-schema.rs` idempotency contract documentation
    - `check-byte-slices.sh` CI lint
+   - **Implementer note for rescue PR + KG bug ticket:** #767 issue body's Related-section AC asks for "links to #757, the rescue PR, the KG bug ticket." The rescue/KG-bug PRs live in the `#752–#759` series. During implementation, run `gh issue view <N>` for each of `#752 #756 #758 #759` and identify which is the rescue PR (the one that introduced `safe_truncate`) and which is the KG bug ticket (the one that filed the panic). Cite both by number in the compound doc's Related section.
 
 ### Step 2 — Add cross-reference in migration code
 

--- a/docs/plans/2026-06-02-001-docs-767-retro-schema-migrations-as-integration-plan.md
+++ b/docs/plans/2026-06-02-001-docs-767-retro-schema-migrations-as-integration-plan.md
@@ -1,0 +1,119 @@
+# Plan: docs(retro) — schema migrations as integration-test events (#767)
+
+## Overview
+
+Write a compound doc at `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md` that captures the meta-pattern: schema migrations that change "what needs processing" queries are **integration-test events**, not just migration-test events. Two incidents from 2026-04-23 (mika#757 cost spike + KG UTF-8 panic) are evidence. The doc includes an operational checklist for future schema PRs.
+
+### Overlap with existing docs
+
+Two existing docs already cover the individual incidents in detail:
+
+- `docs/solutions/best-practices/first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md` — deep dive on #757 (cost spike, budget guards, idempotency, fan-out)
+- `docs/solutions/runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md` — deep dive on the UTF-8 panic (14 sites, `safe_truncate`, CI lint gate)
+
+This new doc is the **synthesis layer** — it abstracts the shared pattern from both incidents rather than repeating their details. The two incident docs are evidence; this doc is the lesson. Sections should reference (not duplicate) incident-specific metrics and fixes.
+
+## Requirements trace
+
+From the ticket's acceptance criteria:
+
+1. **Doc written** at the specified path
+2. **Checklist included** (verbatim from ticket body, or improved if patterns emerge)
+3. **Both incidents cited** with concrete metrics (LLM call counts, dollar estimates, panic counts)
+4. **No implementation work** — pure compound documentation
+5. **Cross-reference from migration code** so future schema authors find the checklist
+
+## Plan
+
+### Step 1 — Write the compound doc
+
+**File:** `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md`
+
+**Frontmatter:**
+```yaml
+---
+title: "Schema migrations as integration-test events"
+module: kg
+date: 2026-04-23
+problem_type: best_practice
+component: database
+severity: high
+tags:
+  - knowledge-graph
+  - schema-migrations
+  - integration-testing
+  - operational-readiness
+related_issues: [757, 767]
+---
+```
+
+**Sections:**
+
+1. **Problem** — Pattern statement: migration correctness ≠ downstream correctness. The `migrate_v25_to_v26` test validates the DDL. It does NOT validate that all code paths processing the now-larger pending set survive realistic production input distributions.
+
+2. **Two concrete incidents** — Brief summaries with metrics, linking to the detailed incident docs:
+   - **Incident 1: #757 cost spike** — 11 agents × 283 docs → 30,400 LLM calls → ~$40–60, Anthropic credit exhausted. Fix: budget guard + hash idempotency. Detail: see `first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md`.
+   - **Incident 2: KG UTF-8 panic** — v26 migration invalidated markers → full re-extraction → resolver scheduled ~5K subjects/agent → first multi-byte char panicked 14 `&s[..N]` sites → 27 panics across 11 agents, KG resolution fully broken. Fix: `safe_truncate` + CI byte-slice lint. Detail: see `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`.
+
+3. **Why migration tests don't catch this** — The schema migration is correct in isolation. The failure is a second-order effect: changing what the pending-work query returns changes the *volume* and *distribution* of inputs to downstream consumers. Migration tests validate DDL + data transformation; they don't exercise the consumer pipeline at the new scale or against the new input distribution.
+
+4. **Operational checklist** — From the ticket body (adapted/improved if warranted during writing):
+   - Pending-set size change? → Estimate upper bound, run downstream pipeline against it
+   - Processing markers invalidated? → Estimate re-processing cost, verify budget guards cap the spike
+   - Realistic input testing? → Not simplified fixtures, actual production-shaped content at scale
+   - Deploy plan includes "watch first restart"? → Cost spikes, panics, backlog growth
+
+5. **Implementation hooks** — Options to enforce, without proposing specific implementation:
+   - CI check that flags migrations touching tracking/marker tables
+   - Plan-template question (first-boot cost) enforced by architect review
+   - Staging-env integration test with production-scale pending set
+   - Mandatory `Post-deploy verification` section in migration PR description template
+
+6. **Related** — Links to:
+   - mika#757, mika#767
+   - `first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md`
+   - `utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`
+   - `kg-schema.rs` idempotency contract documentation
+   - `check-byte-slices.sh` CI lint
+
+### Step 2 — Add cross-reference in migration code
+
+**File:** `crates/mika-agent/src/db/kg_schema.rs`
+
+Add a doc comment at the module level (or near the existing idempotency contract docs) pointing to the new checklist:
+
+```rust
+/// ## Schema migration pre-ship checklist
+///
+/// Before shipping any migration that changes what "pending work" queries return,
+/// consult `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md`
+/// for the operational checklist (mika#767).
+```
+
+This is a comment-only change — no behavior change.
+
+### Step 3 — Verify
+
+- Doc exists at the specified path with correct frontmatter
+- Both incidents cited with concrete metrics
+- Checklist present and complete
+- Cross-reference added in `kg_schema.rs`
+- No implementation code changed
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md` | New — compound doc |
+| `crates/mika-agent/src/db/kg_schema.rs` | Comment-only — cross-reference to checklist |
+
+## Risks
+
+- **Overlap with existing docs:** Mitigated by making this the synthesis/pattern doc that references (not duplicates) the two incident docs.
+- **Checklist goes stale:** Low risk — the checklist is a set of questions, not implementation-specific. Invalidated only if the project moves away from schema migrations entirely.
+
+## Out of scope
+
+- Implementing automated schema-migration integration tests (separate enhancement)
+- Refactoring existing migration patterns
+- Any code changes beyond the cross-reference comment

--- a/docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md
+++ b/docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md
@@ -1,0 +1,94 @@
+---
+title: "Schema migrations as integration-test events"
+module: kg
+date: 2026-04-23
+problem_type: best_practice
+component: database
+severity: high
+tags:
+  - knowledge-graph
+  - schema-migrations
+  - integration-testing
+  - operational-readiness
+related_issues: [757, 767]
+---
+
+# Schema migrations as integration-test events
+
+## Problem
+
+Migration correctness does not imply downstream correctness. A schema migration that changes what a "pending work" query returns is an **integration-test event**, not just a migration-test event.
+
+The `migrate_v25_to_v26` test validates the DDL — it confirms the column is added, the data is transformed, and the schema version is incremented. It does NOT validate that all code paths processing the now-larger pending set survive realistic production input distributions. The migration is correct in isolation. The failures are second-order effects: changing what the pending-work query returns changes the *volume* and *distribution* of inputs to downstream consumers.
+
+This pattern generalizes beyond KG. Any migration that introduces a tracking table, invalidates processing markers, or alters a "what needs doing" query creates a first-boot event whose cost and failure modes must be evaluated before shipping — not discovered at runtime.
+
+## Two concrete incidents (2026-04-23)
+
+Both incidents occurred on the same deploy and share the same root cause: schema v25→v26 changed the pending-work query surface without integration-level verification of the downstream consumers.
+
+### Incident 1: Cost spike (#757)
+
+The v26 migration introduced `kg_extractions` — a tracking table that records which docs have been extracted. On first boot, the table was empty (no prior "already extracted" rows), so the pending-doc query returned every doc across every agent.
+
+- **Scale:** 11 agents × 283 shared docs → ~3,113 extractions + per-entity resolution fan-out → ~30,400 LLM calls over 38 minutes
+- **Cost:** ~$40–60 against `claude-haiku-4-5`, exhausting Anthropic Console API credit
+- **Fix:** Per-batch budget guard (`MIKA_KG_BATCH_BUDGET`, default 500), hash-based content idempotency (`kg_extractions.source_doc_hash`), atomic marker writes within the extraction transaction, provider-choice advisory (`kg_anthropic_provider` startup WARN)
+- **Detail:** See [`first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md`](first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md)
+
+### Incident 2: KG UTF-8 panic (#764)
+
+The same v26 migration invalidated extraction markers, triggering full re-extraction. The resolver then scheduled ~5,000 subject entities per agent. The first multi-byte UTF-8 character (an em-dash at byte offset 2000) panicked the `tokio::spawn`'d resolver tasks via `&str[..N]` byte slicing.
+
+- **Scale:** 14 unsafe byte-slicing sites across resolver, extractor, and workspace-wide code; 27 panic events across all 11 agents in `server.log`
+- **Impact:** KG resolution fully broken — zero `kg_resolutions_log` writes for 5+ hours. Panics invisible to tracing because `tokio::spawn` JoinHandles were discarded
+- **Fix:** Shared `safe_truncate()` helper using `str::floor_char_boundary()`, spawn-site panic containment (outer spawn + JoinHandle await), CI `byte-slice-lint` regression guard
+- **Detail:** See [`../runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`](../runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md)
+
+## Why migration tests don't catch this
+
+Schema migration tests validate three things: (1) DDL correctness (table/column exists after migration), (2) data transformation correctness (existing rows are converted properly), and (3) version increment (schema version advances). All three passed for v25→v26.
+
+The failures are second-order effects that migration tests are structurally unable to catch:
+
+- **Volume amplification.** The migration changed what the pending-work query returns from "incrementally new docs" to "every doc ever ingested." The migration test doesn't run the consumer pipeline, so it can't observe the volume spike.
+- **Input distribution shift.** Pre-migration, the consumer saw small batches of newly-ingested docs. Post-migration, it saw the entire corpus — including docs with multi-byte UTF-8 characters that the consumer had never encountered at scale. The migration test uses simplified fixtures, not production-shaped content.
+- **Fan-out multiplication.** Per-agent isolation means N agents × M docs. The migration test runs against a single-agent test database with a handful of rows.
+
+The gap is structural: migration tests validate the schema change; integration tests validate the system's behavior after the schema change. These are different concerns, and treating the first as sufficient for the second is the failure pattern.
+
+## Operational checklist for schema-change PRs
+
+Before shipping any migration that touches "what needs processing" queries, answer these questions:
+
+1. **Pending-set size change?**
+   Estimate the upper bound of the pending set on first boot after this migration. If the consumer does non-trivial per-unit work (LLM calls, external API calls, heavy compute), multiply by the per-unit cost and by the consumer fan-out multiplier (agents × tenants). Document the estimate in the PR description.
+
+2. **Processing markers invalidated?**
+   Does this migration invalidate existing "already processed" markers (by adding a new tracking table, changing a hash column, or altering the pending-set query)? If yes, estimate the re-processing cost and verify that structural budget guards cap the spike. A prompt-level "be mindful of cost" is not a budget guard.
+
+3. **Realistic input testing?**
+   Run the downstream pipeline against production-shaped content at the estimated scale — not simplified fixtures. The #764 panic only manifested on multi-byte UTF-8 characters that appeared in real compound docs but not in test fixtures.
+
+4. **Deploy plan includes "watch first restart"?**
+   The first restart after a tracking-table migration is a financial and operational event. The deploy plan should include concrete signals to watch: cost spikes, panics, backlog growth rates. See the post-deploy verification signals (Signals A–J) documented in `CLAUDE.md` for the KG-specific instance of this pattern.
+
+## Implementation hooks
+
+These are options to enforce the checklist — not proposals for immediate implementation:
+
+- **CI check** that flags migrations touching tracking or marker tables (e.g., tables matching `*_extractions`, `*_processed`, `*_seen`) and requires a `## First-boot impact` section in the PR description
+- **Plan-template question** ("What is the first-boot cost of this migration?") enforced by architect review — the mika-arch groom-ticket skill could include this as a required consideration for migration-bearing plans
+- **Staging-env integration test** that runs the consumer pipeline against a production-scale pending set after the migration, measuring cost and checking for panics
+- **Mandatory `Post-deploy verification` section** in migration PR description template, with operator-facing signals to watch on the first restart
+
+## Related
+
+- **Incident tickets:** [mika#757](https://github.com/senara-solutions/mika/issues/757), [mika#767](https://github.com/senara-solutions/mika/issues/767)
+- **KG bug ticket (UTF-8 panic):** [mika#764](https://github.com/senara-solutions/mika/issues/764)
+- **Rescue PR (idempotency + budget guard):** [mika#759](https://github.com/senara-solutions/mika/pull/759)
+- **Incident deep-dives:**
+  - [`first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md`](first-boot-cost-spike-after-tracking-table-migration-2026-04-23.md) — #757 cost spike, budget guards, idempotency, fan-out
+  - [`../runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md`](../runtime-errors/utf8-byte-slicing-panic-kg-resolver-extractor-2026-04-23.md) — #764 UTF-8 panic, safe_truncate, spawn containment, CI lint
+- **Code cross-reference:** `crates/mika-agent/src/db/kg_schema.rs` — idempotency contract documentation + pointer to this checklist
+- **CI regression guard:** `scripts/check-byte-slices.sh` — byte-slice lint added after #764


### PR DESCRIPTION
## Summary

Compound doc capturing the meta-pattern from two 2026-04-23 incidents (mika#757 cost spike + KG UTF-8 panic): schema migrations that change "what needs processing" queries are **integration-test events**, not just migration-test events. The `migrate_v25_to_v26` test validates DDL — it does not validate that downstream code paths survive the new input volume/distribution.

Includes operational checklist for future schema PRs and a cross-reference comment in `kg_schema.rs` pointing to the new doc.

## Files

- `docs/solutions/best-practices/schema-migrations-as-integration-events-2026-04-23.md` (new, 94 lines)
- `crates/mika-agent/src/db/kg_schema.rs` (6-line doc comment, no behavior change)

## Pipeline artifacts

- Plan: `docs/plans/2026-06-02-001-docs-767-retro-schema-migrations-as-integration-plan.md`
- Architect first-pass: ITERATE (F1 metric sourcing, F2 rescue-PR resolution)
- Plan revised: commit `d0ca02f5` addresses F1+F2
- Architect second-pass: **GROOMED** (session `b903e59d-f69a-4cd6-bdd2-9f242326467a`)
- Implementation: commit `f7c275ee` via dev-pilot (23 turns, claude-opus-4-6)

## Note

PR opened by orchestrator after dev-pilot completed all quality gates but hit a transient AxiosError 5000ms timeout on the `gh pr create` step. Substrate gap to be ticketed separately.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)