### PR TITLE
fix(packaging,os): sweep no-extension files for mika-server → mika-spirit (mika#1537)

### DIFF
--- a/os/openrc/conf.d/mika-gateway
+++ b/os/openrc/conf.d/mika-gateway
@@ -9,7 +9,7 @@
 # Postgres connection string for the gateway's customer registry
 # MIKA_DATABASE_URL="postgres://mika:password@localhost:5432/mika"
 
-# ── Internal auth (required, must match mika-server) ──
+# ── Internal auth (required, must match mika-spirit) ──
 # MIKA_INTERNAL_TOKEN="<shared-secret — openssl rand -hex 32>"
 
 # ── Telegram (optional) ──

--- a/os/openrc/conf.d/mika-spirit
+++ b/os/openrc/conf.d/mika-spirit
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-# Configuration for mika-server OpenRC service
-# Source: os/openrc/conf.d/mika-server
+# Configuration for mika-spirit OpenRC service
+# Source: os/openrc/conf.d/mika-spirit
 #
-# This file is sourced by the mika-server init script.
+# This file is sourced by the mika-spirit init script.
 # Edit to configure runtime environment for the Mika agent server.
 
 # ── Core paths ──
 MIKA_HOME="/home/mika/.mika"
 MIKA_LOG_FORMAT="json"
-MIKA_SERVER_LOG_FILE="/home/mika/.mika/logs/mika-server.log"
+MIKA_SPIRIT_LOG_FILE="/home/mika/.mika/logs/mika-spirit.log"
 
 # ── Server mode ──
 # Required for server mode (gateway <-> agent communication)

--- a/os/openrc/init.d/mika-gateway
+++ b/os/openrc/init.d/mika-gateway
@@ -16,7 +16,7 @@ output_log="/home/mika/.mika/logs/mika-gateway.log"
 error_log="/home/mika/.mika/logs/mika-gateway.log"
 
 depend() {
-    need net mika-server
+    need net mika-spirit
     after firewall
 }
 

--- a/os/openrc/init.d/mika-spirit
+++ b/os/openrc/init.d/mika-spirit
@@ -1,10 +1,10 @@
 #!/sbin/openrc-run
 # SPDX-License-Identifier: Apache-2.0
-# OpenRC init script for mika-server (Mika AI agent HTTP server)
+# OpenRC init script for mika-spirit (Mika AI agent HTTP server)
 
 description="Mika AI agent HTTP server"
 
-command="/usr/local/bin/mika-server"
+command="/usr/local/bin/mika-spirit"
 command_background="yes"
 pidfile="/run/${RC_SVCNAME}.pid"
 
@@ -12,8 +12,8 @@ command_user="mika:mika"
 
 supervise_daemon_args="--respawn-delay 5 --respawn-max 10 --respawn-period 60"
 
-output_log="/home/mika/.mika/logs/mika-server.log"
-error_log="/home/mika/.mika/logs/mika-server.log"
+output_log="/home/mika/.mika/logs/mika-spirit.log"
+error_log="/home/mika/.mika/logs/mika-spirit.log"
 
 depend() {
     need net
@@ -22,9 +22,9 @@ depend() {
 
 start_pre() {
     # Source environment configuration
-    if [ -f "/etc/conf.d/mika-server" ]; then
-        . "/etc/conf.d/mika-server"
-        export MIKA_HOME MIKA_LOG_FORMAT MIKA_SERVER_LOG_FILE
+    if [ -f "/etc/conf.d/mika-spirit" ]; then
+        . "/etc/conf.d/mika-spirit"
+        export MIKA_HOME MIKA_LOG_FORMAT MIKA_SPIRIT_LOG_FILE
         # Export optional vars only if set
         [ -n "$MIKA_ANTHROPIC_API_KEY" ] && export MIKA_ANTHROPIC_API_KEY
         [ -n "$MIKA_OPENAI_API_KEY" ] && export MIKA_OPENAI_API_KEY

--- a/packaging/debian/mika-spirit.postinst
+++ b/packaging/debian/mika-spirit.postinst
@@ -18,9 +18,9 @@ case "$1" in
 
     # Enable and restart service on upgrade
     systemctl daemon-reload
-    systemctl enable mika-server.service
-    if systemctl is-active --quiet mika-server.service; then
-      systemctl restart mika-server.service
+    systemctl enable mika-spirit.service
+    if systemctl is-active --quiet mika-spirit.service; then
+      systemctl restart mika-spirit.service
     fi
     ;;
 esac

--- a/packaging/debian/mika-spirit.prerm
+++ b/packaging/debian/mika-spirit.prerm
@@ -3,7 +3,7 @@ set -e
 
 case "$1" in
   remove|purge)
-    systemctl stop mika-server.service || true
-    systemctl disable mika-server.service || true
+    systemctl stop mika-spirit.service || true
+    systemctl disable mika-spirit.service || true
     ;;
 esac

--- a/packaging/systemd/mika-spirit.service
+++ b/packaging/systemd/mika-spirit.service
@@ -7,13 +7,13 @@ Wants=network-online.target
 Type=simple
 User=mika
 Group=mika
-ExecStart=/usr/bin/mika-server
+ExecStart=/usr/bin/mika-spirit
 Restart=on-failure
 RestartSec=5
 Environment=MIKA_HOME=/var/lib/mika
 Environment=MIKA_LOG_FORMAT=json
-Environment=MIKA_SERVER_LOG_FILE=/var/log/mika/server.log
-EnvironmentFile=-/etc/mika/mika-server.env
+Environment=MIKA_SPIRIT_LOG_FILE=/var/log/mika/server.log
+EnvironmentFile=-/etc/mika/mika-spirit.env
 WorkingDirectory=/var/lib/mika
 
 # Hardening


### PR DESCRIPTION
## Summary

mika#1535/PR #1536's sed pass missed files with no extension. This sweep fixes the 7 files I missed.

## Files

- \`os/openrc/init.d/mika-spirit\` — OpenRC init script
- \`os/openrc/conf.d/mika-spirit\` — companion env file
- \`os/openrc/init.d/mika-gateway\` — referenced mika-server.log paths
- \`os/openrc/conf.d/mika-gateway\` — same
- \`packaging/systemd/mika-spirit.service\`
- \`packaging/debian/mika-spirit.postinst\`
- \`packaging/debian/mika-spirit.prerm\`

7 files / 21 insertions / 21 deletions — pure mechanical \`mika-server → mika-spirit\` + \`MIKA_SERVER_ → MIKA_SPIRIT_\`.

File NAMES were already renamed via git mv in #1536; this sweep fixes the file CONTENTS.

## Test plan

- [x] \`grep -rl mika-server os/ packaging/\` returns nothing post-sweep
- [x] No Rust build affected (these files are not compiled into binaries — consumed by image builds + systemd/deb packaging)

Closes #1537