### PR TITLE
fix(dispatch-lib): exclude .claude/settings.local.json + .claude/*.local.* from rescue (mika#1552)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -759,14 +759,19 @@ ${RESULT}"
                 DIRTY_FILES=$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null | head -20)
                 if [ -n "$DIRTY_FILES" ]; then
                     # Stage all dirty files EXCEPT worktree-scaffold paths copied by
-                    # _set_up_worktree (mika#1288, mika#1419):
+                    # _set_up_worktree (mika#1288, mika#1419, mika#1552):
                     #   - .claude/commands/         slash-command snapshots from mika-platform
                     #   - .claude/claude-pilot.json relay config cp'd from $PLATFORM_DIR at :489
-                    # Neither is pilot-authored content. Without the second exclusion, the
-                    # rescue commit re-introduces .claude/claude-pilot.json whose intentional
-                    # deletion shipped in PR #1348 (mika#1193 Phase C) — the founding incident
-                    # for mika#1419 (ping-pong on the file's git log).
-                    git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
+                    #   - .claude/settings.local.json  permission allowlist cp'd at :490 (mika#1552)
+                    #   - .claude/*.local.*          general guard for any future Claude-local
+                    #                                files (.env-class — operator-machine-specific)
+                    # None is pilot-authored content. Without the second exclusion, the rescue
+                    # commit re-introduces .claude/claude-pilot.json whose intentional deletion
+                    # shipped in PR #1348 (mika#1193 Phase C) — the founding incident for
+                    # mika#1419. The third + fourth catch the .claude/settings.local.json class
+                    # — cm#5 dispatch (2026-06-16) produced PR #16 whose only "rescued" content
+                    # was a 143-line operator allowlist leak (mika#1552 founding incident).
+                    git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' ':!.claude/settings.local.json' ':!.claude/*.local.*' 2>&9
 
                     # Guard: if pathspec exclusion left nothing staged, skip the rescue
                     # commit. Handles the edge case where the pilot wrote ONLY to scaffold
@@ -794,7 +799,7 @@ ${RESULT}"
                             # Same exclusion pathspec as the initial `git add -A` above
                             # (mika#1288, mika#1419) — keeps scaffold paths out of the
                             # post-fmt re-add.
-                            git -C "$WORKTREE_DIR" add -u -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
+                            git -C "$WORKTREE_DIR" add -u -- ':!.claude/commands/' ':!.claude/claude-pilot.json' ':!.claude/settings.local.json' ':!.claude/*.local.*' 2>&9
                         fi
 
                         # Attempt rescue commit — capture stderr for hook-failure diagnosis (mika#1296).
@@ -849,7 +854,7 @@ ${RESULT}"
                             # Same exclusion pathspec as the initial `git add -A` above
                             # (mika#1288, mika#1419) — scaffold paths stay excluded on the
                             # post-fmt retry path too.
-                            git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9
+                            git -C "$WORKTREE_DIR" add -A -- ':!.claude/commands/' ':!.claude/claude-pilot.json' ':!.claude/settings.local.json' ':!.claude/*.local.*' 2>&9
 
                             # mika#1310: capture both stdout+stderr (see above).
                             if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): impl staged by post-flight recovery (mika#1282)
@@ -946,7 +951,7 @@ ${RESULT}"
                 DIRTY_AFTER_COMMITS=$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null | head -5)
                 if [ -n "$DIRTY_AFTER_COMMITS" ]; then
                     git -C "$WORKTREE_DIR" add -A -- \
-                        ':!.claude/commands/' ':!.claude/claude-pilot.json' 2>&9 || true
+                        ':!.claude/commands/' ':!.claude/claude-pilot.json' ':!.claude/settings.local.json' ':!.claude/*.local.*' 2>&9 || true
                     if ! git -C "$WORKTREE_DIR" diff --cached --quiet 2>&9; then
                         if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): trailing content after pilot end_turn (mika#1383)" 2>&9; then
                             git -C "$WORKTREE_DIR" push origin "$BRANCH" 2>&9 || true

--- a/skills/bundled/_shared/test-dispatch-lib.sh
+++ b/skills/bundled/_shared/test-dispatch-lib.sh
@@ -960,6 +960,70 @@ else
     echo "  ✗ Empty-index guard with both scaffolds: $RESULT_D"
 fi
 
+# Test E (mika#1552): settings.local.json + .claude/*.local.* exclusion —
+# permission allowlist file written by claude-pilot (or worktree setup) MUST NOT
+# ship as pilot-authored content. cm#5 dispatch (2026-06-16) produced PR #16
+# whose ONLY changed file was a 143-line .claude/settings.local.json leak,
+# zero adapter implementation — the founding incident.
+test_auto_rescue_excludes_settings_local_json() {
+    local test_dir
+    test_dir=$(mktemp -d)
+    trap "rm -rf '$test_dir'" RETURN
+
+    git -C "$test_dir" init -q
+    git -C "$test_dir" commit --allow-empty -m "initial" -q
+
+    # 1. settings.local.json — must NOT be staged (mika#1552 explicit case).
+    mkdir -p "$test_dir/.claude"
+    echo '{"permissions": ["Bash(ls)"]}' > "$test_dir/.claude/settings.local.json"
+
+    # 2. hooks.local.json — must NOT be staged (mika#1552 wildcard case via .local.*).
+    echo '{"PreToolUse": []}' > "$test_dir/.claude/hooks.local.json"
+
+    # 3. Pilot-authored new file — must be staged.
+    mkdir -p "$test_dir/src"
+    echo "fn main() {}" > "$test_dir/src/new_feature.rs"
+
+    # Exercise: the mika#1552 extended pathspec exclusion.
+    git -C "$test_dir" add -A -- \
+        ':!.claude/commands/' \
+        ':!.claude/claude-pilot.json' \
+        ':!.claude/settings.local.json' \
+        ':!.claude/*.local.*' 2>/dev/null
+
+    local staged
+    staged=$(git -C "$test_dir" diff --cached --name-only)
+
+    # settings.local.json must NOT appear (mika#1552 explicit exclusion).
+    if echo "$staged" | grep -q '.claude/settings.local.json'; then
+        echo "FAIL: .claude/settings.local.json was staged (mika#1552 leak)"
+        return 1
+    fi
+
+    # hooks.local.json must NOT appear (mika#1552 wildcard exclusion).
+    if echo "$staged" | grep -q '.claude/hooks.local.json'; then
+        echo "FAIL: .claude/hooks.local.json was staged (mika#1552 wildcard gap)"
+        return 1
+    fi
+
+    # Pilot-authored file MUST be staged.
+    if ! echo "$staged" | grep -q 'src/new_feature.rs'; then
+        echo "FAIL: pilot-authored file was not staged"
+        return 1
+    fi
+
+    echo "PASS"
+}
+
+RESULT_E=$(test_auto_rescue_excludes_settings_local_json 2>/dev/null)
+if [ "$RESULT_E" = "PASS" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ settings.local.json + *.local.* excluded (mika#1552 founding case)"
+else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ settings.local.json exclusion: $RESULT_E"
+fi
+
 RESULT_B=$(test_auto_rescue_empty_index_guard 2>/dev/null)
 if [ "$RESULT_B" = "PASS" ]; then
     PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary
- mika#1282 dirty-worktree-rescue pathspec missed `.claude/settings.local.json` (the Claude Code permission allowlist) — when claude-pilot exits dirty with only the allowlist present, the rescue ships it as if it were pilot impl. cm#5 dispatch on 2026-06-16 produced draft PR #16 with a 143-line allowlist leak and zero adapter implementation (n=3 same-day on cm — founding incident).
- Extends the exclusion at all 4 rescue sites in `dispatch-lib.sh`: initial `add -A`, post-fmt `add -u`, cargo-fmt-retry `add -A`, and the mika#1383 trailing-dirty rescue.
- Adds both an explicit `:!.claude/settings.local.json` exclusion AND a general `:!.claude/*.local.*` wildcard (matches the meta-repo .gitignore convention; covers future `hooks.local.json`-class files).
- New Test E covers both the explicit settings.local.json case and the wildcard `.local.*` case (via `hooks.local.json`), plus assertion that real pilot-authored content still gets staged.

## Test plan
- [x] `bash skills/bundled/_shared/test-dispatch-lib.sh` → 251 passed, 0 failed
- [x] All 4 `git add -A`/`add -u` sites in dispatch-lib carry the extended exclusion list
- [ ] Live: next claude-pilot dispatch that exits dirty with only `.claude/settings.local.json` content yields NO PR (empty-index guard fires; settings.local.json was the only dirty content)
- [ ] Live: claude-pilot dispatch with real impl + settings.local.json yields a clean PR with NO settings.local.json in the diff

Closes #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)