### PR TITLE
fix(dispatch-lib): _iterate_groom_loop plan-find content-fallback closes architect-convergence class (#1421)

### DIFF
--- a/docs/plans/2026-06-06-003-fix-1421-iterate-groom-loop-plan-find-content-fallback-plan.md
+++ b/docs/plans/2026-06-06-003-fix-1421-iterate-groom-loop-plan-find-content-fallback-plan.md
@@ -1,0 +1,133 @@
+---
+ticket: mika#1421
+type: fix
+component: skills/bundled/_shared/dispatch-lib.sh
+date: 2026-06-06
+seq: 003
+base_sha: e1ebebc3
+related:
+  - mika#1381  # n=1 architect-convergence observation
+  - mika#771   # n=2 architect-convergence binding (founding incident)
+  - mika#1271  # dispatch-lib content/workflow split (introduced _iterate_groom_loop)
+  - mika#1144  # original issue-scoped plan-find pattern
+  - mika#1033  # >500-byte filter
+milestone: 30  # Loop Trustworthiness
+---
+
+# Fix `_iterate_groom_loop` plan-find pattern — content fallback for date-prefix slug-tail filenames
+
+## Problem
+
+`_iterate_groom_loop` and two sibling functions (`_launch_revise_pilot`, `_write_canonical_callout`) discover the issue-scoped plan file via a brittle filename pattern at three callsites:
+
+```bash
+plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
+    2>/dev/null | sort -r | head -1)
+```
+
+The pattern requires the issue number to be embedded literally in the filename (e.g. `2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md` matches `*-1407-*-plan.md`).
+
+The `/mika-groom-plan-only` skill instructs claude-pilot to save plans to `<repo>/docs/plans/<YYYY-MM-DD>-<NNN>-<type>-<slug-tail>-plan.md`. **Whether `<slug-tail>` includes the issue number is left to the pilot's interpretation**, and the pilot has been observed producing filenames that omit it.
+
+### Founding incident
+
+mika#771 dispatched dev-groom at 2026-06-06 17:22Z. The pilot session (`5e5490e4-56be-409a-b38c-8baeebb02c2c`, 22 turns, $1.89, 392s) wrote, committed, and pushed:
+
+```
+docs/plans/2026-06-06-003-feat-post-condition-guard-send-message-plan.md
+```
+
+The filename has **no issue number embedded**. `_iterate_groom_loop`'s `find -name "*-771-*-plan.md"` returned empty → `plan_path` empty → return 1 → architect never called → ticket lands in half-state: plan committed on branch, body callout never written.
+
+This was n=2 of the architect-convergence class. n=1 was mika#1381's second chain test at 11:37Z — same exact error message, same exit path.
+
+### Why content-fallback closes the class
+
+The plan file itself contains the canonical ticket reference. Line 3 of mika#771's plan:
+
+```markdown
+**Ticket:** mika issue#771
+```
+
+The reference is present in the file's content even when absent from its filename. Grepping the recently-modified plan files for the `**Ticket:** mika [issue]#N` line (or YAML frontmatter `ticket: mika#N`) locates the correct plan without relying on filename convention drift.
+
+Per [[feedback-prompt-enforcement-fragile]]: relying on the pilot's adherence to a filename convention is prompt-level enforcement — fragile. The plan's header is structurally written by the pilot per the same skill, but the failure mode (filename drift) is qualitatively different from the failure mode for content drift (the pilot writes a plan that doesn't reference its own ticket): the latter is a much louder, easier-to-catch failure than the former.
+
+## Approach
+
+Add a `_find_issue_plan` helper next to the existing iterate-loop primitives. The helper:
+
+1. **Primary pass:** `find ... -name "*-${ISSUE_NUM}-*-plan.md" -size +500c` (current behavior).
+2. **Fallback pass:** if primary returns empty, iterate over `find ... -name "*-plan.md" -size +500c` candidates and grep each for an anchored `**Ticket:** mika [issue]#N\b` or YAML `ticket: mika#N\b` line. Return the most-recent match.
+
+Refactor the three brittle callsites (lines 1334, 1462, 1560) to call `_find_issue_plan` instead of inlining the `find` command.
+
+### Why a helper rather than three duplicate fallback blocks
+
+Single source of truth for plan discovery. If the pilot's filename or header convention evolves further, there's one place to update — not three. Sister rationale to `mika-arch-first-dogfood-2026-04-25` (verdict-parsing centralization).
+
+### Anchor discipline on the content match
+
+The fallback grep uses `^(\*\*Ticket:\*\*|ticket:)\s+mika[[:space:]]?(issue)?#${ISSUE_NUM}\b`:
+
+- **Line-anchored:** `^` rejects prose mentions of `#N` mid-paragraph
+- **Keyword-anchored:** requires either `**Ticket:**` (markdown header) or `ticket:` (YAML frontmatter) — refuses casual mentions
+- **Word-boundary:** `\b` after `${ISSUE_NUM}` rejects substring matches (e.g. `#77` matching against searches for `#7`)
+
+The test suite covers a negative case: a plan that mentions `mika#1234` only in prose (without the anchored keyword) does NOT match.
+
+### Most-recent-wins semantics
+
+Both passes use `sort -r | head -1` (the existing convention). When both primary and fallback could match different files for the same issue (re-grooms with mixed filename conventions), **primary always wins** — the fallback only runs when primary returns empty. This preserves backward-compatibility with existing groomed plans that follow the filename convention.
+
+## Acceptance Criteria
+
+- [x] **AC1:** New `_find_issue_plan` helper exists in `skills/bundled/_shared/dispatch-lib.sh`, defined adjacent to other iterate-loop primitives (immediately before `_arch_ask`).
+- [x] **AC2:** All three callsites (`_launch_revise_pilot`, `_write_canonical_callout`, `_iterate_groom_loop`) refactored to call `_find_issue_plan`. Each preserves its original WARN message and return semantics.
+- [x] **AC3:** New test file `skills/bundled/_shared/tests/test_find_issue_plan.sh` with:
+  - Primary-pass test (filename embeds issue number)
+  - Fallback test for the mika#771 founding-incident filename shape
+  - Fallback test for older `**Ticket:** mika#N` shape (no "issue" word)
+  - Fallback test for YAML `ticket:` frontmatter
+  - Negative test: prose `#N` mention without anchor keyword does NOT match
+  - Sort-order: primary wins when both shapes exist; fallback picks most-recent when only fallback matches
+  - Input guards: unset `ISSUE_NUM`, unset `WORKTREE_DIR`, missing `docs/plans` directory, sub-500-byte plan
+- [x] **AC4:** All 11 new test assertions pass; existing `test_parse_disposition.sh` 56-assertion suite still passes.
+- [x] **AC5:** Docblock comment in `_iterate_groom_loop` updated to reference the helper rather than the inline pattern.
+
+## Phase 0 — Pin
+
+Pinned against base SHA `e1ebebc3` (`fix(dispatch-lib): worktree-setup clobbers sub-repo .claude/commands (#1255 regression on every dispatch) (#1418)`, merged 2026-06-06).
+
+Three callsites confirmed at the pinned SHA:
+
+```
+1334: plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
+1462: plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
+1560: plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
+```
+
+(Functions: `_launch_revise_pilot`, `_write_canonical_callout`, `_iterate_groom_loop`.)
+
+Test infrastructure pinned at `skills/bundled/_shared/tests/test_parse_disposition.sh` (the canonical test pattern this fix mirrors).
+
+## Risks
+
+1. **Content-pattern drift in future pilots.** If the pilot evolves to use a different ticket-reference shape (neither `**Ticket:** mika ...` nor `ticket: mika...`), the fallback would not match. Mitigation: the test file documents the three currently-known shapes; new shapes get added when observed (n=1 observe-don't-add).
+
+2. **False-positive on plans with embedded sub-references.** A plan for mika#100 that references mika#1000 in an anchored line could in principle false-positive. Mitigation: `\b` word boundary after the issue number rejects substring matches. Test coverage includes a sort-order case proving most-recent semantics hold.
+
+3. **Performance.** The fallback iterates over all `*-plan.md` files in `docs/plans/`. Today's repo has ~552 plan files; grepping ~552 small text files for one anchored regex line takes <100ms on the dev host. Acceptable for a per-dispatch operation.
+
+## Verification
+
+1. Run new test: `bash skills/bundled/_shared/tests/test_find_issue_plan.sh` — expect 11 passing, exit 0.
+2. Regression: `bash skills/bundled/_shared/tests/test_parse_disposition.sh` — expect 56 passing, exit 0.
+3. Bash syntax: `bash -n skills/bundled/_shared/dispatch-lib.sh` — expect "syntax ok".
+4. Post-deploy live verification: re-dispatch mika#771 by adding the `ready` label; verify dev-groom completes, body callout writes, architect verdict appears in groom-verdict-trail.log. **This is the load-bearing test** — the fix is validated when the founding incident no longer reproduces.
+
+## Sequencing
+
+Implementation is a substrate-pivot (single file + tests + plan doc), shipping by-hand per the established #1414/#1415 morning-pattern. Branch: `fix/1421/iterate-groom-loop-plan-find-content-fallback`. PR open + deploy + re-dispatch all in one cycle.
+
+The fix is freeze-window-safe because the substrate-pivot pattern unwedges the autonomous loop; CLAUDE.md prime directive: *"Autonomous loop always works."*

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1085,6 +1085,59 @@ Dedup-rebase failed (${dedup_conflicts:+conflict: $dedup_conflicts}${dedup_confl
 # docs/plans/2026-05-25-003-feat-1271-iterate-loop-state-machine-plan.md.
 # ============================================================================
 
+_find_issue_plan() {
+    # Locate the plan file for $REPO#$ISSUE_NUM in $WORKTREE_DIR/docs/plans.
+    #
+    # Primary: filename embeds the issue number — `*-${ISSUE_NUM}-*-plan.md`
+    #          (the convention most existing plans follow:
+    #          e.g. `2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md`).
+    #
+    # Fallback: scan recently-written plan files for an explicit ticket
+    #          reference in their content. The pilot is instructed to set
+    #          `**Ticket:** mika issue#N` in the plan header but may also
+    #          name the plan with a date-prefix slug-tail that does NOT
+    #          embed the issue number (e.g. mika#771 wrote
+    #          `2026-06-06-003-feat-post-condition-guard-send-message-plan.md`).
+    #          Without this fallback, `_iterate_groom_loop` returns 1, the
+    #          architect is never called, and the ticket lands in a half-state
+    #          (plan committed, verdict missing). This is the founding
+    #          incident for mika#1421 — bound at n=2 on 2026-06-06 across
+    #          mika#1381 (n=1, 11:37Z) and mika#771 (n=2, 17:29Z).
+    #
+    # Both passes apply the >500-byte filter (mika#1033) and return the
+    # most-recent match. Prints the absolute plan path on success; returns
+    # non-zero with no stdout on failure. Callers must check `[ -n ... ]`
+    # AND `[ -r ... ]` exactly as before.
+    [ -n "$WORKTREE_DIR" ] && [ -n "$ISSUE_NUM" ] || return 1
+
+    # Primary: filename-embedded issue number
+    local plan_path
+    plan_path=$(find "$WORKTREE_DIR/docs/plans" \
+        -name "*-${ISSUE_NUM}-*-plan.md" -size +500c 2>/dev/null \
+        | sort -r | head -1)
+    if [ -n "$plan_path" ] && [ -r "$plan_path" ]; then
+        printf '%s' "$plan_path"
+        return 0
+    fi
+
+    # Fallback: content references the issue. Pattern handles three
+    # shapes the pilot has been observed to produce in plan headers:
+    #   **Ticket:** mika issue#N    (current `/mika-groom-plan-only` shape)
+    #   **Ticket:** mika#N          (older convention)
+    #   ticket: mika#N              (YAML frontmatter)
+    # The grep is line-anchored to avoid false positives on prose
+    # paragraphs that happen to mention an unrelated #N.
+    while IFS= read -r candidate; do
+        [ -r "$candidate" ] || continue
+        if grep -qE "^(\*\*Ticket:\*\*|ticket:)\s+mika[[:space:]]?(issue)?#${ISSUE_NUM}\b" "$candidate" 2>/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done < <(find "$WORKTREE_DIR/docs/plans" -name "*-plan.md" -size +500c 2>/dev/null | sort -r)
+
+    return 1
+}
+
 _arch_ask() {
     # Phase A — architect-call helper. Invokes mika-arch via the CLI with the
     # given skill, delivering plan content via stdin. Returns the full JSON
@@ -1328,12 +1381,10 @@ _launch_revise_pilot() {
     [ -n "$ISSUE_NUM" ] || {
         echo "WARN: _launch_revise_pilot: ISSUE_NUM unset" >&2; return 1; }
 
-    # Find the plan file using the same issue-scoped pattern as elsewhere
-    # in dispatch-lib (mika#1033 >500-byte filter, most-recent first).
+    # Locate the plan file via _find_issue_plan (mika#1421 — filename pattern
+    # with content-fallback for date-prefix slug-tail filenames).
     local plan_path
-    plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
-        2>/dev/null | sort -r | head -1)
-    [ -n "$plan_path" ] && [ -r "$plan_path" ] || {
+    plan_path=$(_find_issue_plan) || {
         echo "WARN: _launch_revise_pilot: no plan file to revise" >&2; return 1; }
 
     # sha256 before revise (detection mechanism; mtime is too coarse).
@@ -1457,11 +1508,10 @@ _write_canonical_callout() {
             ;;
     esac
 
-    # Find the issue-scoped plan file (same pattern as _iterate_groom_loop).
+    # Locate the plan file via _find_issue_plan (mika#1421 — filename pattern
+    # with content-fallback for date-prefix slug-tail filenames).
     local plan_path
-    plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
-        2>/dev/null | sort -r | head -1)
-    [ -n "$plan_path" ] || {
+    plan_path=$(_find_issue_plan) || {
         echo "WARN: write_canonical_callout: no issue-scoped plan file for $REPO#$ISSUE_NUM" >&2
         return 1
     }
@@ -1546,7 +1596,8 @@ _iterate_groom_loop() {
     # until the dev-groom-prompt-update follow-up ships.
     #
     # Guards: requires WORKTREE_DIR, ISSUE_NUM, REPO; finds the plan file via
-    # issue-scoped pattern (`docs/plans/*-${ISSUE_NUM}-*-plan.md`, >500c).
+    # `_find_issue_plan` (issue-scoped filename pattern first, content-grep
+    # fallback for date-prefix slug-tail filenames per mika#1421).
     # Returns 1 if any guard fails.
 
     [ -n "$WORKTREE_DIR" ] && [ -d "$WORKTREE_DIR" ] || {
@@ -1554,12 +1605,10 @@ _iterate_groom_loop() {
     [ -n "$ISSUE_NUM" ] && [ -n "$REPO" ] || {
         echo "WARN: iterate_groom_loop: ISSUE_NUM or REPO unset" >&2; return 1; }
 
-    # Find the plan file: issue-scoped (mika#1144), >500 byte (mika#1033),
-    # most-recent first.
+    # Locate the plan file via _find_issue_plan (mika#1421 — filename pattern
+    # with content-fallback for date-prefix slug-tail filenames).
     local plan_path
-    plan_path=$(find "$WORKTREE_DIR/docs/plans" -name "*-${ISSUE_NUM}-*-plan.md" -size +500c \
-        2>/dev/null | sort -r | head -1)
-    [ -n "$plan_path" ] && [ -r "$plan_path" ] || {
+    plan_path=$(_find_issue_plan) || {
         echo "WARN: iterate_groom_loop: no issue-scoped plan file for $REPO#$ISSUE_NUM" >&2
         return 1
     }

--- a/skills/bundled/_shared/tests/test_find_issue_plan.sh
+++ b/skills/bundled/_shared/tests/test_find_issue_plan.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Test suite for dispatch-lib.sh's _find_issue_plan helper (mika#1421).
+#
+# Verifies plan-file discovery against the two filename conventions the
+# pilot has been observed to produce:
+#   (1) Filename embeds issue number: `2026-06-05-001-fix-1407-...-plan.md`
+#   (2) Filename omits issue number: `2026-06-06-003-feat-post-condition-...-plan.md`
+#       (the pilot writes this when its slug-tail doesn't naturally include
+#       the issue number; content header references `**Ticket:** mika issue#N`)
+#
+# Founding incident: mika#1421 bound the architect-convergence class at n=2
+# on 2026-06-06. The brittle filename-only pattern in three callsites caused
+# `_iterate_groom_loop` to return non-zero with the plan committed but the
+# architect never called.
+#
+# Run: bash skills/bundled/_shared/tests/test_find_issue_plan.sh
+# Expected: all assertions pass, exit 0.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH_LIB="$SCRIPT_DIR/../dispatch-lib.sh"
+
+# shellcheck source=skills/bundled/_shared/dispatch-lib.sh
+source "$DISPATCH_LIB"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✓ $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  ✗ $label"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+    fi
+}
+
+assert_empty() {
+    local label="$1" actual="$2"
+    if [ -z "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✓ $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  ✗ $label (expected empty; got '$actual')"
+    fi
+}
+
+# Set up a temp worktree directory for fixtures
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+mkdir -p "$TMPROOT/docs/plans"
+
+# Helper: write a plan file >500 bytes
+write_plan() {
+    local path="$1" ticket_line="${2:-}"
+    {
+        if [ -n "$ticket_line" ]; then
+            echo "# Plan: example"
+            echo ""
+            echo "$ticket_line"
+            echo ""
+        fi
+        # Pad to >500 bytes
+        for i in $(seq 1 30); do echo "Lorem ipsum dolor sit amet padding line $i."; done
+    } > "$path"
+}
+
+WORKTREE_DIR="$TMPROOT"
+
+# ============================================================================
+# Primary: filename embeds issue number
+# ============================================================================
+
+echo "Primary (filename-embedded issue number):"
+
+write_plan "$TMPROOT/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md" \
+    "**Ticket:** mika#1407"
+ISSUE_NUM=1407
+RESULT=$(_find_issue_plan)
+assert_eq "filename embeds 1407 → matches" \
+    "$TMPROOT/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md" \
+    "$RESULT"
+
+# ============================================================================
+# Fallback: filename omits issue number, content has the Ticket reference
+# ============================================================================
+
+echo
+echo "Fallback (content-grep for **Ticket:** mika issue#N — current pilot shape):"
+
+# This is the EXACT filename mika#771 wrote on 2026-06-06 17:22Z
+write_plan "$TMPROOT/docs/plans/2026-06-06-003-feat-post-condition-guard-send-message-plan.md" \
+    "**Ticket:** mika issue#771"
+ISSUE_NUM=771
+RESULT=$(_find_issue_plan)
+assert_eq "mika#771 founding incident — filename without issue number, content matches" \
+    "$TMPROOT/docs/plans/2026-06-06-003-feat-post-condition-guard-send-message-plan.md" \
+    "$RESULT"
+
+echo
+echo "Fallback (older **Ticket:** mika#N shape):"
+write_plan "$TMPROOT/docs/plans/2026-06-04-001-fix-something-cleanup-plan.md" \
+    "**Ticket:** mika#999"
+ISSUE_NUM=999
+RESULT=$(_find_issue_plan)
+assert_eq "older Ticket shape (mika#999 — no 'issue' word) matches" \
+    "$TMPROOT/docs/plans/2026-06-04-001-fix-something-cleanup-plan.md" \
+    "$RESULT"
+
+echo
+echo "Fallback (YAML frontmatter 'ticket:' shape):"
+write_plan "$TMPROOT/docs/plans/2026-06-04-002-feat-something-else-plan.md" \
+    "ticket: mika#888"
+ISSUE_NUM=888
+RESULT=$(_find_issue_plan)
+assert_eq "YAML frontmatter ticket: mika#N matches" \
+    "$TMPROOT/docs/plans/2026-06-04-002-feat-something-else-plan.md" \
+    "$RESULT"
+
+# ============================================================================
+# Negative: prose mentioning #N is NOT enough (anchor discipline)
+# ============================================================================
+
+echo
+echo "Negative (prose-only mention of #N must NOT match):"
+write_plan "$TMPROOT/docs/plans/2026-06-04-003-unrelated-cleanup-plan.md" \
+    "Sister to mika#1234 but ticket is something else"
+ISSUE_NUM=1234
+RESULT=$(_find_issue_plan || true)
+assert_empty "prose '#1234' in line 3 (not anchored as **Ticket:**) → no match" "$RESULT"
+
+# ============================================================================
+# Most-recent-wins when both shapes exist for the same issue
+# ============================================================================
+
+echo
+echo "Sort order (sort -r over found candidates):"
+# Add a second plan with later date for the same issue (#1407) — content shape
+write_plan "$TMPROOT/docs/plans/2026-06-07-001-revised-fix-plan.md" \
+    "**Ticket:** mika issue#1407"
+ISSUE_NUM=1407
+RESULT=$(_find_issue_plan)
+# Primary pattern matches the 2026-06-05 file (has "-1407-" in name) BEFORE
+# the fallback runs. Primary wins; the 2026-06-05 file is returned even
+# though 2026-06-07 sorts higher in the fallback path.
+assert_eq "primary pattern wins over fallback (returns 2026-06-05 not 2026-06-07)" \
+    "$TMPROOT/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md" \
+    "$RESULT"
+
+# Remove the primary-matching file; rerun. Now only fallback applies.
+rm "$TMPROOT/docs/plans/2026-06-05-001-fix-1407-pilot-push-diagnosis-plan.md"
+RESULT=$(_find_issue_plan)
+assert_eq "fallback-only: most-recent match wins (2026-06-07 returned)" \
+    "$TMPROOT/docs/plans/2026-06-07-001-revised-fix-plan.md" \
+    "$RESULT"
+
+# ============================================================================
+# Guard: unset / missing inputs
+# ============================================================================
+
+echo
+echo "Input guards:"
+ISSUE_NUM=""
+RESULT=$(_find_issue_plan 2>/dev/null || true)
+assert_empty "ISSUE_NUM unset → returns empty" "$RESULT"
+ISSUE_NUM=1407
+
+WORKTREE_DIR_SAVED="$WORKTREE_DIR"
+WORKTREE_DIR=""
+RESULT=$(_find_issue_plan 2>/dev/null || true)
+assert_empty "WORKTREE_DIR unset → returns empty" "$RESULT"
+WORKTREE_DIR="$WORKTREE_DIR_SAVED"
+
+# Non-existent docs/plans directory
+WORKTREE_DIR="$TMPROOT/nonexistent"
+ISSUE_NUM=2222
+RESULT=$(_find_issue_plan 2>/dev/null || true)
+assert_empty "docs/plans absent → returns empty (no crash)" "$RESULT"
+WORKTREE_DIR="$WORKTREE_DIR_SAVED"
+
+# Plan under 500 bytes is excluded
+echo "small content for #5555" > "$TMPROOT/docs/plans/2026-06-04-small-plan.md"
+echo "**Ticket:** mika issue#5555" >> "$TMPROOT/docs/plans/2026-06-04-small-plan.md"
+ISSUE_NUM=5555
+RESULT=$(_find_issue_plan 2>/dev/null || true)
+assert_empty "<500-byte plan filtered by size guard" "$RESULT"
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Substrate-pivot fix for the n=2 architect-convergence class bound this morning across mika#1381 (n=1, 11:37Z) and mika#771 (n=2, 17:29Z). Same exact error message both times: *"PIPELINE FAILURE: architect convergence did not complete (_iterate_groom_loop returned non-zero). Plan exists on branch but architect verdict is missing."*

Root cause: three brittle callsites of `find ... -name "*-${ISSUE_NUM}-*-plan.md"` in `dispatch-lib.sh` require the issue number to be literally embedded in the plan filename. claude-pilot's `/mika-groom-plan-only` writes `<DATE>-<NNN>-<TYPE>-<SLUG_TAIL>-plan.md` where the slug-tail may omit it. For mika#771: pilot wrote `2026-06-06-003-feat-post-condition-guard-send-message-plan.md` (no '771' in the name). find returned empty → return 1 → architect never called → ticket lands in half-state.

The plan internally has `**Ticket:** mika issue#771` on line 3 — content-grep finds it.

## Fix shape

- Add `_find_issue_plan` helper at `skills/bundled/_shared/dispatch-lib.sh:1088`. Primary pass uses the existing filename pattern; fallback grep matches anchored `**Ticket:** mika [issue]#N` or YAML `ticket: mika#N` lines in plan content. Both passes apply the existing >500-byte filter (mika#1033).
- Refactor three callsites (`_launch_revise_pilot`, `_write_canonical_callout`, `_iterate_groom_loop`) to call the helper. Each preserves its original WARN message and return semantics.
- Add tests at `skills/bundled/_shared/tests/test_find_issue_plan.sh` covering both passes, anchor discipline, sort-order semantics, and four input guards.

Sister to mika#1414 / mika#1415 substrate-pivots shipped this morning — same carrier (dispatch-lib), same by-hand ship pattern, same purpose: unwedge the autonomous loop.

## Test plan

- [x] `bash skills/bundled/_shared/tests/test_find_issue_plan.sh` — 11 new assertions pass
- [x] `bash skills/bundled/_shared/tests/test_parse_disposition.sh` — 56-assertion regression suite still passes
- [x] `bash -n skills/bundled/_shared/dispatch-lib.sh` — syntax ok
- [ ] Post-deploy live verification: re-dispatch mika#771 by adding `ready` label; verify dev-groom completes, body callout writes, architect verdict appears in `groom-verdict-trail.log`. **Load-bearing test** — fix validated when the founding incident no longer reproduces.

## Discipline citation

CLAUDE.md prime directive: *"Autonomous loop always works. ... When the loop is wedged, fix the substrate."* This morning's #1414/#1415 substrate-pivots fixed worktree-setup; this evening's fix closes the architect-convergence carrier. Three substrate-pivots shipped today in the same lib.

Closes #1421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)