### PR TITLE
fix(dispatch-lib): extend auto-rescue to commit-pushed-no-PR case (mika#1396)

### DIFF
--- a/docs/plans/2026-06-07-005-fix-1396-extend-auto-rescue-pr-creation-plan.md
+++ b/docs/plans/2026-06-07-005-fix-1396-extend-auto-rescue-pr-creation-plan.md
@@ -1,0 +1,72 @@
+# Plan — fix(dispatch-lib): extend auto-rescue to commit-pushed-no-PR case (mika#1396)
+
+## Problem
+
+mika#1282's auto-rescue opens a draft PR ONLY when `RESCUED_DIRTY_WORKTREE=1` —
+the pilot wrote files but never committed. The trigger condition misses a
+related class:
+
+- Pilot ran /ce:work, /ce:review, /ce:compound cleanly
+- Pilot committed and pushed
+- Pilot ran `gh pr create` — got transient AxiosError 5000ms timeout
+- Pilot exited 1 after session
+- Result: branch has commit on origin, but no PR exists
+
+The existing mika#940 check (line ~860) detects this but classifies as
+PIPELINE FAILURE rather than triggering rescue. Net effect: parent task
+goes blocked; operator hand-opens the PR.
+
+## Fix
+
+Extend the auto-rescue trigger with a SIBLING condition:
+
+```
+RESCUED_PR_URL trigger fires when EITHER:
+  - RESCUED_DIRTY_WORKTREE=1 (mika#1282 original case), OR
+  - PR_URL empty AND branch has commits on origin AND $PRE_RUN_HEAD != $POST_RUN_HEAD
+    (mika#1396 commit-pushed-no-PR case)
+```
+
+Same body template, same draft status. Distinguishes the two recovery
+classes in the PR title and body for audit.
+
+## Why draft PR (not normal)
+
+mika#1282 uses draft because pilot didn't pass review. mika#1396 case is
+different — pilot DID pass /ce:review. But:
+1. Keeping recovery path uniform avoids two distinct PR shapes
+2. Draft signals "operator visit required to verify pilot's review actually completed"
+3. Operator marks ready once they confirm the work is genuinely complete
+
+The audit-trail consistency (always-draft from auto-rescue) outweighs the
+slight inconvenience of operator marking ready.
+
+## AC
+
+- AC1: When pilot exits non-zero AFTER committing+pushing (PRE_RUN_HEAD != POST_RUN_HEAD on origin, PR_URL empty), auto-rescue opens a draft PR.
+- AC2: When pilot exits with RESCUED_DIRTY_WORKTREE=1 (mika#1282 original case), auto-rescue continues to fire as before.
+- AC3: PR body distinguishes the two recovery classes for audit.
+- AC4: Canonical `PR:` line emitted (mika#1352 contract) — already shipped today via mika#1440.
+- AC5: dispatch-lib test suite (174 tests) continues to pass.
+
+## Implementation
+
+In `mika/skills/bundled/_shared/dispatch-lib.sh` around line 1979:
+
+```bash
+# Determine recovery class
+RECOVERY_CLASS=""
+if [ "${RESCUED_DIRTY_WORKTREE:-}" = "1" ]; then
+    RECOVERY_CLASS="dirty-worktree"
+elif [ -z "$PR_URL" ] && [ -n "$PRE_RUN_HEAD" ] && [ -n "$POST_RUN_HEAD" ] && [ "$PRE_RUN_HEAD" != "$POST_RUN_HEAD" ] && [ "$SKILL" = "dev-pilot" ]; then
+    RECOVERY_CLASS="commit-pushed-no-pr"
+fi
+
+if [ -n "$RECOVERY_CLASS" ] && [ -n "$REPO" ] && [ -n "$BRANCH" ] && [ -z "$PR_URL" ]; then
+    # ... existing rescue PR creation, with class noted in title/body ...
+fi
+```
+
+## Cross-repo port
+
+Single-repo fix on mika's dispatch-lib. Deploys via `make deploy` to `~/.mika/skills/_shared/`.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -1970,32 +1970,56 @@ ${RESULT}"
 
     _push_branch
 
-    # Unit 2 (mika#1282): open a draft PR when content was rescued by dispatch-lib's
-    # git-workflow ownership (content/workflow split per mika#1271 architect verdict).
-    # Draft status signals "pilot failed to drive git; substrate owns recovery workflow."
-    # Runs after _push_branch (which handles first-push natively — lines 558-564)
-    # and before _deliver_callback.
-    if [ "${RESCUED_DIRTY_WORKTREE:-}" = "1" ] && [ -n "$REPO" ] && [ -n "$BRANCH" ] && [ -z "$PR_URL" ]; then
+    # Unit 2 (mika#1282 + mika#1396): open a draft PR when content was rescued
+    # by dispatch-lib's git-workflow ownership.
+    #
+    # Recovery classes:
+    # - "dirty-worktree" (mika#1282 original): pilot wrote files but never committed.
+    #   dispatch-lib staged + committed with wip() + pushed; this opens the PR.
+    # - "commit-pushed-no-pr" (mika#1396): pilot committed AND pushed but
+    #   gh pr create failed (e.g., AxiosError 5000ms timeout). Branch has the
+    #   commit on origin; PR was never opened. dispatch-lib opens it.
+    #
+    # Runs after _push_branch (lines 558-564) and before _deliver_callback.
+    local RECOVERY_CLASS=""
+    if [ "${RESCUED_DIRTY_WORKTREE:-}" = "1" ]; then
+        RECOVERY_CLASS="dirty-worktree"
+    elif [ -z "$PR_URL" ] && [ -n "$PRE_RUN_HEAD" ] && [ -n "$POST_RUN_HEAD" ] \
+         && [ "$PRE_RUN_HEAD" != "$POST_RUN_HEAD" ] && [ "$SKILL" = "dev-pilot" ]; then
+        RECOVERY_CLASS="commit-pushed-no-pr"
+    fi
+
+    if [ -n "$RECOVERY_CLASS" ] && [ -n "$REPO" ] && [ -n "$BRANCH" ] && [ -z "$PR_URL" ]; then
+        # Recovery-class-specific PR body
+        local _rescue_title
+        local _rescue_body_note
+        if [ "$RECOVERY_CLASS" = "dirty-worktree" ]; then
+            _rescue_title="wip(${REPO}#${ISSUE_NUM}): rescued impl (dispatch-lib recovery)"
+            _rescue_body_note="The dev-pilot session wrote file changes but never completed the git workflow (no \`git commit\` or \`gh pr create\`). Per the mika#1271 content/workflow split contract, dispatch-lib took ownership of the git layer: staged, committed with \`wip()\` prefix, pushed, and opened this draft PR to preserve the content.
+
+**This is a draft PR requiring human review.** The content has NOT passed \`/ce:review\` and may contain partially-coherent multi-file changes."
+        else
+            _rescue_title="${REPO}#${ISSUE_NUM}: pilot impl (dispatch-lib PR-create recovery, mika#1396)"
+            _rescue_body_note="The dev-pilot session committed and pushed the implementation but \`gh pr create\` failed (typically a transient AxiosError 5000ms timeout from claude-cli's internal HTTP relay). Branch is on origin with the impl commit; only the final PR-creation step needed recovery.
+
+**This is a draft PR — operator should verify pilot's pipeline (/ce:work, /ce:review, /ce:compound) completed before marking ready.** The recovery path is uniform with mika#1282's draft-PR pattern for audit consistency."
+        fi
+
         RESCUED_PR_URL=$(gh pr create \
             --repo "senara-solutions/$REPO" \
             --head "$BRANCH" \
             --base main \
             --draft \
-            --title "wip(${REPO}#${ISSUE_NUM}): rescued impl (dispatch-lib recovery)" \
+            --title "$_rescue_title" \
             --body "$(cat <<RESCUEBODY
-## Rescued implementation (dispatch-lib content/workflow split)
+## Auto-rescued PR (dispatch-lib recovery, class: ${RECOVERY_CLASS})
 
-This PR was created by dispatch-lib's git-workflow recovery (mika#1282).
+This PR was created by dispatch-lib's git-workflow recovery.
 
-The dev-pilot session wrote file changes but never completed the git workflow
-(no \`git commit\` or \`gh pr create\`). Per the mika#1271 content/workflow split
-contract, dispatch-lib took ownership of the git layer: staged, committed with
-\`wip()\` prefix, pushed, and opened this draft PR to preserve the content.
-
-**This is a draft PR requiring human review.** The content has NOT passed
-\`/ce:review\` and may contain partially-coherent multi-file changes.
+${_rescue_body_note}
 
 ### Recovery metadata
+- Recovery class: \`${RECOVERY_CLASS}\`
 - Pilot session: \`${SESSION_ID:-unknown}\`
 - Turns: ${TURNS:-unknown}
 - Cost: \$${COST:-unknown}


### PR DESCRIPTION
## Summary

mika#1282's auto-rescue opens a draft PR only when `RESCUED_DIRTY_WORKTREE=1` (pilot wrote files but never committed). The commit-pushed-no-PR class slips through:

- Pilot ran the full pipeline cleanly
- Pilot committed and pushed
- Pilot's `gh pr create` hit transient AxiosError 5000ms timeout from claude-cli's HTTP relay
- Pilot exited 1
- Branch on origin has the impl commit; PR never opened

Net effect today: parent task goes blocked, operator hand-opens the PR.

## Fix

Extend the rescue trigger with a sibling condition. New recovery class `commit-pushed-no-pr` fires when:
- `$PR_URL` empty (no PR detected by post-flight)
- `$PRE_RUN_HEAD != $POST_RUN_HEAD` (pilot produced commits)
- `$SKILL = dev-pilot` (don't fire on dev-groom — different recovery shape)

Existing `dirty-worktree` class (mika#1282) continues unchanged.

PR title/body distinguish the two recovery classes. Both still ship as **draft** — operator confirms pipeline completed before marking ready. Audit-trail consistency over normal-vs-draft branching.

## AC

- [x] AC1: pilot exits with commits-pushed-no-PR → auto-rescue opens draft PR
- [x] AC2: pilot exits with `RESCUED_DIRTY_WORKTREE=1` → mika#1282 path continues unchanged
- [x] AC3: PR body distinguishes recovery class for audit
- [x] AC4: canonical `PR:` line emitted (mika#1352 contract, shipped today via mika#1440)
- [x] AC5: dispatch-lib test suite **174/174 pass**

Closes mika#1396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)