### PR TITLE
fix(dispatch-lib): extend policy-deny disambiguation to dev-pilot

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -705,11 +705,40 @@ Note: process exited with code ${PILOT_EXIT} after session completed — result 
         if [ -n "$PRE_RUN_HEAD" ] && [ -n "$REPO" ]; then
             POST_RUN_HEAD=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || true)
             if [ -n "$POST_RUN_HEAD" ] && [ "$PRE_RUN_HEAD" = "$POST_RUN_HEAD" ]; then
+                # Policy-deny pre-check (Class C disambiguation, extended to dev-pilot
+                # from dev-groom — companion to mika#1534). If the pilot halted on a
+                # tier1/policy deny mid-flight, "Zero new commits" is the SYMPTOM, not
+                # the cause. Read persistent stderr for [policy:deny] before declaring
+                # the generic HEAD-unchanged failure. Fail-open: missing stderr → empty
+                # POLICY_DENY → fall through to existing messages.
+                #
+                # See: docs/solutions/workflow-issues/
+                #      2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md
+                POLICY_DENY=""
+                PERSISTENT_STDERR_PATH="/var/log/claude-pilot/${LOG_ID}.stderr"
+                if [ -f "$PERSISTENT_STDERR_PATH" ] && [ -r "$PERSISTENT_STDERR_PATH" ]; then
+                    POLICY_DENY=$(sed 's/\x1b\[[0-9;]*[mK]//g' "$PERSISTENT_STDERR_PATH" 2>/dev/null \
+                        | grep -m1 '\[policy:deny\]' || true)
+                fi
+
                 # mika#1333 Unit 2: For dev-groom re-dispatch, HEAD-unchanged is
                 # expected when the plan was already committed in a prior run.
                 # The architect pass (_iterate_groom_loop) is what matters — don't
                 # poison RESULT with PIPELINE FAILURE for the expected re-dispatch state.
-                if [ "$SKILL" = "dev-groom" ] && [ -n "$WORKTREE_DIR" ] && \
+                if [ -n "$POLICY_DENY" ]; then
+                    # Class C — policy-deny halt. The pilot tried to do legitimate
+                    # work and was prevented by a tier1/policy allow-list gap. NOT
+                    # to be confused with LLM drift or genuine dirty-worktree-rescue.
+                    RESULT="PIPELINE FAILURE: claude-pilot session halted by policy deny — not generic exit.
+
+Halt event: ${POLICY_DENY}
+
+Likely a tier1 or tier2 allow-list gap in claude-pilot-py. Investigate the deny rule and either (a) widen the policy to include the legitimate command shape, or (b) rewrite the dispatch context so the pilot avoids the denied command. The pilot was prevented from completing its work — re-dispatching without addressing the substrate gap will hit the same wall.
+
+See: docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md
+
+${RESULT}"
+                elif [ "$SKILL" = "dev-groom" ] && [ -n "$WORKTREE_DIR" ] && \
                    find "$WORKTREE_DIR/docs/plans" -name "*-plan.md" -size +500c 2>/dev/null | grep -q .; then
                     RESULT="Note: HEAD unchanged on dev-groom re-dispatch — plan already committed from prior run. Architect pass will determine outcome.
 

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -2228,6 +2228,47 @@ RESULT=$(_test_policy_deny_check "$POLICY_DENY_FIXTURE_DIR/multi_deny.stderr")
 assert_contains "First deny extracted" "cmd1" "$RESULT"
 assert_not_contains "Subsequent denies not included" "cmd2" "$RESULT"
 
