### PR TITLE
fix(dispatch-lib): disambiguate policy-deny halt from LLM drift

### DIFF
--- a/docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md
+++ b/docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md
@@ -1,0 +1,173 @@
+---
+module: skills/bundled/_shared/dispatch-lib, claude-pilot-py
+tags: [autonomous-loop, dev-groom, claude-pilot, policy-deny, interrupt-true, dispatch-lib, drift-detection]
+problem_type: investigation
+category: workflow-issues
+date: 2026-06-14
+ticket: mika#1318 (related)
+applies_when:
+  - Investigating dev-groom sessions that report "Session drifted into executor mode"
+  - Authoring post-freeze fixes for dispatch-lib's drift detection
+  - Widening claude-pilot-py tier1 policy allow-list
+resolution_type: investigation_finding
+---
+
+# dev-groom "drift" misdiagnosis — policy-deny-induced early halt
+
+## TL;DR
+
+Today's three "drift-into-executor-mode" failures (#96 groom, #624 groom, #625 groom) are **NOT actually LLM drift**. They are pilot sessions halted mid-flight by `interrupt=True` from claude-pilot-py's policy classifier on legitimate research bash commands. dispatch-lib's post-flight message conflates this failure mode (Class C) with mika#1033's genuine LLM drift (Class A) and mika#1097's zero-artifact exit (Class B).
+
+The substrate gaps are in **claude-pilot-py tier1**, not in dev-groom's prompt.
+
+## Founding incidents — 2026-06-14
+
+| Ticket | Session | Cost | Halted on |
+|---|---|---|---|
+| mika#96 (groom) | `ab665c9c-...` | $0.62, 15t | `grep -r "pub fn delete_word\|pub fn delete_line_by_head\|WordBack\|WordForward" /home/samidarko/.cargo/registry/src/*/tui-textarea-*/src/` |
+| mika#624 (groom rescue session) | `1f701234-...` | $0.56, 13t | `gh auth status 2>&1 \| head -10` |
+| mika#625 (groom) | `8ff405b7-...` | $0.56, 15t | `gh release view --repo senara-solutions/mika --json tagName,assets 2>/dev/null \| jq '{tag: .tagName, assets: [.assets[].name]}' \| head -30` |
+
+All three sessions exit with `interrupt=True` halt mid-research. dispatch-lib's post-flight then runs `_iterate_groom_loop` (which fails because the architect canvass can't complete on incomplete input) AND the structural plan-file check (which fails because no plan was produced), producing the conflated message:
+
+> PIPELINE FAILURE: architect convergence did not complete (_iterate_groom_loop returned non-zero). Plan exists on branch but architect verdict is missing.
+> PIPELINE FAILURE: dev-groom produced no valid plan file ... no /ce:plan invocation detected in session log. Session drifted into executor mode.
+
+The first sentence accurately describes the immediate symptom; the second is a misdiagnosis — the pilot did not "drift into executor mode," it never got to execute anything because policy denied its first research move.
+
+## Three distinct failure classes — disambiguation
+
+Today's failures muddle the diagnostic vocabulary. The doctrine should treat these as three separate classes:
+
+### Class A — LLM drift from planner to executor (mika#1033)
+
+- **Symptom**: pilot makes tool calls, but they are workflow commands (cargo build, gh pr create, edit) instead of `/ce:plan` invocation.
+- **Cause**: ticket body's imperative verbs prime the LLM to mode-switch.
+- **Existing guard**: ROLE CONSTRAINT block at the head of `dev-groom/system_prompt.md`; structural post-flight check for plan-file >500 bytes.
+- **Detection signal**: `tool_calls` table shows non-`/ce:plan` invocations during the session window.
+
+### Class B — Zero-artifact exit (mika#1097)
+
+- **Symptom**: session exits `Success` with **zero** tool calls (no `[tool:request]` lines), zero content blocks, ~12 turns of empty SDK turns.
+- **Cause**: prompt block position confusing the model into inhibiting tool use entirely.
+- **Existing guard**: `--trace` diagnostic instrumentation; structural plan-file check.
+- **Detection signal**: zero rows in `tool_calls` for the session_id.
+
+### Class C — Policy-deny-induced early halt (today's pattern, undiagnosed)
+
+- **Symptom**: pilot makes `[tool:request]` calls, claude-pilot logs `[policy:deny]` on a research bash command, session terminates via `interrupt=True` mid-grooming.
+- **Cause**: research bash command falls outside tier1 allow-list AND outside tier2 policy allow-list, triggering default-deny + halt (cpp#20 joint 2).
+- **Existing guard**: **none for diagnosis**. The structural check sees no plan, reports it as drift; the operator-facing message wrongly implicates the LLM.
+- **Detection signal**: `[policy:deny]` line in `/var/log/claude-pilot/<task_id>.{log,stderr}` before the rescue write.
+
+## Substrate gaps surfaced by today's incidents
+
+Three concrete claude-pilot-py tier1 gaps were exercised:
+
+### Gap 1 — Quote-blind compound splitter (FIXED in cpp#31, merged 2026-06-14 14:17Z)
+
+`_split_compound_command` was a single quote-blind regex that matched `|` inside `"..."`. Pre-fix, grep with regex alternation (`grep "a\|b\|c"`) was shredded into nonsense segments, every segment failed safe-list, and chain-safety vetoed the policy allow rule. The fix is a hand-written quote-aware tokenizer mirroring `contains_unquoted_metacharacter` POSIX semantics. 177/177 tier1 tests pass.
+
+mika#96 groom's `grep -r "pub fn ..."` was this class.
+
+### Gap 2 — `bash-jq` policy regex misses pipe-to-jq
+
+Current regex: `^(for\s.*do\s+.*\s)?jq\s|;\s*jq\s` — matches `^jq ` and `; jq ` only.
+
+The pipe-to-jq idiom `cmd | jq '...'` is **not** matched. This is the dominant usage pattern in research bash (gh + jq, cat + jq, curl + jq). With the quote-aware splitter, the segment after `|` is bare `jq '...'` which:
+- Is not tier1-safe (jq isn't in SAFE_SHELL_COMMANDS)
+- Doesn't match the bash-jq policy regex (anchored to `^` or after `;`)
+- Falls through to default-deny
+
+mika#625 groom's `gh release view ... | jq '...' | head` was this class.
+
+**Proposed fix**: extend the bash-jq pattern to cover pipe-to-jq:
+
+```yaml
+- id: bash-jq
+  tool: Bash
+  pattern: "^(for\\s.*do\\s+.*\\s)?jq\\s|[;|]\\s*jq\\s"
+  decision: allow
+```
+
+(Single char-class addition: `[;|]` instead of `;`. Quote-aware splitter still gates compound safety on each segment.)
+
+### Gap 3 — `SAFE_GH_SUBCOMMANDS` missing common research verbs
+
+Current allow-list:
+- `pr`: create, view, list, checkout, diff, checks
+- `issue`: view, list, edit, comment
+- `run`: view, list
+- `repo`: view
+- `release`: view, list
+- `workflow`: view, list
+
+Missing common-and-safe verbs the pilot reaches for during research:
+- `gh auth status` (mika#624 halt) — read-only, surfaces credential state, no side effects
+- `gh auth token` — read-only, but emits secret to stdout — should NOT be in allow-list (leak risk)
+
+**Proposed fix**: extend `auth` to allow `status` only:
+
+```python
+"auth": frozenset({"status"}),
+```
+
+Other candidates to investigate: `gh cache list`, `gh secret list` (NO — leaks names), `gh variable list`, `gh gist list`, `gh extension list`, `gh search code/issues/prs`.
+
+## Proposed dispatch-lib disambiguation (post-freeze)
+
+dispatch-lib's drift detection should distinguish Class A/B from Class C by grepping the session stderr for `[policy:deny]` before declaring drift.
+
+Conceptual change to `skills/bundled/_shared/dispatch-lib.sh`:
+
+```bash
+# After the existing plan-file + /ce:plan check, before declaring drift:
+SESSION_STDERR="/var/log/claude-pilot/${LOG_ID}.stderr"
+POLICY_DENY=""
+if [ -r "$SESSION_STDERR" ]; then
+    POLICY_DENY=$(grep -oE '\[policy:deny\] [A-Za-z]+: [^[]+\[[a-z-]+\]' "$SESSION_STDERR" | head -1)
+fi
+
+if [ -n "$POLICY_DENY" ]; then
+    RESULT="PIPELINE FAILURE: session halted by policy deny on tool — ${POLICY_DENY}.
+
+Likely a tier1/policy allow-list gap in claude-pilot-py. Investigate the deny rule and either (a) widen the policy to include the legitimate research command, or (b) rewrite the dispatch context so the pilot avoids the denied command shape. This is NOT LLM drift — the pilot was prevented from doing its work.
+
+${RESULT}"
+elif [ -z "$VALID_PLAN" ] && [ "$CE_PLAN_INVOKED" != "1" ]; then
+    # Existing Class A drift message
+    ...
+fi
+```
+
+This is a strictly additive log-message change with no behavioral change to the grooming pipeline. Safe to ship without freeze-pivot risk because it does not modify the dev-groom skill prompt or the architect-convergence loop logic.
+
+## Post-freeze fix sequencing (2026-06-18 onward)
+
+| Fix | Layer | Risk | Why this order |
+|---|---|---|---|
+| 1. bash-jq pattern widening | cpp/policies/permissions.yaml | LOW (regex addition only) | Unblocks most common pipe-to-jq research idioms |
+| 2. `gh auth status` allow | cpp/tier1.py SAFE_GH_SUBCOMMANDS | LOW | Tiny additive change, restricted to `status` verb |
+| 3. dispatch-lib drift disambiguation | mika/skills/bundled/_shared/dispatch-lib.sh | LOW (log-message only) | Operator clarity improvement; no pipeline behavior change |
+| 4. Audit other `gh` subcommands | cpp/tier1.py | MEDIUM (more verbs, more attack surface) | Defer until #1-3 measured |
+
+## Out of scope for this investigation
+
+- mika#1410 (recoverable denials for the LLM) — separate substrate problem; this investigation does not change that ticket's scope.
+- dev-groom skill prompt changes — the freeze-pivot subject; not implicated in today's failures.
+- The architect-convergence loop in `_iterate_groom_loop` — failed downstream of the policy deny; not the root cause.
+
+## Evidence trail
+
+- mika#96 groom callback task: `99e104e2-613e-46e4-99f4-e2c66f8c3d9c` (mika.db)
+- mika#624 groom rescue session: `1f701234-98ce-4da0-99d9-37c31fd9f4e3` (recovery task `4614fbe9-...`)
+- mika#625 groom callback task: `545f9918-3bf7-4aad-bb25-0b985f76bf16` (mika.db)
+- cpp#31 (quote-aware splitter fix): merged `94ddf4d` 2026-06-14 14:17Z
+- Prior art: `dev-groom-zero-artifact-exit-2026-05-13.md`, `dev-groom-drift-detection-structural-validation-2026-05-11.md`
+
+## Hand-off
+
+This document is operator/architect-canvassable post-freeze (2026-06-18). A canvass should:
+1. Verify the bash-jq + SAFE_GH_SUBCOMMANDS gaps against current cpp main (the fixes may already have shipped in another PR).
+2. Decide whether the dispatch-lib disambiguation belongs in mika#1097's lineage (zero-artifact lineage) or as a standalone ticket.
+3. Sequence the three proposed fixes against the rest of the 06-18 mission slate.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -918,7 +918,38 @@ ${RESULT}"
                 CE_PLAN_INVOKED="unknown"
             fi
 
-            if [ -z "$VALID_PLAN" ] && [ "$CE_PLAN_INVOKED" != "1" ]; then
+            # Policy-deny pre-check (drift-misdiagnosis fix, docs/solutions/
+            # workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md).
+            # If the pilot was halted by claude-pilot's tier1/policy classifier
+            # on a research bash command, it is NOT LLM drift — the pilot
+            # tried to do its work and was prevented. Disambiguate by reading
+            # the persistent stderr for [policy:deny] before declaring drift.
+            # Fail-open: if stderr is unavailable, fall through to the
+            # existing drift messages.
+            POLICY_DENY=""
+            PERSISTENT_STDERR_PATH="/var/log/claude-pilot/${LOG_ID}.stderr"
+            if [ -f "$PERSISTENT_STDERR_PATH" ] && [ -r "$PERSISTENT_STDERR_PATH" ]; then
+                # Strip ANSI color codes, then extract the first [policy:deny] line.
+                # The line shape is `[policy:deny] <Tool>: <command>[ \[rule-id\]]`.
+                POLICY_DENY=$(sed 's/\x1b\[[0-9;]*[mK]//g' "$PERSISTENT_STDERR_PATH" 2>/dev/null \
+                    | grep -m1 '\[policy:deny\]' || true)
+            fi
+
+            if [ -n "$POLICY_DENY" ]; then
+                # Class C — policy-deny-induced early halt. The pilot made a
+                # legitimate research request that hit a tier1/policy allow-list
+                # gap. This is NOT LLM drift; the operator should investigate
+                # the deny rule, not the pilot's reasoning.
+                RESULT="PIPELINE FAILURE: dev-groom session halted by claude-pilot policy deny — not LLM drift.
+
+Halt event: ${POLICY_DENY}
+
+Likely a tier1 or tier2 allow-list gap in claude-pilot-py. Investigate the deny rule and either (a) widen the policy to include the legitimate research command shape, or (b) rewrite the dispatch context so the pilot avoids the denied command. The pilot was prevented from completing its work — re-grooming this ticket without addressing the substrate gap will hit the same wall.
+
+See: docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md
+
+${RESULT}"
+            elif [ -z "$VALID_PLAN" ] && [ "$CE_PLAN_INVOKED" != "1" ]; then
                 # Both checks failed: no plan file AND /ce:plan never called
                 RESULT="PIPELINE FAILURE: dev-groom produced no valid plan file (no issue-scoped plan >500 bytes found via _find_issue_plan for $REPO#$ISSUE_NUM) and no /ce:plan invocation detected in session log. Session drifted into executor mode.
 

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -2132,6 +2132,102 @@ assert_not_contains "No hardcoded wip() rescue title" \
 assert_not_contains "No hardcoded pilot impl rescue title" \
     'pilot impl (dispatch-lib PR-create recovery' "$RECOVERY_BLOCK"
 
+# --- Test 13: policy-deny disambiguation (drift-misdiagnosis fix) ---
+# Mirrors investigation in docs/solutions/workflow-issues/
+# 2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md.
+# Verifies the new POLICY_DENY pre-check exists, precedes the existing
+# drift-detection chain, reads from the persistent stderr path, and emits
+# a distinct message that does NOT conflate the failure with LLM drift.
+
+echo ""
+echo "Test 13: Policy-deny disambiguation precedes drift detection (structural)"
+echo "-------------------------------------------------------------------------"
+
+DRIFT_BLOCK=$(sed -n '/Post-flight plan validation/,/Issue #138: Discover/p' "$DISPATCH_LIB")
+
+assert_contains "POLICY_DENY variable initialized" \
+    'POLICY_DENY=""' "$DRIFT_BLOCK"
+assert_contains "PERSISTENT_STDERR_PATH uses LOG_ID convention" \
+    'PERSISTENT_STDERR_PATH="/var/log/claude-pilot/${LOG_ID}.stderr"' "$DRIFT_BLOCK"
+assert_contains "Reads from persistent stderr (mika#1097 channel)" \
+    '"$PERSISTENT_STDERR_PATH"' "$DRIFT_BLOCK"
+assert_contains "Strips ANSI before grep (UI ANSI shouldn't break match)" \
+    'sed' "$DRIFT_BLOCK"
+assert_contains "Searches for [policy:deny] marker" \
+    '[policy:deny]' "$DRIFT_BLOCK"
+assert_contains "Class C message identifies policy halt explicitly" \
+    'halted by claude-pilot policy deny' "$DRIFT_BLOCK"
+assert_contains "Class C message explicitly NOT drift" \
+    'not LLM drift' "$DRIFT_BLOCK"
+assert_contains "Class C message links to investigation doc" \
+    'drift-misdiagnosis-policy-deny-halt' "$DRIFT_BLOCK"
+
+# Branch ordering: the POLICY_DENY branch must be the FIRST elif/if, so it wins
+# over the drift messages when both conditions could fire.
+POLICY_DENY_LINE=$(echo "$DRIFT_BLOCK" | grep -n 'if \[ -n "\$POLICY_DENY" \]' | head -1 | cut -d: -f1)
+DRIFT_MSG_LINE=$(echo "$DRIFT_BLOCK" | grep -n 'Session drifted into executor mode' | head -1 | cut -d: -f1)
+if [ -n "$POLICY_DENY_LINE" ] && [ -n "$DRIFT_MSG_LINE" ] && [ "$POLICY_DENY_LINE" -lt "$DRIFT_MSG_LINE" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ POLICY_DENY branch precedes drift message in source"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ POLICY_DENY branch must precede drift message (POLICY_DENY_LINE=$POLICY_DENY_LINE, DRIFT_MSG_LINE=$DRIFT_MSG_LINE)"
+fi
+
+# Behavioral test — extract the policy-deny check logic into a function and
+# exercise it with synthetic stderr fixtures.
+echo ""
+echo "Test 13b: Policy-deny check (behavioral, synthetic stderr fixtures)"
+echo "-------------------------------------------------------------------"
+
+# Minimal reproduction of the policy-deny check from dispatch-lib.sh.
+# Kept in sync with the version in dispatch-lib.sh via the structural
+# assertions above (mirrors the mika#1364 self-test approach).
+_test_policy_deny_check() {
+    local stderr_path="$1"
+    local policy_deny=""
+    if [ -f "$stderr_path" ] && [ -r "$stderr_path" ]; then
+        policy_deny=$(sed 's/\x1b\[[0-9;]*[mK]//g' "$stderr_path" 2>/dev/null \
+            | grep -m1 '\[policy:deny\]' || true)
+    fi
+    printf '%s' "$policy_deny"
+}
+
+POLICY_DENY_FIXTURE_DIR=$(mktemp -d)
+trap "rm -rf '$POLICY_DENY_FIXTURE_DIR'" EXIT
+
+# Fixture 1: stderr with a real ANSI-coded policy-deny line (today's mika#624 shape).
+printf '\x1b[31m[policy:deny]\x1b[0m \x1b[1mBash\x1b[0m: gh auth status 2>&1 | head -10\n' \
+    > "$POLICY_DENY_FIXTURE_DIR/with_deny.stderr"
+RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/with_deny.stderr")
+assert_contains "ANSI-stripped deny line extracted" \
+    '[policy:deny] Bash: gh auth status' "$RESULT"
+
+# Fixture 2: stderr without any policy-deny lines (healthy session).
+printf '[init] Session abc123\n[done] Success | 5 turns | $0.20\n' \
+    > "$POLICY_DENY_FIXTURE_DIR/clean.stderr"
+RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/clean.stderr")
+assert_eq "Clean stderr yields empty POLICY_DENY" "" "$RESULT"
+
+# Fixture 3: stderr missing entirely (fail-open, fall through to drift checks).
+RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/does_not_exist.stderr")
+assert_eq "Missing stderr yields empty POLICY_DENY (fail-open)" "" "$RESULT"
+
+# Fixture 4: deny line with rule-id suffix (today's mika#96 shape).
+printf '\x1b[31m[policy:deny]\x1b[0m \x1b[1mBash\x1b[0m: grep -r "x" /tmp/ [bash-grep]\n' \
+    > "$POLICY_DENY_FIXTURE_DIR/deny_with_rule.stderr"
+RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/deny_with_rule.stderr")
+assert_contains "Deny line with rule-id suffix extracted" \
+    '[bash-grep]' "$RESULT"
+
+# Fixture 5: multiple deny lines — only the first should be extracted (head -1
+# behavior). Operators get the actionable signal without spam.
+printf '[policy:deny] Bash: cmd1\n[policy:deny] Bash: cmd2\n[policy:deny] Bash: cmd3\n' \
+    > "$POLICY_DENY_FIXTURE_DIR/multi_deny.stderr"
+RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/multi_deny.stderr")
+assert_contains "First deny extracted" "cmd1" "$RESULT"
+assert_not_contains "Subsequent denies not included" "cmd2" "$RESULT"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

dispatch-lib's drift detection conflates three distinct failure classes under a single misleading message. Today's three "drift-into-executor-mode" reports (#96, #624, #625 grooms) were all **policy-deny halts**, not LLM drift — the pilot tried to do its work and was prevented by a tier1/policy allow-list gap in claude-pilot-py.

This PR adds a POLICY_DENY pre-check that reads the persistent stderr at \`/var/log/claude-pilot/\${LOG_ID}.stderr\`, strips ANSI, and grep -m1 for the \`[policy:deny]\` marker. When found, dispatch-lib emits a distinct message naming the halt event and pointing the operator at the policy gap. Otherwise, falls through to the existing drift detection chain unchanged.

## Why this is freeze-safe

This is a **log-message only** change. No pipeline behavior changes. No dev-groom skill prompt changes. No architect-convergence loop changes. The dispatch-lib drift detection block is unchanged on the non-deny path. This change just adds a new \`if\` branch that fires first when a real policy halt is detected.

Specifically not implicated in mika#1318 freeze-pivot scope (dev-groom skill prompt).

## Founding incidents (2026-06-14)

| Ticket | Session | Halted on | Substrate gap |
|---|---|---|---|
| mika#96 (groom) | \`ab665c9c-...\` | \`grep "a\\|b\\|c"\` regex alternation | Quote-blind splitter (FIXED in cpp#31) |
| mika#624 (groom rescue) | \`1f701234-...\` | \`gh auth status\` | \`auth\` not in SAFE_GH_SUBCOMMANDS (post-freeze) |
| mika#625 (groom) | \`8ff405b7-...\` | \`gh release view \| jq '...'\` | \`bash-jq\` pattern doesn't cover pipe-to-jq (post-freeze) |

All three were operator-facing reported as "drift," masking three distinct substrate gaps.

## Tests

- **15 new test assertions** added to \`test-dispatch-lib.sh\`:
  - 9 structural assertions verifying the POLICY_DENY block exists, uses the persistent stderr convention, strips ANSI, contains the disambiguation message, and precedes the existing drift detection chain in source order.
  - 6 behavioral assertions running the extracted policy-deny check against synthetic stderr fixtures (ANSI-coded deny line, clean stderr, missing stderr fail-open, deny with rule-id suffix, multi-deny first-match-wins).
- **229/229** test-dispatch-lib.sh assertions pass (214 existing + 15 new).

## Test plan

- [x] \`bash skills/bundled/_shared/test-dispatch-lib.sh\` passes all 229 assertions
- [x] Structural: POLICY_DENY branch precedes drift message in source
- [x] Behavioral: ANSI-stripped deny line extracted from realistic stderr
- [x] Fail-open: missing or unreadable stderr yields empty POLICY_DENY → existing drift behavior

## Related

- Investigation: \`docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md\`
- Prior art: mika#1033 (drift detection), mika#1097 (zero-artifact exit), mika#1303 (Write-tool plan advisory demotion)
- Founding cpp fix: \`senara-solutions/claude-pilot-py#31\` (quote-aware splitter, merged today)
- Queued post-freeze fixes: bash-jq pipe-to-jq pattern widening, SAFE_GH_SUBCOMMANDS \`auth\` allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)