### PR TITLE
chore(labels): add operator-gated routing class to taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -103,6 +103,10 @@
   color: "2ea44f"
   description: Approved for autonomous dispatch
 
+- name: operator-gated
+  color: "8a2be2"
+  description: "Groomed work requiring operator-host-time. Distinct from parked/blocked. No ready label."
+
 - name: pipeline-exempt
   color: "bfdadc"
   description: "Docs-only or non-code PR exempt from pipeline gates"


### PR DESCRIPTION
Mirrors mika-cloud#118 — codifies the `operator-gated` routing class in mika's label taxonomy.

**Class:** work groomed and defined but requiring operator-host-time to execute (live K8s, hardware testing, host-bound verifications). Distinct from `parked` (post-freeze deferred) and `blocked` (waiting on dependency).

**Filing discipline:** file fully groomed; apply `operator-gated` label; do NOT apply `ready` (autonomous-loop dispatch is structurally inappropriate for host-bound work); surface on next operator-presence.

Memory: `feedback_operator_host_time_gated_class` codifies the doctrine. Founding incident: mika-cloud#117.

Companion PR: senara-solutions/mika-cloud#118

Pipeline-Exempt: no-plan, code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)