### PR TITLE
wip(mika#965): rescued impl (dispatch-lib recovery)

### DIFF
--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -942,6 +942,35 @@ impl AsyncDatabase {
         .await
     }
 
+    /// Insert a single row into `task_messages` without a transaction (mika#965).
+    /// Used by the dispatcher for engine-internal task narrative that should NOT
+    /// appear in `messages`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn insert_task_message(
+        &self,
+        task_id: &str,
+        agent_id: &str,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        metadata: Option<&str>,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        let (tid, aid, sid, r, c, m, t) = (
+            task_id.to_owned(),
+            agent_id.to_owned(),
+            session_id.to_owned(),
+            role.to_owned(),
+            content.to_owned(),
+            metadata.map(|s| s.to_owned()),
+            trace_id.map(|s| s.to_owned()),
+        );
+        self.with_db(move |db| {
+            db.insert_task_message(&tid, &aid, &sid, &r, &c, m.as_deref(), t.as_deref())
+        })
+        .await
+    }
+
     /// Load all task messages for a given task, ordered by creation time.
     pub async fn load_task_messages(&self, task_id: &str) -> Result<Vec<TaskMessage>> {
         let tid = task_id.to_owned();

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -7227,6 +7227,28 @@ impl Database {
         Ok(tx.last_insert_rowid())
     }
 
+    /// Insert a single row into `task_messages` without a transaction.
+    /// Used by the dispatcher to write engine-internal task narrative (e.g., callback
+    /// summaries) that should NOT appear in `messages` (mika#965).
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_task_message(
+        &self,
+        task_id: &str,
+        agent_id: &str,
+        session_id: &str,
+        role: &str,
+        content: &str,
+        metadata: Option<&str>,
+        trace_id: Option<&str>,
+    ) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO task_messages (task_id, agent_id, session_id, role, content, metadata, trace_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![task_id, agent_id, session_id, role, content, metadata, trace_id],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
     /// Double-write: insert into `messages` AND `task_messages` in a single transaction.
     /// When `task_id` is `None`, behaves identically to `save_message_with_metadata`
     /// (no transaction overhead, no `task_messages` row).
@@ -17684,6 +17706,57 @@ mod tests {
         assert_eq!(task_msgs[0].content, "first");
         assert_eq!(task_msgs[1].content, "second");
         assert_eq!(task_msgs[2].content, "third");
+    }
+
+    #[test]
+    fn test_insert_task_message_standalone() {
+        let (db, sid) = db_with_session();
+        let task_id = "task-standalone";
+
+        let row_id = db
+            .insert_task_message(
+                task_id,
+                "mika",
+                &sid,
+                "system",
+                "Callback completed: session=abc, turns=5",
+                Some(r#"{"claude_pilot":{"session_id":"abc","turns":5}}"#),
+                Some("trace-123"),
+            )
+            .unwrap();
+        assert!(row_id > 0);
+
+        let msgs = db.load_task_messages(task_id).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].task_id, task_id);
+        assert_eq!(msgs[0].agent_id, "mika");
+        assert_eq!(msgs[0].session_id, sid);
+        assert_eq!(msgs[0].role, "system");
+        assert_eq!(msgs[0].content, "Callback completed: session=abc, turns=5");
+        assert!(
+            msgs[0]
+                .metadata
+                .as_deref()
+                .unwrap()
+                .contains("claude_pilot")
+        );
+        assert_eq!(msgs[0].trace_id.as_deref(), Some("trace-123"));
+    }
+
+    #[test]
+    fn test_insert_task_message_with_none_optional_fields() {
+        let (db, sid) = db_with_session();
+        let task_id = "task-none-fields";
+
+        let row_id = db
+            .insert_task_message(task_id, "mika", &sid, "system", "summary", None, None)
+            .unwrap();
+        assert!(row_id > 0);
+
+        let msgs = db.load_task_messages(task_id).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].metadata.is_none());
+        assert!(msgs[0].trace_id.is_none());
     }
 
     /// Happy-path replay: simulate a milestone dispatch with multiple children.

