### PR TITLE
fix(dispatch-lib): exclude .claude/claude-pilot.json from auto-rescue commits (mika#1419 n=2 closure)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -630,15 +630,20 @@ ${RESULT}"
                 DIRTY_FILES=$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null | head -20)
                 if [ -n "$DIRTY_FILES" ]; then
                     # Stage all dirty files EXCEPT worktree-scaffold paths copied by
-                    # _set_up_worktree (mika#1288). .claude/commands/ contains slash-command
-                    # snapshots from mika-platform — not pilot-authored content.
-                    git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' 2>&9
+                    # _set_up_worktree (mika#1288, mika#1419):
+                    #   - .claude/commands/         slash-command snapshots from mika-platform
+                    #   - .claude/claude-pilot.json relay config cp'd from $PLATFORM_DIR at :489
+                    # Neither is pilot-authored content. Without the second exclusion, the
+                    # rescue commit re-introduces .claude/claude-pilot.json whose intentional
+                    # deletion shipped in PR #1348 (mika#1193 Phase C) — the founding incident
+                    # for mika#1419 (ping-pong on the file's git log).
+                    git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
 
                     # Guard: if pathspec exclusion left nothing staged, skip the rescue
                     # commit. Handles the edge case where the pilot wrote ONLY to scaffold
-                    # paths (mika#1288).
+                    # paths (mika#1288, mika#1419).
                     if git -C "$WORKTREE_DIR" diff --cached --quiet 2>&9; then
-                        echo "NOTE: dirty worktree contained only scaffold paths (.claude/commands/) — no pilot content to rescue" >&2
+                        echo "NOTE: dirty worktree contained only scaffold paths (.claude/commands/, .claude/claude-pilot.json) — no pilot content to rescue" >&2
                         RESCUED_DIRTY_WORKTREE=0
                     else
                         # Compute accurate rescued-files list for the PIPELINE FAILURE
@@ -657,7 +662,10 @@ ${RESULT}"
                         if git -C "$WORKTREE_DIR" diff --cached --name-only 2>&9 | grep -q '\.rs$'; then
                             PROACTIVE_FMT_ERR=$( (cd "$WORKTREE_DIR" && cargo fmt --all) 2>&1 ) || true
                             [ -n "$PROACTIVE_FMT_ERR" ] && echo "NOTE: proactive cargo fmt: ${PROACTIVE_FMT_ERR}" >&2
-                            git -C "$WORKTREE_DIR" add -u -- ':!.claude/commands/' 2>&9
+                            # Same exclusion pathspec as the initial `git add -A` above
+                            # (mika#1288, mika#1419) — keeps scaffold paths out of the
+                            # post-fmt re-add.
+                            git -C "$WORKTREE_DIR" add -u -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
                         fi
 
                         # Attempt rescue commit — capture stderr for hook-failure diagnosis (mika#1296).
