### PR TITLE
ci(check): capture gentux runner diagnostic snapshot at job start (mika#1544)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,28 @@ jobs:
       # then surface any real (non-stale) error.
       - name: Clean stale runner diagnostic pages (mika#1542)
         run: rm -f /var/lib/actions-runner/runner/_diag/pages/*.log 2>/dev/null || true
+      # mika#1544: capture gentux runner state at job start for flake investigation.
+      # The actions/checkout step fails ~3s into the job with "Missing file at path:
+      # _runner_file_commands/set_output_<uuid>" on a corrupted-runner-state class.
+      # Per-job snapshot of _work/_temp/_runner_file_commands/, inode count, and
+      # runner process list narrows the hypothesis (state corruption vs cancel race
+      # vs inode pressure) without requiring host access. Best-effort; never fails.
+      - name: Capture gentux runner diagnostic snapshot (mika#1544)
+        run: |
+          {
+            echo "=== _work/_temp/_runner_file_commands/ contents ==="
+            ls -la /var/lib/actions-runner/runner/_work/_temp/_runner_file_commands/ 2>&1 | head -30 || true
+            echo ""
+            echo "=== _work/_temp/ top-level ==="
+            ls -la /var/lib/actions-runner/runner/_work/_temp/ 2>&1 | head -10 || true
+            echo ""
+            echo "=== inode usage on _work/ filesystem ==="
+            df -i /var/lib/actions-runner/runner/_work/ 2>&1 || true
+            echo ""
+            echo "=== runner processes (first 5) ==="
+            pgrep -af 'Runner\.|actions-runner' 2>&1 | head -5 || true
+          } 2>&1
+        continue-on-error: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Install rustup if missing (self-hosted runner)
         run: |


### PR DESCRIPTION
## Summary

Adds a `continue-on-error: true` step at the top of the Check job that snapshots gentux runner state — `_work/_temp/_runner_file_commands/` contents, inode usage on the work filesystem, and the runner process list.

**This does not fix the flake.** It gives us per-job telemetry the next time the `_runner_file_commands/set_output_* missing` failure fires (filed as **mika#1544**), so we can narrow the three hypotheses without needing host access:

| Hypothesis | What the snapshot reveals |
|---|---|
| 1 — runner state corruption | Whether stale files from prior jobs persist between jobs |
| 2 — cancel-in-progress race | Whether multiple runner processes are racing in the listing |
| 3 — inode/disk pressure | Whether `df -i` shows the filesystem near exhaustion |

## Why this is safe

- `continue-on-error: true` — diagnostic step never fails the Check job
- Best-effort `|| true` on each command — missing paths or permission denial don't crash the snapshot
- Pure read-only — no writes or restarts
- Runs after the existing `_diag/pages` cleanup (mika#1542 fix) so the order is: clean → snapshot → checkout

## Pipeline-Exempt: code-only — pure CI workflow addition, no plan needed.

## Test plan

- [x] yaml validates
- [ ] Next CI run on this PR exercises the new step — snapshot appears in the Check job log regardless of subsequent step outcome
- [ ] If the runner is in its known-corrupted state, the snapshot will show the smoking gun and we can advance mika#1544's diagnosis from speculation to evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)