--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -406,6 +406,9 @@ impl TaskDispatcher {
         // are captured even if the agent exhausts its step budget.
         if is_callback {
             try_extract_callback_metadata(&self.db, task).await;
+            // mika#965: Write a human-readable callback summary to task_messages
+            // so the dispatch session's next rebuild_context() includes it.
+            try_write_callback_summary(&self.db, task).await;
             // #958: If the callback carries a pr_url (success indicator) and the
             // parent was reaped to `failed`, promote it back to `completed`.
             try_promote_parent_on_retry_success(&self.db, task).await;
@@ -1433,6 +1436,110 @@ async fn try_extract_callback_metadata(db: &AsyncDatabase, task: &Task) {
     }
 }
 
+/// Write a human-readable callback summary to `task_messages` keyed to the
+/// scope-root task_id (mika#965).
+///
+/// This closes the narrative gap where `rebuild_context()` merges `task_messages`
+/// but no callback outcome was ever written there. The dispatch session's next
+/// turn sees the callback result in its rebuilt context.
+///
+/// Best-effort, fire-and-forget — same pattern as `try_extract_callback_metadata`.
+async fn try_write_callback_summary(db: &AsyncDatabase, task: &Task) {
+    // 1. Need a parent to resolve scope root from.
+    let parent_id = match &task.parent_task_id {
+        Some(id) => id.clone(),
+        None => return,
+    };
+
+    // 2. Parse result text — if empty or no extractable fields, nothing to write.
+    let result = match &task.result {
+        Some(r) if !r.is_empty() => r,
+        _ => return,
+    };
+
+    let extracted = extract_callback_fields(result);
+    if extracted.is_null() {
+        return;
+    }
+
+    // 3. Resolve scope root — the task_messages row is keyed to the scope root
+    //    so the dispatching session's rebuild_context() picks it up.
+    let scope_root_id = match db.resolve_scope_root_task_id(&parent_id).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // No scope root — parent is not part of a scoped hierarchy.
+            // Fall back to parent_id itself so the summary still lands
+            // somewhere the dispatch session can read.
+            parent_id.clone()
+        }
+        Err(e) => {
+            warn!(
+                parent_task_id = %parent_id,
+                callback_task_id = %task.id,
+                error = %e,
+                "callback_summary: failed to resolve scope root"
+            );
+            return;
+        }
+    };
+
+    // 4. Build human-readable summary from extracted fields.
+    let pilot = &extracted["claude_pilot"];
+    let mut parts = Vec::new();
+
+    if let Some(s) = pilot.get("session_id").and_then(|v| v.as_str()) {
+        parts.push(format!("session={s}"));
+    }
+    if let Some(n) = pilot.get("turns").and_then(|v| v.as_u64()) {
+        parts.push(format!("turns={n}"));
+    }
+    if let Some(c) = pilot.get("cost_usd").and_then(|v| v.as_f64()) {
+        parts.push(format!("cost=${c:.2}"));
+    }
+    if let Some(d) = pilot.get("duration_ms").and_then(|v| v.as_u64()) {
+        parts.push(format!("duration={d}ms"));
+    }
+    if let Some(url) = pilot.get("pr_url").and_then(|v| v.as_str()) {
+        parts.push(format!("PR: {url}"));
+    }
+
+    if parts.is_empty() {
+        return;
+    }
+
+    let summary = format!("Callback completed: {}", parts.join(", "));
+
+    // 5. Use the callback's session as the session_id for the task_message row.
+    let session_id = task.created_by_session.as_deref().unwrap_or("callback");
+    let trace_id = task.execution_trace_id.as_deref();
+    let metadata_json = extracted.to_string();
+
+    match db
+        .insert_task_message(
+            &scope_root_id,
+            &task.agent_id,
+            session_id,
+            "system",
+            &summary,
+            Some(&metadata_json),
+            trace_id,
+        )
+        .await
+    {
+        Ok(_) => info!(
+            scope_root_id = %scope_root_id,
+            callback_task_id = %task.id,
+            "callback_summary: wrote summary to task_messages"
+        ),
+        Err(e) => warn!(
+            scope_root_id = %scope_root_id,
+            callback_task_id = %task.id,
+            error = %e,
+            "callback_summary: failed to write summary to task_messages"
+        ),
+    }
+}
+
 /// Promote the parent task from `failed` → `completed` when a retry callback
 /// succeeds (#958).
 ///