@@ -685,7 +693,7 @@ ${RESULT}"
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection.
-Scaffold paths excluded (mika#1288)." > "$RESCUE_COMMIT_ERR" 2>&1; then
+Scaffold paths excluded (mika#1288, mika#1419)." > "$RESCUE_COMMIT_ERR" 2>&1; then
                             # Commit succeeded on first try — proceed normally
                             rm -f "$RESCUE_COMMIT_ERR"
 
@@ -709,14 +717,17 @@ ${RESULT}"
                             CARGO_FMT_ERR=""
                             echo "NOTE: rescue commit rejected by rust-fmt hook — running cargo fmt and retrying" >&2
                             CARGO_FMT_ERR=$( (cd "$WORKTREE_DIR" && cargo fmt --all) 2>&1 ) || true
-                            git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' 2>&9
+                            # Same exclusion pathspec as the initial `git add -A` above
+                            # (mika#1288, mika#1419) — scaffold paths stay excluded on the
+                            # post-fmt retry path too.
+                            git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
 
                             # mika#1310: capture both stdout+stderr (see above).
                             if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): impl staged by post-flight recovery (mika#1282)
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection (cargo fmt applied).
-Scaffold paths excluded (mika#1288)." > "$RESCUE_COMMIT_ERR" 2>&1; then
+Scaffold paths excluded (mika#1288, mika#1419)." > "$RESCUE_COMMIT_ERR" 2>&1; then
                                 # Retry succeeded after cargo fmt
                                 rm -f "$RESCUE_COMMIT_ERR"
 

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -828,6 +828,105 @@ test_auto_rescue_empty_index_guard() {
     echo "PASS"
 }
 
+# Test C (mika#1419): claude-pilot.json scaffold exclusion — relay-config
+# file is cp'd from $PLATFORM_DIR by _set_up_worktree at line 489 and is NOT
+# pilot-authored content. The rescue commit must exclude it via the same
+# pathspec mechanism mika#1288 uses for .claude/commands/. Without this
+# exclusion, PR #1348's intentional deletion (mika#1193 Phase C) is silently
+# re-introduced on every WIP-rescue flow — the ping-pong on the file's git
+# log is the founding incident for mika#1419.
+test_auto_rescue_excludes_claude_pilot_json() {
+    local test_dir
+    test_dir=$(mktemp -d)
+    trap "rm -rf '$test_dir'" RETURN
+
+    git -C "$test_dir" init -q
+    git -C "$test_dir" commit --allow-empty -m "initial" -q
+
+    # 1. claude-pilot.json scaffold file (untracked, cp'd from meta-repo) —
+    #    must NOT be staged by the rescue commit.
+    mkdir -p "$test_dir/.claude"
+    echo '{"command":"mika","args":["--agent","mika-relay","ask"]}' > "$test_dir/.claude/claude-pilot.json"
+
+    # 2. .claude/commands/ scaffold file — must NOT be staged (mika#1288).
+    mkdir -p "$test_dir/.claude/commands"
+    echo "# scaffold" > "$test_dir/.claude/commands/mika-groom-ticket.md"
+
+    # 3. Pilot-authored new file — must be staged.
+    mkdir -p "$test_dir/src"
+    echo "fn main() {}" > "$test_dir/src/new_feature.rs"
+
+    # Exercise: the mika#1419 pathspec exclusion.
+    git -C "$test_dir" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>/dev/null
+
+    local staged
+    staged=$(git -C "$test_dir" diff --cached --name-only)
+
+    # claude-pilot.json must NOT appear in staged files (mika#1419 regression).
+    if echo "$staged" | grep -q '.claude/claude-pilot.json'; then
+        echo "FAIL: .claude/claude-pilot.json was staged (mika#1419 ping-pong reintroduced)"
+        return 1
+    fi
+
+    # .claude/commands/ scaffold must NOT appear (mika#1288 regression).
+    if echo "$staged" | grep -q '.claude/commands/'; then
+        echo "FAIL: .claude/commands/ scaffold was staged (mika#1288 regression)"
+        return 1
+    fi
+
+    # Pilot-authored file MUST be staged.
+    if ! echo "$staged" | grep -q 'src/new_feature.rs'; then
+        echo "FAIL: pilot-authored file was not staged"
+        return 1
+    fi
+
+    echo "PASS"
+}
+
+RESULT_C=$(test_auto_rescue_excludes_claude_pilot_json 2>/dev/null)
+if [ "$RESULT_C" = "PASS" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ claude-pilot.json scaffold excluded (mika#1419 ping-pong regression)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ claude-pilot.json scaffold exclusion: $RESULT_C"
+fi
+
+# Test D (mika#1419): scaffold-only worktree empty-index guard includes
+# claude-pilot.json. Verifies the empty-index path correctly skips the rescue
+# commit when both scaffold types are the only dirty content.
+test_auto_rescue_empty_index_guard_with_claude_pilot_json() {
+    local test_dir
+    test_dir=$(mktemp -d)
+    trap "rm -rf '$test_dir'" RETURN
+
+    git -C "$test_dir" init -q
+    git -C "$test_dir" commit --allow-empty -m "initial" -q
+
+    # Only scaffold dirt: both commands/ AND claude-pilot.json — no pilot content.
+    mkdir -p "$test_dir/.claude/commands"
+    echo "# scaffold" > "$test_dir/.claude/commands/mika.md"
+    echo '{"command":"mika","args":["--agent","mika-relay","ask"]}' > "$test_dir/.claude/claude-pilot.json"
+
+    git -C "$test_dir" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>/dev/null
+
+    if ! git -C "$test_dir" diff --cached --quiet 2>/dev/null; then
+        echo "FAIL: index is not empty despite only scaffold-class files being dirty"
+        return 1
+    fi
+
+    echo "PASS"
+}
+
+RESULT_D=$(test_auto_rescue_empty_index_guard_with_claude_pilot_json 2>/dev/null)
+if [ "$RESULT_D" = "PASS" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ Empty-index guard covers both scaffold classes (mika#1288 + mika#1419)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ Empty-index guard with both scaffolds: $RESULT_D"
+fi
+
 RESULT_B=$(test_auto_rescue_empty_index_guard 2>/dev/null)
 if [ "$RESULT_B" = "PASS" ]; then
     PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary

Closes #1419 — n=2 of the dispatch-lib scaffold-clobber class.

Phase 0 Pin during grooming revealed the architect's first-pass canvass was off-target. The file content is **NOT hardcoded in dispatch-lib**. The actual mechanism:

1. `_set_up_worktree` at `dispatch-lib.sh:489` copies `.claude/claude-pilot.json` from `$PLATFORM_DIR` (meta-repo) into every worktree.
2. The recovery template's `git add -A -- ':!.claude/commands/'` at line 635 stages whatever's dirty — including the cp'd file.
3. The `wip(mika#N): impl staged by post-flight recovery (mika#1282)` commit then silently re-introduces PR #1348's intentional deletion (mika#1193 Phase C).

This is the **n=2 binding of the dispatch-lib scaffold-clobber class**:
- **n=1:** `.claude/commands/mika.md` — closed by mika#1414/#1415 via PR #1417/#1418.
- **n=2:** `.claude/claude-pilot.json` — this PR.

Same root carrier (dispatch-lib hardcoded scaffold-handling), distinct mechanism (recovery rescue vs initial worktree setup).

## Fix

Extend the pathspec exclusion in **three call sites** of the rescue commit block:
- Line 635: initial `git add -A` at rescue entry
- Line 668: post-cargo-fmt re-add (mika#1336 proactive formatting path)
- Line 720: rust-fmt retry path (mika#1296 reactive formatting path)

All three now use `':!.claude/commands/' ':!.claude/claude-pilot.json'`.

## NF7 verification (mika#1188)

`claude-pilot-py/src/claude_pilot/cli.py:103` defaults to `cwd/.claude/claude-pilot.json` when `--relay-config` is absent. `dispatch-lib.sh:502-505` conditionally passes `--relay-config` only when the file exists. So **claude-pilot handles missing file gracefully** — using its default relay-target logic. This fix does NOT affect runtime behavior; it only stops the rescue commit from propagating the cp'd-from-meta-repo file into branch history.

## Test additions

Two new tests in `test-dispatch-lib.sh`:
- Test C: claude-pilot.json scaffold excluded; pilot content still staged
- Test D: empty-index guard covers both scaffold classes

Test count: 167 → 169 passing (pre-existing 7 failures on main are unrelated — `auto_skipped` prompt text, case-switch dev-pilot mapping, etc).

## Independence from operator-ask

The complementary **meta-repo `.claude/claude-pilot.json` content decision** (delete vs update to `mika-dev`) remains queued under #1382's operator-ask. This fix closes the silent-ping-pong regression **independently** — even if the meta-repo file keeps its current `mika-relay` content, it no longer gets committed to any branch via the rescue path.

## Discipline citation

CLAUDE.md prime directive: *"Autonomous loop always works. When the loop is wedged, fix the substrate."* Today's substrate-pivots in dispatch-lib (all by-hand same-cycle):

| PR | Fix |
|---|---|
| #1417 | mika#1414 — detect dirty-worktree on resume |
| #1418 | mika#1415 — worktree-setup scaffold-clobber (.claude/commands/) |
| #1422 | mika#1421 v1 — `_find_issue_plan` content-fallback |
| #1423 | mika#1421 v2 — header-zone scope on content-grep |
| #1424 | mika#1421 v3 — `_parse_disposition` tier-1b Verdict carry-over |
| **this** | **mika#1419 — rescue-commit scaffold-exclude (claude-pilot.json)** |

Sister to mika#1414/#1415 — same carrier (dispatch-lib), distinct mechanism, same by-hand ship pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)