### PR TITLE
refactor(skills): extract effective_prompt_limit helper to reduce duplication (mika#335)

### DIFF
--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -25,6 +25,25 @@ pub const MAX_PROMPT_SNIPPET_SIZE: u64 = 16 * 1024;
 /// `tests/bundled_skills_load.rs` (mika#852).
 pub const MAX_PROMPT_SIZE_CEILING: u64 = 80 * 1024;
 
+// Compile-time guard: the canonical calculation in `effective_prompt_limit`
+// assumes the default fits within the ceiling. If this relationship changes,
+// the helper's semantics diverge from the test's prior inline form.
+const _: () = assert!(
+    MAX_PROMPT_SNIPPET_SIZE <= MAX_PROMPT_SIZE_CEILING,
+    "effective_prompt_limit assumes the default fits within the ceiling"
+);
+
+/// Effective prompt-size limit for a skill.
+///
+/// Returns the minimum of the manifest's `max_prompt_size` and the hard
+/// ceiling ([`MAX_PROMPT_SIZE_CEILING`]), falling back to the default
+/// snippet size ([`MAX_PROMPT_SNIPPET_SIZE`]) when no override is declared.
+pub fn effective_prompt_limit(max_prompt_size: Option<u64>) -> u64 {
+    max_prompt_size
+        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
+        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE)
+}
+
 /// Maximum size for tools.json files (256 KB).
 const MAX_TOOLS_JSON_SIZE: u64 = 256 * 1024;
 
