### PR TITLE
fix(dispatch-lib): structural completion gate for HEAD-advanced-no-PR (mika#1383)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -918,6 +918,97 @@ ${RESULT}"
                     fi
                 fi
             fi
+
+            # mika#1383: structural completion gate for HEAD-advanced-no-PR.
+            # The pilot session ran content and committed, but ended its turn
+            # before invoking `gh pr create` (Mode 1 = bare `/ce-work` launch
+            # never had commit→PR in scope; Mode 2 = full `/mika` launch hit
+            # prompt-enforcement fragility on the tail). dispatch-lib owns the
+            # git/PR tail per mika#1271 (content/workflow split). Honors
+            # Vincent's pre-reboot framing: "gate the loop until the tail's
+            # fixed". Companion to mika#1282 (handles HEAD-unchanged + dirty);
+            # this block handles HEAD-changed + missing PR.
+            #
+            # Decision matrix when this block fires (HEAD changed):
+            #   dirty worktree           → Phase A: rescue dirty into wip() commit
+            #   PR exists for branch     → Phase B no-op (existing path is success)
+            #   no PR exists for branch  → Phase B: gh pr create from existing commits
+            #
+            # Scoped to dev-pilot only — dev-groom produces plan-only commits
+            # and intentionally has no PR (plan goes on the branch, not in a PR).
+            if [ "$SKILL" = "dev-pilot" ] && \
+               [ -n "$POST_RUN_HEAD" ] && [ "$PRE_RUN_HEAD" != "$POST_RUN_HEAD" ] && \
+               [ -n "$WORKTREE_DIR" ] && [ -n "$BRANCH" ]; then
+
+                # Phase A: rescue any trailing dirty content (pilot committed but
+                # left additional uncommitted changes). Same exclusion pattern as
+                # mika#1282 (scaffold paths must not be re-committed).
+                DIRTY_AFTER_COMMITS=$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null | head -5)
+                if [ -n "$DIRTY_AFTER_COMMITS" ]; then
+                    git -C "$WORKTREE_DIR" add -A -- \
+                        ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9 || true
+                    if ! git -C "$WORKTREE_DIR" diff --cached --quiet 2>&9; then
+                        if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): trailing content after pilot end_turn (mika#1383)" 2>&9; then
+                            git -C "$WORKTREE_DIR" push origin "$BRANCH" 2>&9 || true
+                            POST_RUN_HEAD=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || true)
+                            RESULT="${RESULT}
+
+dispatch-lib (mika#1383): rescued trailing dirty content into wip() commit before PR check."
+                        fi
+                    fi
+                fi
+
+                # Phase B: PR existence check. Use `gh pr list` filtered by
+                # head branch — `gh pr view <branch>` requires the PR exist;
+                # listing is the discoverable read.
+                EXISTING_PR=""
+                if command -v gh &>/dev/null; then
+                    EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json url --jq '.[0].url // ""' 2>/dev/null || true)
+                fi
+
+                if [ -z "$EXISTING_PR" ]; then
+                    # No PR exists for this branch. Auto-create from existing commits.
+                    # Title: derive from latest commit subject (preserves pilot intent).
+                    # Body: link to dispatch-lib's structural completion gate doc.
+                    PR_TITLE=$(git -C "$WORKTREE_DIR" log -1 --format='%s' 2>/dev/null || echo "Auto-PR for ${REPO}#${ISSUE_NUM}")
+                    PR_BODY="$(cat <<PR_BODY_EOF
+Auto-created by dispatch-lib (mika#1383 structural completion gate).
+
+The pilot session completed work and committed but did not reach \`gh pr create\` before its turn ended. dispatch-lib takes ownership of the commit→PR tail per mika#1271 (content/workflow split). The pilot owned content; dispatch-lib owns git/PR.
+
+Pilot session: \`${LOG_ID}\`
+Branch: \`${BRANCH}\`
+
+Closes #${ISSUE_NUM}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PR_BODY_EOF
+)"
+
+                    if PR_CREATE_OUT=$(gh pr create \
+                            --repo "$REPO" \
+                            --base main \
+                            --head "$BRANCH" \
+                            --title "$PR_TITLE" \
+                            --body "$PR_BODY" 2>&1); then
+                        # Re-query the PR URL (gh pr create prints it but parsing is fragile).
+                        EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json url --jq '.[0].url // ""' 2>/dev/null || true)
+                        RESULT="${RESULT}
+
+dispatch-lib (mika#1383): auto-created PR ${EXISTING_PR} from pilot's commits — pilot reached end_turn without invoking gh pr create."
+                    else
+                        # PR creation failed — surface manual recovery.
+                        # Common causes: gh auth scope, branch already has closed PR, base branch mismatch.
+                        RESULT="PIPELINE FAILURE: pilot produced commits on ${BRANCH} but no PR exists, and dispatch-lib's auto-create attempt failed.
+gh pr create error: $(printf '%s' "$PR_CREATE_OUT" | head -5)
+
+Manual recovery:
+  gh pr create --repo ${REPO} --base main --head ${BRANCH} --title \"<title>\" --body \"<body>\"
+
+${RESULT}"
+                    fi
+                fi
+            fi
         fi
 
         # Post-flight plan validation (mika#1033, mika#1032, mika#1394): detect

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -2269,6 +2269,61 @@ else
     echo "    (POLICY_LINE=$POLICY_LINE, GROOM_LINE=$GROOM_LINE, ZERO_COMMITS_LINE=$ZERO_COMMITS_LINE)"
 fi
 
+# --- Test 15: mika#1383 structural completion gate (HEAD-changed + missing PR) ---
+#
+# mika#1383: dispatch-lib now auto-creates a PR when the pilot committed but
+# didn't reach `gh pr create`. This is the structural completion gate for the
+# tail-loss failure modes (Mode 1: bare /ce-work, Mode 2: full /mika tail).
+# Tests validate the placement, scope (dev-pilot only), decision flow.
+
+echo ""
+echo "Test 15: mika#1383 structural completion gate (HEAD-changed + no PR)"
+echo "--------------------------------------------------------------------"
+
+# Block extraction: from the gate's marker comment to the next major section.
+GATE_BLOCK=$(sed -n '/mika#1383: structural completion gate/,/Post-flight plan validation/p' "$DISPATCH_LIB")
+
+assert_contains "Gate references mika#1271 (content/workflow split)" \
+    'mika#1271' "$GATE_BLOCK"
+assert_contains "Gate references mika#1282 (companion handler for HEAD-unchanged + dirty)" \
+    'mika#1282' "$GATE_BLOCK"
+assert_contains "Gate scoped to dev-pilot only (groom intentionally has no PR)" \
+    'SKILL" = "dev-pilot"' "$GATE_BLOCK"
+assert_contains "Gate fires only when HEAD has advanced (PRE != POST)" \
+    'PRE_RUN_HEAD" != "$POST_RUN_HEAD"' "$GATE_BLOCK"
+assert_contains "Gate uses gh pr list --head <branch> for PR existence check" \
+    'gh pr list --repo "$REPO" --head "$BRANCH"' "$GATE_BLOCK"
+assert_contains "Phase A: trailing dirty rescue with wip() prefix" \
+    'wip(${REPO}#${ISSUE_NUM}): trailing content after pilot end_turn (mika#1383)' "$GATE_BLOCK"
+assert_contains "Phase A: same scaffold-path exclusion as mika#1282 (.claude/commands, claude-pilot.json)" \
+    ":!.claude/commands/" "$GATE_BLOCK"
+assert_contains "Phase B: gh pr create with --base main --head BRANCH" \
+    'gh pr create' "$GATE_BLOCK"
+assert_contains "Phase B: PR title derived from latest commit subject" \
+    'git -C "$WORKTREE_DIR" log -1 --format=' "$GATE_BLOCK"
+assert_contains "Phase B: Closes #ISSUE_NUM in body" \
+    'Closes #${ISSUE_NUM}' "$GATE_BLOCK"
+assert_contains "PR-create failure surfaces structured manual recovery command" \
+    'PIPELINE FAILURE: pilot produced commits on' "$GATE_BLOCK"
+assert_contains "Manual recovery names the gh pr create command verbatim" \
+    'Manual recovery:' "$GATE_BLOCK"
+
+# Structural placement: the gate must fire AFTER the mika#1282 dirty-rescue
+# (which only handles HEAD-unchanged) and BEFORE the dev-groom-specific
+# post-flight plan validation. Both bounds verified by source order.
+GATE_LINE=$(grep -n 'mika#1383: structural completion gate' "$DISPATCH_LIB" | head -1 | cut -d: -f1)
+M1282_LINE=$(grep -n 'Unit 1 (mika#1282): detect dirty worktree' "$DISPATCH_LIB" | head -1 | cut -d: -f1)
+GROOM_PLAN_LINE=$(grep -n 'Post-flight plan validation (mika#1033' "$DISPATCH_LIB" | head -1 | cut -d: -f1)
+if [ -n "$GATE_LINE" ] && [ -n "$M1282_LINE" ] && [ -n "$GROOM_PLAN_LINE" ] \
+    && [ "$M1282_LINE" -lt "$GATE_LINE" ] && [ "$GATE_LINE" -lt "$GROOM_PLAN_LINE" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ Gate placement: after mika#1282 dirty-rescue, before dev-groom plan validation"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ Gate placement violated source-order invariant"
+    echo "    (GATE_LINE=$GATE_LINE, M1282_LINE=$M1282_LINE, GROOM_PLAN_LINE=$GROOM_PLAN_LINE)"
+fi
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

Closes [mika#1383](https://github.com/senara-solutions/mika/issues/1383). Substrate fix.

The pilot session sometimes completes work and commits but ends its turn before invoking `gh pr create`, leaving a branch with commits and no PR. The [spawn's transcript analysis](https://github.com/senara-solutions/mika/issues/1383#issuecomment-4698170243) on 2026-06-13 documented this across two structural failure modes:

- **Mode 1** (n=3, #974/#1247/#1398): bare `/ce-work <plan> mika#N` launch — the commit→PR tail is downstream of `/ce:work` and never invoked. #1398 self-initiated `ce-commit-push-pr` and reached commit+push but **not PR-create**.
- **Mode 2** (n=2, #1453/#1394): correct `/mika` launch; ran plan→work→review; ended turn before commit→PR. Prompt-enforcement fragility class.

Vincent's framing: *"bare-/ce-work is intentional per mika#1271 (pilot does content, dispatch-lib owns git); gate the loop until the tail's fixed."* The fix lives in dispatch-lib's post-flight, not in the pilot prompt — composes with the mika#1282 companion (which handles HEAD-unchanged + dirty).

## Decision matrix (when gate fires)

```
dev-pilot + HEAD-advanced + worktree + branch:

  dirty worktree           → Phase A: rescue trailing dirty into wip() commit
  PR exists for branch     → Phase B no-op (existing success path)
  no PR exists for branch  → Phase B: gh pr create from existing commits
  gh pr create fails       → PIPELINE FAILURE with verbatim manual recovery
```

## Scope

- **`dev-pilot` only.** `dev-groom` intentionally has no PR (plan-only commit on branch).
- Structural placement: **after** mika#1282 dirty-rescue (HEAD-unchanged + dirty), **before** dev-groom plan validation. Source-order verified by Test 15 placement invariant.

## What's deliberately NOT in this PR

- **Running `/ce:review` from dispatch-lib.** Mode 1 launches `/ce-work` only, skipping review. To run review, dispatch-lib would need to spawn another claude-pilot session (significant complexity). Accepted as a known limitation in v1 of the gate; the spawn's comment names this "the quality hole."
- **Dispatcher-layer fix (always `/mika`, never bare `/ce-work`).** Per Vincent's framing, bare-`/ce-work` is intentional per mika#1271. Tail completion is dispatch-lib's lane.

## Tests

13 new structural assertions in `test-dispatch-lib.sh`:

- Gate references mika#1271 (content/workflow split) + mika#1282 (companion)
- Gate scoped to dev-pilot only
- Gate fires only when HEAD has advanced
- Uses `gh pr list --head <branch>` for PR existence check (discoverable read)
- Phase A: trailing dirty rescue with `wip()` prefix + scaffold-path exclusion
- Phase B: `gh pr create` with title from latest commit, body with `Closes #N`
- PR-create failure surfaces structured manual recovery command
- **Placement invariant:** gate is between mika#1282 dirty-rescue and dev-groom plan validation (source-order check)

Total: **250 passed, 0 failed.**

## Memory + doc commitments post-merge

- Update `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate` body to note the structural fix landed
- Compound learning doc: `dispatch-lib-structural-completion-gate-2026-06-16.md`
- Close the spawn's counter `dispatch-lib-wip-rescue n=6, root-caused`

Closes #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)