### PR TITLE
fix(dispatch-lib): detect dirty-worktree on resume, route to recovery instead of crashing rebase (mika#1414)

### DIFF
--- a/docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md
+++ b/docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md
@@ -153,16 +153,27 @@ edited ACs are recorded below):
   `dispatch-lib-resume-cleanup-<task_id>-<timestamp>` and log the stash ref for
   operator recovery."*
 
-- **AC4 — "Stash ref logged in task payload" → "logged to durable per-task stderr
-  log."** Decision: on the success path the RESULT "task payload" is owned by the
-  pilot outcome (lines 454-462), assembled long after worktree setup; threading the
-  setup-phase stash into a success RESULT would mean restructuring result assembly,
-  out of proportion to the fix. The stash SHA + `git stash apply` recovery command
-  are emitted to **stderr**, which dispatch-lib already persists durably per task to
-  `/var/log/claude-pilot/${LOG_ID}.stderr` (mika#1097, secret-scrubbed); the stash
-  is additionally recoverable via `git -C <worktree> stash list`. Reconciled AC4
-  wording: *"Stash ref logged to the durable per-task stderr log for operator
-  recovery."*
+- **AC4 — "Stash ref logged in task payload" → "operator-recoverable via the
+  stash itself."** Decision: on the success path the RESULT "task payload" is owned
+  by the pilot outcome (lines 454-462), assembled long after worktree setup;
+  threading the setup-phase stash into a success RESULT would mean restructuring
+  result assembly, out of proportion to the fix.
+
+  **Implementation correction (post-review, mika#1414):** the original draft of this
+  bullet claimed the stash SHA emitted to stderr lands in
+  `/var/log/claude-pilot/${LOG_ID}.stderr`. That is **false** and was corrected
+  during code review. That file is written *only* from the `claude-pilot`
+  subprocess's captured stderr (`_scrub_secrets_from_output < "$STDERR_FILE" >
+  "$PERSISTENT_STDERR"`), and the redirect truncates (`>`); `_clean_worktree_for_rebase`
+  runs during `_set_up_worktree()`, **before** claude-pilot launches, so its `>&2`
+  echo goes to dispatch-lib's own fd 2 (the tool subprocess stderr captured by the
+  engine), not to that per-task file. The **durable, authoritative** operator-recovery
+  path is therefore the stash itself: `git -C <worktree> stash list` shows the entry,
+  whose message embeds `${LOG_ID}` (task id) + UTC timestamp, and the immutable SHA is
+  captured in `RESUME_CLEANUP_STASH`. The stderr echo is a best-effort convenience that
+  lands wherever the engine routes dispatch-lib stderr. Reconciled AC4 wording:
+  *"Stash ref recoverable via `git stash list` (message embeds task id + timestamp);
+  recovery command additionally echoed to dispatch-lib stderr."*
 
 ## Testing
 

--- a/docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md
+++ b/docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md
@@ -1,0 +1,222 @@
+---
+issue: mika#1414
+type: fix
+title: "detect dirty-worktree on resume, route to recovery contract instead of crashing rebase"
+branch: fix/1414/dispatch-lib-detect-dirty-worktree-on
+status: groomed
+date: 2026-06-06
+component: dispatch-lib (skills/bundled/_shared/dispatch-lib.sh)
+milestone: milestone-30 (Loop Trustworthiness)
+---
+
+# Plan — mika#1414: dirty-worktree detection on resume before rebase
+
+## Problem (verified in code)
+
+`_set_up_worktree()` in `skills/bundled/_shared/dispatch-lib.sh` reuses an existing
+worktree on a resume dispatch (lines 260-289), then runs the rebase-or-abort guard
+(lines 291-339). The guard does a **surgical** cleanup of three dispatch-lib-owned
+paths before `git rebase origin/main`:
+
+- `git checkout -- .claude/groom-verdict-trail.log` (line 301, mika#1301)
+- `rm -rf .iterate/` (line 302, mika#1301)
+- `git checkout HEAD -- docs/plans/` (line 311, mika#1311 follow-up)
+
+If the worktree carries **any other** dirty state, `git rebase origin/main` aborts
+with `error: cannot rebase: You have unstaged changes.` → `STATUS=REBASE_CONFLICT`
+with `Rebase failure mode: other`, `Conflicted files: <none>`. The task re-blocks
+with no recovery path. Confirmed n=2 on 2026-06-05 (mika#1255, mika#1381); n=13
+latent across in-flight worktrees.
+
+### Root-cause nuance discovered during planning (informs the fix shape)
+
+`.claude/commands/mika.md`, `.claude/claude-pilot.json`, and
+`.claude/groom-verdict-trail.log` are **tracked files** in the mika repo
+(verified: `git ls-files .claude/`). The dominant re-dirtying mechanism — the
+sibling ticket's `make deploy` writing a stale `mika.md` into worktree working
+trees — therefore surfaces as a **modified tracked file** (` M .claude/commands/mika.md`),
+not as untracked junk. The existing surgical list does **not** cover
+`.claude/commands/`, so this dominant case slips straight through to the crashing
+rebase. The other observed cases (md5sum / `find -exec` crash leftovers) are
+arbitrary residue the surgical list also cannot anticipate.
+
+This splits the fix into two tiers (see Approach): a **surgical extension** for the
+dominant dispatch-lib-owned `.claude/commands/` case (no stash noise, since
+dispatch-lib re-copies it at line 358 anyway), and a **blanket fallback** for the
+genuinely-unexpected residue (stash-as-safety-net, surfaced for operator recovery).
+
+## Scope
+
+- **In scope:** the resume/rebase path inside `_set_up_worktree()` — i.e. the
+  `if [ "$BEHIND" -gt 0 ]` block (lines 293-339). The crash only occurs when a
+  rebase is attempted (BEHIND > 0); a dirty worktree with BEHIND = 0 attempts no
+  rebase and does not crash here.
+- **Out of scope:** the root-cause sibling (`make deploy` re-dirtying worktrees
+  with stale `mika.md`) — that is the paired ticket referenced in the issue's
+  "Sibling fix" section; this ticket fixes the **symptom** (resume must survive a
+  dirty worktree) so the chain stops stalling regardless of what dirtied it.
+- **Out of scope:** the post-pilot dirty-worktree *content rescue* (mika#1282,
+  lines 485-636). That fires after the pilot runs to rescue authored-but-uncommitted
+  content into a draft PR. This ticket is about the *pre-pilot resume* cleanup so
+  the rebase can proceed at all. The two are complementary, not overlapping.
+
+## Approach
+
+Extract the pre-rebase cleanup into a single sourceable helper
+`_clean_worktree_for_rebase()` and call it from `_set_up_worktree()` immediately
+before the rebase attempt. The helper does, in order:
+
+1. **Abort any half-finished rebase (hardening).** If a prior dispatch was killed
+   mid-rebase, the worktree is left in a rebase-in-progress state that would make
+   the stash below fail and re-trigger the exact crash this ticket fixes:
+   ```sh
+   git -C "$WORKTREE_DIR" rebase --abort 2>/dev/null || true
+   ```
+
+2. **Surgical resets (migrated from current lines 301-311, extended).** Reset the
+   dispatch-lib-owned ephemeral/scaffold paths to HEAD. **Add `.claude/commands/`**
+   to the list — it is dispatch-lib-owned scaffold (mika#1288), re-copied fresh at
+   line 358 on every dispatch, so resetting it costs nothing and removes the
+   dominant deploy-re-dirty case without polluting the operator-recovery stash:
+   ```sh
+   git -C "$WORKTREE_DIR" checkout -- .claude/groom-verdict-trail.log 2>/dev/null || true
+   rm -rf "$WORKTREE_DIR/.iterate" 2>/dev/null || true
+   git -C "$WORKTREE_DIR" checkout HEAD -- docs/plans/ 2>/dev/null || true
+   git -C "$WORKTREE_DIR" checkout HEAD -- .claude/commands/ 2>/dev/null || true
+   ```
+
+3. **Blanket fallback for unexpected residue.** Re-check
+   `git status --porcelain`. If still non-empty, the residue is genuinely
+   unexpected (crash leftovers, new untracked files deploy added). Stash it as a
+   safety net, then hard-reset + clean so the rebase precondition holds:
+   ```sh
+   if [ -n "$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null)" ]; then
+       STASH_MSG="dispatch-lib-resume-cleanup-${LOG_ID}-$(date -u +%Y%m%dT%H%M%SZ)"
+       if git -C "$WORKTREE_DIR" stash push --include-untracked -m "$STASH_MSG" >/dev/null 2>&1; then
+           # Capture the IMMUTABLE stash commit SHA (not the positional stash@{0},
+           # which shifts as other worktrees push/pop on the shared stash stack).
+           RESUME_CLEANUP_STASH=$(git -C "$WORKTREE_DIR" rev-parse stash@{0} 2>/dev/null || true)
+           echo "dispatch-lib: resume-cleanup stashed dirty worktree before rebase → stash ${RESUME_CLEANUP_STASH:-<unknown>} (msg: ${STASH_MSG}); recover with: git -C ${WORKTREE_DIR} stash apply ${RESUME_CLEANUP_STASH:-<sha>}" >&2
+       else
+           echo "dispatch-lib: resume-cleanup stash failed (nothing to stash or stash error); proceeding with hard reset" >&2
+       fi
+       # Belt-and-suspenders: ensure a clean tree even if stash captured nothing
+       # (e.g. unmerged paths). Does NOT remove gitignored files (no -x), so the
+       # gitignored .claude/*.local.json is preserved for the line-341 config copy.
+       git -C "$WORKTREE_DIR" reset --hard HEAD 2>/dev/null || true
+       git -C "$WORKTREE_DIR" clean -fd 2>/dev/null || true
+   fi
+   ```
+
+4. The existing rebase attempt (lines 313-338) runs unchanged on the now-clean tree.
+
+### Why stash is safe with the tracked/gitignored split (verified)
+
+- `.claude/*.local.json`, `.claude/worktrees`, `.claude/scheduled_tasks.lock` are
+  gitignored. `git stash --include-untracked` does **not** capture ignored files
+  (would need `--all`) and `git clean -fd` does **not** remove them (would need
+  `-x`). So `settings.local.json` survives and is re-copied at line 344 regardless.
+- `.claude/claude-pilot.json` and `.claude/commands/` are tracked → reset to HEAD
+  by step 2, then re-copied fresh from `$PLATFORM_DIR` at lines 343/358 after the
+  rebase. No loss.
+
+## AC mapping
+
+| AC (reconciled where noted) | Where satisfied |
+|----|-----------------|
+| AC1 — detects dirty-worktree before rebase on resume path | Step 3 `git status --porcelain` check inside `_clean_worktree_for_rebase()`, called before the rebase attempt |
+| AC2 (reconciled) — auto-stashes *unexpected residue* with descriptive name `dispatch-lib-resume-cleanup-<task_id>-<timestamp>` | Step 3 `STASH_MSG` uses `$LOG_ID` (task id) + UTC timestamp; fires only on residue after surgical reset (see Spec reconciliation) |
+| AC3 — rebase proceeds on clean state | Steps 1-3 leave the tree clean; existing rebase at line 316 then succeeds |
+| AC4 (reconciled) — stash ref logged to durable per-task stderr log for operator recovery | Step 3 echoes the **immutable stash commit SHA** + `git stash apply` command to stderr → `/var/log/claude-pilot/${LOG_ID}.stderr` (mika#1097). See Spec reconciliation |
+| AC5 (reconciled) — reproducer: dirty `git status --porcelain` (unexpected residue) + new dispatch → no rebase crash; stash ref logged | New test in `test-dispatch-lib.sh` dirties a non-scaffold tracked file + untracked file (see Testing) |
+
+## Spec reconciliation (AC2 / AC4 / AC5) — committed, issue body to be updated
+
+The two-tier design and the durable-stderr logging are architecturally sound but
+reframe three ACs from their literal wording. Per the project's spec-divergence
+workflow (issue body is updated to match an architect-endorsed plan), these are
+committed reframes; the issue body ACs will be updated to match in Phase 5 (the
+edited ACs are recorded below):
+
+- **AC2 / AC5 — "Auto-stashes" / "stash ref logged" → "stash only unexpected
+  residue."** Decision: the resume stashes **only the dirt that remains after the
+  surgical resets** (step 2). Routine dispatch-lib-owned scaffold/ephemeral paths
+  (`.claude/commands/`, `.claude/groom-verdict-trail.log`, `.iterate/`,
+  `docs/plans/`) are reset to HEAD, not stashed, because dispatch-lib re-copies /
+  re-derives them post-rebase anyway and stashing them would fill operator-recovery
+  stashes with noise. **Consequence (accepted):** when the only dirt is a
+  surgically-handled path (e.g. a stale `mika.md` from deploy), the resume cleans +
+  rebases with **no stash created** — correct, because there is nothing
+  non-recoverable to preserve. The stash + log fire only when genuinely unexpected
+  residue is present. Reconciled AC2/AC5 wording: *"When unexpected dirty residue
+  remains after surgical reset, auto-stash it with descriptive name
+  `dispatch-lib-resume-cleanup-<task_id>-<timestamp>` and log the stash ref for
+  operator recovery."*
+
+- **AC4 — "Stash ref logged in task payload" → "logged to durable per-task stderr
+  log."** Decision: on the success path the RESULT "task payload" is owned by the
+  pilot outcome (lines 454-462), assembled long after worktree setup; threading the
+  setup-phase stash into a success RESULT would mean restructuring result assembly,
+  out of proportion to the fix. The stash SHA + `git stash apply` recovery command
+  are emitted to **stderr**, which dispatch-lib already persists durably per task to
+  `/var/log/claude-pilot/${LOG_ID}.stderr` (mika#1097, secret-scrubbed); the stash
+  is additionally recoverable via `git -C <worktree> stash list`. Reconciled AC4
+  wording: *"Stash ref logged to the durable per-task stderr log for operator
+  recovery."*
+
+## Testing
+
+Add `test_resume_dirty_worktree_cleaned()` to
+`skills/bundled/_shared/test-dispatch-lib.sh`:
+
+1. `_fixture_setup` + `_assert_fixture_is_local`.
+2. Create `feat/resume-dirty` branched one commit back, push it; advance `origin/main`
+   one **non-conflicting** commit (so BEHIND > 0 and a clean rebase is possible).
+3. Dirty the worktree: modify a tracked file (e.g. `echo x >> file.txt`) **and**
+   create an untracked file (`echo y > junk.tmp`).
+4. `source` dispatch-lib and call `_clean_worktree_for_rebase` against the fixture
+   worktree (real code — no inline copy, eliminating the Test-12e drift risk), then
+   run the rebase.
+5. Assertions:
+   - `git status --porcelain` is empty after cleanup (precondition held).
+   - rebase exits 0 (no `STATUS=REBASE_CONFLICT`).
+   - `git stash list` contains an entry whose message matches
+     `dispatch-lib-resume-cleanup-*` (stash safety net created).
+   - the stashed content is recoverable (`git stash show` non-empty / contains the
+     dirtied paths).
+
+Run: `bash skills/bundled/_shared/test-dispatch-lib.sh` (full suite must stay green).
+`cargo build` is not required — this is a shell-only change.
+
+## Committed decisions
+
+1. **Extract, not inline (committed).** The pre-rebase cleanup is extracted into
+   `_clean_worktree_for_rebase()` rather than inlined at the call site. Rationale:
+   (a) the test calls the **real** function instead of copying the guard (Test 12e
+   currently inline-copies the rebase guard and accepts drift risk — this stops
+   repeating that), (b) it consolidates all pre-rebase cleanup (migrated surgical
+   resets + new fallback) in one tested place. Cost: one new function + a one-line
+   call-site change in `_set_up_worktree()`.
+
+2. **Stash only unexpected residue (committed).** See Spec reconciliation AC2/AC5.
+
+3. **Log stash ref to durable stderr (committed).** See Spec reconciliation AC4.
+
+4. **Scope to the `BEHIND > 0` block (committed).** Cleanup runs only on the rebase
+   path. A dirty worktree with `BEHIND == 0` attempts no rebase, so it cannot crash
+   here; the pilot-runs-dirty case is the root-cause sibling ticket's surface, not
+   this symptom fix. See Scope.
+
+## Files touched
+
+- `skills/bundled/_shared/dispatch-lib.sh` — add `_clean_worktree_for_rebase()`;
+  replace lines 301-311 surgical cleanup with a call to it (the helper subsumes and
+  extends them).
+- `skills/bundled/_shared/test-dispatch-lib.sh` — add `test_resume_dirty_worktree_cleaned()`.
+- `docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md` — this plan.
+
+## Rollback
+
+Pure dispatch-lib shell change, copy-deployed (not in-binary). Revert the commit and
+`make deploy` (or re-sync the bundled skill) to restore prior behavior. No schema,
+no migration, no API surface.

--- a/docs/solutions/workflow-issues/dispatch-lib-dirty-worktree-resume-rebase-2026-06-06.md
+++ b/docs/solutions/workflow-issues/dispatch-lib-dirty-worktree-resume-rebase-2026-06-06.md
@@ -1,0 +1,129 @@
+---
+module: skills/bundled/_shared/dispatch-lib.sh
+tags: [autonomous-loop, dispatch-lib, worktree, rebase, resume, recovery, git-stash, milestone-30]
+problem_type: bug
+category: workflow-issues
+date: 2026-06-06
+ticket: mika#1414
+resolution_type: structural_guard
+---
+
+# dispatch-lib: dirty-worktree-on-resume crashes the rebase — 2026-06-06
+
+## Problem
+
+On a **resume** dispatch (`ready`-label re-dispatch into a previously-blocked task),
+`_set_up_worktree()` reuses an existing worktree and rebases it onto `origin/main`
+when `BEHIND > 0`. `git rebase` refuses to run on a dirty tree:
+
+```
+error: cannot rebase: You have unstaged changes.
+→ STATUS=REBASE_CONFLICT, Rebase failure mode: other, Conflicted files: <none>
+```
+
+The task re-blocks with **no recovery path** — the chain stalls indefinitely.
+
+Confirmed n=2 on 2026-06-05 (mika#1255 `md5sum` policy-deny crash leftovers;
+mika#1381 `find -exec` crash leftovers). A worktree survey that night found **13 of
+17** in-flight pilot worktrees dirty — a latent stall waiting in every one. This is
+milestone-30 (Loop Trustworthiness): *a loop that dispatches tickets which never ship
+makes "backlog → 0" lie.*
+
+### Root-cause nuance
+
+The dominant re-dirtying mechanism is **`make deploy` writing a stale pre-#1255
+`.claude/commands/mika.md` into worktree working trees** — a *tracked* file, so it
+shows as ` M .claude/commands/mika.md`, not untracked junk. The pre-existing surgical
+cleanup (mika#1301: `.iterate/`, `groom-verdict-trail.log`; mika#1311: `docs/plans/`)
+did **not** cover `.claude/commands/`, so the dominant case slipped straight through
+to the crashing rebase. (The companion root-cause fix — stop deploy from re-dirtying
+worktrees — is the paired ticket; this fixes the *symptom* so resume survives
+regardless of what dirtied the tree.)
+
+## Fix
+
+Extracted pre-rebase cleanup into a sourceable helper `_clean_worktree_for_rebase()`
+called from the `BEHIND > 0` block. Three tiers, in order:
+
+1. **Abort any half-finished rebase** (`git rebase --abort`) — a dispatch killed
+   mid-rebase would otherwise make the stash fail and re-trigger the exact crash.
+2. **Surgical resets** of dispatch-lib-owned scaffold to HEAD — the mika#1301/#1311
+   paths **plus `.claude/commands/`** (the dominant deploy case). All re-copied /
+   re-derived post-rebase, so resetting them costs nothing and keeps them out of the
+   operator-recovery stash.
+3. **Blanket fallback**: if residue survives, `git stash push --include-untracked`
+   (operator-recoverable safety net), then `git reset --hard` + `git clean -fd` so the
+   rebase precondition holds. `clean -fd` **omits `-x`** so gitignored config
+   (`.claude/*.local.json`) survives for the post-rebase copy.
+
+Extracting (not inlining) lets the test call the **real** function instead of an
+inline copy — eliminating the Test-12e drift class where a copied guard silently
+diverges from production.
+
+## Two non-obvious bugs surfaced in review (the durable learnings)
+
+### 1. `git rev-parse 'stash@{0}' || true` poisons the variable with a literal string
+
+`git rev-parse` on a **missing** ref exits non-zero **but still echoes the literal
+argument** (`stash@{0}`) to stdout. With `RESUME_CLEANUP_STASH=$(... || true)`, the
+`|| true` swallows the failure and the variable captures the bogus string
+`"stash@{0}"` — a worthless recovery handle — whenever `git stash push` reports
+success yet created no entry (e.g. nothing actually stashable, a nested untracked git
+repo). 
+
+**Rule:** to capture an optional git ref, use `rev-parse --verify --quiet <ref>` —
+it prints nothing and exits non-zero on a missing ref, so `$(... || true)` yields an
+empty string, not a literal. Never rely on `2>/dev/null` alone; the poisoning value
+goes to **stdout**, not stderr.
+
+### 2. "Logged to stderr" ≠ "lands in the per-task stderr log file"
+
+The groomed plan claimed the recovery line echoed to `>&2` would land in
+`/var/log/claude-pilot/<id>.stderr`. **False.** That file is written *only* from the
+`claude-pilot` subprocess's captured stderr (`_scrub_secrets_from_output <
+"$STDERR_FILE" > "$PERSISTENT_STDERR"`, and the redirect **truncates**).
+`_clean_worktree_for_rebase` runs during `_set_up_worktree()`, **before** claude-pilot
+launches — its `>&2` goes to dispatch-lib's own fd 2 (the tool subprocess stderr
+captured by the engine), a different stream that the per-task file never receives.
+
+**Rule:** a per-task log file populated from a *specific subprocess's* captured
+stderr does not capture the *parent script's* stderr emitted at other lifecycle
+phases. The **durable, authoritative** recovery path here is the stash itself —
+`git stash list` shows the entry whose message embeds the task id + UTC timestamp.
+Make the recoverable artifact self-describing; treat a log echo as best-effort.
+
+## Residual risks (accepted, documented — not fixed here)
+
+- **Nested untracked git repo** in the worktree survives tier-3 (`stash` skips it,
+  `clean -fd` without `-ff` refuses to delete nested repos) → tree stays dirty and the
+  rebase can still fail honestly (with captured stderr, not a silent corruption).
+  Adding `-ff` would risk deleting a legitimate nested repo (data loss), so it is
+  deliberately not done. mika has no worktree submodules today.
+- **Unmerged paths from a killed *merge/cherry-pick*** (not rebase) make `stash push`
+  fail; the belt-and-suspenders `reset --hard` then discards uncommitted edits in the
+  conflicted files with no stash handle. dispatch-lib worktrees only ever rebase, so
+  this shape does not arise on the live path; committed state always survives.
+- **Concurrent shared-stash race**: the stash stack is shared across a repo's
+  worktrees, so a sibling dispatch pushing between this dispatch's `stash push` and
+  `rev-parse` could shift `stash@{0}`. mika-dev serializes claude-pilot sessions, so
+  the live path is single-flight; the immutable-SHA capture protects recovery *after*
+  a correct capture.
+
+## Verification
+
+- `bash skills/bundled/_shared/test-dispatch-lib.sh` — 165 pass (was 162); 3 new tests:
+  tier-3 stash path (+ gitignore preservation), tier-2 scaffold-only **no-stash**
+  boundary (the dominant production case), tier-1 half-finished-rebase abort. The 7
+  pre-existing failures are unrelated (prompt-content / case-switch / callout tests
+  failing on the branch base, confirmed via stashed-baseline run).
+- Shell-only, copy-deployed (not in-binary) — no `cargo build`. Rollback = revert +
+  `make deploy` / re-sync bundled skill.
+
+## Related
+
+- mika#1255, mika#1381 — the two confirmed victims
+- mika#1301, mika#1311 — prior surgical-reset cleanups this helper subsumes
+- mika#1282 — post-flight dirty-worktree *content* rescue (complementary: post-pilot,
+  not pre-pilot resume)
+- mika#1097 — the per-task `${LOG_ID}.stderr` persistence whose scope the AC4
+  misconception misjudged

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -186,6 +186,90 @@ _scrub_env() {
     unset MIKA_ANTHROPIC_API_KEY MIKA_INTERNAL_TOKEN MIKA_OPENAI_API_KEY MIKA_BRAVE_API_KEY
 }
 
+# mika#1414: Pre-rebase worktree cleanup for the resume path.
+#
+# On a resume dispatch _set_up_worktree() reuses an existing worktree, then
+# rebases it onto origin/main. `git rebase` refuses to run on a dirty tree
+# (`error: cannot rebase: You have unstaged changes` → STATUS=REBASE_CONFLICT
+# with `Rebase failure mode: other`, no real conflict), re-blocking the task
+# with no recovery path (confirmed n=2 on 2026-06-05: mika#1255, mika#1381).
+# This helper guarantees a clean tree before the rebase, in three tiers:
+#
+#   1. Abort any half-finished rebase left by a killed prior dispatch — a
+#      rebase-in-progress state would make the stash below fail and re-trigger
+#      the exact crash this fixes.
+#   2. Surgically reset dispatch-lib-owned scaffold/ephemeral paths to HEAD.
+#      These are re-copied / re-derived post-rebase anyway, so resetting them
+#      costs nothing and keeps them out of the operator-recovery stash. The
+#      `.claude/commands/` reset covers the dominant case: `make deploy` writing
+#      a stale mika.md into worktree working trees (modified TRACKED file).
+#      Subsumes the mika#1301 (.iterate/, groom-verdict-trail.log) and mika#1311
+#      (docs/plans/) surgical resets that previously lived inline.
+#   3. Blanket fallback: if any residue survives the surgical resets it is
+#      genuinely unexpected (crash leftovers, new untracked files deploy added).
+#      Stash it as a safety net — capturing the IMMUTABLE stash commit SHA and
+#      logging a self-contained recovery command — then hard-reset + clean so
+#      the rebase precondition holds. The stash is operator-recoverable via
+#      `git -C <worktree> stash list` (its message embeds the task id +
+#      timestamp) — this is the durable recovery path; the stderr echo is a
+#      convenience and does NOT land in /var/log/claude-pilot/<id>.stderr (that
+#      file captures only the later claude-pilot subprocess stderr). `clean -fd`
+#      omits -x so it never deletes gitignored worktree state (.claude/*.local.json,
+#      .claude/worktrees, scheduled_tasks.lock); the .claude config files are
+#      re-copied from $PLATFORM_DIR post-rebase regardless.
+#
+# Args: $1 = worktree dir (defaults to $WORKTREE_DIR). Reads $LOG_ID for the
+# stash label. Sets RESUME_CLEANUP_STASH to the stash SHA when one is created
+# (empty otherwise). Returns 1 without touching anything if $wt is not a worktree.
+_clean_worktree_for_rebase() {
+    local wt="${1:-$WORKTREE_DIR}"
+    RESUME_CLEANUP_STASH=""
+
+    # Guard: refuse destructive cleanup on an invalid target. `git -C ""` silently
+    # operates on the dispatch process CWD (a live checkout), so an empty/unset $wt
+    # would point `reset --hard` / `clean -fd` at the wrong tree. Not reachable on
+    # the live path (WORKTREE_DIR is always derived first) but the helper is a
+    # sourceable, destructive primitive — fail closed.
+    if [ -z "$wt" ] || ! git -C "$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "dispatch-lib: _clean_worktree_for_rebase got an invalid worktree ('${wt}'); refusing destructive cleanup" >&2
+        return 1
+    fi
+
+    # Tier 1: abort any half-finished rebase (hardening). stdout is suppressed
+    # along with stderr throughout — dispatch-lib reserves stdout for the RESULT
+    # payload, and `reset --hard` / `clean -fd` below print to stdout.
+    git -C "$wt" rebase --abort >/dev/null 2>&1 || true
+
+    # Tier 2: surgical resets of dispatch-lib-owned scaffold/ephemeral paths.
+    git -C "$wt" checkout -- .claude/groom-verdict-trail.log 2>/dev/null || true
+    rm -rf "$wt/.iterate" 2>/dev/null || true
+    git -C "$wt" checkout HEAD -- docs/plans/ 2>/dev/null || true
+    git -C "$wt" checkout HEAD -- .claude/commands/ 2>/dev/null || true
+
+    # Tier 3: blanket fallback for genuinely-unexpected residue.
+    if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+        local stash_msg
+        stash_msg="dispatch-lib-resume-cleanup-${LOG_ID:-unknown}-$(date -u +%Y%m%dT%H%M%SZ)"
+        if git -C "$wt" stash push --include-untracked -m "$stash_msg" >/dev/null 2>&1; then
+            # Capture the IMMUTABLE stash commit SHA — stash@{0} shifts as other
+            # worktrees push/pop on the shared stash stack. Use `--verify --quiet`:
+            # plain `rev-parse 'stash@{0}'` on a missing ref exits non-zero but
+            # echoes the literal string "stash@{0}" to stdout, which `|| true`
+            # would capture as a bogus handle when `stash push` reported success
+            # yet created no entry (e.g. nothing actually stashable). --verify
+            # --quiet prints nothing and exits non-zero in that case → empty.
+            RESUME_CLEANUP_STASH=$(git -C "$wt" rev-parse --verify --quiet 'stash@{0}' 2>/dev/null || true)
+            echo "dispatch-lib: resume-cleanup stashed dirty worktree before rebase → stash ${RESUME_CLEANUP_STASH:-<unknown>} (msg: ${stash_msg}); recover with: git -C ${wt} stash apply ${RESUME_CLEANUP_STASH:-<sha>}" >&2
+        else
+            echo "dispatch-lib: resume-cleanup found nothing to stash or stash errored; proceeding with hard reset" >&2
+        fi
+        # Belt-and-suspenders: ensure a clean tree even if the stash captured
+        # nothing (e.g. unmerged paths). No -x, so gitignored config survives.
+        git -C "$wt" reset --hard HEAD >/dev/null 2>&1 || true
+        git -C "$wt" clean -fd >/dev/null 2>&1 || true
+    fi
+}
+
 _set_up_worktree() {
     # --- Parse repo#number format ---
     # Matches: mika#214, mika-skills#8, mika-cloud#50
@@ -291,24 +375,12 @@ _set_up_worktree() {
         # Rebase-or-abort guard
         BEHIND=$(git -C "$WORKTREE_DIR" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
         if [ "$BEHIND" -gt 0 ]; then
-            # Clean dispatch-lib-owned ephemeral files before rebase (mika#1301):
-            # .claude/groom-verdict-trail.log and .iterate/ are written by the
-            # iterate-loop itself; their presence as unstaged changes blocks
-            # rebase with `error: cannot rebase: You have unstaged changes`,
-            # producing a misleading REBASE_CONFLICT with no actual semantic
-            # conflict. dispatch-lib owns these paths, so it can safely reset
-            # them before rebasing.
-            git -C "$WORKTREE_DIR" checkout -- .claude/groom-verdict-trail.log 2>/dev/null || true
-            rm -rf "$WORKTREE_DIR/.iterate" 2>/dev/null || true
-            # mika#1311 follow-up: reused worktrees can carry uncommitted/
-            # staged docs/plans/ edits from a prior failed dispatch (groom
-            # session crashed before commit, or a commit step was hook-
-            # rejected without retry). The committed plan on origin/$BRANCH
-            # is the canonical source of truth; any leftover unstaged or
-            # staged plan-doc edits are abandoned state. Reset tracked
-            # plan files to HEAD so rebase can proceed. (Untracked plan
-            # files are not affected — only tracked-but-modified ones.)
-            git -C "$WORKTREE_DIR" checkout HEAD -- docs/plans/ 2>/dev/null || true
+            # mika#1414: guarantee a clean tree before rebase on the resume path —
+            # a reused worktree can carry dirty state (dominant case: a stale
+            # .claude/commands/mika.md from `make deploy`) that would otherwise
+            # abort the rebase with a misleading REBASE_CONFLICT and re-block the
+            # task. Rationale + tier design live in _clean_worktree_for_rebase.
+            _clean_worktree_for_rebase "$WORKTREE_DIR"
 
             # Capture rebase stderr instead of discarding to /dev/null (mika#1364 AC#4).
             local rebase_err

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -1575,6 +1575,236 @@ else
     FAIL=$((FAIL + 1)); echo "  ✗ No-op on stale-main conflation (mika#1407): $RESULT_12H"
 fi
 
+# --- Test 12i: Resume with dirty worktree → cleaned + stashed, rebase succeeds (mika#1414) ---
+# A reused worktree carrying UNEXPECTED dirty residue (modified non-scaffold tracked
+# file + untracked file) must not crash `git rebase` on the resume path. The real
+# _clean_worktree_for_rebase helper must stash the residue (operator-recoverable) and
+# leave a clean tree so the rebase proceeds. Calling the real function (not an inline
+# copy of the guard) eliminates the Test-12e drift risk called out in the plan.
+test_resume_dirty_worktree_cleaned() {
+    _fixture_setup
+    _assert_fixture_is_local || return 1
+
+    # Feature branch with its own commit, so the rebase actually replays work.
+    # Commit a .gitignore so we can prove `clean -fd` (no -x) preserves ignored files.
+    git -C "$FIXTURE_CLONE" checkout -q -b feat/resume-dirty
+    echo "feat" > "$FIXTURE_CLONE/feature.txt"
+    printf '*.keep\n' > "$FIXTURE_CLONE/.gitignore"
+    git -C "$FIXTURE_CLONE" add feature.txt .gitignore
+    git -C "$FIXTURE_CLONE" commit -q -m "feature work"
+    git -C "$FIXTURE_CLONE" push -q -u origin feat/resume-dirty
+
+    # Advance origin/main by one NON-conflicting commit (touches a different file)
+    # via a throwaway clone, so BEHIND>0 and a clean rebase is possible.
+    local advance_clone
+    advance_clone=$(mktemp -d)
+    git clone -q "file://$FIXTURE_BARE" "$advance_clone"
+    git -C "$advance_clone" config user.email "test@mika.local"
+    git -C "$advance_clone" config user.name "mika test"
+    echo "advance" > "$advance_clone/main-advance.txt"
+    git -C "$advance_clone" add main-advance.txt
+    git -C "$advance_clone" commit -q -m "advance main"
+    git -C "$advance_clone" push -q origin main
+    rm -rf "$advance_clone"
+    git -C "$FIXTURE_CLONE" fetch -q origin
+
+    # Dirty the worktree with UNEXPECTED residue: a modified non-scaffold tracked
+    # file + an untracked file. Neither is a dispatch-lib-owned scaffold path, so
+    # both survive the surgical resets and must be stashed by the blanket fallback.
+    echo "dirty" >> "$FIXTURE_CLONE/file.txt"
+    echo "junk" > "$FIXTURE_CLONE/junk.tmp"
+    # A gitignored, uncommitted file (stands in for .claude/*.local.json) — must
+    # survive `clean -fd` (no -x), which is the load-bearing reason -x is omitted.
+    echo "keepme" > "$FIXTURE_CLONE/config.keep"
+
+    WORKTREE_DIR="$FIXTURE_CLONE"
+    LOG_ID="test-1414"
+    RESUME_CLEANUP_STASH=""
+
+    # Call the REAL helper.
+    _clean_worktree_for_rebase "$FIXTURE_CLONE"
+
+    local status_after
+    status_after=$(git -C "$FIXTURE_CLONE" status --porcelain 2>/dev/null)
+
+    # The rebase the helper guards must now succeed on the clean tree.
+    local rebase_rc=0
+    git -C "$FIXTURE_CLONE" rebase origin/main >/dev/null 2>&1 || rebase_rc=$?
+
+    local failures=""
+    # AC1 + AC3: tree clean after cleanup, rebase succeeds (no REBASE_CONFLICT).
+    [ -z "$status_after" ] || failures="${failures}worktree not clean after cleanup: [$status_after]; "
+    [ "$rebase_rc" -eq 0 ] || failures="${failures}rebase should succeed on clean tree, got rc=$rebase_rc; "
+    # AC2: a stash with the descriptive name was created.
+    if ! git -C "$FIXTURE_CLONE" stash list 2>/dev/null | grep -qF "dispatch-lib-resume-cleanup-test-1414-"; then
+        failures="${failures}expected stash named dispatch-lib-resume-cleanup-test-1414-*; "
+    fi
+    # AC4: the immutable stash SHA was captured for operator recovery.
+    if [ -z "$RESUME_CLEANUP_STASH" ]; then
+        failures="${failures}RESUME_CLEANUP_STASH should hold the stash SHA; "
+    elif ! git -C "$FIXTURE_CLONE" cat-file -e "$RESUME_CLEANUP_STASH" 2>/dev/null; then
+        failures="${failures}RESUME_CLEANUP_STASH ($RESUME_CLEANUP_STASH) is not a valid git object; "
+    fi
+    # AC5: stashed content is recoverable — both the modified tracked file and the
+    # untracked file. The untracked file lives in the stash's third parent (^3),
+    # created by `stash push --include-untracked`.
+    if [ -n "$RESUME_CLEANUP_STASH" ]; then
+        if ! git -C "$FIXTURE_CLONE" stash show "$RESUME_CLEANUP_STASH" 2>/dev/null | grep -qF 'file.txt'; then
+            failures="${failures}stash diff should contain the dirtied tracked file (file.txt); "
+        fi
+        if ! git -C "$FIXTURE_CLONE" ls-tree -r "${RESUME_CLEANUP_STASH}^3" 2>/dev/null | grep -qF 'junk.tmp'; then
+            failures="${failures}stash should preserve the untracked file (junk.tmp); "
+        fi
+    fi
+    # clean -fd omits -x: the gitignored file must survive the blanket fallback.
+    if [ ! -f "$FIXTURE_CLONE/config.keep" ]; then
+        failures="${failures}gitignored file (config.keep) must survive clean -fd (no -x); "
+    fi
+
+    _fixture_cleanup
+    if [ -z "$failures" ]; then echo "PASS"; else echo "FAIL: $failures"; fi
+}
+
+RESULT_12I=$(test_resume_dirty_worktree_cleaned 2>/dev/null)
+if [ "$RESULT_12I" = "PASS" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ Resume dirty worktree: cleaned + stashed, rebase succeeds (mika#1414)"
+else
+    FAIL=$((FAIL + 1)); echo "  ✗ Resume dirty worktree cleanup (mika#1414): $RESULT_12I"
+fi
+
+# --- Test 12j: Resume with ONLY scaffold dirt → surgical reset, NO stash (mika#1414) ---
+# The dominant production case: a stale committed-plan / .claude/commands edit (e.g. a
+# `make deploy` stale mika.md). Tier-2 surgical resets must clean it to HEAD WITHOUT
+# creating an operator-recovery stash — the plan's accepted-consequence contract (AC2
+# reconciliation). A regression that stashes scaffold residue would fill recovery
+# stashes with noise; this test locks the no-stash boundary.
+test_resume_surgical_only_no_stash() {
+    _fixture_setup
+    _assert_fixture_is_local || return 1
+
+    git -C "$FIXTURE_CLONE" checkout -q -b feat/surgical-only
+    mkdir -p "$FIXTURE_CLONE/docs/plans"
+    echo "plan v1" > "$FIXTURE_CLONE/docs/plans/p.md"
+    echo "feat" > "$FIXTURE_CLONE/feature.txt"
+    git -C "$FIXTURE_CLONE" add docs/plans/p.md feature.txt
+    git -C "$FIXTURE_CLONE" commit -q -m "feature + committed plan"
+    git -C "$FIXTURE_CLONE" push -q -u origin feat/surgical-only
+
+    # Advance origin/main (non-conflicting) so BEHIND>0.
+    local advance_clone
+    advance_clone=$(mktemp -d)
+    git clone -q "file://$FIXTURE_BARE" "$advance_clone"
+    git -C "$advance_clone" config user.email "test@mika.local"
+    git -C "$advance_clone" config user.name "mika test"
+    echo "advance" > "$advance_clone/main-advance.txt"
+    git -C "$advance_clone" add main-advance.txt
+    git -C "$advance_clone" commit -q -m "advance main"
+    git -C "$advance_clone" push -q origin main
+    rm -rf "$advance_clone"
+    git -C "$FIXTURE_CLONE" fetch -q origin
+
+    # Dirty ONLY a dispatch-lib-owned scaffold path (a stale committed-plan edit).
+    echo "stale edit" >> "$FIXTURE_CLONE/docs/plans/p.md"
+
+    WORKTREE_DIR="$FIXTURE_CLONE"
+    LOG_ID="test-1414-surgical"
+    RESUME_CLEANUP_STASH=""
+
+    _clean_worktree_for_rebase "$FIXTURE_CLONE"
+
+    local status_after
+    status_after=$(git -C "$FIXTURE_CLONE" status --porcelain 2>/dev/null)
+    local rebase_rc=0
+    git -C "$FIXTURE_CLONE" rebase origin/main >/dev/null 2>&1 || rebase_rc=$?
+
+    local failures=""
+    [ -z "$status_after" ] || failures="${failures}worktree not clean after surgical reset: [$status_after]; "
+    [ "$rebase_rc" -eq 0 ] || failures="${failures}rebase should succeed, got rc=$rebase_rc; "
+    # The accepted-consequence contract: scaffold-only dirt is reset, NOT stashed.
+    [ -z "$RESUME_CLEANUP_STASH" ] || failures="${failures}scaffold-only dirt must NOT create a stash (got $RESUME_CLEANUP_STASH); "
+    if git -C "$FIXTURE_CLONE" stash list 2>/dev/null | grep -qF "dispatch-lib-resume-cleanup-"; then
+        failures="${failures}no resume-cleanup stash should exist for scaffold-only dirt; "
+    fi
+
+    _fixture_cleanup
+    if [ -z "$failures" ]; then echo "PASS"; else echo "FAIL: $failures"; fi
+}
+
+RESULT_12J=$(test_resume_surgical_only_no_stash 2>/dev/null)
+if [ "$RESULT_12J" = "PASS" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ Resume scaffold-only dirt: surgical reset, no stash (mika#1414)"
+else
+    FAIL=$((FAIL + 1)); echo "  ✗ Resume scaffold-only no-stash (mika#1414): $RESULT_12J"
+fi
+
+# --- Test 12k: Resume aborts a half-finished rebase before cleanup (mika#1414 tier 1) ---
+# A prior dispatch killed mid-rebase leaves a rebase-in-progress state. Tier 1 must
+# `rebase --abort` it; otherwise the stash below fails and the exact crash this fix
+# targets recurs. Locks the hardening tier.
+test_resume_aborts_half_finished_rebase() {
+    _fixture_setup
+    _assert_fixture_is_local || return 1
+
+    # Commit a shared file on main both sides will edit (forces a rebase conflict).
+    echo "base-shared" > "$FIXTURE_CLONE/shared.txt"
+    git -C "$FIXTURE_CLONE" add shared.txt
+    git -C "$FIXTURE_CLONE" commit -q -m "add shared"
+    git -C "$FIXTURE_CLONE" push -q origin main
+
+    git -C "$FIXTURE_CLONE" checkout -q -b feat/half-rebase
+    echo "branch-change" > "$FIXTURE_CLONE/shared.txt"
+    git -C "$FIXTURE_CLONE" add shared.txt
+    git -C "$FIXTURE_CLONE" commit -q -m "branch edits shared"
+    git -C "$FIXTURE_CLONE" push -q -u origin feat/half-rebase
+
+    # Advance origin/main with a CONFLICTING edit to the same file.
+    local advance_clone
+    advance_clone=$(mktemp -d)
+    git clone -q "file://$FIXTURE_BARE" "$advance_clone"
+    git -C "$advance_clone" config user.email "test@mika.local"
+    git -C "$advance_clone" config user.name "mika test"
+    git -C "$advance_clone" checkout -q main
+    echo "main-change" > "$advance_clone/shared.txt"
+    git -C "$advance_clone" add shared.txt
+    git -C "$advance_clone" commit -q -m "main edits shared (conflict)"
+    git -C "$advance_clone" push -q origin main
+    rm -rf "$advance_clone"
+    git -C "$FIXTURE_CLONE" fetch -q origin
+
+    # Start a conflicting rebase and LEAVE it mid-flight (do not abort/resolve).
+    git -C "$FIXTURE_CLONE" rebase origin/main >/dev/null 2>&1 || true
+
+    local mid_rebase=0
+    if [ -d "$FIXTURE_CLONE/.git/rebase-merge" ] || [ -d "$FIXTURE_CLONE/.git/rebase-apply" ]; then
+        mid_rebase=1
+    fi
+
+    WORKTREE_DIR="$FIXTURE_CLONE"
+    LOG_ID="test-1414-abort"
+    RESUME_CLEANUP_STASH=""
+
+    _clean_worktree_for_rebase "$FIXTURE_CLONE"
+
+    local failures=""
+    [ "$mid_rebase" -eq 1 ] || failures="${failures}precondition: expected a mid-rebase state in the fixture; "
+    if [ -d "$FIXTURE_CLONE/.git/rebase-merge" ] || [ -d "$FIXTURE_CLONE/.git/rebase-apply" ]; then
+        failures="${failures}tier 1 did not abort the in-progress rebase; "
+    fi
+    local status_after
+    status_after=$(git -C "$FIXTURE_CLONE" status --porcelain 2>/dev/null)
+    [ -z "$status_after" ] || failures="${failures}tree not clean after abort+cleanup: [$status_after]; "
+
+    _fixture_cleanup
+    if [ -z "$failures" ]; then echo "PASS"; else echo "FAIL: $failures"; fi
+}
+
+RESULT_12K=$(test_resume_aborts_half_finished_rebase 2>/dev/null)
+if [ "$RESULT_12K" = "PASS" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ Resume aborts half-finished rebase (mika#1414 tier 1)"
+else
+    FAIL=$((FAIL + 1)); echo "  ✗ Resume half-finished-rebase abort (mika#1414): $RESULT_12K"
+fi
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Why

On a **resume** dispatch (`ready`-label re-dispatch of a previously-blocked task),
`_set_up_worktree()` reuses an existing worktree and rebases onto `origin/main` when
`BEHIND > 0`. `git rebase` refuses to run on a dirty tree:

```
error: cannot rebase: You have unstaged changes.
→ STATUS=REBASE_CONFLICT, Rebase failure mode: other, Conflicted files: <none>
```

The task re-blocks with **no recovery path** — the chain stalls indefinitely.
Confirmed n=2 on 2026-06-05 (mika#1255, mika#1381); a worktree survey that night
found **13 of 17** in-flight pilot worktrees dirty. milestone-30 (Loop
Trustworthiness): a loop that dispatches tickets which never ship makes
"backlog → 0" lie.

**Root-cause nuance:** the dominant dirtier is `make deploy` writing a stale
pre-#1255 `.claude/commands/mika.md` — a *tracked* file (` M .claude/commands/mika.md`),
which the pre-existing surgical cleanup (mika#1301/#1311) did not cover, so it slipped
straight through to the crashing rebase.

## What

Extract pre-rebase cleanup into `_clean_worktree_for_rebase()`, called before the
rebase in the `BEHIND > 0` block. Three tiers:

1. **Abort any half-finished rebase** — a dispatch killed mid-rebase would otherwise
   make the stash fail and re-trigger the exact crash.
2. **Surgical resets** of dispatch-lib-owned scaffold to HEAD — the mika#1301/#1311
   paths **plus `.claude/commands/`** (re-copied post-rebase, so no recovery-stash
   noise). Subsumes the prior inline resets.
3. **Blanket fallback** — `git stash push --include-untracked` (operator-recoverable),
   then `reset --hard` + `clean -fd` (no `-x`, so gitignored config survives).

Extracting (vs inlining) lets the test call the **real** function — eliminating the
Test-12e inline-copy drift class.

## Review-surfaced hardening (multi-agent review)

- **`rev-parse --verify --quiet`** for the stash SHA: plain `rev-parse 'stash@{0}'
  || true` echoes the literal string `stash@{0}` to stdout on a missing ref,
  poisoning the recovery handle when `stash push` reports success yet created no entry.
- **Empty/invalid `$wt` guard** before destructive ops — `git -C ""` silently
  operates on the dispatch CWD (a live checkout).
- **Corrected the plan's AC4 claim**: the stderr echo does **not** land in
  `/var/log/claude-pilot/<id>.stderr` (that file is written only from claude-pilot's
  own captured stderr, with a truncating redirect). The durable, authoritative
  recovery path is the stash itself — `git stash list` (message embeds task id +
  timestamp).

## Acceptance criteria

- [x] AC1 — dirty-worktree detected before rebase (`status --porcelain` in helper)
- [x] AC2 — unexpected residue auto-stashed with `dispatch-lib-resume-cleanup-<task_id>-<ts>` (scaffold reset, not stashed)
- [x] AC3 — rebase proceeds on clean state
- [x] AC4 — stash ref recoverable via `git stash list` + echoed to stderr (mechanism corrected from plan)
- [x] AC5 — reproducer test: dirty tree + dispatch → no crash, stash logged, tree clean

## Residual risks (documented, accepted)

Nested untracked git repo survives `clean -fd` (no `-ff` — avoids data loss); unmerged
paths from a killed merge/cherry-pick (cannot arise in rebase-only flow); concurrent
shared-stash race (mika-dev serializes dispatch). See the compound doc.

## Tests

`bash skills/bundled/_shared/test-dispatch-lib.sh` → **165 pass** (was 162). +3 tests:
tier-3 stash path (incl. gitignore preservation), tier-2 scaffold-only **no-stash**
boundary (the dominant production case), tier-1 half-finished-rebase abort. The 7
pre-existing failures are **unrelated** (prompt-content / case-switch / callout tests
failing on the branch base — confirmed via stashed-baseline run). Shell-only,
copy-deployed — no `cargo build`.

Compound: `docs/solutions/workflow-issues/dispatch-lib-dirty-worktree-resume-rebase-2026-06-06.md`
Plan: `docs/plans/2026-06-06-001-fix-dispatch-lib-resume-dirty-worktree-plan.md`

Closes #1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)