### PR TITLE
chore(git): union-merge driver for .claude/groom-verdict-trail.log

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Append-only trail logs use the union merge driver — two branches each
+# appending different entries to the file must NOT produce a conflict, since
+# both halves are valid history. Without this, the autonomous loop's
+# parallel grooming dispatches conflict on every base update.
+.claude/groom-verdict-trail.log merge=union


### PR DESCRIPTION
The autonomous loop appends to `.claude/groom-verdict-trail.log` on every grooming dispatch. When main advances between a PR's creation and merge, the PR's trail-log appends conflict with main's — even though both halves are valid history (append-only). Every queued PR ends up `DIRTY/CONFLICTING` until manually resolved.

`merge=union` tells git to keep both sides on conflict instead of flagging it. Standard pattern for append-only logs / CHANGELOG.md / similar files where divergent appends should always be preserved.

## Evidence

Tonight's autonomous queue hit this exact conflict on 5 PRs (#1557, #1558, #1556, plus 2 already manually resolved). Without this fix, every new dispatched ticket will keep conflicting whenever main moves first.

## Verification

After this merges, the next time main advances and a PR with stale `groom-verdict-trail.log` is updated via "Update branch", git will auto-union the two halves instead of marking the PR DIRTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)