### PR TITLE
fix(auto-pull): skip issues with open PRs to prevent duplicate dispatch (mika#1517)

### DIFF
--- a/crates/mika-agent/src/auto_pull.rs
+++ b/crates/mika-agent/src/auto_pull.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Result, anyhow};
 use regex::Regex;
+use std::collections::HashSet;
 use std::sync::OnceLock;
 use tracing::{debug, info, warn};
 
@@ -74,27 +75,27 @@ pub fn priority_rank(labels: &[IssueLabel]) -> u8 {
 
 /// Select the best groomed-not-ready ticket from a list of open issues.
 ///
-/// Filters to groomed-only, ranks by priority (p0 > p1 > p2 > p3 > unlabelled),
-/// then by oldest `updated_at` within same priority.
-pub fn select_best_candidate(issues: Vec<Issue>) -> Option<Issue> {
-    // Filter out issues that already have the `ready` label
-    let without_ready: Vec<_> = issues
+/// Filters to groomed-only, excludes issues that already have an open PR
+/// closing them (mika#1517 — prevents duplicate pilot dispatch when
+/// dispatch-lib's recovery paths leave a DRAFT PR), then ranks by priority
+/// (p0 > p1 > p2 > p3 > unlabelled) and by oldest `updated_at` within same
+/// priority.
+pub fn select_best_candidate(
+    issues: Vec<Issue>,
+    open_pr_issue_numbers: &HashSet<u64>,
+) -> Option<Issue> {
+    let candidates: Vec<_> = issues
         .into_iter()
         .filter(|i| !i.labels.iter().any(|l| l.name == "ready"))
-        .collect();
-
-    // Filter to groomed-only
-    let groomed: Vec<_> = without_ready
-        .into_iter()
+        .filter(|i| !open_pr_issue_numbers.contains(&i.number))
         .filter(|i| is_groomed(&i.body))
         .collect();
 
-    if groomed.is_empty() {
+    if candidates.is_empty() {
         return None;
     }
 
-    // Sort by priority (descending), then by updated_at (ascending = oldest first)
-    groomed.into_iter().max_by(|a, b| {
+    candidates.into_iter().max_by(|a, b| {
         let pa = priority_rank(&a.labels);
         let pb = priority_rank(&b.labels);
         pa.cmp(&pb).then_with(|| b.updated_at.cmp(&a.updated_at))
@@ -166,6 +167,54 @@ async fn gh_list_open_issues(github_token: &str) -> Result<Vec<Issue>> {
     Ok(issues)
 }
 
+/// List open PR closing-issue references via `gh pr list` (mika#1517).
+///
+/// Returns the set of issue numbers that have at least one open PR closing
+/// them. Powered by GitHub's `closingIssuesReferences` field — populated when
+/// a PR body contains `Closes #N` (or equivalent keyword) or the PR is
+/// manually linked to an issue. Issues not so linked are absent from the set.
+async fn gh_list_open_pr_closing_issues(github_token: &str) -> Result<HashSet<u64>> {
+    let mut cmd = tokio::process::Command::new("gh");
+    cmd.args([
+        "pr",
+        "list",
+        "--repo",
+        DEFAULT_REPO,
+        "--state",
+        "open",
+        "--json",
+        "number,closingIssuesReferences",
+        "--limit",
+        "100",
+    ]);
+    cmd.env("GH_TOKEN", github_token);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let output = cmd.output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("gh pr list failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: Vec<serde_json::Value> = serde_json::from_str(&stdout)?;
+
+    let mut closed_issue_numbers = HashSet::new();
+    for pr in raw {
+        if let Some(refs) = pr["closingIssuesReferences"].as_array() {
+            for ref_obj in refs {
+                if let Some(n) = ref_obj["number"].as_u64() {
+                    closed_issue_numbers.insert(n);
+                }
+            }
+        }
+    }
+    Ok(closed_issue_numbers)
+}
+
 /// Apply a label to a GitHub issue.
 async fn gh_apply_label(github_token: &str, issue_number: u64, label: &str) -> Result<()> {
     let mut cmd = tokio::process::Command::new("gh");
@@ -233,8 +282,18 @@ pub async fn auto_pull_groomed_ticket(
         }
     };
 
-    // 3. Select the best groomed-not-ready candidate.
-    let candidate = match select_best_candidate(issues) {
+    // 2b. Fetch open-PR closing-issue refs to skip tickets already in flight (mika#1517).
+    // Fail-open: an empty set preserves pre-fix behavior on infra glitches.
+    let open_pr_issue_numbers = match gh_list_open_pr_closing_issues(github_token).await {
+        Ok(set) => set,
+        Err(e) => {
+            warn!(error = %e, "auto_pull: failed to list open PR closing-issue refs; proceeding without filter");
+            HashSet::new()
+        }
+    };
+
+    // 3. Select the best groomed-not-ready candidate (skip those with open PRs).
+    let candidate = match select_best_candidate(issues, &open_pr_issue_numbers) {
         Some(c) => c,
         None => {
             debug!("auto_pull: no groomed-not-ready candidates found");
@@ -516,7 +575,7 @@ This ticket has been GROOMED and is ready.
             make_issue(1, UNGROOMED_BODY, &["p0"], "2026-06-01T00:00:00Z"),
             make_issue(2, GROOMED_BODY, &["p1"], "2026-06-01T00:00:00Z"),
         ];
-        let selected = select_best_candidate(issues).unwrap();
+        let selected = select_best_candidate(issues, &HashSet::new()).unwrap();
         assert_eq!(selected.number, 2);
     }
 
@@ -526,7 +585,7 @@ This ticket has been GROOMED and is ready.
             make_issue(1, GROOMED_BODY, &["p0", "ready"], "2026-06-01T00:00:00Z"),
             make_issue(2, GROOMED_BODY, &["p1"], "2026-06-01T00:00:00Z"),
         ];
-        let selected = select_best_candidate(issues).unwrap();
+        let selected = select_best_candidate(issues, &HashSet::new()).unwrap();
         assert_eq!(selected.number, 2);
     }
 
@@ -537,7 +596,7 @@ This ticket has been GROOMED and is ready.
             make_issue(2, GROOMED_BODY, &["p0"], "2026-06-01T00:00:00Z"),
             make_issue(3, GROOMED_BODY, &["p1"], "2026-06-01T00:00:00Z"),
         ];
-        let selected = select_best_candidate(issues).unwrap();
+        let selected = select_best_candidate(issues, &HashSet::new()).unwrap();
         assert_eq!(selected.number, 2, "p0 should be selected");
     }
 
@@ -548,7 +607,7 @@ This ticket has been GROOMED and is ready.
             make_issue(2, GROOMED_BODY, &["p1"], "2026-06-01T00:00:00Z"),
             make_issue(3, GROOMED_BODY, &["p1"], "2026-06-03T00:00:00Z"),
         ];
-        let selected = select_best_candidate(issues).unwrap();
+        let selected = select_best_candidate(issues, &HashSet::new()).unwrap();
         assert_eq!(
             selected.number, 2,
             "oldest updated_at within same priority should win"
@@ -563,12 +622,12 @@ This ticket has been GROOMED and is ready.
             &["p0"],
             "2026-06-01T00:00:00Z",
         )];
-        assert!(select_best_candidate(issues).is_none());
+        assert!(select_best_candidate(issues, &HashSet::new()).is_none());
     }
 
     #[test]
     fn test_select_empty_list() {
-        assert!(select_best_candidate(vec![]).is_none());
+        assert!(select_best_candidate(vec![], &HashSet::new()).is_none());
     }
 
     #[test]
@@ -577,7 +636,47 @@ This ticket has been GROOMED and is ready.
             make_issue(1, GROOMED_BODY, &[], "2026-06-01T00:00:00Z"),
             make_issue(2, GROOMED_BODY, &["p3"], "2026-06-01T00:00:00Z"),
         ];
-        let selected = select_best_candidate(issues).unwrap();
+        let selected = select_best_candidate(issues, &HashSet::new()).unwrap();
         assert_eq!(selected.number, 2, "p3 beats unlabelled");
+    }
+
+    #[test]
+    fn test_select_skips_issues_with_open_pr() {
+        // mika#1517: when an issue has an open PR closing it, skip it even if
+        // it's groomed and unlabeled — the previous pilot's work is in flight,
+        // re-dispatching produces a duplicate.
+        let issues = vec![
+            make_issue(606, GROOMED_BODY, &["p2"], "2026-06-13T15:18:00Z"),
+            make_issue(851, GROOMED_BODY, &["p2"], "2026-06-13T16:00:00Z"),
+        ];
+        let mut open_pr_set = HashSet::new();
+        open_pr_set.insert(606); // mika#606 has an open PR — should be skipped
+
+        let selected = select_best_candidate(issues, &open_pr_set);
+        assert!(
+            selected.is_some(),
+            "non-PR-blocked issue should still be selectable"
+        );
+        assert_eq!(
+            selected.unwrap().number,
+            851,
+            "issue with open PR (606) should be skipped; 851 wins"
+        );
+    }
+
+    #[test]
+    fn test_select_skips_all_issues_when_all_have_open_prs() {
+        // When every candidate has an open PR, the selector returns None
+        // (auto-pull will skip this tick — correct behavior).
+        let issues = vec![
+            make_issue(606, GROOMED_BODY, &["p2"], "2026-06-13T15:18:00Z"),
+            make_issue(802, GROOMED_BODY, &["p1"], "2026-06-13T15:00:00Z"),
+        ];
+        let mut open_pr_set = HashSet::new();
+        open_pr_set.insert(606);
+        open_pr_set.insert(802);
+
+        let selected = select_best_candidate(issues, &open_pr_set);
+        assert!(selected.is_none(), "all candidates have open PRs → None");
     }
 }

