### PR TITLE
feat(llm): one-shot OllamaProvider payload dump for OOD diagnostics

### DIFF
--- a/crates/mika-common/src/llm/ollama.rs
+++ b/crates/mika-common/src/llm/ollama.rs
@@ -1,15 +1,79 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{Instrument, debug, info, info_span, warn};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 
 use super::error::LlmError;
 use super::openai::extract_think_block;
 use super::types::*;
 use super::{LlmProvider, RETRY_BUFFER_SECS, TYPICAL_CALL_DURATION_SECS};
+
+/// One-shot debug-flag-gated payload dump (mika#1387).
+///
+/// When `MIKA_OLLAMA_DUMP_PAYLOAD=<path>` is set, the NEXT `/api/chat`
+/// request body through `OllamaProvider` is written to that path, then the
+/// flag flips and subsequent requests are no-ops. Process-scoped — resets
+/// only on process restart.
+///
+/// Bounded at 256 KiB. Overflow appends a truncation marker so the file
+/// stays grep-able and the operator notices.
+const PAYLOAD_DUMP_CAP_BYTES: usize = 256 * 1024;
+static PAYLOAD_DUMP_FIRED: AtomicBool = AtomicBool::new(false);
+
+/// Test-only handle that resets the one-shot flag so each test starts fresh.
+#[cfg(test)]
+pub(crate) fn reset_payload_dump_flag() {
+    PAYLOAD_DUMP_FIRED.store(false, Ordering::Relaxed);
+}
+
+/// If `MIKA_OLLAMA_DUMP_PAYLOAD` is set and the one-shot flag hasn't fired
+/// this process, write `body_json` (capped at `PAYLOAD_DUMP_CAP_BYTES`) to
+/// the configured path. Failure resets the flag so the operator can retry
+/// after fixing the path; success flips it permanently.
+fn try_dump_payload(body_json: &str) {
+    let path = match std::env::var("MIKA_OLLAMA_DUMP_PAYLOAD") {
+        Ok(p) if !p.is_empty() => p,
+        _ => return,
+    };
+
+    // Atomically reserve the one-shot slot.
+    if PAYLOAD_DUMP_FIRED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let total_len = body_json.len();
+    let (slice, truncated) = if total_len > PAYLOAD_DUMP_CAP_BYTES {
+        (&body_json[..PAYLOAD_DUMP_CAP_BYTES], true)
+    } else {
+        (body_json, false)
+    };
+
+    let mut content = String::with_capacity(slice.len() + 128);
+    content.push_str(slice);
+    if truncated {
+        content.push_str(&format!(
+            "\n<!-- TRUNCATED at {PAYLOAD_DUMP_CAP_BYTES} bytes; total payload was {total_len} bytes -->\n"
+        ));
+    }
+
+    match std::fs::write(&path, &content) {
+        Ok(()) => warn!(
+            path = %path,
+            bytes_written = content.len(),
+            truncated,
+            "Ollama payload dumped (one-shot)"
+        ),
+        Err(e) => {
+            // Reset so the operator can retry after fixing the path.
+            PAYLOAD_DUMP_FIRED.store(false, Ordering::Relaxed);
+            error!(path = %path, error = %e, "Ollama payload dump failed");
+        }
+    }
+}
 
 // -- Ollama wire types --
 
@@ -345,11 +409,26 @@ impl OllamaProvider {
             headers.insert(AUTHORIZATION, auth);
         }
 
