### PR TITLE
ci(check): clean stale gentux runner _diag/pages logs before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ jobs:
     name: Check
     runs-on: [self-hosted, Linux, X64, gentux]
     steps:
+      # mika#1542: gentux self-hosted runner's _diag/pages dir can retain
+      # stale .log files from cancelled / concurrent-cancelled prior jobs,
+      # which collide with the new job's diagnostic file at checkout time:
+      #   "The file '/var/lib/actions-runner/runner/_diag/pages/<uuid>_<uuid>_1.log' already exists."
+      # Best-effort cleanup BEFORE actions/checkout removes the stale files
+      # so the new job's logging handler can create its own. Silent fallback
+      # if dir is missing or permissions deny — the next step's checkout will
+      # then surface any real (non-stale) error.
+      - name: Clean stale runner diagnostic pages (mika#1542)
+        run: rm -f /var/lib/actions-runner/runner/_diag/pages/*.log 2>/dev/null || true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Install rustup if missing (self-hosted runner)
         run: |


### PR DESCRIPTION
## Summary

The Check job's `actions/checkout` step has been failing intermittently across many PRs today with:

```
The file '/var/lib/actions-runner/runner/_diag/pages/<uuid>_<uuid>_1.log' already exists.
```

**Root cause:** the gentux self-hosted runner retains stale `.log` files in `/var/lib/actions-runner/runner/_diag/pages/` from cancelled or concurrent-cancelled prior jobs. When the next job's logging handler tries to create its diagnostic file, the path collides with the stale one and `actions/checkout` aborts before any real work.

**Fix:** insert a best-effort cleanup step at the top of the Check job's `steps:` list — runs BEFORE `actions/checkout`, removes `*.log` files in the pages dir, silent fallback on missing-dir / perm-denied so the next step surfaces any real (non-stale) error.

## Why this is the structural unblock

Every PR shipped today (mika#1536, #1539, #1540, #1541) hit this flake and required admin-bypass merge. Once this lands, `gh pr merge --auto` should work on the autonomous loop's path without bypass.

## Test plan

- [x] Verify the cleanup step runs before `actions/checkout` (positionally — top of `steps:`)
- [x] Verify silent fallback semantics (`2>/dev/null || true`)
- [ ] Watch this PR's own Check run — if the cleanup works, Check passes; if the flake re-triggers despite the cleanup, more investigation needed

Closes #1542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)