### PR TITLE
fix(db): wrap migrate_v25_to_v26 else-branch INSERT in transaction (mika#1391)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -3336,9 +3336,14 @@ impl Database {
             tx.commit()?;
         } else {
             // Column already exists (manual re-run in a test / recovery scenario).
-            // Just record the version bump.
-            self.conn
-                .execute("INSERT INTO schema_version (version) VALUES (26)", [])?;
+            // Wrap in TransactionBehavior::Immediate to match the true-branch envelope
+            // (mika#1391): bare INSERT could leave column-exists + schema_version-not-bumped
+            // inconsistent state on failure mid-recovery.
+            let tx = self
+                .conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)?;
+            tx.execute("INSERT INTO schema_version (version) VALUES (26)", [])?;
+            tx.commit()?;
         }
 
         Ok(())

--- a/docs/plans/2026-06-07-003-fix-1391-migrate-v25-v26-tx-plan.md
+++ b/docs/plans/2026-06-07-003-fix-1391-migrate-v25-v26-tx-plan.md
@@ -1,0 +1,22 @@
+# Plan — fix(db): wrap migrate_v25_to_v26 else-branch INSERT (mika#1391)
+
+## Problem
+
+`migrate_v25_to_v26` true-branch wraps `ALTER + INSERT INTO schema_version` in `TransactionBehavior::Immediate`. Else-branch (column-already-exists recovery path) executes a bare `INSERT INTO schema_version` outside any transaction.
+
+If the bare INSERT fails after the column was implicitly added by a previous partial run, the column exists but `schema_version` doesn't reflect v26 — inconsistent state.
+
+## Fix
+
+Mirror the true-branch's transaction envelope around the else-branch INSERT. Same `TransactionBehavior::Immediate` semantic.
+
+## AC
+
+- AC1: Else-branch INSERT wrapped in `TransactionBehavior::Immediate`.
+- AC2: `cargo build -p mika-agent` clean.
+- AC3: `cargo clippy -p mika-agent --tests --no-deps` clean.
+- AC4: Existing v25→v26 convergence test continues to pass.
+
+## Source
+
+mika-qa audit session `64e0a24b-2264-4198-a5e6-20f39fca4ccf`. Non-blocking per qa verdict on #759.


### PR DESCRIPTION
## Summary

`migrate_v25_to_v26` true-branch (ALTER path) wraps `ALTER + INSERT INTO schema_version` in `TransactionBehavior::Immediate`. Else-branch (column-already-exists recovery path) executes a bare `INSERT INTO schema_version` outside any transaction.

This PR mirrors the true-branch's transaction envelope around the else-branch INSERT — same `TransactionBehavior::Immediate` semantic, so a failure mid-recovery cannot leave the DB in column-exists + schema_version-not-bumped state.

## Severity

Non-blocking per mika-qa verdict on #759. Recovery-path hardening for the rare manual-rerun scenario.

## AC

- [x] AC1: Else-branch INSERT wrapped in `TransactionBehavior::Immediate`
- [x] AC2: `cargo build -p mika-agent` clean
- [x] AC3: `cargo clippy -p mika-agent --tests --no-deps -- -D warnings` clean
- [x] AC4: Existing v25→v26 convergence test continues to pass (no test changes; transaction envelope is observation-preserving)

## Source

mika-qa audit session `64e0a24b-2264-4198-a5e6-20f39fca4ccf`.

Closes mika#1391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)