### PR TITLE
fix: demote 'skills loaded' log from INFO to DEBUG

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -189,7 +189,7 @@ Git-based and local skill distribution via `mika skills install/uninstall/update
 
 **Oversized prompt handling (#630):** Skills with prompts exceeding their size limit are hard-skipped at scan time (pushed to `ScanResult.skipped`) regardless of `always_on` status. This prevents zombie skills with tools but no prompt context. Tool-only skills (no `system_prompt.md`) are unaffected — they load with an empty prompt via `SnippetLoadResult::Empty`.
 
-**Startup logging:** `SkillRegistry::log_summary()` emits a three-state `INFO` line (`loaded=N disabled=N skipped=N`) plus per-skip `WARN` lines. Call after both `apply_overrides()` and `apply_load_safety_check()` for accurate counts.
+**Startup logging:** `SkillRegistry::log_summary()` emits a three-state `DEBUG` line (`loaded=N disabled=N skipped=N`) plus per-skip `WARN` lines. Call after both `apply_overrides()` and `apply_load_safety_check()` for accurate counts.
 
 **Validation:** `validate_skill()` checks name-in-keywords rejection (#510), markdown validation (#511), required_tools references, context types, and `{{key}}` placeholders. **Load-time crash-protection (#530, #1335):** `SkillRegistry::apply_load_safety_check()` runs `validate_skill()` on every loaded skill after `apply_overrides()`. This is NOT the validation gate — CI and `mika skills validate` own change-time validation. This method is a runtime safety net that prevents malformed manifests from crashing the agent. Decision matrix: missing handler/broken tools.json → skip skill entirely; deprecated `[llm]` section/name-in-keywords/invalid markdown → load with warning. Results stored in `validated_warnings` for TUI/CLI display. `is_skip_worthy_failure()` classifies Fail diagnostics.
 

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -217,10 +217,10 @@ impl SkillRegistry {
     /// Call **after** both [`apply_overrides()`](Self::apply_overrides) and
     /// [`apply_load_safety_check()`](Self::apply_load_safety_check) so the counts reflect the
     /// final registry state (validation may promote broken skills to skipped).
-    /// Emits one `INFO` summary line and a per-skip `WARN` line for each
+    /// Emits one `DEBUG` summary line and a per-skip `WARN` line for each
     /// skipped skill.
     pub fn log_summary(&self) {
-        tracing::info!(
+        tracing::debug!(
             loaded = self.skills.len(),
             disabled = self.disabled.len(),
             skipped = self.skipped.len(),

--- a/docs/plans/2026-06-12-002-fix-demote-skills-loaded-log-plan.md
+++ b/docs/plans/2026-06-12-002-fix-demote-skills-loaded-log-plan.md
@@ -1,0 +1,51 @@
+---
+title: "fix: Demote 'skills loaded' log from INFO to DEBUG"
+date: 2026-06-12
+type: fix
+origin: "GitHub issue #619"
+status: draft
+---
+
+## Summary
+
+Demote the `skills loaded` log line in `SkillRegistry::log_summary()` from `tracing::info!` to `tracing::debug!` so it no longer pollutes stderr on every CLI subcommand invocation under the default `info` log level.
+
+## Problem Frame
+
+Running any CLI subcommand (e.g., `mika skills list | grep qa`) prints a noisy `INFO skills loaded count=N names=[...]` line to stderr. While stderr correctly bypasses pipes, it clutters the terminal. The root cause is `log_summary()` emitting at INFO unconditionally — including short-lived read-only CLI commands where `log_level = "info"` is the default.
+
+## Requirements
+
+- R1. `tracing::info!` → `tracing::debug!` at the "skills loaded" summary line
+- R2. Per-skip `tracing::warn!` lines remain unchanged
+- R3. `crates/mika-agent/CLAUDE.md` updated to reflect the new level
+- R4. `mika skills list` no longer prints "skills loaded" at default log level
+- R5. `RUST_LOG=debug` or `log_level=debug` still shows the line
+
+## Key Technical Decisions
+
+- **KTD-1: debug, not trace.** The information is useful for diagnosing skill loading issues but not needed in normal operation. `debug` is the correct level — visible when requested, silent by default.
+
+## Implementation Units
+
+### U1. Demote log level and update doc
+
+**Goal:** Change one `tracing::info!` macro call and update the corresponding CLAUDE.md reference.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- `crates/mika-agent/src/skills/mod.rs` (modify)
+- `crates/mika-agent/CLAUDE.md` (modify)
+
+**Approach:** Change `tracing::info!` to `tracing::debug!` at `log_summary()`. Update the doc comment above the method and the CLAUDE.md "Startup logging" paragraph from "INFO" to "DEBUG".
+
+**Patterns to follow:** Existing `tracing::debug!` usage throughout the crate.
+
+**Test scenarios:**
+- Verify `tracing::warn!` per-skip lines are unchanged (code inspection)
+- Verify the doc comment and CLAUDE.md reference say DEBUG, not INFO
+
+**Verification:** `cargo clippy` and `cargo test -p mika-agent` pass. Grep confirms no remaining `info!` at the "skills loaded" callsite.


### PR DESCRIPTION
## Summary

- Demotes the `SkillRegistry::log_summary()` log line from `tracing::info!` to `tracing::debug!` to eliminate CLI noise on every subcommand invocation
- Updates doc comment and `crates/mika-agent/CLAUDE.md` to reflect the new level
- Per-skip `tracing::warn!` lines remain unchanged

Closes #619

## Test plan

- [x] `cargo clippy -p mika-agent` — clean
- [x] `cargo test -p mika-agent --lib -- skills` — 879 tests pass
- [x] Pre-commit hooks pass (fmt, clippy, secrets, file-size)
- [ ] `mika skills list` no longer prints "INFO skills loaded" at default log level
- [ ] `RUST_LOG=debug mika skills list` still shows the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)