-        // Dev-mode body logging
-        if tracing::enabled!(target: "mika::llm_debug", tracing::Level::DEBUG)
-            && let Ok(body_json) = serde_json::to_string(request)
-        {
-            debug!(target: "mika::llm_debug", body = %body_json, provider = "ollama", "llm request body");
+        // Serialize once for both the dev-mode debug log and the one-shot
+        // payload dump (#1387). Either gate may be enabled independently;
+        // if both are off, the serialize cost is skipped.
+        let dump_enabled =
+            std::env::var_os("MIKA_OLLAMA_DUMP_PAYLOAD").is_some_and(|v| !v.is_empty());
+        let debug_log_enabled = tracing::enabled!(target: "mika::llm_debug", tracing::Level::DEBUG);
+        if dump_enabled || debug_log_enabled {
+            match serde_json::to_string(request) {
+                Ok(body_json) => {
+                    if debug_log_enabled {
+                        debug!(target: "mika::llm_debug", body = %body_json, provider = "ollama", "llm request body");
+                    }
+                    if dump_enabled {
+                        try_dump_payload(&body_json);
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "ollama: failed to serialize request for debug log/dump");
+                }
+            }
         }
 
         let response = self
@@ -1189,5 +1268,131 @@ mod tests {
         // Optional fields should be omitted when None
         assert!(json.get("tools").is_none());
         assert!(json["messages"][0].get("tool_calls").is_none());
+    }
+
+    // -- Payload dump tests (mika#1387) -------------------------------------
+
+    /// Tests for `try_dump_payload` use the process-wide env var
+    /// `MIKA_OLLAMA_DUMP_PAYLOAD` and the process-wide one-shot
+    /// `PAYLOAD_DUMP_FIRED` flag — must run serially and reset the flag
+    /// before each case.
+    mod payload_dump {
+        use super::super::*;
+        use serial_test::serial;
+        use tempfile::TempDir;
+
+        const ENV: &str = "MIKA_OLLAMA_DUMP_PAYLOAD";
+
+        struct EnvGuard {
+            key: &'static str,
+        }
+        impl EnvGuard {
+            fn set(key: &'static str, value: &str) -> Self {
+                unsafe { std::env::set_var(key, value) };
+                Self { key }
+            }
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                unsafe { std::env::remove_var(self.key) };
+            }
+        }
+
+        #[test]
+        #[serial]
+        fn r7_basic_dump_writes_body_and_flips_flag() {
+            reset_payload_dump_flag();
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("payload.json");
+            let _guard = EnvGuard::set(ENV, path.to_str().unwrap());
+
+            let body = r#"{"model":"mika","messages":[{"role":"user","content":"hello"}]}"#;
+            try_dump_payload(body);
+
+            let written = std::fs::read_to_string(&path).expect("file should be written");
+            assert_eq!(written, body);
+            assert!(
+                PAYLOAD_DUMP_FIRED.load(Ordering::Relaxed),
+                "one-shot flag should be set after successful dump"
+            );
+            // Cleanup for the next serial test.
+            reset_payload_dump_flag();
+        }
+
+        #[test]
+        #[serial]
+        fn r8_one_shot_second_call_is_noop() {
+            reset_payload_dump_flag();
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("payload.json");
+            let _guard = EnvGuard::set(ENV, path.to_str().unwrap());
+
+            try_dump_payload(r#"{"first":"call"}"#);
+            // Second invocation must not overwrite — content remains the first call's body.
+            try_dump_payload(r#"{"second":"call"}"#);
+
+            let written = std::fs::read_to_string(&path).expect("file should be written");
+            assert_eq!(written, r#"{"first":"call"}"#);
+            reset_payload_dump_flag();
+        }
+
+        #[test]
+        #[serial]
+        fn r9_truncation_marker_when_body_exceeds_cap() {
+            reset_payload_dump_flag();
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("payload.json");
+            let _guard = EnvGuard::set(ENV, path.to_str().unwrap());
+
+            // Body larger than the 256 KiB cap.
+            let body = "x".repeat(PAYLOAD_DUMP_CAP_BYTES + 1024);
+            try_dump_payload(&body);
+
+            let written = std::fs::read_to_string(&path).expect("file should be written");
+            // First PAYLOAD_DUMP_CAP_BYTES bytes preserved verbatim.
+            assert_eq!(
+                &written[..PAYLOAD_DUMP_CAP_BYTES],
+                &body[..PAYLOAD_DUMP_CAP_BYTES]
+            );
+            // Truncation marker appended with both byte counts.
+            assert!(
+                written.contains("<!-- TRUNCATED at "),
+                "expected truncation marker, got tail: {}",
+                &written[written.len().saturating_sub(200)..]
+            );
+            assert!(
+                written.contains(&format!(
+                    "total payload was {} bytes",
+                    PAYLOAD_DUMP_CAP_BYTES + 1024
+                )),
+                "marker should report the total payload length"
+            );
+            reset_payload_dump_flag();
+        }
+
+        #[test]
+        #[serial]
+        fn env_unset_is_noop() {
+            reset_payload_dump_flag();
+            // No env var set — `try_dump_payload` returns without touching anything.
+            unsafe { std::env::remove_var(ENV) };
+            try_dump_payload(r#"{"unused":true}"#);
+            assert!(
+                !PAYLOAD_DUMP_FIRED.load(Ordering::Relaxed),
+                "flag must not flip when env is unset"
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn env_empty_is_noop() {
+            reset_payload_dump_flag();
+            let _guard = EnvGuard::set(ENV, "");
+            try_dump_payload(r#"{"unused":true}"#);
+            assert!(
+                !PAYLOAD_DUMP_FIRED.load(Ordering::Relaxed),
+                "flag must not flip when env value is empty"
+            );
+        }
     }
 }

--- a/docs/plans/1387-ollama-payload-dump-one-shot.md
+++ b/docs/plans/1387-ollama-payload-dump-one-shot.md
@@ -1,0 +1,179 @@
+---
+title: "feat: one-shot OllamaProvider payload dump for MikaModel OOD diagnostics"
+type: feat
+status: active
+date: 2026-06-03
+origin: senara-solutions/mika#1387
+---
+
+# feat: one-shot OllamaProvider payload dump for MikaModel OOD diagnostics
+
+## Overview
+
+Add an env-gated, one-shot debug affordance to `OllamaProvider::send_once` that writes the exact JSON body sent to Ollama's `/api/chat` to a configured file path. Lets the operator (or follow-up diagnostic work) capture mika-server's actual runtime payload — system prompt + messages + tools + options — to diagnose the out-of-distribution behavior observed post-mika#1379 with `MIKA_LLM_PROVIDER=mikamodel mika ask "hello"`.
+
+## Problem Frame
+
+After mika#1379 shipped (PR #1380, commit `368d6b0`), local smoke testing surfaced that the MikaModel provider returns unrelated multi-section workplace-assistant boilerplate ("## Completed Tasks", "## Pending", etc.) rather than responding to the user input. Five direct curl probes against the same Ollama backend with various system-prompt shapes (training-shape, none, math-tutor role, explicit "use status report format" instruction, multi-section markdown) all returned sane conversational output. **The upstream model is healthy in isolation; something specific in mika-server's runtime `/api/chat` payload triggers the OOD behavior.**
+
+Three plausible triggers, in descending likelihood:
+
+1. **The `tools` array.** mika-server passes the full ~82-tool catalog on every request. The largest single structural delta vs the probes (which had no `tools` field set). Most plausible distribution-shift culprit.
+2. **The full multi-section system prompt.** 14 `## Section` headers (Current Time, Communication Channel, Core Memory, Instructions, Tool Usage, Pending Commitments, Silent Mode, Today's Conversations, Recent Audit Events, File Tools, Task Health, Trigger, etc.), each with detailed rules and XML-tagged content.
+3. **Conversation history.** If the agent home dir has prior turns, mika-server appends them; a prior assistant message containing similar structural content could elicit continuation.
+
+Without the actual payload, choosing a fix is guessing — a compact-prompt-builder branch for `ProviderKind::MikaModel` ships fast but is wrong if the trigger is the tools array, and vice versa. The smallest possible affordance to break the guessing cycle is a one-shot dump.
+
+## Requirements Trace
+
+- **R1.** New env var `MIKA_OLLAMA_DUMP_PAYLOAD` accepting a filesystem path. When unset, no dump fires (zero overhead).
+- **R2.** When set, the NEXT `/api/chat` request through `OllamaProvider` serializes its JSON body to that path. Subsequent requests in the same process do NOT overwrite (one-shot semantics, enforced via process-level `AtomicBool`).
+- **R3.** Hard byte cap on the dumped file (default 256 KiB). When truncated, the file ends with a literal `\n<!-- TRUNCATED at N bytes; total payload was M bytes -->\n` marker so grep / `cat` users notice.
+- **R4.** Single `tracing::warn!` log line on successful dump, including the path, bytes written, and truncation status. Failures (e.g. permission denied) emit `tracing::error!` and do NOT flip the one-shot flag — operator can retry after fixing the path.
+- **R5.** Scope: `OllamaProvider` only. Routes for both `ProviderKind::Ollama` and `ProviderKind::MikaModel` so the affordance helps both transports.
+- **R6.** Zero behavioral effect on the actual HTTP request — dump is observation-only, fires after JSON serialization but before the body is moved into `reqwest::RequestBuilder::json()`. Even on dump failure, the request proceeds normally.
+- **R7.** Unit test: with `MIKA_OLLAMA_DUMP_PAYLOAD` set to a `tempfile` path, calling `try_dump_payload(body_json)` writes the expected JSON to the path and flips the one-shot flag.
+- **R8.** Unit test: second call with the same env var is a no-op (one-shot enforced).
+- **R9.** Unit test: when the body exceeds the byte cap, the file ends with the truncation marker.
+
+## Proposed Solution
+
+Add a small helper in `crates/mika-common/src/llm/ollama.rs`:
+
+```rust
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const PAYLOAD_DUMP_CAP_BYTES: usize = 256 * 1024;
+static PAYLOAD_DUMP_FIRED: AtomicBool = AtomicBool::new(false);
+
+fn try_dump_payload(body_json: &str) {
+    let Ok(path) = std::env::var("MIKA_OLLAMA_DUMP_PAYLOAD") else { return };
+    if path.is_empty() { return; }
+
+    // One-shot — flip atomically; if already fired, do nothing.
+    if PAYLOAD_DUMP_FIRED.swap(true, Ordering::Relaxed) { return; }
+
+    let total_len = body_json.len();
+    let (slice, truncated) = if total_len > PAYLOAD_DUMP_CAP_BYTES {
+        (&body_json[..PAYLOAD_DUMP_CAP_BYTES], true)
+    } else {
+        (body_json, false)
+    };
+
+    let mut content = String::with_capacity(slice.len() + 128);
+    content.push_str(slice);
+    if truncated {
+        content.push_str(&format!(
+            "\n<!-- TRUNCATED at {PAYLOAD_DUMP_CAP_BYTES} bytes; total payload was {total_len} bytes -->\n"
+        ));
+    }
+
+    match std::fs::write(&path, &content) {
+        Ok(()) => warn!(
+            path = %path,
+            bytes_written = content.len(),
+            truncated,
+            "Ollama payload dumped (one-shot)"
+        ),
+        Err(e) => {
+            // Reset the flag so the operator can retry after fixing the path.
+            PAYLOAD_DUMP_FIRED.store(false, Ordering::Relaxed);
+            error!(path = %path, error = %e, "Ollama payload dump failed");
+        }
+    }
+}
+```
+
+Wire it in `send_once` right after the existing dev-mode body logging block (line 348-353), before the `reqwest::Client::post()` call. JSON serialization is already done for the debug log — reuse `body_json` if the log block fires; otherwise serialize once for the dump.
+
+Refactor the small dev-log block so JSON serialization happens once whether or not either gate is enabled:
+
+```rust
+let body_json = match serde_json::to_string(request) {
+    Ok(s) => s,
+    Err(e) => {
+        warn!(error = %e, "ollama: failed to serialize request for debug log");
+        // Fall through — the .json() call below will surface the real error.
+        String::new()
+    }
+};
+if !body_json.is_empty() {
+    if tracing::enabled!(target: "mika::llm_debug", tracing::Level::DEBUG) {
+        debug!(target: "mika::llm_debug", body = %body_json, provider = "ollama", "llm request body");
+    }
+    try_dump_payload(&body_json);
+}
+```
+
+## Key Technical Decisions
+
+### Why a process-level `AtomicBool` (not env-var unset, not per-instance flag)
+
+- **Env-var unset.** Would require `unsafe { std::env::remove_var(...) }` (Rust 2024 edition makes env-modification unsafe). We don't want to introduce unsafe blocks for what is fundamentally a debug affordance.
+- **Per-instance flag** (e.g. `AtomicBool` on the `OllamaProvider` struct). Multiple providers can coexist in the same process (mika-agent + cli + gateway in dev workflows); a per-instance flag would let the dump fire once per instance, giving N dumps for N instances. Process-level matches the "one-shot for the operator's diagnostic capture" intent.
+- **Static `AtomicBool` at module scope.** Simplest, lock-free, process-scoped. Resets only on process restart, which matches "one-shot per debug session."
+
+### Why a byte cap (not unlimited, not chunked)
+
+- The payload may include a full 82-tool catalog plus a large conversation history. Unlimited writes can produce multi-megabyte files that hang text editors and complicate `grep` / `jq` triage.
+- 256 KiB is a comfortable budget: a 14-section system prompt + 82-tool catalog typically lands well below 100 KiB; 256 KiB allows 2-3× headroom for conversation history.
+- Chunked / multi-file output: rejected as scope creep. If a real payload exceeds the cap, the truncation marker tells the operator and a future ticket can extend.
+
+### Why fail-fast (do NOT flip flag on dump error)
+
+- A permission-denied or no-such-directory error on first call should be operator-fixable without restarting mika-agent. Flipping the flag would lock the operator out until restart. The error log surfaces the failure; retry on next request after fixing the path.
+
+### Why not generic per-provider dump
+
+- `OpenAiCompatibleProvider` and `AnthropicProvider` would each need their own implementation since the request shape differs. The only known active diagnostic need is MikaModel via OllamaProvider. Premature generalization is YAGNI. If a second provider gains a similar need, lift the helper into `mika-common::llm` then.
+
+## Scope Boundaries
+
+### In scope
+
+- `try_dump_payload` helper + the `send_once` wiring.
+- Unit tests for the three R7/R8/R9 cases.
+- Plan doc (this file) + solution doc.
+
+### Out of scope
+
+- **The actual OOD bug fix.** This ticket ships the diagnostic; the fix lands in a follow-up once the dumped payload identifies the trigger.
+- **Generic LLM-payload-dump affordance for other providers.** Defer until needed.
+- **Production telemetry.** This is a local debug flag, not metrics/logs. Cache scrubbing, secret redaction, etc. are deferred — `OllamaProvider` is typically authless so the auth header issue is mostly moot, but a follow-up could harden if needed.
+- **Configurable byte cap.** Hard-coded 256 KiB until evidence demands flexibility.
+- **Tools array filtering.** A separate follow-up ticket if the dump reveals tools as the trigger.
+
+### Deferred to separate tickets
+
+- Compact-prompt-builder branch for `ProviderKind::MikaModel` (one of the candidate patches — gated on dump evidence).
+- Upstream-model retrain on a distribution-matched prompt shape (the other candidate patch — gated on dump evidence + cost authorization).
+
+## Verification
+
+### Build verification
+
+1. `cargo check --workspace` clean.
+2. `cargo clippy -p mika-common --no-deps -- -D warnings` clean.
+3. `cargo test -p mika-common --lib` — 363 passed (361 prior + 2 new MikaModel tests from #1379) + 3 new dump tests = 366 expected.
+
+### Behavioral verification (post-merge, local)
+
+1. `MIKA_OLLAMA_DUMP_PAYLOAD=/tmp/mika-payload.json MIKA_LLM_PROVIDER=mikamodel mika ask "hello"` writes `/tmp/mika-payload.json` containing the exact serialized JSON sent to Ollama.
+2. The file is valid JSON (assuming no truncation) — `jq . /tmp/mika-payload.json` succeeds.
+3. Re-running `mika ask "..."` in the same process does NOT overwrite — second invocation produces no log line, file mtime unchanged.
+4. Setting the env var to an unwritable path produces a `tracing::error!` line and leaves the request semantics unchanged.
+5. After process restart, the one-shot flag resets — first request dumps again.
+
+## Risks
+
+- **Low.** Affordance is observation-only, fires after JSON serialization, has no effect on the actual HTTP request. Worst case (dump failure): an extra `tracing::error!` log line, request proceeds normally.
+- **Secret leak risk:** OllamaProvider runs typically authless (local Ollama doesn't need auth); the dumped JSON wouldn't contain the bearer token. If a future MikaModel hosted-endpoint deployment uses auth, the dump file would be operator-readable; current scope keeps this acceptable as a local-only diagnostic affordance.
+
+## Out of scope reminder
+
+This plan ships **the diagnostic dump**. It does NOT:
+
+- Fix the MikaModel OOD bug observed post-#1379.
+- Modify behavior of any existing provider or request path.
+- Add production telemetry or persistent logging.
+- Generalize beyond `OllamaProvider`.

--- a/docs/solutions/1387-ollama-payload-dump-one-shot.md
+++ b/docs/solutions/1387-ollama-payload-dump-one-shot.md
@@ -1,0 +1,94 @@
+---
+module: crates/mika-common/src/llm/ollama.rs
+tags: [llm, ollama, debug-affordance, one-shot, observability]
+problem_type: diagnostic-instrumentation
+category: architecture-patterns
+---
+
+# One-shot OllamaProvider payload dump for OOD diagnostics
+
+## Problem
+
+After mika#1379 shipped the MikaModel provider, smoke testing surfaced that the upstream model returns content unrelated to the user input — multi-section workplace-assistant boilerplate ("## Completed Tasks", "## Pending", "## Blockers") instead of responding to "hello" or "what is 2+2". Five direct `curl` probes against the same Ollama backend with various system-prompt shapes (training-shape, none, math-tutor role, "use status report format" instruction, multi-section markdown) all returned sane conversational output. **The model is healthy in isolation; something specific in mika-server's runtime `/api/chat` payload triggers it.**
+
+Without the actual payload, diagnosing the trigger means guessing among three candidates: the full multi-section system prompt, the ~82-tool catalog, or appended conversation history. Patching without evidence risks shipping the wrong fix.
+
+## Solution
+
+Env-gated, one-shot debug affordance in `OllamaProvider::send_once` that writes the next request's serialized JSON body to a configured path. Process-scoped one-shot flag (lock-free `AtomicBool`) ensures one dump per debug session. Hard byte cap (256 KiB) keeps the file grep-able.
+
+```rust
+// MIKA_OLLAMA_DUMP_PAYLOAD=/tmp/payload.json mika ask "hello"
+// → /tmp/payload.json contains the exact JSON sent to /api/chat
+// → tracing::warn!() confirms the dump fired
+// → next mika ask in same process: no-op (one-shot)
+```
+
+### Wire shape
+
+In `send_once`, after auth headers are built and before the `reqwest::post()` call:
+
+```rust
+let dump_enabled = std::env::var_os("MIKA_OLLAMA_DUMP_PAYLOAD").is_some_and(|v| !v.is_empty());
+let debug_log_enabled = tracing::enabled!(target: "mika::llm_debug", tracing::Level::DEBUG);
+if dump_enabled || debug_log_enabled {
+    match serde_json::to_string(request) {
+        Ok(body_json) => {
+            if debug_log_enabled { /* existing debug log */ }
+            if dump_enabled { try_dump_payload(&body_json); }
+        }
+        Err(e) => warn!(error = %e, "ollama: failed to serialize request for debug log/dump"),
+    }
+}
+```
+
+Both gates share the single JSON serialization. When both gates are off, the cost is one `env_var_os` lookup + one `tracing::enabled!` check — both ~zero-cost when not enabled.
+
+### Truncation
+
+When the serialized body exceeds 256 KiB, the dump contains the first 256 KiB verbatim plus a marker line:
+
+```
+<!-- TRUNCATED at 262144 bytes; total payload was <N> bytes -->
+```
+
+Lets the operator see exactly how much was lost and decide whether to raise the cap.
+
+## Key technical decisions
+
+### Why a process-level `AtomicBool` (not env unset, not per-instance flag)
+
+- **Env-unset.** Would need `unsafe { std::env::remove_var }` (Rust 2024 edition makes env-mutation unsafe). We don't introduce unsafe blocks for a debug affordance.
+- **Per-instance flag.** Multiple providers can coexist in the same process; a per-instance flag fires N times for N instances. Process-level matches operator intent ("one dump per debug session").
+- **Static `AtomicBool`.** Simplest, lock-free, resets only on process restart. Test-only helper `reset_payload_dump_flag()` (gated behind `#[cfg(test)]`) lets each serial test start clean.
+
+### Why fail-fast (do NOT flip the flag on dump error)
+
+A permission-denied or no-such-directory error on first call should be operator-fixable without restarting mika-agent. Flipping the flag would lock the operator out until restart. On error, the flag is reset; next request retries the dump.
+
+### Why a byte cap (not unlimited, not chunked)
+
+mika-server's payload likely combines a 14-section system prompt (~50 KiB) + an ~82-tool catalog (~80 KiB) + variable conversation history. 256 KiB is 2-3× headroom for the static parts. Unlimited writes can produce multi-megabyte files that hang text editors. Chunked / multi-file output rejected as scope creep — the truncation marker signals the operator if more is needed.
+
+### Why scoped to `OllamaProvider` (not generic)
+
+`OpenAiCompatibleProvider` and `AnthropicProvider` would each need their own implementation since the request shape differs. The known active diagnostic need is MikaModel via OllamaProvider. Premature generalization is YAGNI. If a second provider gains a similar need, lift the helper into `mika-common::llm`.
+
+## Verification
+
+- 5 new unit tests (R7 basic dump, R8 one-shot semantics, R9 truncation marker, env-unset noop, env-empty noop) — all `#[serial]`-gated to handle the process-wide flag without flakiness.
+- `cargo test -p mika-common --lib` — 368 passed (363 prior + 5 new).
+- `cargo clippy -p mika-common --no-deps --tests -- -D warnings` clean.
+
+## Out of scope
+
+- The actual OOD bug fix (separate follow-up gated on captured payload evidence).
+- Generic per-provider dump affordance.
+- Production telemetry / secret redaction / cache scrubbing.
+- Configurable byte cap.
+
+## Related
+
+- mika#1387 — tracking issue
+- mika#1379 / PR #1380 — parent provider integration whose smoke surfaced the OOD bug
+- `docs/plans/1387-ollama-payload-dump-one-shot.md` — implementation plan


### PR DESCRIPTION
## Summary

Closes #1387 (follow-up to #1379). Adds an env-gated, one-shot debug affordance in `OllamaProvider::send_once` that writes the next request's serialized JSON body to a configured path. Lets the operator capture mika-server's actual runtime `/api/chat` payload to diagnose the OOD behavior observed post-#1379 with `MIKA_LLM_PROVIDER=mikamodel`.

> - **Plan:** `docs/plans/1387-ollama-payload-dump-one-shot.md`
> - **Solution:** `docs/solutions/1387-ollama-payload-dump-one-shot.md`

## Usage

```
MIKA_OLLAMA_DUMP_PAYLOAD=/tmp/payload.json mika ask "hello"
→ /tmp/payload.json contains the exact JSON sent to /api/chat
→ tracing::warn!() confirms the dump fired
→ subsequent mika ask invocations: no-op (one-shot)
```

After process restart, the one-shot flag resets — first request dumps again.

## Implementation

- **Process-scoped static `AtomicBool`** (`PAYLOAD_DUMP_FIRED`) enforces one-shot semantics. Lock-free, resets only on process restart. Test-only `reset_payload_dump_flag()` helper (gated behind `#[cfg(test)]`).
- **256 KiB hard cap**; overflow appends `<!-- TRUNCATED at <N> bytes; total payload was <M> bytes -->` so the operator sees what was lost.
- **Fail-fast:** on dump-write error (permission denied, etc.), the flag resets so the operator can retry after fixing the path. Request semantics never change — dump is observation-only.
- **Single JSON serialization** shared between the existing dev-mode debug log and the new dump. When neither gate is enabled, the serialize cost is skipped (env-var-os check + tracing-enabled check are both ~zero-cost).
- **Scope: `OllamaProvider` only.** Routes for both `ProviderKind::Ollama` and `ProviderKind::MikaModel`, so the affordance helps both transports.

## Files

| File | Change |
|---|---|
| `crates/mika-common/src/llm/ollama.rs` | New `try_dump_payload` helper + static one-shot flag + `send_once` wiring (single JSON serialization shared with the existing dev-mode debug log). 5 new tests in a serial-gated submodule. |
| `docs/plans/1387-ollama-payload-dump-one-shot.md` | Implementation plan with R1–R9 trace + decision rationale. |
| `docs/solutions/1387-ollama-payload-dump-one-shot.md` | Post-merge compound doc with key technical decisions. |

## Test plan

- [x] `cargo test -p mika-common --lib` — **368 passed** (363 prior + 5 new dump tests).
- [x] `cargo clippy -p mika-common --no-deps --tests -- -D warnings` clean.
- [x] Pre-commit hooks (no-secrets, no-large-files, rust-fmt, rust-clippy) all passing.
- [x] Tests are `#[serial]`-gated to handle the process-wide flag without flakiness.

## Diagnostic workflow next steps (separate tickets)

1. **Capture payload locally.** Set the env var, run `mika ask "hello"` with `mikamodel`, attach the JSON to a follow-up issue with the diagnosed trigger (system prompt structure / tools array / conversation history).
2. **Choose fix based on evidence:**
   - **Compact prompt builder branch for `ProviderKind::MikaModel` in mika-common** (localized — ships fast if the trigger is structural).
   - **Upstream model retrain on a distribution-matched prompt shape** (higher cost — separate workspace concern).

## Out of scope

- The actual OOD bug fix (waiting on captured payload evidence).
- Generic per-provider dump for OpenAI / Anthropic (defer until needed).
- Production telemetry / secret redaction / configurable byte cap (defer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)