@@ -2388,6 +2495,280 @@ mod tests {
         let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
         // Should not panic or error — just returns early
         try_extract_callback_metadata(&db, &task).await;
+    }
+
+    // ===== try_write_callback_summary tests (mika#965) =====
+
+    #[tokio::test]
+    async fn test_callback_summary_writes_to_scope_root() {
+        let db = test_db();
+
+        // Create a manual parent task (acts as scope root)
+        let parent = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "Implement feature #965".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: Some("self_dev".to_string()),
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let parent_id = db.create_task(parent).await.unwrap();
+
+        // Create a callback child with result text including pr_url
+        let callback = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.clone()),
+            depth: 1,
+            label: "run_claude_pilot".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("session-cb-1".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let callback_id = db.create_task(callback).await.unwrap();
+        db.update_task_completed(
+            &callback_id,
+            Some(
+                "claude-pilot completed (status: done).\n\
+                 Session: test-session-abc\n\
+                 Turns: 42\n\
+                 Cost: $3.50\n\
+                 Duration: 120000ms\n\
+                 PR: https://github.com/senara-solutions/mika/pull/999",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+        try_write_callback_summary(&db, &task).await;
+
+        // Verify task_messages row was written keyed to the parent (scope root)
+        let msgs = db.load_task_messages(&parent_id).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "system");
+        assert!(msgs[0].content.contains("session=test-session-abc"));
+        assert!(msgs[0].content.contains("turns=42"));
+        assert!(msgs[0].content.contains("cost=$3.50"));
+        assert!(msgs[0].content.contains("duration=120000ms"));
+        assert!(
+            msgs[0]
+                .content
+                .contains("PR: https://github.com/senara-solutions/mika/pull/999")
+        );
+        // Metadata should contain the extracted JSON
+        let meta: serde_json::Value =
+            serde_json::from_str(msgs[0].metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["claude_pilot"]["session_id"], "test-session-abc");
+        assert_eq!(meta["claude_pilot"]["turns"], 42);
+    }
+
+    #[tokio::test]
+    async fn test_callback_summary_noop_no_parent() {
+        let db = test_db();
+
+        // Callback with no parent — should silently return
+        let callback = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "run_claude_pilot".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let callback_id = db.create_task(callback).await.unwrap();
+        db.update_task_completed(&callback_id, Some("Session: abc\nTurns: 10"))
+            .await
+            .unwrap();
+
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+        // Should not panic or error — just returns early
+        try_write_callback_summary(&db, &task).await;
+    }
+
+    #[tokio::test]
+    async fn test_callback_summary_noop_empty_result() {
+        let db = test_db();
+
+        let parent = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "parent".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let parent_id = db.create_task(parent).await.unwrap();
+
+        let callback = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.clone()),
+            depth: 1,
+            label: "run_claude_pilot".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let callback_id = db.create_task(callback).await.unwrap();
+        // Complete with empty result — no fields extractable
+        db.update_task_completed(&callback_id, Some(""))
+            .await
+            .unwrap();
+
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+        try_write_callback_summary(&db, &task).await;
+
+        // No task_messages should be written
+        let msgs = db.load_task_messages(&parent_id).await.unwrap();
+        assert!(msgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_callback_summary_handles_missing_optional_fields() {
+        let db = test_db();
+
+        let parent = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "groom task".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let parent_id = db.create_task(parent).await.unwrap();
+
+        let callback = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.clone()),
+            depth: 1,
+            label: "run_claude_pilot_groom".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("session-groom".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let callback_id = db.create_task(callback).await.unwrap();
+        // Groom callback — no pr_url, just session and turns
+        db.update_task_completed(&callback_id, Some("Session: groom-123\nTurns: 15"))
+            .await
+            .unwrap();
+
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+        try_write_callback_summary(&db, &task).await;
+
+        let msgs = db.load_task_messages(&parent_id).await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].content.contains("session=groom-123"));
+        assert!(msgs[0].content.contains("turns=15"));
+        // Should NOT contain pr_url since it's not in the result
+        assert!(!msgs[0].content.contains("PR:"));
     }
 
     // ===== is_team_child_callback predicate tests =====

