### PR TITLE
fix(gateway): enable sqlx TLS + rust:1.93-bookworm builder (deploy-unblock for mika-cloud#111)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "mika-common",
  "rand 0.9.3",
  "reqwest 0.12.28",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -3133,6 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3638,6 +3640,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -3648,6 +3651,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4753,6 +4757,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ rmcp = { version = "0.17", default-features = false, features = [
 ] }
 
 # Postgres (mika-gateway)
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "uuid", "chrono", "json"] }
 
 # Embedded assets
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,5 +1,9 @@
 # === Builder stage ===
-FROM rust:1.93-slim AS builder
+# Use rust:1.93-bookworm (NOT -slim) to match mika-cloud console image baseline.
+# The -slim variant produced binaries with GLIBC_2.38 link-time symbols that
+# fail to load on debian:bookworm-slim runtime (only has glibc 2.36).
+# See mika-cloud#97 + the 06-18 mission gateway-deploy unblock (2026-06-09).
+FROM rust:1.93-bookworm AS builder
 
 # No native deps needed: uses rustls (no OpenSSL), no rusqlite
 

--- a/crates/mika-gateway/Cargo.toml
+++ b/crates/mika-gateway/Cargo.toml
@@ -30,6 +30,7 @@ secrecy = { workspace = true }
 tower-http = { workspace = true }
 config = { workspace = true }
 dotenvy = { workspace = true }
+rustls = "0.23"
 utoipa.workspace = true
 base64.workspace = true
 bytes.workspace = true

--- a/crates/mika-gateway/src/main.rs
+++ b/crates/mika-gateway/src/main.rs
@@ -24,6 +24,17 @@ use telegram::TelegramClient;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install rustls aws-lc-rs CryptoProvider before any TLS operation. Both
+    // aws-lc-rs and ring are compiled in transitively (sqlx via tls-rustls-aws-lc-rs
+    // and reqwest via rustls-tls-native-roots), so rustls cannot auto-select a
+    // process-default crypto provider. Mirrors the mika-cloud console fix
+    // (mika-cloud#97). Resolves "TLS upgrade required by connect options but
+    // SQLx was built without TLS support enabled" when connecting to RDS with
+    // force_ssl=1.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls aws-lc-rs CryptoProvider");
+
     // Load .env from CWD (gateway has no ~/.mika/ home directory)
     let _ = dotenvy::dotenv();
 


### PR DESCRIPTION
## Summary

Two related fixes surfaced during the first-ever mika-gateway production deploy (mika-cloud#111 06-18 mission, 2026-06-09). Without these, the gateway pod CrashLoopBackOffs on startup.

## Fix 1: sqlx TLS support (commit 7e420bac)

**Symptom**: gateway pod crashed with `TLS upgrade required by connect options but SQLx was built without TLS support enabled` when connecting to RDS (which has `force_ssl = 1`).

**Cause**: workspace `sqlx` features lacked `tls-rustls-aws-lc-rs`; gateway was built without TLS. Same bug as mika-cloud#95 + #97 fixed for the console.

**Fix**:
- Add `tls-rustls-aws-lc-rs` to workspace `sqlx` features in root `Cargo.toml`
- Add direct `rustls = "0.23"` dep to `crates/mika-gateway/Cargo.toml`
- Install `aws_lc_rs::default_provider()` in `mika-gateway/src/main.rs` before any TLS operation (both aws-lc-rs and ring compiled transitively, rustls can't auto-select)

## Fix 2: bookworm builder image (commit 7e5d46c1)

**Symptom**: after Fix 1, gateway binary loaded but ran with `libc.so.6: version 'GLIBC_2.38' not found`.

**Cause**: `Dockerfile.gateway` used `rust:1.93-slim` builder, which produced binaries with newer-glibc link-time symbols than `debian:bookworm-slim` runtime provides (glibc 2.36).

**Fix**: use `rust:1.93-bookworm` (full, not -slim) — matches mika-cloud console image baseline, which uses the same `tls-rustls-aws-lc-rs` feature successfully.

## Fix 3: Cargo.lock (commit f217fa61)

Workspace lockfile updated with new tls-rustls-aws-lc-rs + rustls + ring transitive dep resolution.

## Why critical / why no test plan beyond live deploy

Production gateway is currently running this exact code (image `mika-gateway:7e5d46c1` in ECR, deployed to mika-system-dev). Pod is `1/1 Running`, postgres connected, migrations applied, https://gateway.getmika.ai/livez returns HTTP 200 with valid Let's Encrypt cert. The fix IS validated end-to-end against the production RDS.

Without this PR merged, anyone rebuilding from main ships a broken gateway.

## Files changed

- `Cargo.toml` — workspace sqlx features
- `Cargo.lock` — lockfile update
- `crates/mika-gateway/Cargo.toml` — rustls direct dep
- `crates/mika-gateway/src/main.rs` — CryptoProvider install
- `Dockerfile.gateway` — bookworm builder image

## Pipeline exemption

This is an emergency infrastructure fix during the 06-18 mission gateway deploy — no plan doc was authored upfront (the fix was authored in response to live production CrashLoopBackOff). Validation came from the deploy itself (gateway now `1/1 Running`, https://gateway.getmika.ai/livez serving HTTP 200).

## References

- mika-cloud#111 (06-18 mission)
- mika-cloud#95 (sqlx TLS fix for console, prior art)
- mika-cloud#97 (rustls CryptoProvider for console, prior art)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Pipeline-Exempt: no-plan
Pipeline-Exempt: code-only