### PR TITLE
fix(ci): guard $GITHUB_EVENT_PATH against unbound-variable under set -u (mika#1437 follow-up)

### DIFF
--- a/scripts/verify-pipeline.sh
+++ b/scripts/verify-pipeline.sh
@@ -200,8 +200,9 @@ fi
 # `gh run rerun --failed`. Fall back to a live `gh pr view` fetch when the
 # frozen snapshot did not surface the label, so operators don't need to
 # push an empty commit just to re-trigger CI for label visibility.
-if [[ "$EXEMPT_PR_LABEL_DOCS" == "0" ]] && command -v gh >/dev/null 2>&1; then
-  _pr_number=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH" 2>/dev/null)
+if [[ "$EXEMPT_PR_LABEL_DOCS" == "0" ]] && command -v gh >/dev/null 2>&1 \
+   && [[ -n "${GITHUB_EVENT_PATH:-}" ]] && [[ -f "$GITHUB_EVENT_PATH" ]]; then
+  _pr_number=$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
   if [[ -n "$_pr_number" ]]; then
     if gh pr view "$_pr_number" --json labels --jq '.labels[].name' 2>/dev/null | grep -qx "pipeline-exempt"; then
       EXEMPT_PR_LABEL_DOCS=1


### PR DESCRIPTION
## Summary

mika#1437 (closes mika#1395) added a live `gh pr view` fallback for label-freeze that references `$GITHUB_EVENT_PATH` directly. When the env var is unset, the script's `set -u` semantic errors out before any fallback path can absorb the failure.

This shape was caught porting the same fix to mika-platform (#157 + guard fix-up). mika-platform's self-test harness explicitly unsets `GITHUB_EVENT_PATH` to isolate test fixtures from CI-injected env. mika's self-test currently passes because no existing case exercises the unset-+-gh-available combination.

## Fix

Gate the live-API fallback on:
- `-n "${GITHUB_EVENT_PATH:-}"` — env var actually set
- `-f "$GITHUB_EVENT_PATH"` — and points at an existing file

Plus `|| echo ""` tail on the jq capture for defense-in-depth.

## Verification

- mika self-tests: **14/14 pass** locally
- Same fix landed in mika-platform#157 (verified there with full 19-test suite)

## Pipeline-Exempt rationale

- `no-plan` — defensive guard on shipped mika#1395 fix; identical pattern to mika-platform#157 follow-up
- `code-only` — script-only fix, no plan-doc applicable

Sister PR: mika-platform#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)