### PR TITLE
fix(kg): log-and-skip subject extraction on MaxTokens truncation

### DIFF
--- a/crates/mika-agent/src/kg/subject_extractor.rs
+++ b/crates/mika-agent/src/kg/subject_extractor.rs
@@ -26,7 +26,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
-use mika_common::llm::{LlmMessage, LlmProvider, LlmRequest, LlmRole, LlmUsage};
+use mika_common::llm::{LlmMessage, LlmProvider, LlmRequest, LlmRole, LlmStopReason, LlmUsage};
 
 use crate::async_db::AsyncDatabase;
 
@@ -1249,7 +1249,24 @@ Rules:
             Ok(response) => {
                 let first_latency = start.elapsed().as_millis() as u64;
                 let first_usage = response.usage.clone();
+                let first_stop_reason = response.stop_reason;
                 let text = response.text_content();
+
+                // MaxTokens detection (#1091): a truncated response is guaranteed
+                // incomplete JSON. Skip the parse and the semantic retry entirely —
+                // the retry re-sends the truncated output plus reinforcement, which
+                // only tightens the already-insufficient budget and truncates again.
+                // Distinct event makes the previously-silent failure observable.
+                if first_stop_reason == LlmStopReason::MaxTokens {
+                    warn!(
+                        trace_id = %self.trace_id,
+                        event = "extraction_max_tokens_truncated",
+                        output_len = text.len(),
+                        "LLM hit MaxTokens — response truncated, skipping parse and retry (log-and-skip per C2.3)"
+                    );
+                    return Ok(None);
+                }
+
                 match self.parse_extraction_json(&text) {
                     Ok(output) => Ok(Some(ExtractionResult {
                         output,
@@ -1272,8 +1289,13 @@ Rules:
                             latency_ms: first_latency,
                             kg_phase: "kg_extraction",
                         };
-                        self.retry_with_reinforcement(&request, &text, first_record)
-                            .await
+                        self.retry_with_reinforcement(
+                            &request,
+                            &text,
+                            first_record,
+                            first_stop_reason,
+                        )
+                        .await
                     }
                 }
             }
@@ -1287,7 +1309,22 @@ Rules:
                         Ok(response) => {
                             let latency = retry_start.elapsed().as_millis() as u64;
                             let usage = response.usage.clone();
+                            let stop_reason = response.stop_reason;
                             let text = response.text_content();
+
+                            // MaxTokens detection (#1091) — same as the attempt-1
+                            // branch: a truncated response can't be parsed and the
+                            // semantic retry would only truncate again.
+                            if stop_reason == LlmStopReason::MaxTokens {
+                                warn!(
+                                    trace_id = %self.trace_id,
+                                    event = "extraction_max_tokens_truncated",
+                                    output_len = text.len(),
+                                    "LLM hit MaxTokens — response truncated, skipping parse and retry (log-and-skip per C2.3)"
+                                );
+                                return Ok(None);
+                            }
+
                             return match self.parse_extraction_json(&text) {
                                 Ok(output) => Ok(Some(ExtractionResult {
                                     output,
@@ -1303,8 +1340,13 @@ Rules:
                                         latency_ms: latency,
                                         kg_phase: "kg_extraction",
                                     };
-                                    self.retry_with_reinforcement(&request, &text, first_record)
-                                        .await
+                                    self.retry_with_reinforcement(
+                                        &request,
+                                        &text,
+                                        first_record,
+                                        stop_reason,
+                                    )
+                                    .await
                                 }
                             };
                         }
@@ -1349,6 +1391,7 @@ Rules:
         original_request: &LlmRequest,
         bad_output: &str,
         first_record: LlmCallRecord,
+        first_attempt_stop_reason: LlmStopReason,
     ) -> Result<Option<ExtractionResult>> {
         let reinforcement = format!(
             "Your previous response was not valid JSON. The output was:\n{}\n\n\
@@ -1390,6 +1433,7 @@ Rules:
                             trace_id = %self.trace_id,
                             error = %e,
                             event = "extraction_semantic_exhausted",
+                            first_stop_reason = ?first_attempt_stop_reason,
                             "semantic retry also failed — log-and-skip per C2.3"
                         );
                         Ok(None)
@@ -2609,5 +2653,82 @@ mod tests {
         let roster = test_roster();
         let result = validate_extraction_output(&output, 5, &roster, "test-agent", "test.md");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // MaxTokens log-and-skip (#1091)
+    // -----------------------------------------------------------------------
+
+    /// Build a `SubjectExtractor` over an in-memory DB and the given mock
+    /// provider. Only the LLM + trace_id are exercised by `call_llm_with_retry`,
+    /// but a real `AsyncDatabase` is required to construct the extractor.
+    fn extractor_with_mock(mock: Arc<mika_common::llm::mock::MockLlmProvider>) -> SubjectExtractor {
+        use crate::db::Database;
+        let db = AsyncDatabase::new(Database::open_in_memory().unwrap());
+        SubjectExtractor::new(db, mock, PathBuf::from("/tmp/docs"), Some("test-maxtokens"))
+    }
+
+    /// A MaxTokens (truncated) first response must log-and-skip immediately:
+    /// `Ok(None)` with exactly ONE LLM call — the doomed semantic retry is NOT
+    /// consumed. Pre-fix, this path made a second (also-truncating) call before
+    /// ending in `extraction_semantic_exhausted`.
+    #[tokio::test]
+    async fn call_llm_max_tokens_logs_and_skips_without_retry() {
+        use mika_common::llm::mock::{MockLlmProvider, max_tokens_response};
+
+        // Truncated, unparseable JSON body + MaxTokens stop reason.
+        let mock = Arc::new(
+            MockLlmProvider::builder()
+                .response(max_tokens_response(
+                    r#"{"entities": [{"type": "skill", "na"#,
+                ))
+                .build(),
+        );
+        let extractor = extractor_with_mock(mock.clone());
+
+        let prompt = ("system".to_string(), "user".to_string());
+        let result = extractor.call_llm_with_retry(&prompt).await.unwrap();
+
+        assert!(
+            result.is_none(),
+            "MaxTokens truncation must log-and-skip (Ok(None))"
+        );
+        assert_eq!(
+            mock.calls_made(),
+            1,
+            "MaxTokens must NOT consume the semantic retry — exactly one LLM call"
+        );
+    }
+
+    /// Regression guard: a NON-truncated malformed first response still enters
+    /// the semantic retry (two calls) and recovers when the retry returns valid
+    /// JSON. Confirms the MaxTokens early-return is gated strictly on the stop
+    /// reason and does not short-circuit legitimate semantic recovery.
+    #[tokio::test]
+    async fn call_llm_non_truncated_malformed_still_retries() {
+        use mika_common::llm::mock::{MockLlmProvider, text_response};
+
+        let mock = Arc::new(
+            MockLlmProvider::builder()
+                // First: EndTurn (not truncated) but unparseable.
+                .response(text_response("not json at all"))
+                // Second (semantic retry): valid empty extraction.
+                .response(text_response(r#"{"entities": [], "relationships": []}"#))
+                .build(),
+        );
+        let extractor = extractor_with_mock(mock.clone());
+
+        let prompt = ("system".to_string(), "user".to_string());
+        let result = extractor.call_llm_with_retry(&prompt).await.unwrap();
+
+        assert!(
+            result.is_some(),
+            "non-truncated malformed JSON should recover via semantic retry"
+        );
+        assert_eq!(
+            mock.calls_made(),
+            2,
+            "semantic retry path must still make two calls when not truncated"
+        );
     }
 }

--- a/docs/plans/2026-06-26-004-investigate-1091-kg-subject-extractor-maxtokens-plan.md
+++ b/docs/plans/2026-06-26-004-investigate-1091-kg-subject-extractor-maxtokens-plan.md
@@ -1,146 +1,154 @@
-# Plan: investigate(kg) — Subject extractor MaxTokens / extraction_semantic_exhausted on gpt-5-nano
+# Plan: fix(kg) — Subject extractor log-and-skip on MaxTokens truncation (gpt-5-nano)
 
 **Ticket:** senara-solutions/mika#1091
-**Type:** Investigation + fix
+**Type:** fix
 **Branch:** `investigate/1091/kg-subject-extractor-hits-maxtokens`
+**Depth:** Lightweight (single-file behavior change + one threaded param + unit tests)
 
-## Problem Statement
+---
 
-The KG subject extractor running on `openrouter/openai/gpt-5-nano` silently hits `MaxTokens` exits. The truncated LLM output fails JSON parsing, enters the C2.2 semantic retry path, which also truncates, producing `extraction_semantic_exhausted` → `Ok(None)` → subjects silently dropped from the knowledge graph.
+## Problem Frame
 
-**Root cause:** The extractor has no `LlmStopReason::MaxTokens` detection. When the response is truncated, it falls through to JSON parse failure → semantic retry (which re-sends the full conversation including the truncated output, making the token budget even tighter) → exhaustion → silent drop. The global `llm_max_tokens` default (4096) is applied uniformly to all LLM paths, but the extraction prompt (system + roster + chunk markers + full doc text) can easily consume most of that budget, leaving insufficient room for the JSON output.
+The KG subject extractor running on `openrouter/openai/gpt-5-nano` silently hits `MaxTokens` exits. The truncated LLM output fails JSON parsing, falls through the C2.2 **semantic retry** path — which re-sends the full conversation *plus* the truncated output, making the token budget even tighter, so it truncates again — and finally logs `extraction_semantic_exhausted` → `Ok(None)` → subjects silently dropped from the knowledge graph.
 
-**Secondary issue:** Token accounting for OpenRouter calls records 0 input/0 output tokens (mika#799 sibling), so there's no telemetry to measure the problem's scope.
+**Root cause (verified by reading code on this branch):** `call_llm_with_retry()` has **no `LlmStopReason::MaxTokens` detection**. A truncated response returns `Ok(response)` (not `Err`), so the truncation is invisible to the retry taxonomy and is mishandled as a malformed-JSON semantic failure.
 
-## Strategic Context (from ticket)
+**Why this is more than a one-off drop:** On the `Ok(None)` path, `extract_document` returns `Ok(ExtractionStats::default())` at `crates/mika-agent/src/kg/subject_extractor.rs:725-731` — *before* `write_extraction_results` writes the `kg_extractions` idempotency marker (step 7, ~line 789). So a truncating doc **never gets a marker, stays pending, and is re-attempted every 30-minute tick — burning 2 doomed LLM calls per cycle, indefinitely.** The failure is silent (no distinct event) and unbounded in cost.
 
-KG query-side (`query_knowledge_graph`) is being deprecated for mika-arch (decision A from 2026-05-12 KG audit). The extraction-side question is whether to fix, pause, or leave as-is. This plan addresses the "fix" path — the cheapest structural improvement that also provides the data to make the pause/continue decision with evidence.
+---
 
-## Investigation Steps
+## Scope
 
-### Step 1: Add MaxTokens-aware detection to the extractor
+**In scope (Vincent's direct dispatch, deliberately narrowed):** "Implement the log-and-skip pattern at the subject extractor on MaxTokens hits per the issue body." Concretely — detect the `MaxTokens` stop-reason, skip *immediately* (no doomed semantic retry), and emit a distinct, greppable telemetry event so the previously-silent failure mode becomes observable.
 
-**File:** `crates/mika-agent/src/kg/subject_extractor.rs`
+This is the cheapest structural improvement that also produces the data to make the strategic fix-vs-pause-vs-leave decision later. It does **not** make that decision.
 
-In `call_llm_with_retry()` (line ~1248), after the first `self.llm.send_message(&request).await` succeeds, check `response.stop_reason` before attempting JSON parse:
+### What this fix does and does NOT change
 
-```rust
-Ok(response) => {
-    let first_latency = start.elapsed().as_millis() as u64;
-    let first_usage = response.usage.clone();
-    let stop_reason = response.stop_reason;
-    let text = response.text_content();
+- **Improves:** the truncation path is now *fast* (one call, not two), *observable* (distinct WARN event), and *budget-cheaper* (eliminates the guaranteed-doomed semantic retry — halves per-cycle cost for truncating docs).
+- **Preserves intentionally:** the doc still stays **pending** (no marker newly written). Truncation can be transient — the doc text, the roster-injected prompt section, or the model can change between ticks — so permanently marking the doc "done/skipped" would lose a future-recoverable extraction. Eliminating the perpetual re-attempt is the *strategic* decision (pause/fix/leave), which is out of scope here per the issue body's own "Out of scope" section.
 
-    // MaxTokens detection: if the response was truncated, log it
-    // distinctly and skip the parse attempt — the JSON is guaranteed
-    // incomplete. This avoids wasting a semantic retry on unfixable input.
-    if stop_reason == LlmStopReason::MaxTokens {
-        warn!(
-            trace_id = %self.trace_id,
-            event = "extraction_max_tokens_truncated",
-            output_len = text.len(),
-            "LLM hit MaxTokens — response truncated, skipping parse (log-and-skip per C2.3)"
-        );
-        return Ok(None);
-    }
+---
 
-    match self.parse_extraction_json(&text) {
-        // ... existing code
-    }
-}
-```
+## Evidence (code references on this branch)
 
-**Rationale:** The semantic retry path is counterproductive for MaxTokens — it sends the truncated output + reinforcement prompt as additional messages, consuming even more of the already-insufficient token budget. Early detection saves a wasted LLM call and produces a distinct log event for telemetry.
+| Claim | Reference |
+|-------|-----------|
+| `LlmResponse` carries `stop_reason: LlmStopReason` | `crates/mika-common/src/llm/types.rs:102` |
+| `LlmStopReason::MaxTokens` variant exists | `crates/mika-common/src/llm/types.rs:154` |
+| OpenAI/OpenRouter map `finish_reason: "length"` → `LlmStopReason::MaxTokens` | `crates/mika-common/src/llm/openai.rs:750` |
+| OpenRouter uses the OpenAI-compatible provider path | gpt-5-nano truncation therefore surfaces as `MaxTokens` |
+| `Ok(None)` path returns before the idempotency-marker write | `crates/mika-agent/src/kg/subject_extractor.rs:725-731` vs step 7 `~789` |
+| Attempt-1 success branch (parse site 1) | `subject_extractor.rs` `call_llm_with_retry` `~1248` |
+| Transport-retry success branch (parse site 2) | `subject_extractor.rs` `~1286` |
+| Semantic-exhausted WARN (to be enriched) | `subject_extractor.rs` `retry_with_reinforcement` `~1388` |
 
-Apply the same check in the transport retry path (line ~1291) where parse is attempted after a successful retry.
+---
 
-### Step 2: Add `MIKA_KG_EXTRACTION_MAX_TOKENS` configuration
+## Key Technical Decisions
 
-**File:** `crates/mika-common/src/config.rs`
+**KTD-1: Detect at the response boundary, not the parse boundary.** Check `response.stop_reason == LlmStopReason::MaxTokens` immediately after each successful `send_message`, before `parse_extraction_json`. A truncated response is *guaranteed* to be incomplete JSON; attempting to parse it and then semantically retry is wasted work. Early detection is both correct (distinct cause) and cheaper (no retry).
 
-Add a new config field:
+**KTD-2: Skip both retry arms.** MaxTokens detection returns `Ok(None)` directly — it does NOT enter `retry_with_reinforcement` (semantic) nor the transport-retry loop. Re-sending a longer conversation against the same `max_tokens` budget would truncate again with certainty.
 
-```rust
-/// Max tokens for KG extraction LLM responses. Extraction outputs are
-/// structured JSON with entities and relationships — typically requires
-/// more output budget than conversational responses.
-/// Falls back to `llm_max_tokens` (4096) if unset.
-#[serde(default)]
-pub kg_extraction_max_tokens: Option<u32>,
-```
+**KTD-3: Distinct event name for observability.** Use `extraction_max_tokens_truncated` (WARN) rather than reusing `extraction_semantic_exhausted`. This makes the failure class greppable and separates "model ran out of output budget" from "model emitted malformed JSON" — two different remediations (raise budget / switch model vs. prompt-shape fix).
 
-Add a resolver method on `Settings`:
+**KTD-4: Enrich the exhaustion event too.** Even with KTD-1, a *non-truncated* first attempt can still semantically fail and the retry can truncate. Thread the first-attempt `stop_reason` into `retry_with_reinforcement` and log it on `extraction_semantic_exhausted` so operators can retroactively attribute exhaustion to truncation vs. malformed JSON.
 
-```rust
-pub fn kg_extraction_max_tokens(&self) -> u32 {
-    self.kg_extraction_max_tokens.unwrap_or(self.llm_max_tokens)
-}
-```
+**KTD-5: Preserve stay-pending semantics.** Do not write an idempotency marker on the MaxTokens path. (See Scope § "What this fix does and does NOT change.")
 
-**File:** `crates/mika-common/src/config.rs` — `make_kg_extraction_provider()` method
+---
 
-Thread the `kg_extraction_max_tokens()` value through to the provider constructor so the extraction provider uses a separate max_tokens from the global default.
+## Implementation Units
 
-**Default behavior:** When unset, falls back to `llm_max_tokens` (4096) — no behavioral change for existing deployments. Operator can set `MIKA_KG_EXTRACTION_MAX_TOKENS=8192` to give extraction more output headroom.
+### U1. MaxTokens early-detection in `call_llm_with_retry()`
 
-### Step 3: Add structured telemetry for MaxTokens events
+**Goal:** Detect a truncated (`MaxTokens`) LLM response at both parse sites and log-and-skip immediately, bypassing the doomed semantic/transport retries.
 
-**File:** `crates/mika-agent/src/kg/subject_extractor.rs`
+**Requirements:** Ticket AC "Implementation: MaxTokens detection prevents wasted retry calls and produces actionable telemetry."
 
-The `extraction_max_tokens_truncated` event from Step 1 provides the detection signal. Additionally, enrich the existing `extraction_semantic_exhausted` event with `stop_reason` information so operators can retroactively distinguish MaxTokens-caused exhaustion from genuine malformed-JSON exhaustion:
+**Dependencies:** none.
 
-```rust
-Err(e) => {
-    warn!(
-        trace_id = %self.trace_id,
-        error = %e,
-        event = "extraction_semantic_exhausted",
-        first_stop_reason = ?first_attempt_stop_reason,  // NEW
-        "semantic retry also failed — log-and-skip per C2.3"
-    );
-    Ok(None)
-}
-```
+**Files:**
+- `crates/mika-agent/src/kg/subject_extractor.rs` (modify `call_llm_with_retry`)
 
-Thread `first_attempt_stop_reason` through `retry_with_reinforcement()` as an additional parameter.
+**Approach:**
+- Parse site 1 — the attempt-1 `Ok(response)` branch (`~1248`): after capturing `usage`/`latency`, read `response.stop_reason`. If `== LlmStopReason::MaxTokens`, emit the distinct WARN (`extraction_max_tokens_truncated`) with `trace_id` and `output_len` (= `text.len()`), and `return Ok(None)` before `parse_extraction_json`.
+- Parse site 2 — the transport-retry `Ok(response)` branch (`~1286`): apply the identical check before its parse attempt.
+- `LlmStopReason` is already reachable via the existing `mika_common::llm` import surface; confirm the import line includes it (add if absent — a one-symbol import, not a new dependency).
+- Do NOT alter the `Err(...)` arms (transport/config) — they already log-and-skip correctly.
 
-### Step 4: Document env var
+**Patterns to follow:** Mirror the existing `warn!(trace_id = %self.trace_id, event = "...", ...)` structured-log shape already used for `extraction_transport_exhausted` / `extraction_config_error` in the same function. Return type stays `Result<Option<ExtractionResult>>`; `Ok(None)` is the established log-and-skip signal consumed by `extract_document` at `:725-731`.
 
-**File:** root `CLAUDE.md` — Environment Variables section, under KG optional vars
+**Test scenarios:** see U3.
 
-Add `MIKA_KG_EXTRACTION_MAX_TOKENS` with description matching the config field.
+**Verification:** A unit test proves that a `MaxTokens` response yields `Ok(None)` after exactly one `send_message` (no retry consumed). `cargo build -p mika-agent` and `cargo clippy -p mika-agent` clean.
 
-**File:** `.env.example`
+---
 
-Add the new env var with a comment.
+### U2. Enrich `extraction_semantic_exhausted` with first-attempt stop-reason
 
-## Files Changed
+**Goal:** When semantic retry still fails, record whether the *first* attempt was itself truncated, so exhaustion can be attributed to MaxTokens vs. genuine malformed JSON.
 
-| File | Change |
-|------|--------|
-| `crates/mika-agent/src/kg/subject_extractor.rs` | MaxTokens early-detection in `call_llm_with_retry()`, enriched `extraction_semantic_exhausted` logging |
-| `crates/mika-common/src/config.rs` | `kg_extraction_max_tokens: Option<u32>` field + resolver method |
-| `crates/mika-common/src/config.rs` | Thread KG-specific max_tokens through `make_kg_extraction_provider()` |
-| `CLAUDE.md` | Document `MIKA_KG_EXTRACTION_MAX_TOKENS` env var |
-| `.env.example` | Add `MIKA_KG_EXTRACTION_MAX_TOKENS` |
+**Requirements:** Ticket AC "produces actionable telemetry"; supports the deferred strategic decision with data.
 
-## Testing
+**Dependencies:** U1 (same function/region; land together to avoid churn).
 
-- **Unit test:** Add a test in `subject_extractor.rs` that constructs a `MockLlmProvider` returning a response with `stop_reason: LlmStopReason::MaxTokens` and truncated text, asserts `call_llm_with_retry()` returns `Ok(None)` without attempting a retry call (mock sequence length = 1).
-- **Unit test:** Verify `Settings::kg_extraction_max_tokens()` returns the field value when set, falls back to `llm_max_tokens` when unset.
-- **Grounding regression test:** Not needed — this is detection/telemetry, not a fabrication-class guard.
+**Files:**
+- `crates/mika-agent/src/kg/subject_extractor.rs` (modify `retry_with_reinforcement` signature + its `extraction_semantic_exhausted` WARN)
 
-## Out of Scope
+**Approach:**
+- Add a parameter `first_attempt_stop_reason: LlmStopReason` to `retry_with_reinforcement`.
+- Thread it from both call sites that invoke `retry_with_reinforcement` (attempt-1 parse-failure path and transport-retry parse-failure path), passing the `stop_reason` captured from the corresponding successful response.
+- Add `first_stop_reason = ?first_attempt_stop_reason` as a field on the existing `extraction_semantic_exhausted` WARN at `~1388`.
+- Note: with U1 in place, a `MaxTokens` first attempt no longer *reaches* the semantic retry — so in practice `first_stop_reason` here will usually be `EndTurn`. The field still earns its place: it confirms (rather than assumes) the first attempt was non-truncated, and it remains correct if U1's call-ordering is ever refactored.
 
-- **Token accounting fix (mika#799):** Separate ticket with existing worktree.
-- **Strategic pause/continue decision:** This fix provides the telemetry; the decision is operator-level.
-- **KG query-side deprecation (decision A):** Already committed.
-- **Corpora backfill (mika#1076) and resolver instrumentation (mika#1077):** Paused per audit decision.
-- **Raising the default `llm_max_tokens` globally:** Would affect all LLM paths; the per-use-case config is safer.
+**Patterns to follow:** existing `?`-debug field rendering on structured `warn!` calls in this module (e.g. `chunk_indices = ?entity.chunk_indices`).
+
+**Test scenarios:** see U3.
+
+**Verification:** `cargo build` / `cargo clippy` clean; the enriched field appears in the test's captured log (or is asserted via the function's return-path test).
+
+---
+
+### U3. Unit tests for MaxTokens detection
+
+**Goal:** Lock in the log-and-skip-on-truncation behavior and the no-wasted-retry guarantee.
+
+**Requirements:** Testing contract from the dispatch.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `crates/mika-agent/src/kg/subject_extractor.rs` (`#[cfg(test)] mod tests` — add cases)
+
+**Approach / test scenarios:**
+1. **MaxTokens → single call, no retry (happy path of the fix).** Construct a `MockLlmProvider` whose response sequence is length 1, returning `stop_reason: LlmStopReason::MaxTokens` with truncated/partial-JSON text. Drive `call_llm_with_retry`. Assert: returns `Ok(None)`; the mock recorded exactly **one** `send_message` call (the doomed semantic retry was NOT consumed). This is the core regression guard — pre-fix, this path consumed 2 calls and ended in `extraction_semantic_exhausted`.
+2. **Non-truncated malformed JSON still retries (no regression to existing semantic path).** Mock sequence length 2: first response `stop_reason: EndTurn` with unparseable text, second response `EndTurn` with valid JSON. Assert: returns `Ok(Some(_))` with the parsed output, and the mock recorded **two** calls. Confirms U1's early-return is gated strictly on `MaxTokens` and does not short-circuit legitimate semantic recovery.
+3. **(If cheaply expressible with the mock) MaxTokens in the transport-retry branch.** If the mock harness can exercise parse site 2, assert the same `Ok(None)` + single-effective-parse behavior there. If the harness cannot reach that branch without a transport-error fixture, note it as covered-by-inspection rather than forcing a brittle test.
+
+**Patterns to follow:** Existing `MockLlmProvider` usage in this crate (`mika_common::llm::mock`, sequence-based) and the inline `#[cfg(test)] mod tests` convention. Check whether `subject_extractor.rs` already has mock-based tests to mirror; if extraction tests currently live under `tests/eval/`, follow the closest existing pattern for constructing a `SubjectExtractor` with a mock provider.
+
+**Test expectation:** behavioral — scenarios 1 and 2 are required; scenario 3 is best-effort.
+
+**Verification:** `cargo test -p mika-agent` passes including the new cases.
+
+---
+
+## Out of Scope / Deferred to Follow-Up Work
+
+- **`MIKA_KG_EXTRACTION_MAX_TOKENS` config knob (raise extraction output budget).** This is option **1a** ("raise the extractor's max-tokens") from the issue body — a *different* fix direction than log-and-skip, explicitly enumerated as separate. It would give extraction more output headroom (and could be combined with a per-use-case provider). **Deliberately deferred:** the dispatch scoped to log-and-skip, and whether to spend more budget on extraction (vs. switch model, vs. chunk inputs, vs. pause the path entirely during the `query_knowledge_graph` deprecation window) is the strategic decision that belongs to the operator. The telemetry shipped here (`extraction_max_tokens_truncated` event) is precisely the data needed to make that call. File as a follow-up ticket if/when the strategic direction is chosen.
+- **Strategic pause/fix/leave decision** for KG extraction during the deprecation window (issue scope item 2) — operator-level; out of scope per the issue's own "Out of scope."
+- **OpenRouter token accounting** recording 0 input/0 output tokens (issue scope item 3) — sibling of mika#799, which has its own worktree.
+- **KG query-side deprecation (decision A)** — already committed in the 2026-05-12 brainstorm.
+- **Corpora backfill (mika#1076), resolver `no_match` instrumentation (mika#1077)** — paused per audit decision A.
+- **Raising the global `llm_max_tokens` default** — would affect every LLM path; a per-use-case lever (the deferred config knob above) is the safer shape if budget is ever the chosen fix.
+
+---
 
 ## Acceptance Criteria (from ticket, mapped)
 
-- [x] **Investigation:** Root cause confirmed — MaxTokens truncation → parse failure → silent drop. No content-correlation investigation needed (the mechanism is structural, not content-dependent).
-- [ ] **Decision:** Fix path chosen — add detection + per-use-case config. Does not preclude a future "pause extraction" decision.
-- [ ] **Implementation:** MaxTokens detection prevents wasted retry calls and produces actionable telemetry.
-- [ ] **No downstream consumer breaks:** Detection is additive; existing log-and-skip behavior preserved (just reached via a faster path with better diagnostics).
+- [x] **Investigation — correlate MaxTokens exits with content vs. distributed.** Resolved structurally: the mechanism is **not content-dependent in a way that changes the fix.** Any doc whose (system + roster + chunk-marked full text) prompt leaves gpt-5-nano insufficient output budget truncates; the extractor's response to truncation is what's broken, regardless of which docs trip it. Per-doc content correlation would refine the *strategic* fix choice (raise budget vs. chunk vs. switch model), which is deferred.
+- [x] **Decision — fix path chosen:** log-and-skip cleanly + observable telemetry (this plan). Does not preclude a later pause/raise-budget decision.
+- [ ] **Implementation:** U1 (detection + immediate skip) + U2 (enriched exhaustion telemetry). *(satisfied on merge)*
+- [ ] **No downstream consumer breaks:** detection is additive; the existing `Ok(None)` log-and-skip contract consumed by `extract_document` is unchanged — the truncation case just reaches it via a faster, observable path. Stay-pending semantics preserved. *(verified by U3 scenario 2 + review)*

--- a/docs/plans/2026-06-26-004-investigate-1091-kg-subject-extractor-maxtokens-plan.md
+++ b/docs/plans/2026-06-26-004-investigate-1091-kg-subject-extractor-maxtokens-plan.md
@@ -1,0 +1,146 @@
+# Plan: investigate(kg) — Subject extractor MaxTokens / extraction_semantic_exhausted on gpt-5-nano
+
+**Ticket:** senara-solutions/mika#1091
+**Type:** Investigation + fix
+**Branch:** `investigate/1091/kg-subject-extractor-hits-maxtokens`
+
+## Problem Statement
+
+The KG subject extractor running on `openrouter/openai/gpt-5-nano` silently hits `MaxTokens` exits. The truncated LLM output fails JSON parsing, enters the C2.2 semantic retry path, which also truncates, producing `extraction_semantic_exhausted` → `Ok(None)` → subjects silently dropped from the knowledge graph.
+
+**Root cause:** The extractor has no `LlmStopReason::MaxTokens` detection. When the response is truncated, it falls through to JSON parse failure → semantic retry (which re-sends the full conversation including the truncated output, making the token budget even tighter) → exhaustion → silent drop. The global `llm_max_tokens` default (4096) is applied uniformly to all LLM paths, but the extraction prompt (system + roster + chunk markers + full doc text) can easily consume most of that budget, leaving insufficient room for the JSON output.
+
+**Secondary issue:** Token accounting for OpenRouter calls records 0 input/0 output tokens (mika#799 sibling), so there's no telemetry to measure the problem's scope.
+
+## Strategic Context (from ticket)
+
+KG query-side (`query_knowledge_graph`) is being deprecated for mika-arch (decision A from 2026-05-12 KG audit). The extraction-side question is whether to fix, pause, or leave as-is. This plan addresses the "fix" path — the cheapest structural improvement that also provides the data to make the pause/continue decision with evidence.
+
+## Investigation Steps
+
+### Step 1: Add MaxTokens-aware detection to the extractor
+
+**File:** `crates/mika-agent/src/kg/subject_extractor.rs`
+
+In `call_llm_with_retry()` (line ~1248), after the first `self.llm.send_message(&request).await` succeeds, check `response.stop_reason` before attempting JSON parse:
+
+```rust
+Ok(response) => {
+    let first_latency = start.elapsed().as_millis() as u64;
+    let first_usage = response.usage.clone();
+    let stop_reason = response.stop_reason;
+    let text = response.text_content();
+
+    // MaxTokens detection: if the response was truncated, log it
+    // distinctly and skip the parse attempt — the JSON is guaranteed
+    // incomplete. This avoids wasting a semantic retry on unfixable input.
+    if stop_reason == LlmStopReason::MaxTokens {
+        warn!(
+            trace_id = %self.trace_id,
+            event = "extraction_max_tokens_truncated",
+            output_len = text.len(),
+            "LLM hit MaxTokens — response truncated, skipping parse (log-and-skip per C2.3)"
+        );
+        return Ok(None);
+    }
+
+    match self.parse_extraction_json(&text) {
+        // ... existing code
+    }
+}
+```
+
+**Rationale:** The semantic retry path is counterproductive for MaxTokens — it sends the truncated output + reinforcement prompt as additional messages, consuming even more of the already-insufficient token budget. Early detection saves a wasted LLM call and produces a distinct log event for telemetry.
+
+Apply the same check in the transport retry path (line ~1291) where parse is attempted after a successful retry.
+
+### Step 2: Add `MIKA_KG_EXTRACTION_MAX_TOKENS` configuration
+
+**File:** `crates/mika-common/src/config.rs`
+
+Add a new config field:
+
+```rust
+/// Max tokens for KG extraction LLM responses. Extraction outputs are
+/// structured JSON with entities and relationships — typically requires
+/// more output budget than conversational responses.
+/// Falls back to `llm_max_tokens` (4096) if unset.
+#[serde(default)]
+pub kg_extraction_max_tokens: Option<u32>,
+```
+
+Add a resolver method on `Settings`:
+
+```rust
+pub fn kg_extraction_max_tokens(&self) -> u32 {
+    self.kg_extraction_max_tokens.unwrap_or(self.llm_max_tokens)
+}
+```
+
+**File:** `crates/mika-common/src/config.rs` — `make_kg_extraction_provider()` method
+
+Thread the `kg_extraction_max_tokens()` value through to the provider constructor so the extraction provider uses a separate max_tokens from the global default.
+
+**Default behavior:** When unset, falls back to `llm_max_tokens` (4096) — no behavioral change for existing deployments. Operator can set `MIKA_KG_EXTRACTION_MAX_TOKENS=8192` to give extraction more output headroom.
+
+### Step 3: Add structured telemetry for MaxTokens events
+
+**File:** `crates/mika-agent/src/kg/subject_extractor.rs`
+
+The `extraction_max_tokens_truncated` event from Step 1 provides the detection signal. Additionally, enrich the existing `extraction_semantic_exhausted` event with `stop_reason` information so operators can retroactively distinguish MaxTokens-caused exhaustion from genuine malformed-JSON exhaustion:
+
+```rust
+Err(e) => {
+    warn!(
+        trace_id = %self.trace_id,
+        error = %e,
+        event = "extraction_semantic_exhausted",
+        first_stop_reason = ?first_attempt_stop_reason,  // NEW
+        "semantic retry also failed — log-and-skip per C2.3"
+    );
+    Ok(None)
+}
+```
+
+Thread `first_attempt_stop_reason` through `retry_with_reinforcement()` as an additional parameter.
+
+### Step 4: Document env var
+
+**File:** root `CLAUDE.md` — Environment Variables section, under KG optional vars
+
+Add `MIKA_KG_EXTRACTION_MAX_TOKENS` with description matching the config field.
+
+**File:** `.env.example`
+
+Add the new env var with a comment.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/kg/subject_extractor.rs` | MaxTokens early-detection in `call_llm_with_retry()`, enriched `extraction_semantic_exhausted` logging |
+| `crates/mika-common/src/config.rs` | `kg_extraction_max_tokens: Option<u32>` field + resolver method |
+| `crates/mika-common/src/config.rs` | Thread KG-specific max_tokens through `make_kg_extraction_provider()` |
+| `CLAUDE.md` | Document `MIKA_KG_EXTRACTION_MAX_TOKENS` env var |
+| `.env.example` | Add `MIKA_KG_EXTRACTION_MAX_TOKENS` |
+
+## Testing
+
+- **Unit test:** Add a test in `subject_extractor.rs` that constructs a `MockLlmProvider` returning a response with `stop_reason: LlmStopReason::MaxTokens` and truncated text, asserts `call_llm_with_retry()` returns `Ok(None)` without attempting a retry call (mock sequence length = 1).
+- **Unit test:** Verify `Settings::kg_extraction_max_tokens()` returns the field value when set, falls back to `llm_max_tokens` when unset.
+- **Grounding regression test:** Not needed — this is detection/telemetry, not a fabrication-class guard.
+
+## Out of Scope
+
+- **Token accounting fix (mika#799):** Separate ticket with existing worktree.
+- **Strategic pause/continue decision:** This fix provides the telemetry; the decision is operator-level.
+- **KG query-side deprecation (decision A):** Already committed.
+- **Corpora backfill (mika#1076) and resolver instrumentation (mika#1077):** Paused per audit decision.
+- **Raising the default `llm_max_tokens` globally:** Would affect all LLM paths; the per-use-case config is safer.
+
+## Acceptance Criteria (from ticket, mapped)
+
+- [x] **Investigation:** Root cause confirmed — MaxTokens truncation → parse failure → silent drop. No content-correlation investigation needed (the mechanism is structural, not content-dependent).
+- [ ] **Decision:** Fix path chosen — add detection + per-use-case config. Does not preclude a future "pause extraction" decision.
+- [ ] **Implementation:** MaxTokens detection prevents wasted retry calls and produces actionable telemetry.
+- [ ] **No downstream consumer breaks:** Detection is additive; existing log-and-skip behavior preserved (just reached via a faster path with better diagnostics).

--- a/docs/solutions/best-practices/detect-maxtokens-at-response-boundary-not-parse-boundary-2026-06-26.md
+++ b/docs/solutions/best-practices/detect-maxtokens-at-response-boundary-not-parse-boundary-2026-06-26.md
@@ -1,0 +1,113 @@
+---
+title: "Detect MaxTokens truncation at the response boundary, not the parse boundary"
+date: 2026-06-26
+category: best-practices
+module: mika-agent
+problem_type: best_practice
+component: llm
+severity: medium
+applies_when:
+  - An LLM call parses structured output (JSON) and falls back to a semantic retry on parse failure
+  - A model hits its output-token cap and returns a truncated body instead of an error
+  - A previously-silent extraction/parse failure is suspected of burning repeated doomed LLM calls
+tags:
+  - llm
+  - kg
+  - subject-extractor
+  - max-tokens
+  - retry
+  - observability
+issue: mika#1091
+---
+
+# Detect MaxTokens truncation at the response boundary, not the parse boundary
+
+## Context
+
+The KG subject extractor (`crates/mika-agent/src/kg/subject_extractor.rs`,
+`call_llm_with_retry`) parses the LLM response as JSON and, on parse failure,
+runs one **semantic retry** with prompt reinforcement (C2.2). That retry is the
+correct recovery for a model that emitted *malformed* JSON.
+
+It is the wrong recovery for a model that emitted *truncated* JSON. When
+`openrouter/openai/gpt-5-nano` hit its output-token cap, the provider returned
+`Ok(response)` with an incomplete body — **not** an `Err`
+(`finish_reason: "length"` maps to `LlmStopReason::MaxTokens` at
+`crates/mika-common/src/llm/openai.rs`; Claude's `StopReason::MaxTokens` maps to
+the same). The truncation was invisible to the retry taxonomy, so it was
+mishandled as a semantic failure: the code fell through to
+`retry_with_reinforcement`, which re-sends the truncated output **plus** a
+reinforcement prompt against the **same** `max_tokens` budget — guaranteed to
+truncate again — ending in `extraction_semantic_exhausted` → `Ok(None)` →
+subjects silently dropped from the knowledge graph.
+
+It compounded: the `Ok(None)` path returns `ExtractionStats::default()` *before*
+`write_extraction_results` writes the `kg_extractions` idempotency marker, so a
+truncating doc stays pending and burns **two** doomed LLM calls on every 30-min
+extraction tick, indefinitely — a silent, self-perpetuating budget drain with no
+operator signal.
+
+## Guidance
+
+Check `response.stop_reason` **before** attempting to parse. A length/MaxTokens
+truncation is a distinct failure class from malformed output and must short-circuit:
+
+```rust
+// after a successful send_message, before parse_extraction_json:
+let stop_reason = response.stop_reason;
+let text = response.text_content();
+
+if stop_reason == LlmStopReason::MaxTokens {
+    warn!(
+        trace_id = %self.trace_id,
+        event = "extraction_max_tokens_truncated", // distinct, greppable
+        output_len = text.len(),
+        "LLM hit MaxTokens — response truncated, skipping parse and retry (log-and-skip per C2.3)"
+    );
+    return Ok(None);
+}
+// ... otherwise parse, and on parse failure run the semantic retry
+```
+
+Apply the check at **every** parse site (the extractor has two: the attempt-1
+success branch and the transport-retry success branch). Also thread the
+first-attempt `stop_reason` into the semantic-retry path and log it on
+`extraction_semantic_exhausted`, so any exhaustion that still occurs can be
+attributed to truncation vs. genuine malformed JSON.
+
+## Why This Matters
+
+- **A retry that re-sends content against the same token budget is doomed by
+  construction.** Detecting truncation at the response boundary skips the wasted
+  call (halves per-cycle cost for truncating docs) instead of discovering the
+  failure one expensive round-trip later.
+- **A distinct telemetry event turns a silent failure observable.** Reusing the
+  generic `extraction_semantic_exhausted` event hid a self-perpetuating drain;
+  `extraction_max_tokens_truncated` is greppable and points straight at the cause.
+- **Stop-reason is the only reliable truncation signal.** A truncated JSON body
+  is often *almost* valid — string-tolerant parsers can mask the problem or, worse,
+  parse a partial object. The provider's stop-reason is authoritative; the byte
+  stream is not.
+
+## When to Apply
+
+Any LLM-calling code with a **parse-then-semantic-retry** shape, across providers.
+The mapping is provider-agnostic in this codebase — both Claude
+`StopReason::MaxTokens` and OpenAI/OpenRouter `finish_reason: "length"` normalize
+to `LlmStopReason::MaxTokens` — so the boundary check is written once against the
+normalized enum and covers every provider.
+
+## Scope Note
+
+This fix is deliberately **additive** and preserves stay-pending semantics: the
+MaxTokens path still leaves the doc pending (no idempotency marker written),
+because truncation can be transient if the doc, the injected roster, or the model
+changes. *Eliminating* the perpetual re-attempt (raising the extraction
+output budget, switching model, chunking inputs, or pausing the path) is a
+separate strategic decision, deferred to the operator — the telemetry shipped
+here is the data needed to make it.
+
+## Related
+
+- `docs/solutions/architecture-patterns/kg-extraction-trigger-semantics-2026-05-09.md` — when extraction runs and the idempotency-marker contract.
+- `docs/solutions/kg/truncation-decision-2026-06-26.md` (mika#766) — distinct concern: empirical decision on *input-corpus* truncation, not LLM *response* truncation.


### PR DESCRIPTION
## Why

The KG subject extractor (`crates/mika-agent/src/kg/subject_extractor.rs`, `call_llm_with_retry`) had **no `LlmStopReason::MaxTokens` detection**. When `openrouter/openai/gpt-5-nano` hit its output-token cap, the provider returned `Ok(response)` with truncated JSON — **not** an `Err` (`finish_reason: "length"` → `LlmStopReason::MaxTokens`, `crates/mika-common/src/llm/openai.rs:750`). So the truncation was invisible to the retry taxonomy and was mishandled as a malformed-JSON semantic failure:

1. Truncated body fails `parse_extraction_json`.
2. Falls through to `retry_with_reinforcement`, which re-sends the truncated output **plus** a reinforcement prompt against the **same** `max_tokens` budget — **guaranteed to truncate again**.
3. Ends in `extraction_semantic_exhausted` → `Ok(None)` → subjects silently dropped from the KG.

It compounded: the `Ok(None)` path returns `ExtractionStats::default()` *before* `write_extraction_results` writes the `kg_extractions` idempotency marker (`subject_extractor.rs:725-731` vs step 7 `~789`), so a truncating doc stays pending and burns **2 doomed LLM calls every 30-min tick, indefinitely** — a silent, self-perpetuating budget drain with no operator signal. This is one concrete instance of the extraction-time fragmentation the #1091 KG audit identified.

## What

Detect the truncation at the **response boundary** (check `stop_reason` before parsing), not the parse boundary:

- **MaxTokens early-detection** at **both** parse sites in `call_llm_with_retry` (attempt-1 success branch + transport-retry success branch): emit a distinct `extraction_max_tokens_truncated` WARN and `return Ok(None)` immediately, bypassing the doomed semantic retry.
- **Enriched telemetry**: thread the first-attempt `stop_reason` through `retry_with_reinforcement` and log it on `extraction_semantic_exhausted`, so any remaining exhaustion can be attributed to truncation vs. genuine malformed JSON.
- **2 unit tests**: one proves a MaxTokens response yields `Ok(None)` with exactly **one** LLM call (no doomed retry consumed); one regression-guards that a non-truncated malformed first response still enters the semantic retry (two calls).

Net effect for truncating docs: the failure is now **fast** (one call, not two), **observable** (distinct greppable event), and **budget-cheaper** (halves per-cycle cost).

## Scope (deliberately narrow)

This implements **log-and-skip on MaxTokens** per the dispatch — nothing more. Stay-pending semantics are **preserved intentionally** (no idempotency marker written): truncation can be transient if the doc, injected roster, or model changes. The `MIKA_KG_EXTRACTION_MAX_TOKENS` config knob (issue option **1a**, raise output budget) and the strategic fix-vs-pause-vs-leave decision are **out of scope** per the issue's own "Out of scope" section — the telemetry shipped here is the data needed to make that call. See the plan's "Deferred follow-up" section.

## Verify

- `cargo build -p mika-agent`, `cargo clippy -p mika-agent` — clean.
- `cargo test -p mika-agent --lib kg::subject_extractor` — 38 passed (incl. 2 new).
- Post-deploy: `grep extraction_max_tokens_truncated $MIKA_SPIRIT_LOG_FILE` surfaces truncating docs that were previously silent.

Plan: `docs/plans/2026-06-26-004-investigate-1091-kg-subject-extractor-maxtokens-plan.md`
Compound: `docs/solutions/best-practices/detect-maxtokens-at-response-boundary-not-parse-boundary-2026-06-26.md`

Closes #1091