### PR TITLE
chore(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,9 +3010,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
RUSTSEC-2026-0185 (high severity, CVSS 7.5) dropped earlier today flagging quinn-proto 0.11.14. Every PR run after that point fails the Security job at the cargo-audit step — the autonomous queue currently has 6 tickets in flight, all blocked on this same advisory.

`cargo update -p quinn-proto` is a clean lockfile-only bump to 0.11.15 (upstream's fix). No source code changes, no transitive surgery.

## Verification

- [x] `cargo update -p quinn-proto` — locks 0.11.15 cleanly, no other deps affected
- [x] `cargo check --workspace` — compiles clean
- [x] `cargo audit` — exit 0 (advisory cleared)

## Why this is urgent

Without merging this, the entire autonomous loop overnight throughput is dead. The 6 in-flight PRs (mika#1404, #1167, #1091, #766, #1410, plus #1484) all fail Security regardless of their own correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)