### PR TITLE
feat(memory): extract memory/ module from db.rs (mika#1259)

### DIFF
--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -4383,20 +4383,6 @@ impl Database {
         Ok(())
     }
 
-    /// List all corpora registered for an agent.
-    /// Returns `(docs_root_hash, docs_root_path)` pairs.
-    pub fn list_agent_corpora(&self, agent_id: &str) -> Result<Vec<(String, String)>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT docs_root_hash, docs_root_path FROM agent_kg_corpora WHERE agent_id = ?1",
-        )?;
-        let rows = stmt
-            .query_map(params![agent_id], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(rows)
-    }
-
     pub fn register_agent(&self, id: &str, name: &str, home_dir: &str) -> Result<()> {
         self.conn.execute(
             "INSERT INTO agents (id, name, home_dir) VALUES (?1, ?2, ?3)
@@ -7365,58 +7351,6 @@ impl Database {
 
     // ===== Core Memory =====
 
-    pub fn get_core_memory(&self, agent_id: &str, key: &str) -> Result<Option<CoreMemoryEntry>> {
-        self.conn
-            .query_row(
-                "SELECT key, value, token_count, updated_at
-                  FROM core_memory WHERE agent_id = ?1 AND key = ?2",
-                params![agent_id, key],
-                |r| {
-                    Ok(CoreMemoryEntry {
-                        key: r.get(0)?,
-                        value: r.get(1)?,
-                        token_count: r.get(2)?,
-                        updated_at: r.get(3)?,
-                    })
-                },
-            )
-            .optional()
-            .map_err(Into::into)
-    }
-
-    pub fn get_all_core_memory(&self, agent_id: &str) -> Result<Vec<CoreMemoryEntry>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT key, value, token_count, updated_at
-              FROM core_memory WHERE agent_id = ?1 ORDER BY key",
-        )?;
-        let rows = stmt
-            .query_map(params![agent_id], |r| {
-                Ok(CoreMemoryEntry {
-                    key: r.get(0)?,
-                    value: r.get(1)?,
-                    token_count: r.get(2)?,
-                    updated_at: r.get(3)?,
-                })
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-        Ok(rows)
-    }
-
-    /// Insert or update a core memory entry. Returns the new token count.
-    pub fn set_core_memory(&self, agent_id: &str, key: &str, value: &str) -> Result<i32> {
-        let token_count = (value.len() / 4).max(1) as i32;
-        self.conn.execute(
-            "INSERT INTO core_memory (agent_id, key, value, token_count)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(agent_id, key) DO UPDATE SET
-                value = excluded.value,
-                token_count = excluded.token_count,
-                updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
-            params![agent_id, key, value, token_count],
-        )?;
-        Ok(token_count)
-    }
-
     pub fn seed_core_memory(&self, agent_id: &str, user_md_content: Option<&str>) -> Result<()> {
         for (key, default) in CORE_MEMORY_SECTIONS {
             let existing = self.get_core_memory(agent_id, key)?;
@@ -7458,90 +7392,6 @@ impl Database {
     }
 
     // ===== People =====
-
-    pub fn upsert_person(
-        &self,
-        agent_id: &str,
-        name: &str,
-        relationship: Option<&str>,
-        notes: Option<&str>,
-    ) -> Result<i64> {
-        let existing: Option<i64> = self
-            .conn
-            .query_row(
-                "SELECT id FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
-                params![agent_id, name],
-                |r| r.get(0),
-            )
-            .optional()?;
-        if let Some(id) = existing {
-            self.conn.execute(
-                "UPDATE people SET relationship = COALESCE(?1, relationship),
-                  notes = COALESCE(?2, notes),
-                  last_mentioned = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
-                  mention_count = mention_count + 1
-                  WHERE id = ?3",
-                params![relationship, notes, id],
-            )?;
-            Ok(id)
-        } else {
-            self.conn.execute(
-                "INSERT INTO people (agent_id, canonical_name, relationship, notes)
-                  VALUES (?1, ?2, ?3, ?4)",
-                params![agent_id, name, relationship, notes],
-            )?;
-            Ok(self.conn.last_insert_rowid())
-        }
-    }
-
-    pub fn get_person(&self, agent_id: &str, name: &str) -> Result<Option<Person>> {
-        self.conn
-            .query_row(
-                "SELECT id, canonical_name, relationship, notes,
-                         first_mentioned,
-                         last_mentioned,
-                         mention_count
-                  FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
-                params![agent_id, name],
-                |r| {
-                    Ok(Person {
-                        id: r.get(0)?,
-                        canonical_name: r.get(1)?,
-                        relationship: r.get(2)?,
-                        notes: r.get(3)?,
-                        first_mentioned: r.get(4)?,
-                        last_mentioned: r.get(5)?,
-                        mention_count: r.get(6)?,
-                    })
-                },
-            )
-            .optional()
-            .map_err(Into::into)
-    }
-
-    pub fn list_people(&self, agent_id: &str) -> Result<Vec<Person>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, canonical_name, relationship, notes,
-                     first_mentioned,
-                     last_mentioned,
-                     mention_count
-              FROM people WHERE agent_id = ?1 ORDER BY canonical_name",
-        )?;
-        let rows = stmt
-            .query_map(params![agent_id], |r| {
-                Ok(Person {
-                    id: r.get(0)?,
-                    canonical_name: r.get(1)?,
-                    relationship: r.get(2)?,
-                    notes: r.get(3)?,
-                    first_mentioned: r.get(4)?,
-                    last_mentioned: r.get(5)?,
-                    mention_count: r.get(6)?,
-                })
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-        Ok(rows)
-    }
 
     pub fn search_people(&self, agent_id: &str, query: &str) -> Result<Vec<Person>> {
         let pattern = format!("%{}%", query);
@@ -7682,34 +7532,6 @@ impl Database {
         Ok(self.conn.last_insert_rowid())
     }
 
-    pub fn get_preference(&self, agent_id: &str, category: &str) -> Result<Option<String>> {
-        self.conn
-            .query_row(
-                "SELECT value FROM preferences WHERE agent_id = ?1 AND category = ?2",
-                params![agent_id, category],
-                |r| r.get(0),
-            )
-            .optional()
-            .map_err(Into::into)
-    }
-
-    pub fn list_preferences(&self, agent_id: &str) -> Result<Vec<Preference>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT category, value, updated_at
-              FROM preferences WHERE agent_id = ?1 ORDER BY category",
-        )?;
-        let rows = stmt
-            .query_map(params![agent_id], |r| {
-                Ok(Preference {
-                    category: r.get(0)?,
-                    value: r.get(1)?,
-                    updated_at: r.get(2)?,
-                })
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-        Ok(rows)
-    }
-
     pub fn search_preferences(&self, agent_id: &str, query: &str) -> Result<Vec<Preference>> {
         let pattern = format!("%{}%", query);
         let mut stmt = self.conn.prepare(
@@ -7743,25 +7565,6 @@ impl Database {
             params![agent_id, description, event_date, context],
         )?;
         Ok(self.conn.last_insert_rowid())
-    }
-
-    pub fn list_events(&self, agent_id: &str) -> Result<Vec<Event>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, description, event_date, context, created_at
-              FROM events WHERE agent_id = ?1 ORDER BY created_at DESC",
-        )?;
-        let rows = stmt
-            .query_map(params![agent_id], |r| {
-                Ok(Event {
-                    id: r.get(0)?,
-                    description: r.get(1)?,
-                    event_date: r.get(2)?,
-                    context: r.get(3)?,
-                    created_at: r.get(4)?,
-                })
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-        Ok(rows)
     }
 
     pub fn search_events(&self, agent_id: &str, query: &str) -> Result<Vec<Event>> {
@@ -8054,68 +7857,6 @@ impl Database {
         Ok(updated)
     }
 
-    /// Delete a person by canonical name. Unlinks commitments first (sets person_id = NULL).
-    /// Returns true if a person was deleted.
-    pub fn delete_person_by_name(&self, agent_id: &str, name: &str) -> Result<bool> {
-        // Unlink commitments from this person
-        let person_id: Option<i64> = self
-            .conn
-            .query_row(
-                "SELECT id FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
-                params![agent_id, name],
-                |r| r.get(0),
-            )
-            .optional()?;
-        let Some(pid) = person_id else {
-            return Ok(false);
-        };
-        self.conn.execute(
-            "UPDATE commitments SET person_id = NULL WHERE person_id = ?1",
-            params![pid],
-        )?;
-        // Delete search content
-        self.delete_search_content(agent_id, "person", pid)?;
-        // Delete the person
-        let deleted = self.conn.execute(
-            "DELETE FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
-            params![agent_id, name],
-        )?;
-        Ok(deleted > 0)
-    }
-
-    /// Delete a preference by category. Returns true if deleted.
-    pub fn delete_preference(&self, agent_id: &str, category: &str) -> Result<bool> {
-        // Clean up search content — preference content is "{category}: {value}".
-        // source_id from set_preference (last_insert_rowid) can be unreliable for upserts,
-        // so we find the search_content row by content prefix match instead.
-        let content_prefix = format!("{category}: ");
-        let existing: Option<(i64, String)> = self
-            .conn
-            .query_row(
-                "SELECT id, content FROM search_content
-                  WHERE agent_id = ?1 AND source_type = 'preference' AND content LIKE ?2 || '%'",
-                params![agent_id, content_prefix],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            )
-            .optional()?;
-        if let Some((id, content)) = existing {
-            let _ = self.conn.execute(
-                "INSERT INTO fts_search(fts_search, rowid, content) VALUES ('delete', ?1, ?2)",
-                params![id, content],
-            );
-            let _ = self
-                .conn
-                .execute("DELETE FROM vec_search WHERE rowid = ?1", params![id]);
-            self.conn
-                .execute("DELETE FROM search_content WHERE id = ?1", params![id])?;
-        }
-        let deleted = self.conn.execute(
-            "DELETE FROM preferences WHERE agent_id = ?1 AND category = ?2",
-            params![agent_id, category],
-        )?;
-        Ok(deleted > 0)
-    }
-
     /// Delete a commitment by description. Returns true if deleted.
     pub fn delete_commitment_by_description(
         &self,
@@ -8137,27 +7878,6 @@ impl Database {
         let deleted = self.conn.execute(
             "DELETE FROM commitments WHERE id = ?1 AND agent_id = ?2",
             params![cid, agent_id],
-        )?;
-        Ok(deleted > 0)
-    }
-
-    /// Delete an event by description. Returns true if deleted.
-    pub fn delete_event_by_description(&self, agent_id: &str, description: &str) -> Result<bool> {
-        let event_id: Option<i64> = self
-            .conn
-            .query_row(
-                "SELECT id FROM events WHERE agent_id = ?1 AND description = ?2 COLLATE NOCASE",
-                params![agent_id, description],
-                |r| r.get(0),
-            )
-            .optional()?;
-        let Some(eid) = event_id else {
-            return Ok(false);
-        };
-        self.delete_search_content(agent_id, "event", eid)?;
-        let deleted = self.conn.execute(
-            "DELETE FROM events WHERE id = ?1 AND agent_id = ?2",
-            params![eid, agent_id],
         )?;
         Ok(deleted > 0)
     }
@@ -8982,109 +8702,6 @@ impl Database {
                 })
             })
             .collect())
-    }
-
-    pub fn get_all_facts_for_indexing(&self, agent_id: &str) -> Result<Vec<(String, i64, String)>> {
-        let mut results = Vec::new();
-        // People
-        let mut stmt = self.conn.prepare(
-            "SELECT id, canonical_name || COALESCE(' - ' || relationship, '')
-                        || COALESCE(': ' || notes, '')
-              FROM people WHERE agent_id = ?1",
-        )?;
-        let rows: Vec<(i64, String)> = stmt
-            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<rusqlite::Result<_>>()?;
-        for (id, content) in rows {
-            results.push(("person".to_string(), id, content));
-        }
-        // Commitments
-        let mut stmt = self.conn.prepare(
-            "SELECT id, description || ' [' || status || ']'
-              FROM commitments WHERE agent_id = ?1",
-        )?;
-        let rows: Vec<(i64, String)> = stmt
-            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<rusqlite::Result<_>>()?;
-        for (id, content) in rows {
-            results.push(("commitment".to_string(), id, content));
-        }
-        // Preferences
-        let mut stmt = self.conn.prepare(
-            "SELECT rowid, category || ': ' || value FROM preferences WHERE agent_id = ?1",
-        )?;
-        let rows: Vec<(i64, String)> = stmt
-            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<rusqlite::Result<_>>()?;
-        for (id, content) in rows {
-            results.push(("preference".to_string(), id, content));
-        }
-        // Events
-        let mut stmt = self.conn.prepare(
-            "SELECT id, description || COALESCE(': ' || context, '')
-              FROM events WHERE agent_id = ?1",
-        )?;
-        let rows: Vec<(i64, String)> = stmt
-            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<rusqlite::Result<_>>()?;
-        for (id, content) in rows {
-            results.push(("event".to_string(), id, content));
-        }
-        Ok(results)
-    }
-
-    /// Returns paginated structured facts for the dashboard with total count.
-    pub fn list_facts_paginated_with_count(
-        &self,
-        agent_id: &str,
-        limit: u32,
-        offset: u32,
-    ) -> Result<(Vec<DashboardFact>, u64)> {
-        let count: u64 = self.conn.query_row(
-            "SELECT
-                (SELECT COUNT(*) FROM people WHERE agent_id = ?1) +
-                (SELECT COUNT(*) FROM commitments WHERE agent_id = ?1) +
-                (SELECT COUNT(*) FROM preferences WHERE agent_id = ?1) +
-                (SELECT COUNT(*) FROM events WHERE agent_id = ?1)",
-            params![agent_id],
-            |r| r.get(0),
-        )?;
-
-        let mut stmt = self.conn.prepare(
-            "SELECT id, category, key, value, updated_at FROM (
-                SELECT id, 'People' AS category, canonical_name AS key,
-                    CASE WHEN relationship IS NOT NULL AND notes IS NOT NULL THEN relationship || ': ' || notes WHEN relationship IS NOT NULL THEN relationship WHEN notes IS NOT NULL THEN notes ELSE '' END AS value,
-                    last_mentioned AS updated_at
-                FROM people WHERE agent_id = ?1
-                UNION ALL
-                SELECT id, 'Commitments' AS category, description AS key,
-                    '[' || status || ']' || COALESCE(' due: ' || due_date, '') AS value,
-                    created_at AS updated_at
-                FROM commitments WHERE agent_id = ?1
-                UNION ALL
-                SELECT rowid AS id, 'Preferences' AS category, category AS key,
-                    value AS value, updated_at AS updated_at
-                FROM preferences WHERE agent_id = ?1
-                UNION ALL
-                SELECT id, 'Events' AS category, description AS key,
-                    COALESCE(context, '') AS value, created_at AS updated_at
-                FROM events WHERE agent_id = ?1
-            ) ORDER BY updated_at DESC LIMIT ?2 OFFSET ?3",
-        )?;
-
-        let data = stmt
-            .query_map(params![agent_id, limit, offset], |r| {
-                Ok(DashboardFact {
-                    id: r.get(0)?,
-                    category: r.get(1)?,
-                    key: r.get(2)?,
-                    value: r.get(3)?,
-                    updated_at: r.get(4)?,
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-
-        Ok((data, count))
     }
 
     // ===== Utilities =====

--- a/crates/mika-agent/src/lib.rs
+++ b/crates/mika-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod db;
 pub(crate) mod github_graphql;
 pub mod kg;
 pub mod mcp;
+pub mod memory;
 pub mod messaging;
 pub mod operational;
 pub mod panic_hook;

--- a/crates/mika-agent/src/memory/mod.rs
+++ b/crates/mika-agent/src/memory/mod.rs
@@ -1,0 +1,415 @@
+//! Core memory, structured facts, search, and KG bridges.
+//!
+//! Owns Database query/write methods for:
+//! - Core memory (key-value identity blocks injected per-turn)
+//! - People (entity records used in conversation context)
+//! - Preferences (operator-stamped routing hints)
+//! - Events (factual record of state-of-world entries)
+//! - Facts (semantic memory store)
+//! - KG corpora bridges (integration with `crate::kg`'s ingestion + resolution)
+//!
+//! Per Foundation §6: reads `OperationalItem` to inform retrieval;
+//! writes Evidence on persistence ops.
+
+use anyhow::Result;
+use rusqlite::OptionalExtension;
+use rusqlite::params;
+
+use crate::db::{CoreMemoryEntry, DashboardFact, Database, Event, Person, Preference};
+
+impl Database {
+    // === Core memory ===
+
+    pub fn get_core_memory(&self, agent_id: &str, key: &str) -> Result<Option<CoreMemoryEntry>> {
+        self.conn
+            .query_row(
+                "SELECT key, value, token_count, updated_at
+                  FROM core_memory WHERE agent_id = ?1 AND key = ?2",
+                params![agent_id, key],
+                |r| {
+                    Ok(CoreMemoryEntry {
+                        key: r.get(0)?,
+                        value: r.get(1)?,
+                        token_count: r.get(2)?,
+                        updated_at: r.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn get_all_core_memory(&self, agent_id: &str) -> Result<Vec<CoreMemoryEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT key, value, token_count, updated_at
+              FROM core_memory WHERE agent_id = ?1 ORDER BY key",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |r| {
+                Ok(CoreMemoryEntry {
+                    key: r.get(0)?,
+                    value: r.get(1)?,
+                    token_count: r.get(2)?,
+                    updated_at: r.get(3)?,
+                })
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(rows)
+    }
+
+    /// Insert or update a core memory entry. Returns the new token count.
+    pub fn set_core_memory(&self, agent_id: &str, key: &str, value: &str) -> Result<i32> {
+        let token_count = (value.len() / 4).max(1) as i32;
+        self.conn.execute(
+            "INSERT INTO core_memory (agent_id, key, value, token_count)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(agent_id, key) DO UPDATE SET
+                value = excluded.value,
+                token_count = excluded.token_count,
+                updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+            params![agent_id, key, value, token_count],
+        )?;
+        Ok(token_count)
+    }
+
+    // === People ===
+
+    pub fn upsert_person(
+        &self,
+        agent_id: &str,
+        name: &str,
+        relationship: Option<&str>,
+        notes: Option<&str>,
+    ) -> Result<i64> {
+        let existing: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT id FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
+                params![agent_id, name],
+                |r| r.get(0),
+            )
+            .optional()?;
+        if let Some(id) = existing {
+            self.conn.execute(
+                "UPDATE people SET relationship = COALESCE(?1, relationship),
+                  notes = COALESCE(?2, notes),
+                  last_mentioned = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'),
+                  mention_count = mention_count + 1
+                  WHERE id = ?3",
+                params![relationship, notes, id],
+            )?;
+            Ok(id)
+        } else {
+            self.conn.execute(
+                "INSERT INTO people (agent_id, canonical_name, relationship, notes)
+                  VALUES (?1, ?2, ?3, ?4)",
+                params![agent_id, name, relationship, notes],
+            )?;
+            Ok(self.conn.last_insert_rowid())
+        }
+    }
+
+    pub fn get_person(&self, agent_id: &str, name: &str) -> Result<Option<Person>> {
+        self.conn
+            .query_row(
+                "SELECT id, canonical_name, relationship, notes,
+                         first_mentioned,
+                         last_mentioned,
+                         mention_count
+                  FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
+                params![agent_id, name],
+                |r| {
+                    Ok(Person {
+                        id: r.get(0)?,
+                        canonical_name: r.get(1)?,
+                        relationship: r.get(2)?,
+                        notes: r.get(3)?,
+                        first_mentioned: r.get(4)?,
+                        last_mentioned: r.get(5)?,
+                        mention_count: r.get(6)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn list_people(&self, agent_id: &str) -> Result<Vec<Person>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, canonical_name, relationship, notes,
+                     first_mentioned,
+                     last_mentioned,
+                     mention_count
+              FROM people WHERE agent_id = ?1 ORDER BY canonical_name",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |r| {
+                Ok(Person {
+                    id: r.get(0)?,
+                    canonical_name: r.get(1)?,
+                    relationship: r.get(2)?,
+                    notes: r.get(3)?,
+                    first_mentioned: r.get(4)?,
+                    last_mentioned: r.get(5)?,
+                    mention_count: r.get(6)?,
+                })
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(rows)
+    }
+
+    /// Delete a person by canonical name. Unlinks commitments first (sets person_id = NULL).
+    /// Returns true if a person was deleted.
+    pub fn delete_person_by_name(&self, agent_id: &str, name: &str) -> Result<bool> {
+        // Unlink commitments from this person
+        let person_id: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT id FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
+                params![agent_id, name],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let Some(pid) = person_id else {
+            return Ok(false);
+        };
+        self.conn.execute(
+            "UPDATE commitments SET person_id = NULL WHERE person_id = ?1",
+            params![pid],
+        )?;
+        // Delete search content
+        self.delete_search_content(agent_id, "person", pid)?;
+        // Delete the person
+        let deleted = self.conn.execute(
+            "DELETE FROM people WHERE agent_id = ?1 AND canonical_name = ?2",
+            params![agent_id, name],
+        )?;
+        Ok(deleted > 0)
+    }
+
+    // === Preferences ===
+
+    pub fn get_preference(&self, agent_id: &str, category: &str) -> Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM preferences WHERE agent_id = ?1 AND category = ?2",
+                params![agent_id, category],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn list_preferences(&self, agent_id: &str) -> Result<Vec<Preference>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT category, value, updated_at
+              FROM preferences WHERE agent_id = ?1 ORDER BY category",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |r| {
+                Ok(Preference {
+                    category: r.get(0)?,
+                    value: r.get(1)?,
+                    updated_at: r.get(2)?,
+                })
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(rows)
+    }
+
+    /// Delete a preference by category. Returns true if deleted.
+    pub fn delete_preference(&self, agent_id: &str, category: &str) -> Result<bool> {
+        // Clean up search content — preference content is "{category}: {value}".
+        // source_id from set_preference (last_insert_rowid) can be unreliable for upserts,
+        // so we find the search_content row by content prefix match instead.
+        let content_prefix = format!("{category}: ");
+        let existing: Option<(i64, String)> = self
+            .conn
+            .query_row(
+                "SELECT id, content FROM search_content
+                  WHERE agent_id = ?1 AND source_type = 'preference' AND content LIKE ?2 || '%'",
+                params![agent_id, content_prefix],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()?;
+        if let Some((id, content)) = existing {
+            let _ = self.conn.execute(
+                "INSERT INTO fts_search(fts_search, rowid, content) VALUES ('delete', ?1, ?2)",
+                params![id, content],
+            );
+            let _ = self
+                .conn
+                .execute("DELETE FROM vec_search WHERE rowid = ?1", params![id]);
+            self.conn
+                .execute("DELETE FROM search_content WHERE id = ?1", params![id])?;
+        }
+        let deleted = self.conn.execute(
+            "DELETE FROM preferences WHERE agent_id = ?1 AND category = ?2",
+            params![agent_id, category],
+        )?;
+        Ok(deleted > 0)
+    }
+
+    // === Events ===
+
+    pub fn list_events(&self, agent_id: &str) -> Result<Vec<Event>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, description, event_date, context, created_at
+              FROM events WHERE agent_id = ?1 ORDER BY created_at DESC",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |r| {
+                Ok(Event {
+                    id: r.get(0)?,
+                    description: r.get(1)?,
+                    event_date: r.get(2)?,
+                    context: r.get(3)?,
+                    created_at: r.get(4)?,
+                })
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(rows)
+    }
+
+    /// Delete an event by description. Returns true if deleted.
+    pub fn delete_event_by_description(&self, agent_id: &str, description: &str) -> Result<bool> {
+        let event_id: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT id FROM events WHERE agent_id = ?1 AND description = ?2 COLLATE NOCASE",
+                params![agent_id, description],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let Some(eid) = event_id else {
+            return Ok(false);
+        };
+        self.delete_search_content(agent_id, "event", eid)?;
+        let deleted = self.conn.execute(
+            "DELETE FROM events WHERE id = ?1 AND agent_id = ?2",
+            params![eid, agent_id],
+        )?;
+        Ok(deleted > 0)
+    }
+
+    // === Facts ===
+
+    pub fn get_all_facts_for_indexing(&self, agent_id: &str) -> Result<Vec<(String, i64, String)>> {
+        let mut results = Vec::new();
+        // People
+        let mut stmt = self.conn.prepare(
+            "SELECT id, canonical_name || COALESCE(' - ' || relationship, '')
+                        || COALESCE(': ' || notes, '')
+              FROM people WHERE agent_id = ?1",
+        )?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (id, content) in rows {
+            results.push(("person".to_string(), id, content));
+        }
+        // Commitments
+        let mut stmt = self.conn.prepare(
+            "SELECT id, description || ' [' || status || ']'
+              FROM commitments WHERE agent_id = ?1",
+        )?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (id, content) in rows {
+            results.push(("commitment".to_string(), id, content));
+        }
+        // Preferences
+        let mut stmt = self.conn.prepare(
+            "SELECT rowid, category || ': ' || value FROM preferences WHERE agent_id = ?1",
+        )?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (id, content) in rows {
+            results.push(("preference".to_string(), id, content));
+        }
+        // Events
+        let mut stmt = self.conn.prepare(
+            "SELECT id, description || COALESCE(': ' || context, '')
+              FROM events WHERE agent_id = ?1",
+        )?;
+        let rows: Vec<(i64, String)> = stmt
+            .query_map(params![agent_id], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (id, content) in rows {
+            results.push(("event".to_string(), id, content));
+        }
+        Ok(results)
+    }
+
+    /// Returns paginated structured facts for the dashboard with total count.
+    pub fn list_facts_paginated_with_count(
+        &self,
+        agent_id: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<(Vec<DashboardFact>, u64)> {
+        let count: u64 = self.conn.query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM people WHERE agent_id = ?1) +
+                (SELECT COUNT(*) FROM commitments WHERE agent_id = ?1) +
+                (SELECT COUNT(*) FROM preferences WHERE agent_id = ?1) +
+                (SELECT COUNT(*) FROM events WHERE agent_id = ?1)",
+            params![agent_id],
+            |r| r.get(0),
+        )?;
+
+        let mut stmt = self.conn.prepare(
+            "SELECT id, category, key, value, updated_at FROM (
+                SELECT id, 'People' AS category, canonical_name AS key,
+                    CASE WHEN relationship IS NOT NULL AND notes IS NOT NULL THEN relationship || ': ' || notes WHEN relationship IS NOT NULL THEN relationship WHEN notes IS NOT NULL THEN notes ELSE '' END AS value,
+                    last_mentioned AS updated_at
+                FROM people WHERE agent_id = ?1
+                UNION ALL
+                SELECT id, 'Commitments' AS category, description AS key,
+                    '[' || status || ']' || COALESCE(' due: ' || due_date, '') AS value,
+                    created_at AS updated_at
+                FROM commitments WHERE agent_id = ?1
+                UNION ALL
+                SELECT rowid AS id, 'Preferences' AS category, category AS key,
+                    value AS value, updated_at AS updated_at
+                FROM preferences WHERE agent_id = ?1
+                UNION ALL
+                SELECT id, 'Events' AS category, description AS key,
+                    COALESCE(context, '') AS value, created_at AS updated_at
+                FROM events WHERE agent_id = ?1
+            ) ORDER BY updated_at DESC LIMIT ?2 OFFSET ?3",
+        )?;
+
+        let data = stmt
+            .query_map(params![agent_id, limit, offset], |r| {
+                Ok(DashboardFact {
+                    id: r.get(0)?,
+                    category: r.get(1)?,
+                    key: r.get(2)?,
+                    value: r.get(3)?,
+                    updated_at: r.get(4)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok((data, count))
+    }
+
+    // === KG bridges ===
+
+    /// List all corpora registered for an agent.
+    /// Returns `(docs_root_hash, docs_root_path)` pairs.
+    pub fn list_agent_corpora(&self, agent_id: &str) -> Result<Vec<(String, String)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT docs_root_hash, docs_root_path FROM agent_kg_corpora WHERE agent_id = ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}

--- a/docs/plans/2026-06-08-001-refactor-1446-memory-module-extract-plan.md
+++ b/docs/plans/2026-06-08-001-refactor-1446-memory-module-extract-plan.md
@@ -1,0 +1,173 @@
+# Plan — refactor(mika#1259): extract memory/ module (mika#1446)
+
+## Phase 0 — Pin
+
+**A. Foundation §6** (`mika/docs/architecture/operational-partner-frame.md`):
+> `memory/` — Core memory, structured facts, search, KG bridges. Reads `OperationalItem` to inform retrieval; writes Evidence on persistence ops.
+
+**B. Sibling-accretion from #1445 (Wave 2.1) — 5 methods classified as memory/ during dashboard_queries/ grooming:**
+
+| Line | Function | Classification grounds |
+|---|---|---|
+| 4383 | `list_agent_corpora` | KG bridges per §6 |
+| 7517 | `list_people` | Person = memory-layer entity ("structured facts") |
+| 7691 | `list_preferences` | Preferences = memory-layer per §6 |
+| 7743 | `list_events` | Events = facts-of-state (memory) — confirmed via body-read at this canvass (no longer provisional) |
+| 9032 | `list_facts_paginated_with_count` | "Structured facts" per §6 |
+
+**Sibling-accretion validation outcome**: all 5 accreted classifications confirm at memory/ body-read. **Sibling-accretion-as-grounding-input mechanism validated at n=1** — accreted classifications were correct; #1446 grounding-gate firing absorbs them without conflict.
+
+**C. Additional memory/ methods surfaced via #1446 body-read** (memory-relevant methods NOT yet in any sub-issue's accretion):
+
+| Line | Function | Domain | In #1446 scope? |
+|---|---|---|---|
+| 7363 | `get_core_memory` | Core memory access | YES |
+| 7382 | `get_all_core_memory` | Core memory bulk-read | YES |
+| 7401 | `set_core_memory` | Core memory write | YES |
+| 7457 | `upsert_person` | People write | YES |
+| 7492 | `get_person` | People read | YES |
+| 7680 | `get_preference` | Preferences read | YES |
+| 8054 | `delete_person_by_name` | People delete | YES |
+| 8082 | `delete_preference` | Preferences delete | YES |
+| 8140 | `delete_event_by_description` | Events delete | YES |
+| 8982 | `get_all_facts_for_indexing` | Facts bulk-read (indexing path) | YES |
+
+**Total #1446 scope**: 5 accreted + 10 newly surfaced = 15 methods. Estimated LoC: ~1,500-2,500 lines (smaller per-method bodies than dashboard_queries paginated aggregations).
+
+**D. What stays OUT of memory/:**
+
+- **`kg/` module dir already exists** at `crates/mika-agent/src/kg/` with budget.rs, chunker.rs, config.rs, domain_builder.rs, entity_resolver.rs, ingestion_orchestrator.rs, lexical_ingestor.rs, query.rs, resolver_tick.rs. **kg/ is NOT absorbed into memory/.** Foundation §6 memory/ has "KG bridges" — i.e., the integration-layer methods on Database that bridge to kg/'s machinery. kg/'s own modules stay as-is.
+- **`db/kg_schema.rs` and `db/operational.rs`** stay where they are. These are schema/migration code, not domain-method-owner code. db/ is its own infrastructure layer.
+- **Audit-events methods split**: `list_audit_events_paginated*` (9495, 9813) went to dashboard_queries/ in #1445 (dashboard surface). `get_audit_events*` (7834, 7846, 7929) belong to **evidence/** per §6 ("tool-call audit trail") — NOT memory/. Belong to #1444 evidence/ grooming.
+
+**E. Cross-module dependency check (grep for cross-§6-module calls):**
+
+The 15 methods read `agents`, `core_memory`, `people`, `preferences`, `events`, `facts`, `agent_kg_corpora` tables. They do NOT call other §6 module methods (no `evidence::*`, no `task_state::*`, no `commitments::*`, no `dashboard_queries::*`). Pure leaf-with-respect-to-§6.
+
+Memory/ does have a soft-dependency on **kg/** (KG bridges call into kg/ machinery), but kg/ is NOT a §6 module — it's infrastructure that memory/ depends on. That's not a §6-module-cross-dependency.
+
+**F. Tests landscape**: existing tests reference these methods via `database.get_core_memory(...)`, `database.set_core_memory(...)`, etc. After extraction (methods stay `impl Database`), tests don't need changes.
+
+## Hypothesis (committed)
+
+**Extraction shape**: move the 15 memory/-domain methods from `db.rs` into `crates/mika-agent/src/memory/mod.rs`. Methods stay as `impl Database` to minimize call-site churn (per #1445's established pattern and parent AC3).
+
+**Sibling-accretion bookkeeping**: the 5 accreted methods are explicit + verified at canvass-time, not silently absorbed. Phase 0 §B is the audit trail.
+
+**Why NOT absorb kg/**: kg/ is an infrastructure module (ingestion orchestrator, chunker, entity resolver, etc.) that pre-dates Foundation §6 and serves multiple consumers. §6 memory/ provides KG-bridge methods on Database that callers use; kg/ provides the machinery those bridges drive. Different layers, different ownership.
+
+## Approach (committed)
+
+### A. Create the module
+
+`crates/mika-agent/src/memory/mod.rs`:
+
+```rust
+//! Core memory, structured facts, search, and KG bridges.
+//!
+//! Owns Database query/write methods for:
+//! - Core memory (key-value identity blocks injected per-turn)
+//! - People (entity records used in conversation context)
+//! - Preferences (operator-stamped routing hints)
+//! - Events (factual record of state-of-world entries)
+//! - Facts (semantic memory store)
+//! - KG corpora bridges (integration with `crate::kg`'s ingestion + resolution)
+//!
+//! Per Foundation §6: reads `OperationalItem` to inform retrieval;
+//! writes Evidence on persistence ops (evidence/ owns the actual Evidence
+//! writes — memory/ owns the persistence side that triggers them).
+
+use crate::db::Database;
+// ... (move impl blocks from db.rs into this file)
+```
+
+### B. Move impl blocks
+
+Migrate the 15 method definitions per Phase 0 §B + §C into `memory/mod.rs`. Each method's body unchanged; only the enclosing `impl Database { ... }` block relocates.
+
+Group by data-kind in the new file:
+- Core memory (get_core_memory, get_all_core_memory, set_core_memory)
+- People (upsert_person, get_person, list_people, delete_person_by_name)
+- Preferences (get_preference, list_preferences, delete_preference)
+- Events (list_events, delete_event_by_description)
+- Facts (get_all_facts_for_indexing, list_facts_paginated_with_count)
+- KG bridges (list_agent_corpora)
+
+### C. Update `lib.rs`
+
+Add `pub mod memory;` to `crates/mika-agent/src/lib.rs`.
+
+### D. Verify
+
+- `cargo build -p mika-agent` clean
+- `cargo clippy -p mika-agent --tests --no-deps -- -D warnings` clean
+- `cargo test -p mika-agent --lib` passes
+- `wc -l crates/mika-agent/src/db.rs` shows ~1,500-2,500 line reduction
+
+## Acceptance Criteria
+
+1. **AC1**: `crates/mika-agent/src/memory/mod.rs` created with one-paragraph doc-comment naming "core memory, structured facts, search, KG bridges" per Foundation §6 (per parent AC4).
+
+2. **AC2**: Exactly the 15 classified memory/-domain methods (per Phase 0 §B + §C tables) relocate to `memory/mod.rs`. Methods stay `impl Database` to minimize call-site churn.
+
+3. **AC3**: `crates/mika-agent/src/lib.rs` declares `pub mod memory;` (per parent AC4).
+
+4. **AC4**: `cargo test -p mika-agent` passes unchanged (per parent AC2).
+
+5. **AC5**: `cargo clippy -p mika-agent --tests --no-deps -- -D warnings` clean.
+
+6. **AC6**: No behavior change — pure module split (per parent AC3).
+
+7. **AC7**: `wc -l crates/mika-agent/src/db.rs` shows reduction by ~1,500-2,500 lines.
+
+8. **AC8**: kg/ module dir untouched (not absorbed). Verified by `git diff crates/mika-agent/src/kg/` returning empty.
+
+## Files to change
+
+- `crates/mika-agent/src/memory/mod.rs` — new file (extracted memory methods + doc-comment)
+- `crates/mika-agent/src/db.rs` — remove relocated methods
+- `crates/mika-agent/src/lib.rs` — add `pub mod memory;` declaration
+
+## Out of scope
+
+- HTTP handlers in `server/dashboard.rs` (transport layer; dashboard_queries already extracted, dashboard surfaces still call `database.list_people()` etc. via the relocated `impl Database` block — no signature change)
+- kg/ machinery (separate infrastructure layer, pre-dates §6, multiple consumers)
+- db/kg_schema.rs and db/operational.rs (db/ infrastructure, not domain-owner)
+- audit_events methods (split between dashboard_queries/ already + evidence/ for #1444)
+- Other §6 modules (#1444 evidence/, #1447 notifications/, etc. — separate sub-issues)
+
+## Risk
+
+Low (matches #1445's risk profile).
+- **Impl-block relocation across files**: standard Rust; compiler stitches automatically; no call-site churn.
+- **Sibling-accretion validity**: validated at body-read — all 5 accreted classifications hold.
+- **kg/ scope clarity**: Phase 0 §D explicitly excludes kg/ absorption to prevent scope-creep. Future #1444 evidence/ grooming might surface additional kg/-related-but-not-memory/ methods; those route via separate sub-issue scoping.
+
+## Test plan
+
+1. `cargo build -p mika-agent` clean
+2. `cargo test -p mika-agent --lib` passes (relies on `database.get_core_memory()`, `database.set_core_memory()`, `database.upsert_person()`, etc. — these still resolve to memory/mod.rs's impl Database block)
+3. `cargo clippy -p mika-agent --tests --no-deps -- -D warnings` clean
+4. `git diff crates/mika-agent/src/kg/` returns empty (kg/ untouched)
+5. `wc -l` on db.rs shows ~1,500-2,500 line reduction
+
+## Implementation order
+
+1. Create `memory/mod.rs` with doc-comment shell + `use crate::db::Database;`
+2. For each of the 15 methods (Phase 0 §B + §C), copy from db.rs into memory/mod.rs preserving impl Database block + comments + tests-references
+3. Remove the 15 methods from db.rs
+4. Add `pub mod memory;` to lib.rs
+5. Run `cargo build` — fix compile errors if any (unlikely — pure relocation)
+6. Run `cargo clippy` + `cargo test`
+7. Manual smoke per §test plan
+
+## Sibling-accretion mechanism observation (for current_priorities ledger)
+
+**n=1 of sibling-accretion-as-grounding-input** validated at this canvass. The mechanism shape:
+
+- A sibling sub-issue's grounding-gate firing produces classification claims about methods that belong to OTHER sub-issues' scope
+- Those classifications accrete into the not-yet-groomed siblings' scope-evidence
+- The next sibling's grounding-gate firing verifies-or-refines the accretion
+- Verified accretion (this canvass) → mechanism validated; refined/refuted accretion → mechanism + classifications get refined
+
+Held lightly; not folded into bedrock. If a second sibling firing also validates inherited classifications, that's n=2 evidence the mechanism is stable across sub-issues.


### PR DESCRIPTION
Wave 2 sub-issue of mika#1259 (post-foundation module extraction).

## Summary

Foundation §6 \`memory/\` module — 15 methods relocated from \`db.rs\`:
- **Core memory** (3): get_core_memory, get_all_core_memory, set_core_memory
- **People** (4): upsert_person, get_person, list_people, delete_person_by_name
- **Preferences** (3): get_preference, list_preferences, delete_preference
- **Events** (2): list_events, delete_event_by_description
- **Facts** (2): get_all_facts_for_indexing, list_facts_paginated_with_count
- **KG bridges** (1): list_agent_corpora

5 sibling-accreted from #1445 (validated) + 10 surfaced via body-read = 15 total.

Methods stay \`impl Database\` (zero call-site churn) per parent AC3.

Closes #1446

Plan: docs/plans/2026-06-08-001-refactor-1446-memory-module-extract-plan.md

## Test plan
- [x] cargo check -p mika-agent (clean)
- [x] cargo fmt
- [x] cargo clippy (pre-commit hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)