### PR TITLE
fix(dispatch-lib): _find_issue_plan content-grep scope to header-zone (mika#1421 v2)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1125,11 +1125,19 @@ _find_issue_plan() {
     #   **Ticket:** mika issue#N    (current `/mika-groom-plan-only` shape)
     #   **Ticket:** mika#N          (older convention)
     #   ticket: mika#N              (YAML frontmatter)
-    # The grep is line-anchored to avoid false positives on prose
-    # paragraphs that happen to mention an unrelated #N.
+    #
+    # Header-zone scope: the grep is restricted to the first 20 lines of
+    # each plan file. The canonical ticket reference always sits in YAML
+    # frontmatter or the markdown header above the Problem section.
+    # Without this scope, a plan that QUOTES another ticket's `**Ticket:**`
+    # line in body prose (e.g. to illustrate a founding incident) would
+    # false-positive — observed during the mika#1421 v1 self-test where
+    # the #1421 plan quoted mika#771's header on line 49 and matched
+    # `ISSUE_NUM=771`. Headers stay in the first 20 lines; bodies don't.
     while IFS= read -r candidate; do
         [ -r "$candidate" ] || continue
-        if grep -qE "^(\*\*Ticket:\*\*|ticket:)\s+mika[[:space:]]?(issue)?#${ISSUE_NUM}\b" "$candidate" 2>/dev/null; then
+        if head -n 20 "$candidate" 2>/dev/null \
+            | grep -qE "^(\*\*Ticket:\*\*|ticket:)\s+mika[[:space:]]?(issue)?#${ISSUE_NUM}\b"; then
             printf '%s' "$candidate"
             return 0
         fi

--- a/skills/bundled/_shared/tests/test_find_issue_plan.sh
+++ b/skills/bundled/_shared/tests/test_find_issue_plan.sh
@@ -135,6 +135,44 @@ ISSUE_NUM=1234
 RESULT=$(_find_issue_plan || true)
 assert_empty "prose '#1234' in line 3 (not anchored as **Ticket:**) → no match" "$RESULT"
 
+echo
+echo "Negative (quoted **Ticket:** line in BODY prose must NOT match):"
+# Regression test for self-test failure: mika#1421's plan QUOTED mika#771's
+# `**Ticket:** mika issue#771` header on line 49 (a body quote) to illustrate
+# the founding incident. The v1 helper false-positive'd on ISSUE_NUM=771 and
+# returned the #1421 plan instead of the actual #771 plan. The header-zone
+# scope (first 20 lines) closes this class.
+{
+    echo "---"
+    echo "ticket: mika#5050"  # CANONICAL ticket in YAML frontmatter
+    echo "type: fix"
+    echo "---"
+    echo ""
+    echo "# Plan: Some other thing"
+    echo ""
+    echo "Some preamble text in the header zone."
+    echo ""
+    # Pad to push the quoted Ticket reference past line 20
+    for i in $(seq 1 25); do echo "Body padding line $i — discussion of approach."; done
+    # NOW the quoted reference appears in BODY (past line 20)
+    echo "Line 35 quotes another plan's header to illustrate a point:"
+    echo ""
+    echo "**Ticket:** mika issue#6060"  # This is a QUOTE, not the real ticket
+    echo ""
+    for i in $(seq 1 10); do echo "More body discussion line $i."; done
+} > "$TMPROOT/docs/plans/2026-06-04-004-fix-something-with-quoted-example-plan.md"
+
+ISSUE_NUM=6060
+RESULT=$(_find_issue_plan || true)
+assert_empty "quoted **Ticket:** mika issue#6060 in body (line ~35) → no false-positive match" "$RESULT"
+
+# And verify the canonical issue (5050) still matches via its frontmatter header
+ISSUE_NUM=5050
+RESULT=$(_find_issue_plan)
+assert_eq "canonical YAML 'ticket: mika#5050' in frontmatter (line 2) → matches" \
+    "$TMPROOT/docs/plans/2026-06-04-004-fix-something-with-quoted-example-plan.md" \
+    "$RESULT"
+
 # ============================================================================
 # Most-recent-wins when both shapes exist for the same issue
 # ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #1422. v1 matched **quoted `**Ticket:**` lines in body prose**.

**Self-test failure during live verification of #1422:** re-dispatching mika#771 caused `_find_issue_plan(ISSUE_NUM=771)` to return the **#1421 plan itself**, because mika#1421's plan QUOTED mika#771's `**Ticket:** mika issue#771` header on line 49 (an illustrative quote of the founding incident). The architect was sent the wrong plan, reviewed mika#1421's content, and emitted `Disposition: READY` (first-pass-shaped) on the second-pass invocation. `_parse_verdict` couldn't match the keyword — second pass landed UNPARSED → return 1 → ticket stayed in half-state.

## Fix

Restrict the fallback grep to `head -n 20` of each candidate plan. The canonical ticket reference always sits in YAML frontmatter or the markdown header above the Problem section. Body quotes can't false-positive past line 20.

## Test additions

New regression test: a plan with canonical `ticket: mika#5050` in YAML frontmatter (line 2) and a quoted `**Ticket:** mika issue#6060` in body prose (line ~35). Helper must match #5050 and must NOT match #6060.

Test count rises 11 → 13. test_parse_disposition regression still passes (56/56).

Live-scenario validation against the actual #771 worktree:
- Before v2: `_find_issue_plan(771)` returned the #1421 plan (wrong)
- After v2: `_find_issue_plan(771)` returns the actual #771 plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)