### PR TITLE
fix(dispatch-lib): _parse_disposition tier-1b accept Verdict: carry-over from session memory (mika#1421 v3)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1289,15 +1289,26 @@ _parse_disposition() {
     # Phase B — first-pass verdict parser. Reads architect response text from
     # stdin, emits READY|ITERATE|ESCALATE on stdout (or nothing on no match).
     #
-    # Two-tier matching (mika#1272):
-    #   Tier 1: strict literal `Disposition: <X>` (zero-cost fast path)
-    #   Tier 2: fuzzy paraphrase matching (conservative, ESCALATE wins ties)
-    # Writes "1" to $_DISPOSITION_FUZZY_FILE when tier 2 fires, "0" when tier 1
-    # fires. Callers read _disposition_was_fuzzy() after the $(...) returns.
+    # Tiered matching:
+    #   Tier 1a: strict literal `Disposition: <X>` (zero-cost fast path).
+    #   Tier 1b: literal `Verdict: GROOMED`/`Verdict: ESCALATE` (mika#1421 v3).
+    #            When mika-arch's session memory has prior ITERATE findings on
+    #            the same plan, a first-pass invocation can return second-pass
+    #            keyword shapes — the architect has effectively "carried over"
+    #            into a second-review stance. Without this tolerance, the
+    #            iterate-loop logs UNPARSED, _iterate_groom_loop returns 1, and
+    #            the groom lands in the half-state #1421 v1+v2 closed for a
+    #            different sub-class. Mapping: GROOMED → READY (loop runs a
+    #            confirmatory second-pass), ESCALATE → ESCALATE.
+    #   Tier 2:  fuzzy paraphrase matching (conservative, ESCALATE wins ties).
+    # Writes "1" to $_DISPOSITION_FUZZY_FILE when tier 2 fires, "0" when tier
+    # 1a/1b fires. Callers read _disposition_was_fuzzy() after the $(...)
+    # returns.
     printf '0' > "$_DISPOSITION_FUZZY_FILE"
     local text
     text=$(cat)
     local result
+    # Tier 1a — canonical first-pass shape
     result=$(printf '%s' "$text" | grep -oE 'Disposition:[[:space:]]*(READY|ITERATE|ESCALATE)' \
         | grep -oE '(READY|ITERATE|ESCALATE)' \
         | head -1)
@@ -1305,6 +1316,23 @@ _parse_disposition() {
         echo "$result"
         return
     fi
+    # Tier 1b — Verdict-shape carry-over from architect session memory
+    local verdict_keyword
+    verdict_keyword=$(printf '%s' "$text" | grep -oE 'Verdict:[[:space:]]*(GROOMED|ESCALATE)' \
+        | grep -oE '(GROOMED|ESCALATE)' \
+        | head -1)
+    case "$verdict_keyword" in
+        GROOMED)
+            echo "_parse_disposition: tier 1b accepted Verdict: GROOMED → READY (mika#1421 v3 session-carry-over tolerance)" >&2
+            echo "READY"
+            return
+            ;;
+        ESCALATE)
+            echo "_parse_disposition: tier 1b accepted Verdict: ESCALATE → ESCALATE (mika#1421 v3 session-carry-over tolerance)" >&2
+            echo "ESCALATE"
+            return
+            ;;
+    esac
     # Tier 2 fallback
     result=$(printf '%s' "$text" | _parse_disposition_fuzzy)
     if [ -n "$result" ]; then

