### PR TITLE
fix(engine): narrow webhook_zero_tools to skip three informational prefixes (mika#1469)

### DIFF
--- a/crates/mika-agent/src/agent.rs
+++ b/crates/mika-agent/src/agent.rs
@@ -5847,10 +5847,22 @@ const INTENT_GUARDS: &[IntentPrecondition] = &[
              [GitHub] events (comments, other labels, edits) use Webhook \
              Fallthrough: the engine expects acknowledgement without dispatching.",
     },
-    // #696 — webhook events require at least one successful tool call.
+    // #696, #1469 — webhook events require at least one successful tool call.
+    //
+    // Prefix-narrowed (mika#1469): three always-informational event classes are
+    // excluded from the trigger so the guard does not misfire on no-op webhooks:
+    //   - `[GitHub] Check suite success on …` — no agent action for green CI
+    //   - `[GitHub] PR closed: …` — informational; merge/close is complete
+    //   - `[GitHub] discussion.*` — discussion events have no actionable response
+    //
+    // These three classes produced 25+ documented misfires (2026-06-09) where
+    // the guard pressured the agent to call a tool just to satisfy the
+    // precondition.  Correlation-aware filtering for the remaining long-tail
+    // misfires (e.g., CI failure on untracked branches) is deferred to a
+    // follow-up — see mika#1469 plan § Deferred to Follow-Up Work.
     IntentPrecondition {
         label: "webhook_zero_tools",
-        trigger: |msg| msg.starts_with("[GitHub]"),
+        trigger: webhook_zero_tools_trigger,
         satisfied: |summaries| summaries.iter().any(|s| s.success),
         correction_message: "[mika-engine] A GitHub webhook event was received but the \
              response was text-only with zero tool calls. Webhook events require \
@@ -5957,6 +5969,28 @@ fn ready_label_dispatch_satisfied(summaries: &[ToolCallSummary]) -> bool {
     summaries
         .iter()
         .any(|s| s.name == "run_claude_pilot" || s.name == "run_claude_pilot_groom")
+}
+
+/// #696, #1469 — Triggers on `[GitHub]` webhook turns that are potentially
+/// action-bearing.  Excludes three always-informational prefix classes that
+/// have no actionable response regardless of correlation state:
+///   - `Check suite success on` — green CI, nothing to do
+///   - `PR closed:` — merge/close is terminal
+///   - `discussion.` — discussion events are informational
+///
+/// See mika#1469 for the empirical misfire evidence (25+ incidents).
+fn webhook_zero_tools_trigger(msg: &str) -> bool {
+    if !msg.starts_with("[GitHub]") {
+        return false;
+    }
+    // Skip: always-informational event classes (mika#1469).
+    if msg.starts_with("[GitHub] Check suite success on")
+        || msg.starts_with("[GitHub] PR closed:")
+        || msg.starts_with("[GitHub] discussion.")
+    {
+        return false;
+    }
+    true
 }
 
 /// #910, #1102 — Triggers on `[GitHub]` webhook turns that represent
@@ -10542,6 +10576,70 @@ mod tests {
              webhook_zero_tools (idx={zero_idx}) so the more specific trigger \
              fires first"
         );
+    }
+
+    // -- #1469 webhook_zero_tools_trigger prefix-narrowing tests --
+
+    #[test]
+    fn webhook_zero_tools_trigger_skips_check_suite_success() {
+        assert!(!webhook_zero_tools_trigger(
+            "[GitHub] Check suite success on senara-solutions/mika (branch: main)"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_skips_pr_closed() {
+        assert!(!webhook_zero_tools_trigger(
+            "[GitHub] PR closed: senara-solutions/mika#1000 — title (branch: foo)"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_skips_discussion() {
+        assert!(!webhook_zero_tools_trigger(
+            "[GitHub] discussion.created on senara-solutions/mika"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_fires_on_check_suite_failure() {
+        assert!(webhook_zero_tools_trigger(
+            "[GitHub] Check suite failure on senara-solutions/mika (branch: fix/foo)"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_fires_on_ready_label() {
+        assert!(webhook_zero_tools_trigger(
+            "[GitHub] Issue labeled ready on senara-solutions/mika#933 — title"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_fires_on_pr_review() {
+        assert!(webhook_zero_tools_trigger(
+            "[GitHub] PR review (approved) on senara-solutions/mika#1000 (title) by @reviewer"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_fires_on_new_comment() {
+        assert!(webhook_zero_tools_trigger(
+            "[GitHub] New comment on senara-solutions/mika#933 (title) by @samidarko"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_fires_on_non_ready_label() {
+        assert!(webhook_zero_tools_trigger(
+            "[GitHub] Issue labeled bug on senara-solutions/mika#999"
+        ));
+    }
+
+    #[test]
+    fn webhook_zero_tools_trigger_skips_non_github() {
+        assert!(!webhook_zero_tools_trigger("[Slack] message"));
+        assert!(!webhook_zero_tools_trigger(""));
     }
 
     // -- #910 webhook_no_unauthorized_dispatch trigger tests --

--- a/crates/mika-agent/tests/eval/grounding_regressions/mod.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/mod.rs
@@ -62,3 +62,4 @@ pub mod required_suffix_line_caught;
 pub mod required_suffix_line_unconstrained;
 pub mod required_tools_retry_thin_final_turn;
 pub mod summary_conversational_recall;
+pub mod webhook_zero_tools_no_correlation;

--- a/crates/mika-agent/tests/eval/grounding_regressions/webhook_zero_tools_no_correlation.rs
+++ b/crates/mika-agent/tests/eval/grounding_regressions/webhook_zero_tools_no_correlation.rs
@@ -1,0 +1,119 @@
+//! Scenario: webhook_zero_tools guard prefix-narrowing for no-correlation events (mika#1469)
+//!
+//! Context: three always-informational GitHub webhook event classes
+//! (`Check suite success`, `PR closed`, `discussion.*`) were triggering
+//! the `webhook_zero_tools` intent-precondition guard even though they
+//! have no actionable response. The guard re-prompted the LLM, producing
+//! 25+ documented misfires where the agent was pressured to call a tool
+//! just to satisfy the precondition.
+//!
+//! mika#1469 narrows the trigger so these three prefix classes are skipped.
+//!
+//! ## Hard Assertions
+//! - **Skipped prefixes:** text-only EndTurn on `Check suite success`,
+//!   `PR closed:`, `discussion.` → guard does NOT fire → 1 LLM call.
+//! - **Retained prefix (regression):** text-only EndTurn on `Check suite
+//!   failure` → guard DOES fire → 2 LLM calls.
+//!
+//! Reference: mika#1469
+
+use super::*;
+
+/// `[GitHub] Check suite success on …` + text-only EndTurn → guard skipped.
+#[tokio::test]
+async fn test_check_suite_success_no_guard_fire() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![text_response("CI passed on main. No action needed.")])
+        .build()
+        .await?;
+
+    let trace = harness
+        .run("[GitHub] Check suite success on senara-solutions/mika (branch: main)")
+        .await?;
+
+    assert_eq!(
+        trace.llm_call_count, 1,
+        "webhook_zero_tools guard should NOT fire on Check suite success \
+         (expected 1 LLM call, got {})",
+        trace.llm_call_count
+    );
+
+    Ok(())
+}
+
+/// `[GitHub] PR closed: …` + text-only EndTurn → guard skipped.
+#[tokio::test]
+async fn test_pr_closed_no_guard_fire() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![text_response(
+            "Noted the PR closure event. No action needed on this one.",
+        )])
+        .build()
+        .await?;
+
+    let trace = harness
+        .run("[GitHub] PR closed: senara-solutions/mika#999 — title (branch: foo)")
+        .await?;
+
+    assert_eq!(
+        trace.llm_call_count, 1,
+        "webhook_zero_tools guard should NOT fire on PR closed \
+         (expected 1 LLM call, got {})",
+        trace.llm_call_count
+    );
+
+    Ok(())
+}
+
+/// `[GitHub] discussion.created on …` + text-only EndTurn → guard skipped.
+#[tokio::test]
+async fn test_discussion_no_guard_fire() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![text_response(
+            "Discussion event noted. No action required.",
+        )])
+        .build()
+        .await?;
+
+    let trace = harness
+        .run("[GitHub] discussion.created on senara-solutions/mika")
+        .await?;
+
+    assert_eq!(
+        trace.llm_call_count, 1,
+        "webhook_zero_tools guard should NOT fire on discussion events \
+         (expected 1 LLM call, got {})",
+        trace.llm_call_count
+    );
+
+    Ok(())
+}
+
+/// Regression: `[GitHub] Check suite failure on …` + text-only EndTurn →
+/// guard STILL fires → correction injected → 2 LLM calls.
+#[tokio::test]
+async fn test_check_suite_failure_guard_fires() -> anyhow::Result<()> {
+    let harness = EvalHarness::builder()
+        .responses(vec![
+            // Turn 1: text-only response (no tool calls) — guard fires.
+            text_response("CI failed on fix/foo."),
+            // Turn 2: after correction re-prompt, still text-only.
+            // Guard has already used its single retry, so this EndTurn is accepted.
+            text_response("Acknowledged the CI failure."),
+        ])
+        .build()
+        .await?;
+
+    let trace = harness
+        .run("[GitHub] Check suite failure on senara-solutions/mika (branch: fix/foo)")
+        .await?;
+
+    assert!(
+        trace.llm_call_count > 1,
+        "webhook_zero_tools guard should fire on Check suite failure \
+         (expected >1 LLM calls, got {})",
+        trace.llm_call_count
+    );
+
+    Ok(())
+}

--- a/crates/mika-agent/tests/eval/test_callback_milestone_advance.rs
+++ b/crates/mika-agent/tests/eval/test_callback_milestone_advance.rs
@@ -1570,20 +1570,19 @@ async fn webhook_milestone_advance_single_retry_semantics() {
 async fn webhook_milestone_advance_no_marker_no_fire() {
     let harness = EvalHarness::builder()
         .responses(vec![
-            // Step 1: Text-only EndTurn — webhook_milestone_advance guard
-            // should NOT fire (no marker). However, the `webhook_zero_tools`
-            // INTENT_GUARD (entry c) WILL fire on `[GitHub]` messages with
-            // zero tool calls. After that single retry:
+            // Single step: text-only EndTurn — both `webhook_milestone_advance`
+            // and `webhook_zero_tools` should NOT fire.
+            //
+            // Post-mika#1469: `webhook_zero_tools` no longer fires on
+            // `[GitHub] PR closed:` messages (added to the trigger's prefix-skip
+            // list — see agent.rs `webhook_zero_tools_trigger`). PR-closed events
+            // for out-of-band PRs are always informational; the agent's text-only
+            // acknowledgement is the correct response and the engine accepts it
+            // without re-prompting.
+            //
+            // `webhook_milestone_advance` separately does NOT fire because the
+            // message carries no `[milestone-parent: ...]` marker.
             text_response("PR merged. No milestone context."),
-            // Step 2: After webhook_zero_tools re-prompt, agent calls a tool
-            // and responds. Still no milestone advance guard fire because
-            // there's no [milestone-parent:] marker.
-            tool_call_response(
-                "update_task_status",
-                json!({"task_id": "some-task", "status": "completed"}),
-            ),
-            // Step 3: Final text
-            text_response("Task updated after webhook zero-tools correction."),
         ])
         .tools(tools_with_webhook_milestone_stubs())
         .build()
@@ -1601,9 +1600,10 @@ async fn webhook_milestone_advance_no_marker_no_fire() {
         .unwrap();
 
     assert_has_output(&trace);
-    // 3 steps — webhook_zero_tools fires once, but webhook_milestone_advance
-    // does NOT fire (no milestone-parent marker present).
-    assert_exact_steps(&trace, 3);
+    // 1 step — post-mika#1469, `[GitHub] PR closed:` is in the
+    // `webhook_zero_tools` prefix-skip list, so no guard re-prompt fires
+    // and the text-only EndTurn is accepted on the first step.
+    assert_exact_steps(&trace, 1);
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/plans/2026-06-09-004-fix-1469-webhook-zero-tools-guard-prefix-narrowing-plan.md
+++ b/docs/plans/2026-06-09-004-fix-1469-webhook-zero-tools-guard-prefix-narrowing-plan.md
@@ -1,0 +1,239 @@
+---
+title: "fix(engine): webhook_zero_tools guard prefix-narrowing for no-correlation events"
+status: active
+created: 2026-06-09
+type: fix
+origin: GitHub issue mika#1469
+groom_session_id: 557a7808-17f2-4f7e-bcfe-25e8df3021d9
+---
+
+# fix(engine): webhook_zero_tools guard prefix-narrowing for no-correlation events
+
+## Summary
+
+Narrow the `webhook_zero_tools` intent-precondition guard (`crates/mika-agent/src/agent.rs:5852`) so it stops firing on three documented no-op event classes: `Check suite success`, `PR closed`, and `discussion.*`. These events have no actionable response — the agent's correct behavior is text-only acknowledgement — but the current guard's trigger (`msg.starts_with("[GitHub]")`) fires on every webhook and re-prompts the LLM, producing the 25+ misfires documented in `current_priorities` core memory as of 2026-06-09.
+
+The fix is a single-function-pointer change to the trigger predicate plus regression tests. Scope is intentionally minimal: high-confidence prefix-based skip-list using only message-text signals already available to the trigger's `fn(&str) -> bool` signature. Correlation-aware filtering (which would require widening the trigger signature or adding DB lookups at message construction) is out of scope — that's a follow-up if these three prefix skips don't cover the long tail.
+
+## Problem frame
+
+**Current behavior:**
+
+The `webhook_zero_tools` intent-precondition guard in `INTENT_GUARDS` (`agent.rs:5852-5862`):
+
+```rust
+IntentPrecondition {
+    label: "webhook_zero_tools",
+    trigger: |msg| msg.starts_with("[GitHub]"),
+    satisfied: |summaries| summaries.iter().any(|s| s.success),
+    correction_message: "[mika-engine] A GitHub webhook event was received but the \
+         response was text-only with zero tool calls. Webhook events require \
+         action — the engine expects at least one tool call ...",
+},
+```
+
+fires on any user message whose text begins with `[GitHub]`. When fired, the engine injects the correction message and re-prompts the LLM once (single-retry, tracked via `intent_guard_retries: HashSet<&'static str>`).
+
+**Misfire patterns (from issue body):**
+
+1. `check_suite.completed(success)` on `main` — no in-progress tasks → guard fires
+2. `check_suite.completed(failure)` on `main` for recurring Release Please failure with no correlated task → guard fires
+3. `pull_request.closed(merged: true)` for out-of-band PRs (no sprint work item) → guard fires
+4. `pull_request_review.submitted` (QA pass) for out-of-band PRs → guard fires
+5. `issue_comment.created` closure comments on already-merged PRs → guard fires
+
+**Empirical evidence:** 25+ documented misfires as of 2026-06-09 in `current_priorities` core memory. Each misfire pressures the agent to call a tool (`list_tasks`, `send_message`, etc.) just to satisfy the guard, violating dispatch discipline.
+
+## Scope
+
+### In scope (this plan, this PR)
+
+- Narrow the `webhook_zero_tools` trigger function to **skip three prefix classes** that are always informational and never action-bearing:
+  - `[GitHub] Check suite success on ...`
+  - `[GitHub] PR closed: ...`
+  - `[GitHub] discussion.*`
+- Regression tests in `crates/mika-agent/tests/eval/grounding_regressions/` covering:
+  - Each of the three skipped prefix classes → guard does NOT fire → text-only response accepted
+  - Each retained prefix class (`Issue labeled ready`, `Check suite failure`, `PR opened`, `PR review`, `New comment on`, `Issue labeled <other>`) → guard STILL fires → text-only response rejected (or accepted iff the agent called a tool)
+- A short documentation note in the guard source comment explaining the prefix skip rationale + the empirical-misfire reference.
+
+### Deferred to Follow-Up Work
+
+- **Correlation-aware filtering** — if the long-tail of misfires includes `Check suite failure` on untracked branches, `PR review` on out-of-band PRs, or `New comment on` already-merged PRs, those require knowing whether the event is "correlated with an active task." The trigger function's signature today is `fn(&str) -> bool` — it doesn't see DB state. A correlation-aware approach would either (a) widen the trigger signature to accept context (invasive across 10+ guards), or (b) add a DB lookup at the webhook router's message-construction site to encode correlation into the prefix (e.g., `[GitHub:no-correlation] ...`). Both are larger changes than this slice and should be triaged after observing whether the three-prefix skip is sufficient.
+- **Prompt-side language** — the agent's system prompt has language about "webhook events require action" that should be aligned with the narrower guard. Out of scope for this slice; flag for the next prompt-cleanup pass.
+
+### Outside this fix's identity
+
+- Restructuring the `INTENT_GUARDS` registry framework itself.
+- Removing `webhook_zero_tools` entirely — the guard still has a load-bearing role on action-bearing events (CI failure on a tracked PR, etc.).
+
+## Requirements
+
+- **R1.** The guard MUST NOT fire on `[GitHub] Check suite success on ...` messages.
+- **R2.** The guard MUST NOT fire on `[GitHub] PR closed: ...` messages.
+- **R3.** The guard MUST NOT fire on `[GitHub] discussion.<anything>` messages.
+- **R4.** The guard MUST continue to fire on `[GitHub] Issue labeled ready on ...` messages (regression — the existing `webhook_ready_label_dispatch` more-specific guard at agent.rs:5805 handles this case first, but `webhook_zero_tools` is the fallback if ready-label-dispatch is somehow skipped).
+- **R5.** The guard MUST continue to fire on `[GitHub] Check suite failure on ...` messages — failures are potentially action-bearing.
+- **R6.** The guard MUST continue to fire on `[GitHub] PR review (...) on ...` messages — reviews may carry QA verdicts requiring action.
+- **R7.** The guard MUST continue to fire on `[GitHub] New comment on ...` messages — comments may carry directives requiring action.
+- **R8.** The guard MUST continue to fire on `[GitHub] PR opened: ...`, `[GitHub] Issue opened: ...`, `[GitHub] Issue assigned: ...`, `[GitHub] Issue labeled <non-ready>` — all are potentially action-bearing.
+
+## Key Technical Decisions
+
+### KTD1. Prefix-based skip, not correlation lookup
+
+The architect's pass-2 review (session `557a7808-17f2-4f7e-bcfe-25e8df3021d9`) noted that the proposed `[GitHub:no-correlation]` marker approach (approach α from the brief) would require the webhook router to perform a DB lookup at message-construction time to determine correlation — a larger change than initially scoped. Source reading in `crates/mika-agent/src/webhook_dispatch.rs:30-184` confirmed:
+
+- The current webhook message text has NO `task_id` field, NO `correlated_task_id`, and NO marker shape suitable for correlation signaling.
+- For issue/PR/comment/review events, the message contains `<repo>#<n>` (parseable, but the lookup is still DB-side).
+- For `Check suite` events, the message contains only `(branch: <name>)` — no `<repo>#<n>` — and determining "is this branch tracked by an active task" requires a branch→SHA→PR→task chain of DB lookups.
+
+This is significant DB plumbing for a single guard. **This plan adopts the simpler shape: prefix-based skip on the three highest-frequency no-op classes.** The three classes (`Check suite success`, `PR closed`, `discussion.*`) are always informational regardless of correlation state — there's nothing useful the agent can do with them even when correlated. The minority remaining misfires (failure events on untracked branches, etc.) are deferred to the follow-up correlation-aware pass when warranted.
+
+### KTD2. Keep the trigger function's signature unchanged
+
+`IntentPrecondition::trigger: fn(&str) -> bool` is used by 10+ guards in the registry. Widening the signature to accept context state would force a no-op edit to every other guard. The fix stays within the existing function-pointer shape: a slightly more elaborate predicate that inspects multiple prefix patterns.
+
+### KTD3. Single-function-pointer change, no new types
+
+The fix is a single `trigger` predicate replacement on the existing `IntentPrecondition` entry. No new types, no new traits, no new modules. This is intentionally minimal — the change is small enough that the test suite is more code than the production change.
+
+### KTD4. Test fixtures use the existing webhook message shapes from `webhook_dispatch::tests`
+
+`webhook_dispatch.rs:60-184` already maintains a test corpus of canonical webhook message shapes for all event classes. Tests in this plan use the same string literals so the test corpus stays in lock-step with the routing layer. If `webhook_dispatch.rs` changes a prefix shape in a future ticket, the regression tests here surface the divergence.
+
+## High-Level Technical Design
+
+```
+                          BEFORE                                AFTER
+                                                                
+agent.rs:5852                                       agent.rs:5852
+INTENT_GUARDS entry                                 INTENT_GUARDS entry
+   trigger: |msg|                                      trigger: |msg|
+     msg.starts_with("[GitHub]")  ───┐                   webhook_zero_tools_trigger(msg)
+                                     │                                 │
+   ──── fires on EVERY                                   ──── fires only on action-bearing
+        [GitHub]-prefixed                                     [GitHub]-prefixed events
+        message                                               (excludes 3 known no-op prefixes)
+                                                                
+                                                    fn webhook_zero_tools_trigger(msg: &str) -> bool {
+                                                        if !msg.starts_with("[GitHub]") { return false; }
+                                                        // Skip: always-informational event classes
+                                                        if msg.starts_with("[GitHub] Check suite success on")
+                                                            || msg.starts_with("[GitHub] PR closed:")
+                                                            || msg.starts_with("[GitHub] discussion.")
+                                                        {
+                                                            return false;
+                                                        }
+                                                        true
+                                                    }
+```
+
+Directional only — exact identifier/lint compliance resolved at execution time.
+
+## Implementation Units
+
+### U1. Extract trigger to a named function + add skip-list
+
+**Goal:** Replace the closure `|msg| msg.starts_with("[GitHub]")` on the `webhook_zero_tools` registry entry with a named function that adds the three-prefix skip list.
+
+**Requirements:** R1, R2, R3 (the skips); R4–R8 (regressions: all other prefixes still fire).
+
+**Dependencies:** none.
+
+**Files:**
+- `crates/mika-agent/src/agent.rs` — modify the `webhook_zero_tools` IntentPrecondition entry at line 5852; add a new `fn webhook_zero_tools_trigger(msg: &str) -> bool` near the other guard predicates (sibling to `ready_label_dispatch_trigger` at line ~5900).
+
+**Approach:**
+- Extract the inline closure into a named function — better for testability + matches the existing pattern for the more-specific guards (`webhook_ready_label_dispatch` uses `ready_label_dispatch_trigger`, etc.).
+- The new function body checks the `[GitHub]` prefix, then short-circuits on the three documented no-op prefixes.
+- Update the registry entry to reference the new function pointer.
+- Update the doc comment above the entry to cite mika#1469 and reference the three skipped prefix classes.
+
+**Patterns to follow:**
+- `ready_label_dispatch_trigger` at `agent.rs:5930` — the existing named-trigger pattern for the sibling more-specific guard.
+- `webhook_no_unauthorized_dispatch_trigger` (search for it) — another sibling named trigger.
+
+**Test scenarios** (inline `#[cfg(test)] mod tests` in `agent.rs`):
+- `webhook_zero_tools_trigger` returns `false` for `[GitHub] Check suite success on senara-solutions/mika (branch: main)`.
+- `webhook_zero_tools_trigger` returns `false` for `[GitHub] PR closed: senara-solutions/mika#1000 — title (branch: foo)`.
+- `webhook_zero_tools_trigger` returns `false` for `[GitHub] discussion.created on senara-solutions/mika`.
+- `webhook_zero_tools_trigger` returns `true` for `[GitHub] Check suite failure on senara-solutions/mika (branch: fix/foo)` (regression — failures still fire).
+- `webhook_zero_tools_trigger` returns `true` for `[GitHub] Issue labeled ready on senara-solutions/mika#933 — title` (regression).
+- `webhook_zero_tools_trigger` returns `true` for `[GitHub] PR review (approved) on senara-solutions/mika#1000 (title) by @reviewer` (regression).
+- `webhook_zero_tools_trigger` returns `true` for `[GitHub] New comment on senara-solutions/mika#933 (title) by @samidarko` (regression).
+- `webhook_zero_tools_trigger` returns `true` for `[GitHub] Issue labeled bug on senara-solutions/mika#999` (regression — non-ready labels still fire).
+- `webhook_zero_tools_trigger` returns `false` for `[Slack] message` (regression — non-[GitHub] prefix never fires).
+
+**Verification:** `cargo test -p mika-agent agent::tests::webhook_zero_tools_trigger` passes all 9 scenarios.
+
+### U2. End-to-end eval test in `tests/eval/grounding_regressions/`
+
+**Goal:** Prove the guard-narrowing fix prevents the documented misfire pattern end-to-end through the full agent loop, not just at the predicate level.
+
+**Requirements:** R1, R2, R3.
+
+**Dependencies:** U1.
+
+**Files:**
+- `crates/mika-agent/tests/eval/grounding_regressions/webhook_zero_tools_no_correlation.rs` (NEW) — sibling to `engine_correction_rejection.rs`.
+
+**Approach:**
+- Use the existing `EvalHarness` builder (`crates/mika-agent/tests/eval/harness.rs` — pattern documented in mika/CLAUDE.md) with `MockLlmProvider` to drive a synthetic agent turn.
+- The mock LLM returns a text-only EndTurn for a `[GitHub] Check suite success on ...` user message.
+- Assert that the engine does NOT inject the `webhook_zero_tools` correction message — i.e., no second LLM call is made.
+- Repeat for `[GitHub] PR closed:` and `[GitHub] discussion.` prefixes.
+- Negative-case test: a text-only EndTurn for `[GitHub] Check suite failure on ...` STILL triggers the correction injection (regression check on R5).
+
+**Patterns to follow:**
+- `crates/mika-agent/tests/eval/grounding_regressions/engine_correction_rejection.rs` — sibling test that exercises the `webhook_ready_label_dispatch` intent-guard's correction path. The new test inverts that pattern: assert correction is NOT injected for the three skipped prefixes.
+- `EvalHarness` builder documented in mika/CLAUDE.md § Testing.
+
+**Test scenarios:**
+- `[GitHub] Check suite success on senara-solutions/mika (branch: main)` + text-only EndTurn → no correction injection, no second LLM call.
+- `[GitHub] PR closed: senara-solutions/mika#999 — title (branch: foo)` + text-only EndTurn → no correction injection.
+- `[GitHub] discussion.created on senara-solutions/mika` + text-only EndTurn → no correction injection.
+- **Regression:** `[GitHub] Check suite failure on senara-solutions/mika (branch: fix/foo)` + text-only EndTurn → correction IS injected → second LLM call attempted.
+
+**Verification:** `cargo test -p mika-agent --test eval -- grounding_regressions::webhook_zero_tools_no_correlation` passes all four scenarios.
+
+### U3. Update guard doc comment + reference mika#1469
+
+**Goal:** Future maintainers reading the guard registry understand the prefix skip-list rationale without needing to re-derive it.
+
+**Requirements:** documentation hygiene.
+
+**Dependencies:** U1.
+
+**Files:**
+- `crates/mika-agent/src/agent.rs` — extend the doc comment above the `webhook_zero_tools` IntentPrecondition entry.
+
+**Approach:**
+- One-paragraph addition citing mika#1469 (this fix), naming the three skipped prefix classes, and noting that correlation-aware filtering for the long tail is a deferred follow-up.
+
+**Test expectation: none — pure doc comment change.**
+
+**Verification:** the comment is present and grammatically clean; covered by review-time read.
+
+## Risks & Dependencies
+
+- **Risk: A new event class is added in the future** that ALSO is always informational, and contributors forget to add it to the skip list. **Mitigation:** the skip list lives next to the trigger predicate function with a clear comment; the eval-test corpus uses the same string literals as `webhook_dispatch::tests`, so any new event class added to the routing layer will surface in the test corpus at the same time.
+- **Risk: A skipped prefix matches an action-bearing event** the issue body didn't list. **Mitigation:** the three skipped prefixes (`Check suite success`, `PR closed`, `discussion.*`) are by construction informational — there's no agent action that should follow a successful CI or a closed PR or a discussion event. If a counter-example surfaces in production, the fix is to remove that prefix from the skip list and re-tighten with correlation-aware filtering.
+- **Dependency: `webhook_dispatch::tests` corpus is stable.** The test fixtures use the canonical message shapes from `webhook_dispatch.rs:60-184`. If those shapes change without a sibling test update, the regression tests here may falsely pass against a stale corpus. **Mitigation:** the test file imports or copies the literal strings directly from `webhook_dispatch`'s test module where possible.
+
+## Open Questions (deferred to execution)
+
+- Whether the `webhook_zero_tools_trigger` function should live in `agent.rs` alongside the other named triggers, or be extracted to a sibling module if `agent.rs` is already at its line-count budget. Resolved at execution time by checking file size — current `agent.rs` is 10k lines per mika#1259, so a small addition here is acceptable.
+- Exact wording of the correction message — current message stays as-is for this slice; future prompt-cleanup pass owns rewording.
+
+## Sources & Research
+
+- **Origin:** GitHub issue mika#1469 — `bug(engine): engine guard misfires on webhook events with no correlated work item`.
+- **Pinned guard source:** `crates/mika-agent/src/agent.rs:5852-5862` (the `webhook_zero_tools` IntentPrecondition entry).
+- **Pinned routing source:** `crates/mika-agent/src/webhook_dispatch.rs:30-184` (the message prefix shapes + the existing `is_unauthorized_webhook_dispatch` / `is_ready_label_dispatch_marker` predicates).
+- **Sibling guards:** `webhook_ready_label_dispatch` (agent.rs:5805), `webhook_no_unauthorized_dispatch` (agent.rs:5820), `resume_reconcile`, `callback_terminal_action`, `deferred_dispatch_action`.
+- **Test pattern reference:** `crates/mika-agent/tests/eval/grounding_regressions/engine_correction_rejection.rs`.
+- **Orthogonal sibling ticket:** mika#1324 — `dispatch_arg_match` reframed in grooming as tool-fabrication at request-assembly. Fix layer: tool-filter, not guard-trigger. Confirmed orthogonal to this fix; both can ship independently.
+- **Grooming history:**
+  - First-pass review session: `557a7808-17f2-4f7e-bcfe-25e8df3021d9`
+  - Brief iterations: initial brief (ITERATE — 4 findings) → revised brief with pinned source (ITERATE — 2 sharpening findings) → final pin via direct source reading (this plan)


### PR DESCRIPTION
Closes mika#1469. Implements the groomed plan at `docs/plans/2026-06-09-004-fix-1469-webhook-zero-tools-guard-prefix-narrowing-plan.md`.

## What

Narrows the `webhook_zero_tools` intent-precondition guard at `crates/mika-agent/src/agent.rs:5852` so it skips three documented always-informational prefix classes:

- `[GitHub] Check suite success on ...`
- `[GitHub] PR closed: ...`
- `[GitHub] discussion.*`

All other `[GitHub]` events (Issue labeled, Check suite failure, PR review, PR opened, New comment on, non-ready labels) continue to fire the guard unchanged — these are potentially action-bearing.

## Why

25+ documented misfires (per `current_priorities` core memory as of 2026-06-09) where the guard pressured the agent to call a tool on no-op events — most commonly CI-success on `main` with no active work, out-of-band PR-closed events, and GitHub discussion events. Each misfire was the agent making a noise `list_tasks` call just to satisfy the guard, violating dispatch discipline.

## How (decisions)

- **Prefix-based skip, not correlation lookup** (KTD1) — the trigger function inspects the message prefix directly, no DB lookup at message-construction time. Correlation-aware filtering for the long tail is deferred.
- **Trigger signature unchanged** (KTD2) — stays `fn(&str) -> bool`. Avoids invasive change to 10+ other guards.
- **Single function-pointer change** (KTD3) — no new types, no new modules.

## Test plan

- [x] 9 inline unit-test assertions on `webhook_zero_tools_trigger` (3 skip + 5 regression-fire + 1 non-GitHub fallthrough). All pass.
- [x] 4 new end-to-end eval scenarios in `tests/eval/grounding_regressions/webhook_zero_tools_no_correlation.rs` (3 no-correction-injection + 1 regression-fire). All pass.
- [x] Updated existing `webhook_milestone_advance_no_marker_no_fire` test to reflect post-#1469 behavior: `[GitHub] PR closed:` now produces a 1-step trace (text-only acknowledgement) instead of the previous 3-step zero-tools-retry shape. Test rationale documented in the test's comment.
- [x] Full `cargo test --workspace` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

## Deferred (follow-up)

- **Correlation-aware filtering** for CI failure on untracked branches, PR review on out-of-band PRs, issue_comment closures on already-merged PRs. These require message-construction-time DB lookups; triage after empirical data on whether the three-prefix skip is sufficient.
- **Prompt-side language realignment** with the narrower guard.

## Grooming history

- **Plan**: `docs/plans/2026-06-09-004-fix-1469-webhook-zero-tools-guard-prefix-narrowing-plan.md`
- **First-pass session** `557a7808-17f2-4f7e-bcfe-25e8df3021d9`: two ITERATE rounds (4 findings → 2 sharpening) → final pin via direct source read of `webhook_dispatch.rs:30-184`
- **Second-pass**: GROOMED

## Implementation history

Auto-implemented via the autonomous loop (claude-pilot). Post-flight recovery (mika#1282) auto-staged the work as `wip(...)` after a regression surfaced in the existing `webhook_milestone_advance_no_marker_no_fire` test. Orchestrator-CC reviewed, updated the test to reflect the new behavior, amended the commit with a proper message, and promoted the draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)