+# --- Test 14: policy-deny disambiguation extended to dev-pilot ---
+# Companion to mika#1534 (dev-groom disambiguation). The Class C policy-deny
+# check now also fires on dev-pilot post-flight before the generic "Zero new
+# commits" / "HEAD unchanged" message. Validates the structural placement.
+
+echo ""
+echo "Test 14: Policy-deny disambiguation extended to dev-pilot (structural)"
+echo "----------------------------------------------------------------------"
+
+POSTFLIGHT_BLOCK=$(sed -n '/Post-flight diff check: detect zero-commit/,/Unit 1 (mika#1282)/p' "$DISPATCH_LIB")
+
+assert_contains "Class C check fires on HEAD-unchanged for ALL skills (not just dev-groom)" \
+    'Policy-deny pre-check (Class C disambiguation, extended to dev-pilot' "$POSTFLIGHT_BLOCK"
+assert_contains "POLICY_DENY variable set in HEAD-unchanged path" \
+    'POLICY_DENY=""' "$POSTFLIGHT_BLOCK"
+assert_contains "Reads persistent stderr at LOG_ID path" \
+    'PERSISTENT_STDERR_PATH="/var/log/claude-pilot/${LOG_ID}.stderr"' "$POSTFLIGHT_BLOCK"
+assert_contains "Strips ANSI before grep" \
+    'sed' "$POSTFLIGHT_BLOCK"
+assert_contains "Searches for [policy:deny] marker" \
+    '[policy:deny]' "$POSTFLIGHT_BLOCK"
+assert_contains "Class C message — halted by policy deny, NOT generic exit" \
+    'halted by policy deny — not generic exit' "$POSTFLIGHT_BLOCK"
+assert_contains "Links to investigation doc" \
+    'drift-misdiagnosis-policy-deny-halt' "$POSTFLIGHT_BLOCK"
+
+# Branch ordering: POLICY_DENY must precede BOTH the dev-groom-re-dispatch
+# Note AND the generic "Zero new commits" message in source order.
+POLICY_LINE=$(echo "$POSTFLIGHT_BLOCK" | grep -n 'if \[ -n "\$POLICY_DENY" \]' | head -1 | cut -d: -f1)
+GROOM_LINE=$(echo "$POSTFLIGHT_BLOCK" | grep -n 'HEAD unchanged on dev-groom re-dispatch' | head -1 | cut -d: -f1)
+ZERO_COMMITS_LINE=$(echo "$POSTFLIGHT_BLOCK" | grep -n 'Zero new commits produced' | head -1 | cut -d: -f1)
+if [ -n "$POLICY_LINE" ] && [ -n "$GROOM_LINE" ] && [ -n "$ZERO_COMMITS_LINE" ] \
+    && [ "$POLICY_LINE" -lt "$GROOM_LINE" ] && [ "$POLICY_LINE" -lt "$ZERO_COMMITS_LINE" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ POLICY_DENY branch precedes both dev-groom-note and zero-commits messages"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ POLICY_DENY branch must precede both messages in HEAD-unchanged block"
+    echo "    (POLICY_LINE=$POLICY_LINE, GROOM_LINE=$GROOM_LINE, ZERO_COMMITS_LINE=$ZERO_COMMITS_LINE)"
+fi
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

Completes mika#1534 by extending the Class C policy-deny disambiguation message to the dev-pilot slot. The dev-groom side already had it; dev-pilot's HEAD-unchanged check still reported "Zero new commits produced" without naming the actual halt cause.

## Founding incident

mika#742 dispatch yesterday: pilot ran \`/ce:review\` (compound-engineering upstream plugin) which sets up its log dir with:

\`\`\`bash
RUN_ID=\$(date +%Y%m%d-%H%M%S)-\$(head -c4 /dev/urandom | od -An -tx1 | tr -d ' ') && echo "\$RUN_ID" && mkdir -p "/tmp/compound-engineering/ce-code-review/\$RUN_ID"
\`\`\`

\`\$()\` is in \`_SUBSTITUTION_MARKERS\` (tier1 deny by design — command-injection vector). Policy halts the pilot, dispatch-lib reports "Zero new commits produced", operator-facing message implicates the LLM instead of the substrate.

## Fix

Lift POLICY_DENY check above the HEAD-unchanged branch chain. Fires for ANY skill before the generic / dev-groom-specific messages. Operator sees the actual halt event + link to investigation doc + actionable unblock guidance.

Pure additive: when no policy-deny in stderr, falls through to existing messages unchanged.

## Tests

8 new structural assertions in test-dispatch-lib.sh covering:
- POLICY_DENY variable initialized in HEAD-unchanged path
- Reads from persistent stderr at LOG_ID convention
- Strips ANSI before grep
- Class C message naming "halted by policy deny — not generic exit"
- Links to investigation doc
- POLICY_DENY branch precedes BOTH dev-groom-note AND zero-commits messages in source order

**237/237** test-dispatch-lib.sh assertions pass (229 prior + 8 new).

## Related

- Predecessor: #1534 (dev-groom side)
- Investigation: \`mika/docs/solutions/workflow-issues/2026-06-14-dev-groom-drift-misdiagnosis-policy-deny-halt.md\`
- Founding incident: #742 \`/ce:review\` \`\$()\` halt

🤖 Generated with [Claude Code](https://claude.com/claude-code)