--- a/docs/plans/2026-06-12-006-feat-965-callback-summary-task-messages-plan.md
+++ b/docs/plans/2026-06-12-006-feat-965-callback-summary-task-messages-plan.md
@@ -1,0 +1,113 @@
+---
+title: "feat: append callback summary to task_messages for dispatch session continuity"
+date: 2026-06-12
+type: feat
+origin: "mika#965"
+depth: Lightweight
+---
+
+# feat: append callback summary to task_messages for dispatch session continuity
+
+## Summary
+
+After `try_extract_callback_metadata()` parses structured fields from a callback result (session_id, turns, cost_usd, duration_ms, pr_url), write a summary message directly to `task_messages` keyed to the scope-root task_id. This closes the narrative gap where the dispatching session's `rebuild_context()` merges `task_messages` but no callback outcome was ever written there — the dispatch session's next turn sees the callback result in its rebuilt context.
+
+## Problem Frame
+
+mika#974 shipped the `task_messages` parallel narrative table and the `rebuild_context()` merge path. The agent's context assembly now reads from `task_messages` when a `scope_task_id` resolves. However, the callback delivery path in `dispatcher.rs` writes extracted metadata only to `tasks.metadata` (via `try_extract_callback_metadata`, line 1375). No code path writes a human-readable summary to `task_messages`. The dispatch session's next context rebuild therefore has no record of what the callback produced — no PR URL, no cost, no outcome status.
+
+This is a correctness gap independent of any concurrency framing: even in a fully sequential loop, "the callback summary should land in a way the originating dispatch session can read" is unmet.
+
+## Requirements
+
+- **R1.** After successful callback metadata extraction, a structured summary message is written to `task_messages` with the scope-root `task_id` as key.
+- **R2.** The summary includes all fields extracted by `extract_callback_fields()`: `session_id`, `turns`, `cost_usd`, `duration_ms`, `pr_url` (when present).
+- **R3.** The write is best-effort, fire-and-forget — matches the existing `try_extract_callback_metadata()` error discipline (warn on failure, never blocks callback dispatch).
+- **R4.** The summary is written to `task_messages` only (not to `messages`) — it is engine-internal task narrative, not a conversation message.
+- **R5.** Scope-root resolution reuses the existing `resolve_scope_root_task_id()` walker — no new hierarchy traversal logic.
+
+## Key Technical Decisions
+
+**KTD-1: task_messages-only write (not double-write).** The callback summary is engine-internal narrative for task continuity, not a conversation message. Writing to `messages` would pollute channel history. A new `insert_task_message()` method (standalone, non-transactional) on `Database` and `AsyncDatabase` exposes the existing `INSERT INTO task_messages` without the `messages` double-write. This method is `pub` so the dispatcher can call it directly.
+
+**KTD-2: role = "system" for callback summaries.** The summary is engine-generated, not user or assistant content. Using `role = "system"` distinguishes it from agent-authored narrative in `rebuild_context()` output. Matches the session creation pattern in `dispatch_resume_agent()` which uses `"system"` channel type.
+
+**KTD-3: Write site is immediately after metadata extraction.** The summary write fires at `dispatcher.rs` line ~1433, right after `try_extract_callback_metadata()` persists to `tasks.metadata`. This location guarantees the extracted fields are available and the parent task has been verified. It runs BEFORE the silent agent turn, so the callback turn's `rebuild_context()` already includes the summary.
+
+**KTD-4: Idempotency via content shape.** No explicit dedup key — the write fires once per callback delivery (the `dispatch_resume_agent` path is single-entry per task). The `task_messages` table is append-only; a duplicate on restart retry is acceptable (the content is identical, and `rebuild_context()` dedup on `(session_id, role, content, created_at)` handles it).
+
+## Scope Boundaries
+
+### In scope
+- New `insert_task_message` / `insert_task_message_async` methods
+- New `try_write_callback_summary_to_task_messages()` function in dispatcher
+- Tests for the new write path
+
+### Deferred to Follow-Up Work
+- PR-review write-back (mika-qa → mika-dev) — separate ticket if needed
+- Scheduled task / cron firing write-back
+- Cross-agent dispatch summaries
+- Dashboard UI for task-narrative views
+
+---
+
+## Implementation Units
+
+### U1. Add standalone `insert_task_message` to Database and AsyncDatabase
+
+**Goal:** Expose a public, non-transactional `INSERT INTO task_messages` method that the dispatcher can call without the `messages` double-write.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- `crates/mika-agent/src/db.rs` — new `pub fn insert_task_message()`
+- `crates/mika-agent/src/async_db.rs` — new `pub async fn insert_task_message()`
+- `crates/mika-agent/src/db.rs` (test module) — unit test
+
+**Approach:** Extract the SQL from the existing `insert_task_message_tx` but operate on `self.conn` directly instead of a caller-provided transaction. Signature: `(task_id, agent_id, session_id, role, content, metadata, trace_id) -> Result<i64>`. The async wrapper follows the standard `with_db` closure pattern already used by `save_message_with_task_context`.
+
+**Patterns to follow:** `save_message_with_metadata` (non-transactional single insert), `load_task_messages` async wrapper.
+
+**Test scenarios:**
+- Insert a task message and verify it appears in `load_task_messages()` output with correct fields
+- Insert with `None` metadata and trace_id — verify no crash and fields are NULL
+
+### U2. Write callback summary to task_messages after metadata extraction
+
+**Goal:** After `try_extract_callback_metadata()` succeeds, resolve the scope-root task_id and write a structured summary to `task_messages`.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- `crates/mika-agent/src/task_engine/dispatcher.rs` — new `try_write_callback_summary()` async fn, call site after line ~1408
+- `crates/mika-agent/tests/eval/` or inline test module — integration test
+
+**Approach:** New async function `try_write_callback_summary(db: &AsyncDatabase, task: &Task)` in `dispatcher.rs`. Steps:
+1. Guard: `parent_task_id` must exist (same guard as `try_extract_callback_metadata`)
+2. Parse result via `extract_callback_fields()` (reuse, not re-parse — or accept the extracted `serde_json::Value` as parameter to avoid double-parsing)
+3. Resolve scope-root via `db.resolve_scope_root_task_id(parent_id)` — if `None`, return silently (no scope root = no task narrative to append to)
+4. Format summary content as a human-readable string (e.g., `"Callback completed: session=<id>, turns=<n>, cost=$<usd>, duration=<ms>ms, PR: <url>"`)
+5. Call `db.insert_task_message(scope_root_id, agent_id, callback_session_id, "system", summary_content, Some(extracted_json), trace_id)`
+6. Log success/failure at info/warn level, matching `try_extract_callback_metadata` discipline
+
+Call site: `dispatcher.rs` in `dispatch_resume_agent()`, immediately after `try_extract_callback_metadata(&self.db, task).await` (line ~408). The function is fire-and-forget — errors are logged, never propagated.
+
+**Design consideration:** To avoid double-parsing the callback result, either (a) have `try_extract_callback_metadata` return the extracted `Value` so the caller can pass it to `try_write_callback_summary`, or (b) accept the minor cost of re-parsing (the result text is small, O(1KB)). Option (b) is simpler and matches the existing fire-and-forget pattern where each function is self-contained.
+
+**Patterns to follow:** `try_extract_callback_metadata` (guard structure, fire-and-forget error handling, logging pattern), `try_promote_parent_on_retry_success` (sibling best-effort function).
+
+**Test scenarios:**
+- Callback with parent task and valid result — verify `task_messages` row written with scope-root task_id, role "system", and content containing PR URL
+- Callback with no parent task — verify no write, no error
+- Callback with parent but no scope root resolvable — verify no write, no error
+- Callback with empty result — verify no write
+- Verify the summary content includes all extracted fields (session_id, turns, cost_usd, duration_ms, pr_url) when present
+- Verify the summary content gracefully handles missing optional fields (e.g., no pr_url on groom callbacks)
+
+## Open Questions
+
+None — the approach follows established precedent (`try_extract_callback_metadata` pattern) and uses shipped infrastructure (`task_messages`, `resolve_scope_root_task_id`).


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: dirty-worktree)

This PR was created by dispatch-lib's git-workflow recovery.

The dev-pilot session wrote file changes but never completed the git workflow (no `git commit` or `gh pr create`). Per the mika#1271 content/workflow split contract, dispatch-lib took ownership of the git layer: staged, committed with `wip()` prefix, pushed, and opened this draft PR to preserve the content.

**This is a draft PR requiring human review.** The content has NOT passed `/ce:review` and may contain partially-coherent multi-file changes.

### Recovery metadata
- Recovery class: `dirty-worktree`
- Pilot session: `28ba036c-df4e-4f25-9090-acd5da47ef55`
- Turns: 39
- Cost: $3.7174061999999997

Closes #965