--- a/docs/plans/2026-06-13-009-fix-1517-auto-pull-skip-open-pr-plan.md
+++ b/docs/plans/2026-06-13-009-fix-1517-auto-pull-skip-open-pr-plan.md
@@ -1,0 +1,200 @@
+---
+ticket: mika#1517
+branch: fix/1517/auto-pull-skip-open-pr
+status: active
+date: 2026-06-13
+origin: https://github.com/senara-solutions/mika/issues/1517
+execution: code
+---
+
+# Plan: auto_pull skips issues with open PRs (mika#1517)
+
+## Problem frame
+
+`crates/mika-agent/src/auto_pull.rs::select_best_candidate` filters out `ready`-labeled issues but does not check whether an issue already has an open PR closing it. When `dispatch-lib`'s recovery paths (mika#1282 dirty-worktree, mika#1396 commit-pushed-no-pr) create a DRAFT PR and the `ready` label is subsequently removed, the next auto-pull tick (cron `0 */10 * * * *`) re-promotes the same ticket, triggering a parallel pilot session. Today's session confirmed n=3 same-day on mika#606 alone (15:18Z PR creation → 16:50Z pilot 2 → 19:00Z pilot 3 in flight), burning ~$3–5 per redundant pilot.
+
+## Scope boundaries
+
+**In scope:**
+- Add a candidate filter that excludes issues with an open PR closing them.
+- Populate the filter set by querying `gh pr list --state open --json number,closingIssuesReferences` once per auto-pull tick.
+- Update existing tests with the new `select_best_candidate` signature.
+- Add a test for the PR-existence filter.
+
+**Out of scope:**
+- Callback-time re-validation (direction C in mika#1517's comment) — separate concern, separate plan.
+- Removing the `ready` label inside dispatch-lib's recovery paths (direction B').
+- Worktree-prep idempotency (direction D).
+- Backfill of existing draft PRs on `senara-solutions/mika`.
+
+## Implementation Units
+
+### U1 — Add `gh_list_open_pr_closing_issues` helper
+
+**Goal:** Fetch the set of issue numbers that have an open PR closing them.
+
+**Files:**
+- Modify: `crates/mika-agent/src/auto_pull.rs` — add new async helper.
+
+**Approach:**
+
+```rust
+async fn gh_list_open_pr_closing_issues(github_token: &str) -> Result<HashSet<u64>> {
+    let mut cmd = tokio::process::Command::new("gh");
+    cmd.args([
+        "pr", "list",
+        "--repo", DEFAULT_REPO,
+        "--state", "open",
+        "--json", "number,closingIssuesReferences",
+        "--limit", "100",
+    ]);
+    cmd.env("GH_TOKEN", github_token);
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let output = cmd.output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("gh pr list failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let raw: Vec<serde_json::Value> = serde_json::from_str(&stdout)?;
+
+    let mut closed_issue_numbers = HashSet::new();
+    for pr in raw {
+        if let Some(refs) = pr["closingIssuesReferences"].as_array() {
+            for ref_obj in refs {
+                if let Some(n) = ref_obj["number"].as_u64() {
+                    closed_issue_numbers.insert(n);
+                }
+            }
+        }
+    }
+    Ok(closed_issue_numbers)
+}
+```
+
+**Verification:** Manual smoke (the test layer mocks the candidate set directly; this helper is the thin gh-shell, same shape as `gh_list_open_issues`).
+
+### U2 — Update `select_best_candidate` signature + filter
+
+**Goal:** Candidate selection skips issues with open PRs.
+
+**Files:**
+- Modify: `crates/mika-agent/src/auto_pull.rs::select_best_candidate`.
+
+**Approach:** Add a `&HashSet<u64>` parameter and a `.filter()` step before the `is_groomed` filter:
+
+```rust
+pub fn select_best_candidate(
+    issues: Vec<Issue>,
+    open_pr_issue_numbers: &HashSet<u64>,
+) -> Option<Issue> {
+    let candidates: Vec<_> = issues
+        .into_iter()
+        .filter(|i| !i.labels.iter().any(|l| l.name == "ready"))
+        .filter(|i| !open_pr_issue_numbers.contains(&i.number))
+        .filter(|i| is_groomed(&i.body))
+        .collect();
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    candidates.into_iter().max_by(|a, b| {
+        let pa = priority_rank(&a.labels);
+        let pb = priority_rank(&b.labels);
+        pa.cmp(&pb).then_with(|| b.updated_at.cmp(&a.updated_at))
+    })
+}
+```
+
+**Verification:** `cargo test -p mika-agent --lib auto_pull::tests::test_select_*` — all existing tests updated with `&HashSet::new()` as the new param; new test asserts that an issue in the open-PR set is skipped.
+
+### U3 — Wire caller to populate `open_pr_issue_numbers`
+
+**Goal:** `auto_pull_groomed_ticket` calls the new helper and threads the result into `select_best_candidate`.
+
+**Files:**
+- Modify: `crates/mika-agent/src/auto_pull.rs::auto_pull_groomed_ticket`.
+
+**Approach:** After step 2 (fetch open issues) and before step 3 (select candidate), fetch the open-PR set. On error, log warn and use an empty set (fail-open — duplicate dispatch is worse than the substrate but better than no dispatch at all):
+
+```rust
+let open_pr_issue_numbers = match gh_list_open_pr_closing_issues(github_token).await {
+    Ok(set) => set,
+    Err(e) => {
+        warn!(error = %e, "auto_pull: failed to list open PR closing-issue refs; proceeding without filter");
+        HashSet::new()
+    }
+};
+
+let candidate = match select_best_candidate(issues, &open_pr_issue_numbers) {
+    // ...
+};
+```
+
+**Verification:** Build clean. Behavioral test deferred to U2 (the filter logic lives in `select_best_candidate`).
+
+### U4 — Update existing tests
+
+**Goal:** All existing `select_best_candidate` tests compile and pass with the new signature.
+
+**Files:**
+- Modify: `crates/mika-agent/src/auto_pull.rs::tests` — every call to `select_best_candidate` gets a second arg `&HashSet::new()`.
+
+**Approach:** Mechanical — pass `&HashSet::new()` to every call site. Tests are not exercising the new filter, so an empty set preserves their current semantics.
+
+### U5 — Add filter regression test
+
+**Goal:** Prove the new filter excludes issues with open PRs.
+
+**Files:**
+- Modify: `crates/mika-agent/src/auto_pull.rs::tests` — add `test_select_skips_issues_with_open_pr`.
+
+**Approach:**
+
+```rust
+#[test]
+fn test_select_skips_issues_with_open_pr() {
+    let body = groomed_body();
+    let issues = vec![
+        make_issue(606, &body, &["p2-normal"], "2026-06-13T15:18Z"),
+        make_issue(851, &body, &["p2-normal"], "2026-06-13T16:00Z"),
+    ];
+    let mut open_pr_set = HashSet::new();
+    open_pr_set.insert(606); // mika#606 has an open PR — should be skipped
+
+    let result = select_best_candidate(issues, &open_pr_set);
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().number, 851);
+}
+```
+
+## Acceptance Criteria
+
+- AC1: `select_best_candidate` skips any issue whose number is in `open_pr_issue_numbers`.
+- AC2: `auto_pull_groomed_ticket` fetches the open-PR closing-issue set once per tick via `gh pr list --json closingIssuesReferences` and passes it to `select_best_candidate`.
+- AC3: On `gh_list_open_pr_closing_issues` failure, the function logs warn and proceeds with an empty set (fail-open — preserves current behavior on infra glitches).
+- AC4: All existing `auto_pull::tests` pass with the new signature.
+- AC5: New regression test `test_select_skips_issues_with_open_pr` asserts the filter behavior.
+- AC6: `cargo clippy --all-targets --all-features -- -D warnings` clean.
+
+## Risk shape
+
+- **Failure mode of the filter**: false negatives (PR exists but no `closingIssuesReferences` link). Mitigation: operator can link PR via `gh issue edit --add-link` or PR body `Closes #N`. This is an existing convention.
+- **GH API rate**: one extra `gh pr list` call per 10min auto-pull tick — negligible.
+- **Backwards compatibility**: only public function `select_best_candidate` signature changes. Only caller is `auto_pull_groomed_ticket` in the same module.
+
+## References
+
+- Substrate ticket: mika#1517 (filed 2026-06-13 by mika-platform-claude with code-level root cause + sharpened fix proposal)
+- Founding incidents: mika#802 (PRs #1512+#1516), mika#606 (PR #1514, n=3 dispatches same day)
+- Sibling substrate: mika#1513 (Check preemption — makes recovery PRs sit longer)
+- Sibling substrate: mika#1515 (recovery PR title hygiene)
+- Sibling direction (not in scope): C (callback re-validation at pilot-spawn)
+- Operator memory: `feedback_n_equals_2_is_the_signal` — n=2 triggers tactical fix
+- Operator memory: `feedback_samidarko_claude_new_center_keep_pushing` — auto-ship warrant for the resulting PR


