### PR TITLE
fix(mika#802): KG resolver + extractor graceful shutdown on SIGTERM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.9.12+spec-1.1.0",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.91"
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream"] }

--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -390,7 +390,9 @@ docs_roots = [
 
 **Sole-writer contract:** This module is the sole writer of `kg_subject_entities`, `kg_subject_relationships`, `kg_chunk_subjects`, `kg_chunk_subject_relationships`, and `kg_extractions` rows.
 
-**Execution contexts (D2):** (1) Startup: background `tokio::spawn` per agent after lexical ingestion, non-blocking. (2) Compound hook: synchronous inline after doc write via `IngestionOrchestrator`, failure non-fatal (C2.3 log-and-skip).
+**Execution contexts (D2):** (1) Startup: background `tokio::spawn` per agent after lexical ingestion, non-blocking. (2) Compound hook: synchronous inline after doc write via `IngestionOrchestrator`, failure non-fatal (C2.3 log-and-skip). (3) Periodic tick (#1052): runs as Phase 1 of `resolver_tick` every 30 minutes.
+
+**Graceful shutdown (mika#802):** The periodic tick loop accepts a `CancellationToken` (parent created in `server/mod.rs`, child tokens per agent). On SIGTERM, the parent token cancels all per-agent child tokens. The loop checks cancellation between iterations via `tokio::select!` and before starting each batch. In-flight LLM calls complete (bounded by reqwest timeout, typically <2s); remaining pending work is abandoned (not written). Half-extracted docs stay pending for the next startup. This prevents the OLD-binary-writes-under-stale-config drift documented in mika#802's incident.
 
 **Extraction flow (D1, D4):** Read full doc from disk → insert `[CHUNK N]` markers at chunk boundaries → LLM call → parse/validate JSON output → UPSERT entities and relationships with provenance in single transaction.
 
@@ -414,7 +416,9 @@ docs_roots = [
 
 **Two-stage pipeline (D1):** Stage 1: case-insensitive exact match against `kg_entities.entity_key`. If match found and extraction confidence > 0.9, resolve immediately (confidence = extraction_confidence). Stage 2: LLM disambiguation with candidate list (max 50) and source chunk prose context. Combined confidence = min(extraction_confidence, llm_confidence). Discovered types (solution_path, failure_mode, pattern) skip resolution entirely — no domain counterpart exists.
 
-**Execution contexts (D5):** (1) Startup: background `tokio::spawn` per agent after extraction tasks, non-blocking. (2) Compound hook: `IngestionOrchestrator` spawns async resolution after extraction commits. (3) Periodic tick (#906): `kg::resolver_tick::spawn_resolver_tick_task()` runs `resolve_pending(budget)` every 30 minutes per KG-enabled agent, decoupling drain rate from restart cadence. First fire skipped (startup spawn covers it). Fail-open (log-and-skip per C2.3). Lifecycle tied to tokio runtime drop (same pattern as `checkpoint_task`). Structured log events: `kg_resolver_tick.start`, `kg_resolver_tick.complete`, `kg_resolver_tick.error`.
+**Execution contexts (D5):** (1) Startup: background `tokio::spawn` per agent after extraction tasks, non-blocking. (2) Compound hook: `IngestionOrchestrator` spawns async resolution after extraction commits. (3) Periodic tick (#906): `kg::resolver_tick::spawn_resolver_tick_task()` runs `resolve_pending(budget)` every 30 minutes per KG-enabled agent, decoupling drain rate from restart cadence. First fire skipped (startup spawn covers it). Fail-open (log-and-skip per C2.3). Structured log events: `kg_resolver_tick.start`, `kg_resolver_tick.complete`, `kg_resolver_tick.error`.
+
+**Graceful shutdown (mika#802):** The periodic tick loop accepts a `CancellationToken` (parent created in `server/mod.rs`, child tokens per agent). On SIGTERM, the parent token cancels all per-agent child tokens. The loop checks cancellation between iterations via `tokio::select!` and before starting each batch. In-flight LLM calls complete (bounded by reqwest timeout, typically <2s); remaining pending work is abandoned (not written). Half-resolved subjects stay `pending` for the next startup. This prevents the OLD-binary-writes-under-stale-config drift documented in mika#802's incident (279-424 rows/agent written under stale `docs_root_hash` during a 3-5s deploy window).
 
 **Pending-entity detection (D4):** `kg_resolutions_log` tracking table with `UNIQUE(agent_id, subject_entity_id)`. Pending query: subject entities with well-known types that have no log row, or whose `source_extraction_trace_id` differs from the latest `kg_chunk_subjects` extraction.
 

--- a/crates/mika-agent/Cargo.toml
+++ b/crates/mika-agent/Cargo.toml
@@ -43,6 +43,7 @@ cron.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tower-http.workspace = true
 subtle.workspace = true
 secrecy.workspace = true

--- a/crates/mika-agent/src/kg/entity_resolver.rs
+++ b/crates/mika-agent/src/kg/entity_resolver.rs
@@ -192,6 +192,10 @@ pub struct SubjectEntityResolver {
     /// instead of `agent_id`. Writes to `kg_subject_resolutions` and
     /// `kg_resolutions_log` still use `agent_id` (per-agent).
     docs_root_hashes: Vec<String>,
+    /// Optional cancellation token for graceful shutdown (#802).
+    /// When set and cancelled, the per-entity resolution loop abandons
+    /// remaining work — half-resolved subjects stay pending for next startup.
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
 }
 
 impl SubjectEntityResolver {
@@ -225,7 +229,18 @@ impl SubjectEntityResolver {
             llm,
             trace_id,
             docs_root_hashes,
+            cancel_token: None,
         }
+    }
+
+    /// Set the cancellation token for graceful shutdown (#802).
+    ///
+    /// When cancelled, the per-entity resolution loop abandons remaining
+    /// work between LLM calls. In-flight calls complete (bounded by reqwest
+    /// timeout); unresolved subjects stay pending for next startup.
+    pub fn with_cancel_token(mut self, token: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel_token = Some(token);
+        self
     }
 
     /// Resolve entities produced by a single doc's extraction (D5).
@@ -354,6 +369,21 @@ impl SubjectEntityResolver {
         };
 
         for (i, entity) in entities.iter().enumerate() {
+            // Graceful shutdown: abandon remaining entities (#802).
+            if let Some(ref ct) = self.cancel_token
+                && ct.is_cancelled()
+            {
+                info!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    resolved_so_far = i,
+                    remaining = entities.len() - i,
+                    event = "kg_resolution_cancelled_mid_batch",
+                    "resolution abandoned mid-batch (graceful shutdown) — remaining subjects stay pending"
+                );
+                break;
+            }
+
             // Per-corpus fairness tracking (#927).
             *stats
                 .per_corpus_attempted

--- a/crates/mika-agent/src/kg/resolver_tick.rs
+++ b/crates/mika-agent/src/kg/resolver_tick.rs
@@ -33,6 +33,7 @@ use mika_common::llm::LlmProvider;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 /// Tick interval in seconds. Hard-coded for v1 (#906).
@@ -58,6 +59,7 @@ const RESOLVER_TICK_INTERVAL_SECS: u64 = 30 * 60;
 /// * `budget` — Per-batch LLM call cap (from `MIKA_KG_BATCH_BUDGET`).
 /// * `interval_secs` — Tick interval override (for testing). Pass `None` to
 ///   use the default 30-minute interval.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_resolver_tick_task(
     agent_id: String,
     db: AsyncDatabase,
@@ -66,6 +68,7 @@ pub fn spawn_resolver_tick_task(
     kg_config: &KgAgentConfig,
     budget: u32,
     interval_secs: Option<u64>,
+    cancel: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     let (docs_root_hashes, corpora_roots): (Vec<String>, Vec<PathBuf>) = match kg_config {
         KgAgentConfig::Enabled { corpora } => (
@@ -87,7 +90,22 @@ pub fn spawn_resolver_tick_task(
         interval.tick().await;
 
         loop {
-            interval.tick().await;
+            // Cooperative cancellation: exit between ticks on SIGTERM (#802).
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = cancel.cancelled() => {
+                    info!(
+                        agent_id = %agent_id,
+                        event = "kg_tick_cancelled",
+                        "KG resolver tick cancelled (graceful shutdown)"
+                    );
+                    return;
+                }
+            }
+            // Double-check before starting a potentially long batch.
+            if cancel.is_cancelled() {
+                return;
+            }
             tick_body(
                 &agent_id,
                 &db,
@@ -499,6 +517,7 @@ mod tests {
             &kg_config,
             500,
             Some(1), // 1-second interval (won't fire since task exits)
+            CancellationToken::new(),
         );
 
         // Task should complete quickly since KG is disabled.
@@ -533,6 +552,7 @@ mod tests {
             &kg_config,
             500,
             Some(3600), // long interval so we can abort before it fires
+            CancellationToken::new(),
         );
 
         handle.abort();
@@ -541,6 +561,44 @@ mod tests {
         assert!(
             result.unwrap_err().is_cancelled(),
             "error should be cancellation"
+        );
+    }
+
+    /// Test that cancelling the token exits the tick loop cleanly (#802).
+    #[tokio::test]
+    async fn test_cancellation_token_exits_cleanly() {
+        use crate::kg::config::CorpusConfig;
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db = crate::db::Database::open(tmp.path()).unwrap();
+        let async_db = AsyncDatabase::new_with_agent(db, "test-agent");
+
+        let kg_config = KgAgentConfig::Enabled {
+            corpora: vec![CorpusConfig {
+                docs_root: PathBuf::from("/nonexistent"),
+                docs_root_hash: "abcdef1234567890".to_string(),
+            }],
+        };
+
+        let cancel = CancellationToken::new();
+        let handle = spawn_resolver_tick_task(
+            "test-agent".to_string(),
+            async_db,
+            None,
+            None,
+            &kg_config,
+            500,
+            Some(3600), // long interval
+            cancel.clone(),
+        );
+
+        // Cancel the token — the task should exit cleanly (Ok, not Err).
+        cancel.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(result.is_ok(), "task should complete within timeout");
+        assert!(
+            result.unwrap().is_ok(),
+            "cancelled task should exit cleanly (Ok), not via abort (Err)"
         );
     }
 }

--- a/crates/mika-agent/src/kg/resolver_tick.rs
+++ b/crates/mika-agent/src/kg/resolver_tick.rs
@@ -114,12 +114,14 @@ pub fn spawn_resolver_tick_task(
                 &corpora_roots,
                 &docs_root_hashes,
                 budget,
+                &cancel,
             )
             .await;
         }
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn tick_body(
     agent_id: &str,
     db: &AsyncDatabase,
@@ -128,6 +130,7 @@ async fn tick_body(
     corpora_roots: &[PathBuf],
     docs_root_hashes: &[String],
     budget: u32,
+    cancel: &CancellationToken,
 ) {
     let trace_id = mika_common::trace::generate_trace_id();
 
@@ -135,7 +138,21 @@ async fn tick_body(
     // Run extraction before resolution so newly-extracted entities are
     // immediately available for resolution in the same tick.
     if let Some(ext_llm) = extraction_llm {
-        tick_extraction(agent_id, db, ext_llm, corpora_roots, budget, &trace_id).await;
+        tick_extraction(
+            agent_id,
+            db,
+            ext_llm,
+            corpora_roots,
+            budget,
+            &trace_id,
+            cancel,
+        )
+        .await;
+    }
+
+    // Graceful shutdown: skip remaining phases if cancelled (#802).
+    if cancel.is_cancelled() {
+        return;
     }
 
     // --- Phase 2: Resolution (#906) ---
@@ -146,8 +163,14 @@ async fn tick_body(
         docs_root_hashes,
         budget,
         &trace_id,
+        cancel,
     )
     .await;
+
+    // Graceful shutdown: skip coverage report if cancelled (#802).
+    if cancel.is_cancelled() {
+        return;
+    }
 
     // --- Phase 3: Coverage report (#1052) ---
     // Log per-corpus extraction coverage after both phases complete.
@@ -171,6 +194,7 @@ async fn tick_extraction(
     corpora_roots: &[PathBuf],
     budget: u32,
     trace_id: &str,
+    cancel: &CancellationToken,
 ) {
     // Phase 1: Count pending docs per corpus.
     let mut corpus_pending: Vec<u32> = Vec::new();
@@ -222,9 +246,14 @@ async fn tick_extraction(
     let mut total_failed: usize = 0;
 
     for (idx, (extractor, per_budget)) in extractors.into_iter().zip(allocated.iter()).enumerate() {
+        // Graceful shutdown: skip remaining corpora (#802).
+        if cancel.is_cancelled() {
+            break;
+        }
         if *per_budget == 0 {
             continue;
         }
+        let extractor = extractor.with_cancel_token(cancel.child_token());
         match extractor.extract_pending(*per_budget).await {
             Ok(stats) => {
                 let corpus_key = corpora_roots[idx].display().to_string();
@@ -270,13 +299,15 @@ async fn tick_resolution(
     docs_root_hashes: &[String],
     budget: u32,
     trace_id: &str,
+    cancel: &CancellationToken,
 ) {
     let resolver = SubjectEntityResolver::new(
         db.clone(),
         llm.clone(),
         docs_root_hashes.to_vec(),
         Some(trace_id),
-    );
+    )
+    .with_cancel_token(cancel.child_token());
 
     // Count pending before resolution for observability.
     let pending_before = match resolver.count_pending().await {

--- a/crates/mika-agent/src/kg/subject_extractor.rs
+++ b/crates/mika-agent/src/kg/subject_extractor.rs
@@ -577,6 +577,10 @@ pub struct SubjectExtractor {
     docs_root: PathBuf,
     /// Precomputed `hash_docs_root(&docs_root)` — shared-corpus key for v27 KG tables.
     docs_root_hash: String,
+    /// Optional cancellation token for graceful shutdown (#802).
+    /// When set and cancelled, the per-doc extraction loop abandons
+    /// remaining work — half-extracted docs stay pending for next startup.
+    cancel_token: Option<tokio_util::sync::CancellationToken>,
 }
 
 impl SubjectExtractor {
@@ -602,7 +606,18 @@ impl SubjectExtractor {
             trace_id,
             docs_root,
             docs_root_hash,
+            cancel_token: None,
         }
+    }
+
+    /// Set the cancellation token for graceful shutdown (#802).
+    ///
+    /// When cancelled, the per-doc extraction loop abandons remaining
+    /// work between LLM calls. In-flight calls complete (bounded by reqwest
+    /// timeout); unextracted docs stay pending for next startup.
+    pub fn with_cancel_token(mut self, token: tokio_util::sync::CancellationToken) -> Self {
+        self.cancel_token = Some(token);
+        self
     }
 
     /// Returns the precomputed docs_root_hash (shared-corpus key for v27 KG tables).
@@ -936,6 +951,21 @@ impl SubjectExtractor {
         }
 
         for (i, doc_path) in pending_docs.iter().enumerate() {
+            // Graceful shutdown: abandon remaining docs (#802).
+            if let Some(ref ct) = self.cancel_token
+                && ct.is_cancelled()
+            {
+                info!(
+                    trace_id = %self.trace_id,
+                    agent_id = %agent_id,
+                    extracted_so_far = stats.docs_extracted,
+                    remaining = pending_docs.len() - i,
+                    event = "kg_extraction_cancelled_mid_batch",
+                    "extraction abandoned mid-batch (graceful shutdown) — remaining docs stay pending"
+                );
+                break;
+            }
+
             // Budget guard: abort cleanly once we've made `budget` LLM calls.
             if stats.llm_calls >= budget {
                 warn!(

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
@@ -816,6 +817,12 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
     // Per-agent docs_root resolved from identity.toml [kg] section (#778).
     // Agents with matching docs_root share a corpus via docs_root_hash (v27).
     // Agents with [kg] enabled=false are skipped entirely.
+    //
+    // Graceful shutdown token for KG background tasks (#802).
+    // Cancelled on SIGTERM/Ctrl-C before tick handle abort, giving
+    // in-flight batches a cooperative exit point.
+    let kg_shutdown_token = CancellationToken::new();
+    let mut kg_tick_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
     {
         for entry in agents.iter() {
             let agent_name = entry.key();
@@ -1223,7 +1230,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                 // at the existing budget, decoupling drain rate from restart
                 // cadence. The startup spawn above handles the immediate
                 // post-restart drain; this tick handles steady-state.
-                crate::kg::resolver_tick::spawn_resolver_tick_task(
+                let kg_tick_handle = crate::kg::resolver_tick::spawn_resolver_tick_task(
                     agent_name.clone(),
                     agent_state.db.clone(),
                     extraction_llm_for_tick.clone(),
@@ -1231,7 +1238,9 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
                     &agent_state.kg_config,
                     kg_batch_budget,
                     None, // default 30-min interval
+                    kg_shutdown_token.child_token(),
                 );
+                kg_tick_handles.push(kg_tick_handle);
             }
         }
     }
@@ -1395,11 +1404,19 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         info!("server ready");
     }
 
-    // Serve with graceful shutdown; abort all tick loops once the signal fires
+    // Serve with graceful shutdown; cancel KG tasks cooperatively first (#802),
+    // then abort all remaining tick loops.
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             shutdown_signal().await;
+            // Signal KG background tasks to stop cooperatively. They check
+            // this between iterations and between per-entity LLM calls,
+            // so worst-case latency is one LLM call (~1-2s).
+            kg_shutdown_token.cancel();
             for handle in &tick_handles {
+                handle.abort();
+            }
+            for handle in &kg_tick_handles {
                 handle.abort();
             }
         })

--- a/docs/plans/2026-06-13-007-fix-802-kg-resolver-graceful-shutdown-plan.md
+++ b/docs/plans/2026-06-13-007-fix-802-kg-resolver-graceful-shutdown-plan.md
@@ -1,0 +1,186 @@
+---
+ticket: mika#802
+branch: fix/802/kg-resolver-graceful-shutdown
+status: active
+date: 2026-06-13
+origin: https://github.com/senara-solutions/mika/issues/802
+execution: code
+---
+
+# Plan: KG resolver + extractor graceful shutdown on SIGTERM (mika#802)
+
+## Problem frame
+
+Per-agent background tasks spawned by `server/mod.rs` — `kg::entity_resolver::SubjectEntityResolver` (resolver_tick, mika#906) and `kg::subject_extractor::SubjectExtractor` (extraction_tick, mika#1052) — do not respond to SIGTERM. During `make deploy`'s `stop → install → restart` window (~3-5s before supervise-daemon force-kills), these tasks continue writing rows under the OLD binary's config. The NEW binary then inherits stale rows and treats them as already-resolved, bypassing per-agent re-resolution.
+
+Documented incident (2026-04-25 deploy of #795/#796):
+- OLD binary's resolver wrote 279-424 rows/agent at 09:39:46-48Z under global `mika` docs_root_hash
+- NEW binary at 09:39:50Z started with per-agent #778 routing
+- Result: 3 odds-engine agents permanently `[DRIFT]`; required manual `mika kg purge --agent <name> --yes` to recover
+
+Same failure mode applies to the extractor on its periodic tick.
+
+## Directional decisions (per first-pass architect)
+
+- **Grace period: 5 seconds.** Within typical OpenRC supervise-daemon defaults (10s SIGKILL grace). Implementer can tune via const.
+- **Partial-write strategy: abandon.** On cancellation, in-progress LLM call results are dropped without writing. Half-resolved subjects stay `pending` for next startup. This is safer than "flush partial with sentinel outcome" because the sentinel outcome itself becomes a wire-protocol-style commitment.
+- **Scope: both loops.** Resolver AND extractor both get the cancellation token. Asymmetric coverage would leak the same drift via the unfixed loop.
+
+## Scope boundaries
+
+- Pass a `tokio_util::sync::CancellationToken` into every per-agent tokio::spawn of resolver_tick + extraction_tick in `server/mod.rs`.
+- Inside each tick loop, between iterations: `tokio::select!` on (a) next-tick deadline, (b) cancellation.
+- Inside each LLM batch: check cancellation before initiating the next call; mid-call cancellation is bounded by `reqwest` request timeout (handler doesn't need to abort in-flight HTTP — the next-call check catches it within one call's duration).
+- Wire SIGTERM handler in server main loop to trigger the token (mika-server uses Tokio's signal handlers; the existing graceful-shutdown path may already exist for axum).
+- **Out of scope:** cancellation for non-KG background tasks (`checkpoint_task`, watchdog, reaper, parent-completer — those run for ms each cycle and don't have the drift failure mode); per-batch progress checkpointing (atomic-batch is the existing contract — abandon is sufficient); SIGTERM handling unification across all background tasks (separate concern).
+
+## Implementation Units
+
+### U1 — Add `CancellationToken` to resolver + extractor lifecycle
+
+**Goal:** Both tick tasks accept a token; cooperative-cancel between iterations.
+
+**Files:**
+- Modify: `crates/mika-agent/src/kg/entity_resolver.rs` (resolver_tick spawn site or its inner loop)
+- Modify: `crates/mika-agent/src/kg/subject_extractor.rs` (extraction_tick spawn site or its inner loop)
+- Modify: `crates/mika-agent/src/kg/resolver_tick.rs` if separate
+- Modify: `Cargo.toml` — add `tokio-util` if not already a dep (likely already pulled in transitively)
+
+**Approach:** The existing loops likely look like:
+
+```rust
+async fn tick_loop(...) {
+    loop {
+        sleep(interval).await;
+        run_one_tick(...).await;
+    }
+}
+```
+
+Change to:
+
+```rust
+async fn tick_loop(..., cancel: CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = sleep(interval) => {}
+            _ = cancel.cancelled() => {
+                tracing::info!("kg tick cancelled (graceful shutdown)");
+                return;
+            }
+        }
+        // Check cancel before starting a batch — bounded latency
+        if cancel.is_cancelled() {
+            return;
+        }
+        run_one_tick(...).await;
+    }
+}
+```
+
+For mid-batch responsiveness, plumb the token into `run_one_tick` and check it between each LLM call inside the loop over pending entities:
+
+```rust
+async fn run_one_tick(..., cancel: &CancellationToken) {
+    for entity in pending {
+        if cancel.is_cancelled() { return; }  // abandon remaining
+        // ... LLM call + DB write
+    }
+}
+```
+
+Per-iteration check means worst-case latency is one LLM call (~1-2s). With the 5s grace period, this is ample.
+
+**Test scenarios:**
+- **Token never cancelled:** loops run as before (verify existing tests still pass).
+- **Token cancelled between batches:** loop exits cleanly without starting the next batch.
+- **Token cancelled mid-batch:** current LLM call completes; subsequent entities are abandoned (not written).
+
+**Verification:** unit tests using `CancellationToken::cancel()` against a mocked loop; integration test via test harness.
+
+### U2 — Wire SIGTERM in server main loop
+
+**Goal:** SIGTERM triggers the cancellation token; all per-agent KG tasks observe it.
+
+**Files:**
+- Modify: `crates/mika-agent/src/server/mod.rs` (the main loop / shutdown path)
+- Modify: `crates/mika-agent/src/bin/mika-server.rs` if signal handling is there
+
+**Approach:**
+
+```rust
+// Create the parent token once, before per-agent setup
+let kg_shutdown_token = CancellationToken::new();
+
+// Per-agent spawn site
+let agent_token = kg_shutdown_token.child_token();
+tokio::spawn(resolver_tick_loop(..., agent_token.clone()));
+tokio::spawn(extractor_tick_loop(..., agent_token));
+
+// Main loop: install SIGTERM handler that fires the parent token
+tokio::spawn({
+    let token = kg_shutdown_token.clone();
+    async move {
+        let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate()).expect("sigterm handler");
+        sigterm.recv().await;
+        tracing::info!("SIGTERM received; cancelling KG background tasks");
+        token.cancel();
+    }
+});
+
+// On graceful axum shutdown, await tasks complete (within grace window)
+```
+
+The 5s grace is enforced naturally by supervise-daemon: it sends SIGTERM, waits 10s, then SIGKILL. The KG tasks observe the cancel within one LLM call (~2s), cleanup completes, axum's existing shutdown finishes. We don't need an explicit deadline — supervisor's 10s window absorbs any tail latency.
+
+**Test scenarios:**
+- **SIGTERM received → token cancelled.** Manual test via test harness.
+- **Tasks observe cancel within 5s.** Smoke test with `kill -TERM` + log monitoring.
+- **Axum's existing shutdown still works.** No regression on HTTP server graceful exit.
+
+**Verification:** integration smoke test on a local mika-server; check for the `kg tick cancelled` log line.
+
+### U3 — Document the contract
+
+**Goal:** `crates/mika-agent/CLAUDE.md` § Knowledge Graph documents the cancellation behavior.
+
+**Files:**
+- Modify: `crates/mika-agent/CLAUDE.md` § Knowledge Graph — Subject Extractor and § Entity Resolver sections
+
+**Approach:** Add a paragraph under each:
+
+> **Graceful shutdown (mika#802):** The tick loop accepts a `CancellationToken`. On SIGTERM (wired in server main), the parent token cancels all per-agent child tokens. The loop checks cancellation between iterations and inside per-batch entity loops. In-flight LLM calls complete (bounded by the per-request reqwest timeout, ~120s default but typically <2s); remaining pending work is abandoned (not written). Half-resolved subjects stay `pending` for the next startup. This prevents the OLD-binary-writes-under-stale-config drift documented in mika#802's incident.
+
+**Verification:** manual read.
+
+## Dependencies / sequencing
+
+- U1 → U2 (U2 wires the token U1 plumbs through)
+- U3 ships in same PR; last
+
+## Patterns to follow (cross-cutting)
+
+- `tokio_util::sync::CancellationToken` — standard tokio cancellation pattern, parent→child propagation
+- `tokio::select!` on (interval, cancel) — common shutdown idiom
+- Existing tick tasks in `kg::resolver_tick` / `kg::extractor_tick` — current loop shape
+
+## Verification (top-level)
+
+- `cargo test -p mika-agent kg::` passes (existing + new tests)
+- `cargo clippy --workspace` clean
+- `cargo fmt --all -- --check` clean
+- Manual smoke: `kill -TERM <mika-server-pid>` mid-tick; verify `kg tick cancelled` log line; verify no DB rows written after the cancel timestamp; confirm no zombie task warnings.
+
+## Risk / known unknowns
+
+- **In-flight LLM call duration.** Each LLM call has a 120s `reqwest` timeout. In practice, KG calls return in 1-2s. Worst case (provider hang) means a stuck call holds shutdown for up to 120s — supervise-daemon's 10s SIGKILL backstop catches this. Within typical operation, cancellation observes within 2-3s.
+- **Atomic-batch contract.** Existing code may rely on "a tick either fully completes or has not started" for idempotency. Abandon-mid-batch means a tick partially writes — subsequent restarts may see some entities resolved and others pending. This is already the existing contract (a batch can fail mid-way via LLM error); `resolve_pending` is idempotent — it re-attempts pending entities. Verified by reading existing code; no change to contract.
+- **Test surface for cancellation.** Mocking `CancellationToken::cancelled()` requires an async test harness; standard tokio test patterns handle this.
+
+## Out-of-scope (explicit)
+
+- Cancellation for non-KG background tasks (`checkpoint_task`, watchdog, reaper, parent-completer) — those run for milliseconds per cycle and don't have the drift failure mode.
+- Mid-LLM-call abort (drops the response). Bounded by reqwest timeout; not worth the complexity.
+- Per-batch checkpoint files for resume-after-cancel — existing pending-detection handles this via DB state.
+- Unified shutdown coordinator across all background tasks (separate architectural concern).
+- Cancellation token threading through synchronous helpers — the loops are the natural cancellation boundary.


### PR DESCRIPTION
## Summary

- Plumbs `tokio_util::sync::CancellationToken` into KG periodic tick loops (resolver + extractor) and mid-batch entity/doc loops for cooperative shutdown on SIGTERM
- Wires a parent `CancellationToken` in `server/mod.rs` that cancels all per-agent KG child tokens before aborting tick handles on graceful shutdown
- Prevents the OLD-binary-writes-under-stale-config drift documented in the 2026-04-25 incident (279-424 stale rows/agent during `make deploy` window)

Closes #802

## Approach

Three-layer cancellation:
1. **Between tick iterations** — `tokio::select!` on (interval, cancel) exits the loop cleanly
2. **Between batch phases** — `is_cancelled()` check between extraction → resolution → coverage phases
3. **Inside batch loops** — per-entity (resolver) and per-doc (extractor) `is_cancelled()` check abandons remaining work without writing

Half-resolved subjects and half-extracted docs stay `pending` for the next startup — this is already the existing contract (a batch can fail mid-way via LLM error; `resolve_pending` and `extract_pending` are idempotent).

Grace period is naturally enforced by supervise-daemon's 10s SIGKILL window. KG tasks observe cancel within one LLM call (~1-2s).

## Test plan

- [x] `cargo test -p mika-agent -- resolver_tick` — 3 tests pass (disabled agent, abort, **cancellation token exits cleanly**)
- [x] `cargo clippy -p mika-agent -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual smoke: `kill -TERM <mika-server-pid>` mid-tick; verify `kg_tick_cancelled` log line; verify no DB rows written after cancel timestamp

## Post-Deploy Monitoring & Validation

**Log queries:**
- `grep kg_tick_cancelled server.log` — should appear on every SIGTERM (confirms cooperative exit)
- `grep kg_resolution_cancelled_mid_batch server.log` — appears when SIGTERM arrives during a resolution batch
- `grep kg_extraction_cancelled_mid_batch server.log` — appears when SIGTERM arrives during an extraction batch

**Expected healthy signals:**
- All three `kg_tick_cancelled` / `kg_*_cancelled_mid_batch` events include `agent_id`, `resolved_so_far`/`extracted_so_far`, and `remaining` counts
- No `[DRIFT]` agents after `make deploy` (the incident this fixes)

**Failure signals:**
- KG rows written AFTER the `kg_tick_cancelled` timestamp → cancellation not observed (regression)
- Agent `[DRIFT]` after deploy → same failure mode as the 2026-04-25 incident

**Validation window:** First `make deploy` after merge. Owner: operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>