### PR TITLE
chore(meta): update claude-pilot.json to use mika-dev (mika#1420 workstream a)

### DIFF
--- a/.claude/claude-pilot.json
+++ b/.claude/claude-pilot.json
@@ -1,5 +1,5 @@
 {
   "command": "mika",
-  "args": ["--agent", "mika-relay", "ask"],
+  "args": ["--agent", "mika-dev", "ask"],
   "timeout": 120000
 }


### PR DESCRIPTION
## Summary

mika-relay deprecation Phase C completion — workstream (a). Replaces `mika-relay` → `mika-dev` in this repo's `.claude/claude-pilot.json`.

## Why this file matters

`claude-pilot-py/src/claude_pilot/cli.py:103` reads `<cwd>/.claude/claude-pilot.json` when `--relay-config` is not passed (manual / non-dispatch-lib invocations from this repo's cwd). Updating it ensures direct invocations also use mika-dev.

## Cross-repo PR set

This is one of 5 parallel PRs across the meta-repo set:

| # | Repo | Status |
|---|---|---|
| 1/5 | mika-platform | senara-solutions/mika-platform#156 (ships FIRST as source for dispatch-lib scaffold-copy) |
| 2/5 | claude-pilot-py | parallel |
| 3/5 | mika-skills | parallel |
| 4/5 | mika-cloud | parallel |
| 5/5 | mika | parallel (scope expansion from pre-flight n=5 catch — mika repo's file was not content-updated by PR mika#1427, only rescue-excluded) |

## Test plan

- [ ] CI green on this PR
- [ ] All 5 PRs in the set merge
- [ ] Post-merge: spawn a fresh dispatch-lib worktree, grep the copied `.claude/claude-pilot.json`, confirm `mika-dev`

## Pipeline-Exempt

Code-only config change. Single-line diff. Pre-flight verification by Mika Prime (canonical replacement = `mika-dev` per `claude-pilot-py/CLAUDE.md:7`).

Closes part of mika#1420 (workstream a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)