### PR DESCRIPTION
## Summary

- `select_best_candidate` previously filtered only by `ready` label — issues with an in-flight DRAFT PR (created by dispatch-lib's recovery paths, mika#1282 / mika#1396) were treated as eligible whenever their `ready` label was subsequently removed.
- Result: auto-pull cron (`0 */10 * * * *`) re-promoted the same ticket every 10 min, spawning duplicate pilot sessions. n=3 same-day on mika#606 alone (15:18Z PR → 16:50Z pilot 2 force-pushed branch → 19:00Z pilot 3). ~\$3-5 per redundant pilot.
- Fix: `select_best_candidate` now takes a `&HashSet<u64>` of issue numbers that have an open PR closing them. Caller populates it via new `gh_list_open_pr_closing_issues` helper (`gh pr list --json closingIssuesReferences`). Fail-open on infra error preserves pre-fix behavior.

Closes #1517

## Test plan

- [x] `cargo test -p mika-agent --lib auto_pull::` — 23/23 pass including two new regression tests (`test_select_skips_issues_with_open_pr`, `test_select_skips_all_issues_when_all_have_open_prs`)
- [x] `cargo clippy -p mika-agent --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Verify in production: after this lands, the 20:00Z auto-pull tick does NOT re-promote mika#606 (which still has open PR #1514). Confirmed via absence of a new parent task with `label='Support property filters on skill listing'` in `~/.mika/data/mika.db` after the tick fires.

## Plan

[docs/plans/2026-06-13-009-fix-1517-auto-pull-skip-open-pr-plan.md](docs/plans/2026-06-13-009-fix-1517-auto-pull-skip-open-pr-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)