### PR TITLE
fix(ci): trackedIssues GraphQL hotfix (#527 follow-up)

### DIFF
--- a/scripts/check-pr-body-consistency.sh
+++ b/scripts/check-pr-body-consistency.sh
@@ -59,12 +59,14 @@ add_error() {
 get_open_sub_issues() {
     local parent_number="$1"
     local query
+    # GitHub's GraphQL `trackedIssues` field doesn't accept a `states` argument
+    # (mika#527 hotfix). Fetch all and filter to OPEN client-side via jq.
     query='query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $number) {
-      trackedIssues(first: 50, states: OPEN) {
+      trackedIssues(first: 50) {
         totalCount
-        nodes { number }
+        nodes { number state }
       }
     }
   }
@@ -91,10 +93,11 @@ get_open_sub_issues() {
     local total_count
     total_count="$(echo "$result" | jq -r '.data.repository.issue.trackedIssues.totalCount')"
     if [[ "$total_count" -gt 50 ]]; then
-        echo "WARNING: Issue #${parent_number} has ${total_count} open sub-issues; only the first 50 are checked." >&2
+        echo "WARNING: Issue #${parent_number} has ${total_count} tracked sub-issues; only the first 50 are inspected." >&2
     fi
 
-    echo "$result" | jq -r '.data.repository.issue.trackedIssues.nodes[].number'
+    # Filter to OPEN sub-issues (states arg not supported on trackedIssues — mika#527 hotfix)
+    echo "$result" | jq -r '.data.repository.issue.trackedIssues.nodes[] | select(.state == "OPEN") | .number'
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hotfix for the PR body validation script shipped via mika#527 / PR #1503.

The GraphQL query used `trackedIssues(first: 50, states: OPEN)` but `trackedIssues` doesn't accept a `states` argument — only `first`/`after`/`orderBy`. Every PR opened after #1503 merged failed the `validate` gate with:

\`\`\`
Field 'trackedIssues' doesn't accept argument 'states'
ERROR: GraphQL query failed for issue #N
\`\`\`

This was visible on PR #1505, blocking the autonomous loop's flow.

## Fix

- Drop `states: OPEN` from the GraphQL query
- Add `state` to each node in `nodes { number state }`
- Filter to OPEN in the jq downstream pipe: `| select(.state == "OPEN") | .number`
- Rename `total_count` warning text from "open sub-issues" to "tracked sub-issues" (since the pre-filter count includes closed too)

## Verification

\`\`\`
bash scripts/check-pr-body-consistency.sh 1505
PR body validation passed.
\`\`\`

Tested locally against PR #1505 (the failing case) — passes clean.

## Test plan

- [x] Local smoke against #1505
- [ ] CI `validate` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)