### PR TITLE
fix(dispatch-lib): name three git states in _push_branch + lock no-op invariant (mika#1407)

### DIFF
--- a/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md
+++ b/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md
@@ -1,0 +1,215 @@
+---
+title: "fix: stop the dev-groom pilot from mis-diagnosing 'branch ahead of remote' on stale local main"
+status: active
+date: 2026-06-05
+type: fix
+issue: senara-solutions/mika#1407
+branch: fix/1407/dispatch-lib-pilot-mis-diagnoses-branch
+milestone: 30
+---
+
+# fix(dispatch-lib): pilot mis-diagnoses 'branch ahead of remote' when worktree's local main is stale
+
+> **Cross-repo plan.** Primary work lands in `mika` (this repo). One companion change lands in `mika-platform` on the same branch name (`fix/1407/dispatch-lib-pilot-mis-diagnoses-branch`). Paths are repo-relative to their stated repo.
+
+---
+
+## Summary
+
+The autonomous dev-groom pilot, running the `/mika-groom-plan-only` command, aborts a grooming session with `Plan committed locally — remote divergence detected; abort to dispatch-lib for reconciliation` even when there is nothing to push (HEAD already equals `origin/<branch>`). The command prompt instructs the pilot to `git push` and emit that abort string "if the remote is ahead," but the prompt's push step is **redundant** — `dispatch-lib.sh::_push_branch` already pushes structurally after the session, and its own comment declares it "the sole git-push site for dev-groom dispatches." The redundant prompt-level push is also the **fragile predicate** that mis-fires: an LLM reading a stale local `main` ref concludes "branch ahead of remote → diverged → abort," conflating three distinct git states.
+
+The fix removes the fragile predicate rather than making it smarter: strip the pilot's push + abort protocol from the command prompt (the pilot generates the plan, commits, and exits), and let dispatch-lib's already-correct structural push own the git layer. In `mika`, the three git states are named explicitly in `_push_branch` and locked with a regression test, satisfying the issue's testable acceptance criteria in the repo where they are testable.
+
+---
+
+## Problem Frame
+
+### What happened (evidence)
+
+- **Incident:** Mika Prime's first Stage-1 dispatch (groom of mika#1255, milestone-30 P0) went to `blocked` in 31s. Pilot log `fbe1481e-...`:
+  > "The branch is ahead of the remote (the local has been rebased onto updated main)… I need to push to sync the remote. Plan committed locally — remote divergence detected; abort to dispatch-lib for reconciliation."
+- **Actual worktree state (verified, mika#1407 body):** `git rev-parse HEAD` and `git rev-parse origin/<branch>` both `e8a444a6…` — identical SHA. **Nothing to push.** The only real divergence was the worktree's local `main` ref at the branch merge-base (`c0ea9a01`) while `origin/main` was at `64d11cf0` — *branch base behind main*, which is orthogonal to *branch ahead of remote*.
+
+### Root cause (verified by code reading)
+
+- The exact abort string is emitted under instruction from `mika-platform/.claude/commands/mika-groom-plan-only.md:57` (Phase 2, step 7). The prompt tells the pilot to `git push -u origin <branch>` and, on push rejection / "remote ahead," exit with that string. It never tells the model to first check whether anything needs pushing, nor to distinguish the three states.
+- The dev-groom **skill** prompt `skills/bundled/dev-groom/system_prompt.md` contains **no** push/abort/divergence instructions (grep-confirmed). The only prompt artifact driving the push is the mika-platform command.
+- `skills/bundled/_shared/dispatch-lib.sh::_push_branch` (≈777–835) is **already correct and structural**: fetches `origin/$BRANCH`, computes `ahead=$(git rev-list "origin/$BRANCH..HEAD" --count)`, returns early (no-op) when `ahead==0`, and uses `--force-with-lease` only when ancestry proves genuine divergence. Its comment (≈833): *"this helper is now the sole git-push site for dev-groom dispatches."*
+- Run flow (`dispatch-lib.sh` ≈1687–1719): `_set_up_worktree` (rebases the branch onto `origin/main`, owns the *base-behind-main* concern) → `_run_claude_pilot` (`/mika-groom-plan-only`) → `_iterate_groom_loop` (architect; reads the **local** committed plan; may add revise commits) → `_push_branch` (the authoritative push). The pilot's push is therefore pure redundancy that contradicts the "sole git-push site" contract — the command prompt is **stale**, left behind when `_push_branch` became authoritative (mika#1271 content/workflow split, mika#1268/#1364 push hardening).
+
+### The three conflated states
+
+| State | Correct detection | Correct action | Owner |
+|-------|-------------------|----------------|-------|
+| HEAD == `@{u}` (`origin/<branch>`) | `rev-list origin/$BRANCH..HEAD == 0` | nothing to push — **no-op, NOT a divergence** | `_push_branch` (early return) |
+| HEAD ahead of `@{u}` | `rev-list origin/$BRANCH..HEAD > 0`, FF or diverged | push (`--force-with-lease` only if diverged) | `_push_branch` |
+| Branch base behind `origin/main` | `rev-list HEAD..origin/main > 0` | rebase — **orthogonal to push** | `_set_up_worktree` |
+
+The mis-diagnosis was reading the third state's symptom (stale local `main`) and firing the second state's action (push) and then the abort. The durable fix is to stop asking the LLM to make this call at all.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Remove the pilot's push + abort-string protocol from `/mika-groom-plan-only` (mika-platform).
+- Make the three-state distinction explicit in `_push_branch` (mika) and lock it with a regression test (mika).
+
+### Out of scope (true non-goals)
+- Any change to `_push_branch`'s push **behavior** — it is already correct. Only documentation/comment clarity plus a test are added (unless the test reveals a real gap, see U2).
+- `/mika-groom-ticket` (the operator-facing full pipeline) — it owns its own architect + body-callout flow and is unaffected; its Phase-2 push semantics are not in scope here.
+- The `_set_up_worktree` rebase logic (it already owns base-behind-main correctly).
+- Anything touching the polymorphic `/mika` repo-targeting (this is a content/contract fix only).
+
+### Deferred to follow-up work
+- A broader audit of whether `/mika-revise-plan` (the revise pilot) carries the same redundant-push pattern. Noted for a separate ticket if confirmed; not pulled into this fix.
+
+---
+
+## Key Technical Decisions
+
+### KTD-1 — Remove the predicate, don't refine it (structural over prompt)
+The issue's stated approach ("fix the diagnostic to compare against `@{u}`") could be satisfied by rewriting the prompt to be smarter. We reject that: a smarter prompt is still an LLM judgment over three git states, and project doctrine is structural enforcement over prompt prose (`docs/solutions` lineage; memory `feedback_prompt_enforcement_fragile`, `feedback_structural_enforcement_layer_for_tool_requirements`). Because `_push_branch` **already** performs the correct push structurally and unconditionally after the session, the pilot's push is removable with zero behavior loss. Removing it eliminates the load-bearing-but-wrong predicate entirely. This is the milestone-30 (Loop Trustworthiness) thesis applied: a dispatch must not hinge on a fragile prompt-level git judgment.
+
+### KTD-2 — `mika` is the ticket repo and the invariant's home
+mika#1407 is filed on `mika` and titled `fix(dispatch-lib)`. The behavioral bug lives in the mika-platform prompt, but the **invariant** the prompt now delegates to (`_push_branch` is the sole, correct push authority) lives in `mika`. The testable acceptance criteria — "three-state comparison named explicitly in the diagnostic logic" and "test covers the conflated case" — are satisfiable only where there is testable code: `mika`. So `mika` carries the doc-comment + regression test; `mika-platform` carries the prompt edit. Same branch name on both repos per cross-repo convention.
+
+### KTD-3 — Test style follows the existing harness, with a behavioral fixture if cleanly feasible
+`skills/bundled/_shared/test-dispatch-lib.sh` is a **source-introspection** suite — it extracts function bodies as text and asserts on structure; it explicitly does not spin up real git. The regression test (U2) is primarily **structural**: assert `_push_branch` compares against `origin/$BRANCH` (the remote-tracking ref) and not local `main`, and returns early when `ahead==0`. If `_push_branch` proves cleanly invokable against a self-contained local bare-repo fixture at work time, add a **behavioral** assertion for the conflated case (HEAD==origin/branch + stale local main → no push, no error, no abort). Behavioral feasibility is an execution-time discovery (the function reads `REPO`/`WORKTREE_DIR`/`BRANCH` globals and calls `_check_duplicate_commits` which fetches `origin main`); the structural assertions are the guaranteed floor.
+
+---
+
+## Implementation Units
+
+### U1. Make the three git states explicit in `_push_branch` (mika)
+
+**Goal:** Name the three conflated states and the ownership boundary directly in the diagnostic code, so the intent is legible and the invariant the prompt delegates to is self-documenting. Satisfies AC: "three-state comparison is named explicitly in the diagnostic logic."
+
+**Requirements:** mika#1407 AC-2.
+
+**Dependencies:** none.
+
+**Files:**
+- `skills/bundled/_shared/dispatch-lib.sh` (modify — comment block within `_push_branch`, ≈777–835)
+
+**Approach:**
+- Add a concise comment block at the top of the existing-remote branch of `_push_branch` enumerating the three states from the Problem Frame table: (a) `HEAD == origin/$BRANCH` → ahead==0 → return 0, **not** a divergence; (b) `HEAD` ahead of `origin/$BRANCH` → push (FF or `--force-with-lease` per ancestry); (c) branch base behind `origin/main` → owned by `_set_up_worktree`, orthogonal to push.
+- Explicitly state the comparison is against the **remote-tracking branch** (`origin/$BRANCH`), never local `main` — citing mika#1407 as the conflation this guards against.
+- **No behavior change.** The code at the `ahead` computation and early `return 0` already realizes states (a) and (b); this unit only makes the intent explicit and cites the ticket.
+
+**Patterns to follow:** the existing mika#-citation comment style already used throughout `_push_branch` (e.g. the mika#1364 KTD-1 ancestry comment).
+
+**Test scenarios:** Covered by U2 (the comment is verified indirectly by the structural assertions there). No standalone test for a comment.
+
+**Verification:** `_push_branch` contains an inline three-state enumeration citing mika#1407 and naming `origin/$BRANCH` as the comparison ref; `cargo`/shell behavior unchanged (no logic edited).
+
+---
+
+### U2. Regression test locking the remote-tracking-branch comparison (mika)
+
+**Goal:** Prove the diagnostic distinguishes "branch equal to remote" (no-op) from any local-`main` comparison, so the conflated case can never silently regress. Satisfies AC: "test covers the conflated case."
+
+**Requirements:** mika#1407 AC-3 (and AC-1 reproducer, to the extent shell-testable).
+
+**Dependencies:** U1 (asserts on the clarified `_push_branch`).
+
+**Files:**
+- `skills/bundled/_shared/test-dispatch-lib.sh` (modify — add a `_push_branch` assertion group)
+
+**Approach:**
+- **Structural assertions (guaranteed floor), in the existing `assert_contains` / `assert_not_contains` style:**
+  - Extract the `_push_branch` body and assert it computes `ahead` from `origin/$BRANCH..HEAD` (remote-tracking ref).
+  - Assert the early `return 0` exists in the `ahead == 0` branch (no-op when HEAD==origin/branch).
+  - Assert `_push_branch` does **not** compare against `main`/`origin/main` for the push decision (`assert_not_contains` the local-main comparison in the push-decision region) — i.e. base-behind-main does not drive the push decision.
+  - Assert the three-state comment from U1 is present (anchor: the `#1407` citation + "remote-tracking" phrasing).
+- **Behavioral assertion (add if cleanly feasible at work time — KTD-3):** build a self-contained fixture — a local bare repo as `origin`, a working clone with a branch whose HEAD equals `origin/<branch>` and whose local `main` is intentionally stale (behind `origin/main`) — source `dispatch-lib.sh`, set `REPO`/`WORKTREE_DIR`/`BRANCH`, call `_push_branch`, and assert: return code 0, no new commits on `origin/<branch>`, and `RESULT` contains no abort/divergence string. If isolation proves infeasible (global/dependency coupling), record that in the test file as a comment and rely on the structural assertions.
+
+**Patterns to follow:** existing extraction-and-assert groups in `test-dispatch-lib.sh` (e.g. the `_detect_plan_on_branch` group ≈190–217); `set -euo pipefail`; `PASS`/`FAIL` counters.
+
+**Test scenarios:**
+- Happy path: `_push_branch` body contains `origin/$BRANCH..HEAD` ahead computation → assert present.
+- Conflated case (the bug): push decision region does not reference local `main` → `assert_not_contains`.
+- No-op guard: `ahead == 0` path returns 0 → assert present.
+- Intent doc: three-state comment citing `#1407` present → assert present.
+- (Behavioral, if feasible) `Covers AC-1/AC-3.` HEAD==origin/branch + stale local main → `_push_branch` returns 0, pushes nothing, emits no abort string.
+
+**Verification:** `bash skills/bundled/_shared/test-dispatch-lib.sh` exits 0 with the new assertions passing; the suite still passes in full.
+
+---
+
+### U3. Strip the redundant pilot push + abort protocol from `/mika-groom-plan-only` (mika-platform)
+
+> **Target repo: `mika-platform`.** Companion change on the same branch. Paths below are repo-relative to `mika-platform`.
+
+**Goal:** Remove the fragile, redundant push from the pilot's content-only command so the pilot never makes a push-state judgment. The pilot generates the plan, commits, and exits; `dispatch-lib::_push_branch` owns the push. This is the change that actually stops the mis-diagnosis from recurring.
+
+**Requirements:** mika#1407 AC-1, AC-2 ("…or its prompt").
+
+**Dependencies:** Conceptually relies on the mika invariant (U1) being true — it already is in shipped code; U1 documents it. No build-time dependency.
+
+**Files:**
+- `.claude/commands/mika-groom-plan-only.md` (modify)
+
+**Approach (edits, each removing a push-judgment surface):**
+- **Exit contract (≈22–31):** drop item 2 ("The branch pushed to origin"). New exit contract: a plan file committed on the grooming branch. Add one line stating dispatch-lib's `_push_branch` performs the push after the session — the pilot must not push.
+- **Phase 2 step 7 (≈52–57):** remove the `git push -u origin <branch>` step and the entire "remote ahead / abort to dispatch-lib for reconciliation" protocol paragraph, including the abort string. Replace with an explicit instruction: after committing, **exit without pushing** — pushing is dispatch-lib's job (`_push_branch`, the sole git-push site for dev-groom dispatches). Keep the existing "never force-push" prohibition framed as "the pilot performs no pushes at all."
+- **Phase 3 step 8 (≈59–61):** adjust so the clean-exit text no longer presumes a prior `git push` ("After `git push` succeeds…" → "After committing the plan…").
+- **"What this command does NOT do" (≈64–71):** update the force-push bullet to state the pilot performs **no** git push of any kind; reconciliation and push both belong to dispatch-lib.
+- **Failure modes (≈73–77):** remove the "Push fails" bullet's reliance on the pilot push; keep the commit-fails bullet. Note that push failures are surfaced by dispatch-lib's `_push_branch` post-flight, not the pilot.
+- Preserve everything about plan generation, idempotent re-groom detection, commit-unconditionally, and the no-architect / no-callout / no-comment contract — those are unchanged.
+
+**Patterns to follow:** the command's existing mika#-citation style; keep the content/workflow split framing from mika#1271 (pilot = content, dispatch-lib = git workflow) — this edit makes the command consistent with that split.
+
+**Test scenarios:** `Test expectation: none — prose command file, not executable.` Verification is by inspection + the downstream behavioral effect. (The reproducer AC is satisfied behaviorally: with the push step gone, a re-dispatch on a branch where HEAD==origin/branch produces a clean groom because the pilot commits-or-noops and exits, and `_push_branch` no-ops.)
+
+**Verification:**
+- `grep -n "git push\|remote divergence detected\|abort to dispatch-lib for reconciliation" .claude/commands/mika-groom-plan-only.md` returns no pilot-push instruction and no abort string.
+- The exit contract and "does NOT do" sections consistently state the pilot performs no push.
+
+---
+
+## System-Wide Impact
+
+- **Autonomous dev-groom loop (primary beneficiary):** re-dispatches on an already-groomed ticket (HEAD==origin/branch) no longer false-abort. The groom proceeds: pilot commits-or-noops → architect converges → `_push_branch` no-ops or pushes revise commits. Directly unblocks the milestone-30 failure class.
+- **No behavior change to `_push_branch`** → no risk to the impl (dev-pilot) push path, which already used `_push_branch` exclusively.
+- **Ordering safety (verified):** the architect (`_iterate_groom_loop`) reads the **local** committed plan, not origin; `_push_branch` runs after it and before `_deliver_callback`, so origin receives the branch (plan + any revise commits) before the dispatch completes — the next dispatch's `_set_up_worktree` still finds `origin/$BRANCH`. Removing the pilot push does not strand the branch.
+- **Deploy:** `dispatch-lib.sh` is copy-deployed (not in-binary); the command file is copied into pilot worktrees by `_set_up_worktree` (dispatch-lib.sh:359) from `mika-platform/.claude/commands/`. Both changes take effect via the normal `make deploy` / next-dispatch worktree refresh — no migration.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| A consumer relies on the pilot having pushed before architect runs | Low | Verified architect reads local plan; `_push_branch` pushes after. No origin dependency before `_push_branch`. |
+| `_push_branch` not cleanly invokable for a behavioral test | Medium | KTD-3: structural assertions are the guaranteed floor; behavioral test is additive-if-feasible, documented either way. |
+| Prompt edit accidentally weakens the no-force-push safety language (mika#1318) | Low | Reframe force-push prohibition as "no pushes at all" — strictly stronger; keep the mika#1318 citation. |
+| Stale copies of the command in existing pilot worktrees | Low | `_set_up_worktree` re-copies `.claude/commands/` on every dispatch (dispatch-lib.sh:359); no manual cleanup needed. |
+
+---
+
+## Cross-Repo Sequencing
+
+1. **mika (primary):** U1 (comment) → U2 (test) → run `bash skills/bundled/_shared/test-dispatch-lib.sh`. Commit on `fix/1407/dispatch-lib-pilot-mis-diagnoses-branch`. PR closes mika#1407; cross-references the companion.
+2. **mika-platform (companion):** U3 (prompt edit) on the same branch name, committed directly. Companion PR cross-references the mika PR (`Companion PR: senara-solutions/mika#<n>`).
+3. Both PR bodies lead with the WHY (this Problem Frame) and the structural-over-prompt rationale (KTD-1).
+
+---
+
+## Acceptance Criteria Trace (mika#1407)
+
+- **AC-1 (reproducer / clean groom under fix):** satisfied behaviorally by U3 — with the pilot push removed, HEAD==origin/branch + stale local main yields a clean groom (pilot commits-or-noops, exits; `_push_branch` no-ops). Shell-level reproduction added in U2 if `_push_branch` isolation is feasible.
+- **AC-2 (three-state comparison named explicitly in the diagnostic logic or its prompt):** satisfied by U1 (in `_push_branch`) and reinforced by U3 (prompt no longer makes the flawed comparison).
+- **AC-3 (test covers the conflated case):** satisfied by U2 — structural assertions that the push decision uses `origin/$BRANCH..HEAD` and not local `main`, plus the behavioral conflated-case test when feasible.
+
+---
+
+## Sources & Research
+
+- mika#1407 (issue body — incident evidence, three-state framing, ACs).
+- `skills/bundled/_shared/dispatch-lib.sh` — `_push_branch` (≈777–835), run flow (≈1687–1719), command-copy (≈359), dev-groom entry (≈1668–1681).
+- `mika-platform/.claude/commands/mika-groom-plan-only.md` — push/abort protocol (≈52–71).
+- `skills/bundled/dev-groom/system_prompt.md` — confirmed no push/abort logic (grep).
+- `skills/bundled/_shared/test-dispatch-lib.sh` — harness style (source-introspection).
+- mika#1271 (content/workflow split), mika#1268/#1364 (`_push_branch` introduction + push hardening), mika#1318 (force-push-destroyed-substrate, the reason the pilot must not force-push).
+- Doctrine: `feedback_prompt_enforcement_fragile`, `feedback_structural_enforcement_layer_for_tool_requirements`.

--- a/docs/solutions/architecture-patterns/structural-owner-decides-not-just-acts-2026-06-05.md
+++ b/docs/solutions/architecture-patterns/structural-owner-decides-not-just-acts-2026-06-05.md
@@ -1,0 +1,71 @@
+---
+module: mika-skills
+tags: [dispatch-lib, dev-groom, autonomous-loop, prompt-vs-structural, git-state, mika-1407, mika-1271, contract-design]
+problem_type: contract-design
+category: architecture-patterns
+date: 2026-06-05
+---
+
+# The structural owner of an action must also own the decision to perform it
+
+## Context
+
+The `dev-groom` autonomous-loop pilot runs the `/mika-groom-plan-only` command (in `mika-platform/.claude/commands/`) to generate a plan, then exits; `dispatch-lib.sh::_push_branch` (in the `mika` repo) pushes the branch afterward. The [pilot-vs-substrate contract split](pilot-vs-substrate-contract-split-2026-05-25.md) already established *who DOES the git work*: the pilot owns content (the plan), dispatch-lib owns workflow (push, architect convergence, body callout). `_push_branch`'s own comment declares it "the sole git-push site for dev-groom dispatches."
+
+But the command prompt still told the pilot to `git push -u origin <branch>` itself and, on push rejection, to exit with `Plan committed locally — remote divergence detected; abort to dispatch-lib for reconciliation`. So the *action* was owned structurally, while a *duplicate of the action plus a decision about it* lived in the prompt. On milestone-30's first Stage-1 dispatch (groom of mika#1255), the pilot fired that abort in ~30s on a branch where `HEAD == origin/<branch>` — **nothing to push** — and the groom went to `blocked`.
+
+## Guidance
+
+**When a deterministic structural layer already owns an action, do not also make a prompt-level layer judge whether or how to perform it.** Two harms compound:
+
+1. **Duplication.** `_push_branch` was going to push regardless (it runs after the session, on every dispatch). The pilot's push was pure redundancy — and redundant action under two owners is how recovery layers stack recursively (the failure mode the [contract split](pilot-vs-substrate-contract-split-2026-05-25.md) was created to stop).
+2. **Fragile judgment over volatile state.** To push "only if needed," the prompt forced an LLM to distinguish three git states from inside the session:
+   - `HEAD == @{u}` (`origin/$BRANCH`) → nothing to push — a no-op, **not** a divergence
+   - `HEAD` ahead of `@{u}` → push (fast-forward, or `--force-with-lease` if rebased)
+   - branch base behind `origin/main` → a **rebase** concern, orthogonal to push
+   A stale local `main` ref (sitting at the branch's merge-base while `origin/main` advanced) made the model read state 3's symptom and fire state 2's action, then abort. Git refs are exactly the kind of volatile state an LLM re-derives wrongly under prompt pressure.
+
+The cure is to **remove the predicate, not refine it** (a smarter prompt is still an LLM judging three git states). Let the structural owner make the decision in deterministic code, keyed on the remote-tracking branch:
+
+- **mika-platform:** the command now says generate plan, commit, **exit** — no push, no abort string. The pilot makes no push-state judgment at all.
+- **mika:** `_push_branch` documents the three states explicitly and is locked by a behavioral regression test (`test_noop_when_head_equals_remote_stale_main`) proving the no-op when `HEAD == origin/<branch>` even with a stale local `main`.
+
+This sharpens the contract split: it is not only "who DOES the git work" but **"who DECIDES it."** A decision keyed on volatile state belongs in code the action's owner controls, never in prose a downstream LLM re-derives.
+
+## Why This Matters
+
+This is the milestone-30 (Loop Trustworthiness) thesis in miniature: *a loop that dispatches tickets which never ship makes "backlog → 0" lie.* The pilot's pre-push diagnostic was a load-bearing predicate on the critical path of every groom; because it was wrong, every dispatch was one stale ref away from a false abort. Removing the predicate (rather than hardening the prose) is what makes the path trustworthy — it eliminates the class of failure instead of patching one instance. Reinforces the standing doctrine that prompt-level enforcement is rationalizable and fragile; structural enforcement is control (see `feedback_prompt_enforcement_fragile`, `feedback_structural_enforcement_layer_for_tool_requirements` in core memory).
+
+## When to Apply
+
+- Any time a prompt instructs an agent to perform an action that a deterministic layer (dispatch-lib, a hook, a post-flight step) already performs — the prompt copy is redundant and should be deleted, not kept "for safety."
+- Any time a prompt asks an LLM to branch on volatile runtime state (git refs, queue depth, lock status, remote state) to decide whether to act. Move the branch into the code that owns the action.
+- **Stale-local-`main` is a recurring false-"divergence" root cause.** Whenever a diagnostic compares branch state, compare against the remote-tracking branch (`@{u}` / `origin/$BRANCH`), never local `main`. Siblings: mika#1255 (first victim), mika#1364 (push lacked `--force-with-lease`), mika#1383 (chronic stall investigation) — all variants of stale local refs misdiagnosed as divergence. See also [mid-session duplicate-commit pre-push guard](../logic-errors/mid-session-duplicate-commit-pre-push-guard-2026-05-26.md).
+
+## Examples
+
+Before (mika-platform `/mika-groom-plan-only`, Phase 2) — the pilot judges and acts:
+
+```
+7. Push the branch:
+     git push -u origin <branch>
+   ... If `git push` fails because the remote is ahead, ... exit with
+   `Plan committed locally — remote divergence detected; abort to
+   dispatch-lib for reconciliation.`
+```
+
+After — the pilot neither pushes nor judges:
+
+```
+7. Do not push. Exit after committing. dispatch-lib's _push_branch runs after
+   this session and is the sole git-push site for dev-groom dispatches. It
+   pushes only when origin/$BRANCH..HEAD shows local-ahead commits ... The
+   pilot performs no git push of any kind.
+```
+
+The decision now lives only here, in `_push_branch` (mika `skills/bundled/_shared/dispatch-lib.sh`), keyed on the remote-tracking branch:
+
+```bash
+ahead=$(git -C "$WORKTREE_DIR" rev-list "origin/$BRANCH..HEAD" --count 2>/dev/null || echo 0)
+[ "${ahead:-0}" -eq 0 ] && return 0   # HEAD == origin/$BRANCH: nothing to push — NOT a divergence
+```

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -795,11 +795,28 @@ Push: SKIPPED — duplicate-commit guard detected patch-equivalent commits on br
     # Fetch fresh remote state. No-ops if origin/$BRANCH doesn't exist (first-push).
     git -C "$WORKTREE_DIR" fetch origin "$BRANCH" 2>/dev/null || true
 
+    # Three git states, distinguished against the REMOTE-TRACKING branch
+    # (origin/$BRANCH) — never against local `main` (mika#1407):
+    #   (a) HEAD == origin/$BRANCH         → nothing to push. NO-OP, NOT a
+    #                                        divergence (early `return 0` below).
+    #   (b) HEAD ahead of origin/$BRANCH   → push (fast-forward, or
+    #                                        --force-with-lease when ancestry
+    #                                        proves the branch was rebased).
+    #   (c) branch base behind origin/main → a REBASE concern owned by
+    #                                        _set_up_worktree; ORTHOGONAL to the
+    #                                        push decision and not consulted here.
+    # mika#1407: the dev-groom pilot used to make this call in prose and
+    # conflated (c) — a stale local `main` ref — with (b), emitting a spurious
+    # "remote divergence detected; abort" on a branch that had nothing to push.
+    # The push decision lives here in code, keyed solely on origin/$BRANCH..HEAD,
+    # so the stale-main symptom can never drive it.
+    #
     # Branch on remote-ref existence (F1 fix from architect review on mika#1268):
     # Determine push mode: first-push, fast-forward, or diverged (mika#1364).
     local push_mode="first-push"
     if git -C "$WORKTREE_DIR" rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
-        # Existing-remote case — push only if HEAD is ahead.
+        # Existing-remote case — state (a)/(b). Push only if HEAD is ahead of
+        # the remote-tracking branch; ahead==0 is state (a), a clean no-op.
         local ahead
         ahead=$(git -C "$WORKTREE_DIR" rev-list "origin/$BRANCH..HEAD" --count 2>/dev/null || echo 0)
         [ "${ahead:-0}" -eq 0 ] && return 0

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -1500,6 +1500,81 @@ DEDUP_FUNC=$(declare -f _check_duplicate_commits)
 assert_contains "Dedup rebase captures stderr to temp file" "dedup-rebase-err" "$DEDUP_FUNC"
 assert_contains "Dedup rebase surfaces reason in RESULT" "Dedup-rebase failed" "$DEDUP_FUNC"
 
+# --- Test 12h: mika#1407 — push decision keyed on the remote-tracking branch ---
+echo ""
+echo "Test 12h: Stale-main conflation no-op (mika#1407)"
+echo "-------------------------------------------------"
+
+# Structural: the three-state rationale is documented in source, and the push
+# decision is keyed on origin/$BRANCH..HEAD (the remote-tracking branch), never
+# on local main. Comments are stripped by `declare -f`, so read the source file.
+PUSH_SRC=$(sed -n '/^_push_branch() {/,/^}/p' "$DISPATCH_LIB")
+assert_contains "_push_branch documents mika#1407 three-state rationale" "mika#1407" "$PUSH_SRC"
+assert_contains "_push_branch keys push decision on origin/\$BRANCH..HEAD" 'origin/$BRANCH..HEAD' "$PUSH_SRC"
+
+# Behavioral: HEAD == origin/<branch> (nothing to push) WHILE local `main` is
+# stale (behind origin/main). _push_branch must no-op — return 0, push nothing,
+# emit no divergence/abort text. base-behind-main is orthogonal to the push
+# decision; the pilot's old prose diagnostic conflated the two (mika#1407).
+test_noop_when_head_equals_remote_stale_main() {
+    _fixture_setup
+    _assert_fixture_is_local || return 1
+
+    # Feature branch at HEAD == origin/<branch> (ahead==0).
+    git -C "$FIXTURE_CLONE" checkout -q -b fix/1407-noop
+    echo "plan" > "$FIXTURE_CLONE/plan.txt"
+    git -C "$FIXTURE_CLONE" add plan.txt
+    git -C "$FIXTURE_CLONE" commit -q -m "groom plan (content-only)"
+    git -C "$FIXTURE_CLONE" push -q -u origin fix/1407-noop
+
+    # Advance origin/main via a throwaway clone so the working clone's local
+    # `main` ref falls behind origin/main — the exact conflation trigger.
+    local advance_clone
+    advance_clone=$(mktemp -d)
+    git clone -q "file://$FIXTURE_BARE" "$advance_clone"
+    git -C "$advance_clone" config user.email "test@mika.local"
+    git -C "$advance_clone" config user.name "mika test"
+    echo "advance" > "$advance_clone/main-advance.txt"
+    git -C "$advance_clone" add main-advance.txt
+    git -C "$advance_clone" commit -q -m "advance main"
+    git -C "$advance_clone" push -q origin main
+    rm -rf "$advance_clone"
+    # Update remote-tracking refs but leave local `main` behind origin/main.
+    git -C "$FIXTURE_CLONE" fetch -q origin
+
+    local behind remote_before
+    behind=$(git -C "$FIXTURE_CLONE" rev-list --count main..origin/main 2>/dev/null || echo 0)
+    remote_before=$(git -C "$FIXTURE_CLONE" rev-parse "origin/fix/1407-noop")
+
+    WORKTREE_DIR="$FIXTURE_CLONE"
+    BRANCH="fix/1407-noop"
+    REPO="mika"
+    RESULT=""
+    local rc=0
+    _push_branch || rc=$?
+
+    local remote_after
+    remote_after=$(git -C "$FIXTURE_CLONE" rev-parse "origin/fix/1407-noop")
+
+    local failures=""
+    [ "$rc" -eq 0 ] || failures="${failures}expected return 0 (no-op), got $rc; "
+    [ "${behind:-0}" -ge 1 ] || failures="${failures}fixture should leave local main behind origin/main; "
+    [ "$remote_before" = "$remote_after" ] || failures="${failures}remote HEAD must be unchanged (nothing pushed); "
+    if printf '%s' "$RESULT" | grep -qiE "divergence|abort|reconciliation|Push: pushed|Push: FAILED"; then
+        failures="${failures}RESULT must contain no push/abort/divergence text; "
+    fi
+
+    _fixture_cleanup
+    if [ -z "$failures" ]; then echo "PASS"; else echo "FAIL: $failures"; fi
+}
+
+RESULT_12H=$(test_noop_when_head_equals_remote_stale_main 2>/dev/null)
+if [ "$RESULT_12H" = "PASS" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ No-op when HEAD==origin/branch + stale local main (mika#1407)"
+else
+    FAIL=$((FAIL + 1)); echo "  ✗ No-op on stale-main conflation (mika#1407): $RESULT_12H"
+fi
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Why

The dev-groom autonomous-loop pilot mis-diagnosed `branch ahead of remote` and aborted a grooming session in ~30s with `Plan committed locally — remote divergence detected; abort to dispatch-lib for reconciliation` — even though `HEAD == origin/<branch>` (nothing to push). milestone-30's first Stage-1 dispatch (groom of mika#1255) hit this and went to `blocked`.

**Root cause** (verified by code reading): the `/mika-groom-plan-only` command prompt told the pilot to `git push` and emit that abort string on "remote ahead." That push was **redundant** — `_push_branch` already runs after the session and is "the sole git-push site for dev-groom dispatches" (it keys on `origin/$BRANCH..HEAD` and no-ops when `ahead==0`) — and **fragile**: it forced an LLM to distinguish three git states (`HEAD==@{u}` / `HEAD` ahead of `@{u}` / branch-base-behind-`origin/main`). A stale local `main` ref made the model read the third state's symptom and fire the second's action, then abort.

## What (this PR — mika side)

The behavioral fix is removing the pilot's push (companion PR below). This PR defends the invariant the prompt now delegates to:

- **`_push_branch`** (`skills/bundled/_shared/dispatch-lib.sh`): a three-state doc-comment making explicit that the push decision is keyed on the remote-tracking branch (`origin/$BRANCH..HEAD`), never local `main`. **No behavior change** — the code already no-ops when `ahead==0`.
- **`test-dispatch-lib.sh`**: new behavioral regression test `test_noop_when_head_equals_remote_stale_main` (HEAD==origin/branch + stale local main → `_push_branch` returns 0, pushes nothing, emits no abort) + two structural assertions. Verified by **mutation testing** in review: removing the `return 0` no-op flips the test to FAIL.

## Acceptance criteria (mika#1407)

- [x] AC-2 — three-state comparison named explicitly in the diagnostic logic (`_push_branch`).
- [x] AC-3 — test covers the conflated case (branch-base-behind-main + branch-equal-to-remote does NOT trigger the abort).
- [x] AC-1 — clean groom under the fix: delivered behaviorally by the companion prompt change; shell-level no-op reproduced here.

## Testing

`bash skills/bundled/_shared/test-dispatch-lib.sh` → 162 passed, 7 failed. The 7 failures are **pre-existing on `main`** (unrelated stale assertions — e.g. case-switch text drift now that dev-groom uses `/mika-groom-plan-only`, mika#988 prompt drift). This change adds +3 passing, +0 new failures. Pre-existing failures tracked separately in #1412 (stale test assertions, test-only).

Companion PR: senara-solutions/mika-platform#155 (removes the redundant pilot push from `/mika-groom-plan-only`).

Plan: `docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md`
Compound: `docs/solutions/architecture-patterns/structural-owner-decides-not-just-acts-2026-06-05.md`

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