@@ -570,11 +589,7 @@ pub fn scan_skills_dir(skills_dir: &Path) -> ScanResult {
 
         // Load prompt snippet eagerly at startup (cached in SkillEntry)
         let snippet_path = path.join("system_prompt.md");
-        let max_size = manifest
-            .skill
-            .max_prompt_size
-            .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-            .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+        let max_size = effective_prompt_limit(manifest.skill.max_prompt_size);
         if let Some(requested) = manifest.skill.max_prompt_size
             && requested > MAX_PROMPT_SIZE_CEILING
         {
@@ -1126,11 +1141,7 @@ pub fn validate_skill(skill_dir: &Path) -> Vec<SkillDiagnostic> {
     // 6. Check prompt snippet size against effective limit
     let snippet_path = skill_dir.join("system_prompt.md");
     if snippet_path.exists() {
-        let effective_limit = manifest
-            .skill
-            .max_prompt_size
-            .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-            .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+        let effective_limit = effective_prompt_limit(manifest.skill.max_prompt_size);
 
         if let Ok(meta) = std::fs::metadata(&snippet_path) {
             let size = meta.len();
@@ -1247,11 +1258,7 @@ pub fn validate_skill(skill_dir: &Path) -> Vec<SkillDiagnostic> {
                     continue;
                 }
 
-                let effective_limit = manifest
-                    .skill
-                    .max_prompt_size
-                    .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-                    .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+                let effective_limit = effective_prompt_limit(manifest.skill.max_prompt_size);
 
                 // Validate override parseability and check for identity fields
                 if has_override {
@@ -1592,11 +1599,7 @@ fn scan_provider_variants(skill_dir: &Path, manifest: &SkillManifest) -> Variant
         }
     };
 
-    let max_size = manifest
-        .skill
-        .max_prompt_size
-        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+    let max_size = effective_prompt_limit(manifest.skill.max_prompt_size);
 
     for dir_entry in read_dir.flatten() {
         let path = dir_entry.path();
@@ -1774,11 +1777,7 @@ fn scan_generated_variants(skill_dir: &Path, manifest: &SkillManifest) -> HashMa
     let mut out = HashMap::new();
 
     let generated_root = skill_dir.join("generated");
-    let max_size = manifest
-        .skill
-        .max_prompt_size
-        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+    let max_size = effective_prompt_limit(manifest.skill.max_prompt_size);
 
     let provider_dirs = match std::fs::read_dir(&generated_root) {
         Ok(rd) => rd,

--- a/crates/mika-agent/src/skills/variants.rs
+++ b/crates/mika-agent/src/skills/variants.rs
@@ -17,8 +17,7 @@ use serde::Serialize;
 use tracing::warn;
 
 use super::index::{
-    DiagnosticLevel, MAX_PROMPT_SIZE_CEILING, MAX_PROMPT_SNIPPET_SIZE, SkillDiagnostic,
-    sanitize_model_dir_name,
+    DiagnosticLevel, SkillDiagnostic, effective_prompt_limit, sanitize_model_dir_name,
 };
 use super::manifest::SkillManifest;
 
@@ -355,11 +354,7 @@ pub fn validate_variant(
     let mut results = Vec::with_capacity(4);
 
     // Rule 1: Size limit
-    let max_size = manifest
-        .skill
-        .max_prompt_size
-        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
-        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE);
+    let max_size = effective_prompt_limit(manifest.skill.max_prompt_size);
     let content_bytes = content.len() as u64;
 
     if content_bytes > max_size {

--- a/crates/mika-agent/tests/bundled_skills_load.rs
+++ b/crates/mika-agent/tests/bundled_skills_load.rs
@@ -27,9 +27,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use mika_agent::skills::index::{
-    MAX_PROMPT_SIZE_CEILING, MAX_PROMPT_SNIPPET_SIZE, scan_skills_dir,
-};
+use mika_agent::skills::index::{effective_prompt_limit, scan_skills_dir};
 use mika_agent::skills::manifest::SkillManifest;
 
 fn bundled_skills_dir() -> PathBuf {
@@ -134,9 +132,7 @@ fn bundled_skills_approaching_max_prompt_size_warns() {
             None
         };
 
-        let effective_cap = manifest_max
-            .unwrap_or(MAX_PROMPT_SNIPPET_SIZE)
-            .min(MAX_PROMPT_SIZE_CEILING);
+        let effective_cap = effective_prompt_limit(manifest_max);
 
         let actual = fs::metadata(&prompt_path)
             .unwrap_or_else(|e| panic!("failed to stat {}: {}", prompt_path.display(), e))

--- a/docs/plans/2026-06-05-003-enhancement-335-extract-effective-prompt-limit-helper-plan.md
+++ b/docs/plans/2026-06-05-003-enhancement-335-extract-effective-prompt-limit-helper-plan.md
@@ -1,0 +1,92 @@
+# Plan: Extract effective_prompt_limit helper to reduce duplication
+
+**Ticket:** mika issue#335
+**Type:** enhancement (refactor)
+**Risk:** low — pure mechanical extraction, no behavioral change
+
+## Problem
+
+The effective prompt limit calculation is duplicated 6 times across `crates/mika-agent/src/skills/index.rs` (5 sites) and `crates/mika-agent/src/skills/variants.rs` (1 site):
+
+```rust
+.map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
+.unwrap_or(MAX_PROMPT_SNIPPET_SIZE)
+```
+
+Additionally, the integration test at `crates/mika-agent/tests/bundled_skills_load.rs` reimplements the same logic inline.
+
+## Solution
+
+Extract a `pub(super)` free function in `index.rs` that encapsulates the calculation, then replace all 6 internal call sites + the test's inline reimplementation.
+
+## Implementation Steps
+
+### Step 1 — Add the helper function in `index.rs`
+
+Add near the constant definitions (around line 28, after `MAX_PROMPT_SIZE_CEILING`):
+
+```rust
+/// Effective prompt-size limit for a skill.
+///
+/// Returns the minimum of the manifest's `max_prompt_size` and the hard
+/// ceiling ([`MAX_PROMPT_SIZE_CEILING`]), falling back to the default
+/// snippet size ([`MAX_PROMPT_SNIPPET_SIZE`]) when no override is declared.
+pub fn effective_prompt_limit(max_prompt_size: Option<u64>) -> u64 {
+    max_prompt_size
+        .map(|v| v.min(MAX_PROMPT_SIZE_CEILING))
+        .unwrap_or(MAX_PROMPT_SNIPPET_SIZE)
+}
+```
+
+Visibility: `pub` (not `pub(super)`) — the integration test in `tests/bundled_skills_load.rs` needs access, and both constants are already `pub`.
+
+### Step 2 — Replace 5 call sites in `index.rs`
+
+Replace each occurrence of the duplicated pattern with a call to `effective_prompt_limit(entry.manifest.skill.max_prompt_size)` (or the equivalent local binding). The 5 sites are:
+
+1. **`load_skill_entry()`** (~line 576) — prompt snippet truncation
+2. **`validate_skill()`** (~line 1129) — base prompt size diagnostic
+3. **`validate_skill()`** (~line 1250) — variant override size diagnostic
+4. **`scan_variants_by_provider()`** (~line 1595) — hand-authored variant truncation
+5. **`scan_generated_variants()`** (~line 1777) — auto-generated variant truncation
+
+### Step 3 — Replace 1 call site in `variants.rs`
+
+`validate_variant()` (~line 358) imports `MAX_PROMPT_SIZE_CEILING` and `MAX_PROMPT_SNIPPET_SIZE` from `super::index`. Replace the inline calculation with `super::index::effective_prompt_limit(...)`.
+
+### Step 4 — Update the integration test
+
+In `crates/mika-agent/tests/bundled_skills_load.rs` (~line 138), replace the inline reimplementation:
+
+```rust
+let effective_cap = manifest_max
+    .unwrap_or(MAX_PROMPT_SNIPPET_SIZE)
+    .min(MAX_PROMPT_SIZE_CEILING);
+```
+
+with:
+
+```rust
+let effective_cap = effective_prompt_limit(manifest_max);
+```
+
+Add `effective_prompt_limit` to the existing `use mika_agent::skills::index::{...}` import.
+
+### Step 5 — Verify
+
+- `cargo test -p mika-agent` — all existing tests pass
+- `cargo test -p mika-agent --test bundled_skills_load` — integration test passes
+- `cargo clippy -p mika-agent` — no warnings
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/skills/index.rs` | Add `effective_prompt_limit()`, replace 5 inline calculations |
+| `crates/mika-agent/src/skills/variants.rs` | Replace 1 inline calculation with helper call |
+| `crates/mika-agent/tests/bundled_skills_load.rs` | Replace inline reimplementation with helper call |
+
+## Out of Scope
+
+- No new tests needed — existing tests already exercise all code paths; the refactor is behavior-preserving.
+- No changes to `mod.rs` — `apply_overrides()` does not contain the duplicated pattern (ticket description was slightly outdated; the duplication was fully within `index.rs` and `variants.rs`).


### PR DESCRIPTION
## Summary

Extracts the `effective_prompt_limit()` helper to a single source of truth in `index.rs:41`, replacing 6 inline duplications across the codebase.

## Changes

- **Helper added:** `effective_prompt_limit()` at `crates/mika-agent/src/skills/index.rs:41`
- **Call sites updated:**
  - `index.rs` (5 sites): lines 592, 1144, 1261, 1602, 1780
  - `variants.rs` (1 site): line 357
- **Test updated:** integration test now uses the helper (line 135)
- **Compile-time guard:** `const_assert!(MAX_PROMPT_SNIPPET_SIZE <= MAX_PROMPT_SIZE_CEILING)` added for invariant safety

## Verification

- `cargo clippy` clean
- Integration tests pass
- Compile-time guard ensures the invariant holds at build time

## Closes

Closes #335