--- a/skills/bundled/_shared/tests/test_parse_disposition.sh
+++ b/skills/bundled/_shared/tests/test_parse_disposition.sh
@@ -69,6 +69,43 @@ result=$(printf 'Some preamble.\n\nDisposition: READY\n\nSome trailing text.' | 
 assert_eq "literal READY with surrounding text" "READY" "$result"
 
 # ============================================================================
+# _parse_disposition — tier 1b (Verdict carry-over from architect session memory)
+# mika#1421 v3: when mika-arch's session memory has prior ITERATE findings on
+# the same plan, a first-pass invocation can return second-pass keyword shapes.
+# Without this tolerance, the iterate-loop logged UNPARSED and returned 1 on a
+# valid GROOMED architect response. Mapping: Verdict:GROOMED → READY (loop
+# continues to confirmatory second-pass); Verdict:ESCALATE → ESCALATE.
+# ============================================================================
+echo ""
+echo "Test: _parse_disposition — Verdict carry-over (tier 1b)"
+echo "------------------------------------------------------"
+
+# Founding-incident response — actual mika#771 architect output on 2026-06-06
+# 20:10:53Z (session 9ef3d670-048c-4212-b157-cd8aa5f4c6f9). 85-byte response
+# emitted via the mika-arch-groom-ticket skill but in Verdict-shape because
+# the architect's session had carried the prior plan-state into a second-pass
+# stance.
+result=$(printf 'All prior findings resolved. The plan is ready for implementation.\n\nVerdict: GROOMED' | _parse_disposition 2>/dev/null)
+assert_eq "mika#771 founding-incident: Verdict: GROOMED → READY (session carry-over)" "READY" "$result"
+
+# Verdict: ESCALATE on first-pass → ESCALATE
+result=$(printf 'Architectural concerns remain.\n\nVerdict: ESCALATE' | _parse_disposition 2>/dev/null)
+assert_eq "Verdict: ESCALATE on first-pass → ESCALATE" "ESCALATE" "$result"
+
+# Tier 1b must not fire on partial/empty Verdict lines
+result=$(printf 'Verdict: undefined\n\nDisposition: ITERATE' | _parse_disposition 2>/dev/null)
+assert_eq "tier 1a wins when both Disposition: <X> and unrecognized Verdict: shape present" "ITERATE" "$result"
+
+# Tier 1a still wins when both keywords are present
+result=$(printf 'Disposition: READY\n\nVerdict: GROOMED' | _parse_disposition 2>/dev/null)
+assert_eq "tier 1a wins over tier 1b when both Disposition: <X> and Verdict: <X> present" "READY" "$result"
+
+# Tier 1b fuzzy-flag NOT set (it's a tier-1 path, just with a different keyword)
+printf 'Verdict: GROOMED' | _parse_disposition >/dev/null 2>&1
+fuzzy=$(check_fuzzy)
+assert_eq "tier 1b does not set the fuzzy flag" "0" "$fuzzy"
+
+# ============================================================================
 # _parse_disposition — tier 2 (fuzzy)
 # ============================================================================
 echo ""


### PR DESCRIPTION
## Summary

Closes a sub-class of #1421 surfaced during the post-merge live verification of #1422 + #1423.

mika#771's grooming at 20:10:53Z (architect session `9ef3d670-048c-4212-b157-cd8aa5f4c6f9`) reproduced the symptom. The architect's response (85 bytes):

> *"All prior findings resolved. The plan is ready for implementation. Verdict: GROOMED"*

was emitted via the `mika-arch-groom-ticket` first-pass skill but in `Verdict:`-shape because mika-arch's session memory had the prior ITERATE findings from the same plan; on this fresh invocation it treated the response as a second-pass continuation.

`_parse_disposition` recognized only `Disposition:` keyword on tier-1; `Verdict:` fell to tier-2 fuzzy which didn't match. Result: UNPARSED → `_iterate_groom_loop` returned 1 → half-state (plan committed, body callout missing).

## Fix

Add tier-1b to `_parse_disposition`:
- `Verdict: GROOMED` → READY (loop runs a confirmatory second-pass, which the architect's session will re-emit as GROOMED)
- `Verdict: ESCALATE` → ESCALATE (same iterate-loop branch as `Disposition: ESCALATE`)

Tier 1a (`Disposition:`) still wins when both keywords are present (preserves backward-compat for grooms that emit the canonical shape). Tier 1b does not set the fuzzy flag — it's a literal-tier-1 path, just with a different keyword.

## Test additions

Five new test assertions in `test_parse_disposition.sh`:
1. Founding-incident reproduction: actual mika#771 architect response → READY
2. `Verdict: ESCALATE` on first-pass → ESCALATE
3. Tier 1a wins when both `Disposition: <X>` and unrecognized `Verdict: <X>` shapes present
4. Tier 1a wins over tier 1b when both `Disposition: <X>` and `Verdict: <X>` present
5. Tier 1b does not set the fuzzy flag

Test count: 56 → 61. `test_find_issue_plan` unchanged (13/13). `bash -n` clean.

## Discipline citation

CLAUDE.md prime directive: *"Autonomous loop always works. ... When the loop is wedged, fix the substrate."* This is the third substrate-pivot on the iterate-groom-loop class today, all by-hand same-cycle:

- #1422 — `_find_issue_plan` content-fallback (filename pattern brittle)
- #1423 — header-zone scope (false-positive on body quotes)
- this PR — Verdict-carry-over tolerance (parser too strict on first-pass shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)