### PR TITLE
feat(ci,skills): make verify-bundled-skills target — structural counterpart to AC2 (mika#1575)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Verify bundled skills structural invariants (mika#1575)
+        run: make verify-bundled-skills
+
       - name: Test (with telemetry feature)
         run: cargo test --workspace --features telemetry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,11 +280,13 @@ Skills are loaded at runtime from this generated constant — no filesystem acce
 ### Adding a New Bundled Skill
 
 1. Create `skills/bundled/<skill-name>/` directory
-2. Add `skill.toml` with required fields:
+2. Add `skill.toml` with required fields. Keywords live under `[triggers]` (required unless `always_on = true`):
    ```toml
    [skill]
    name = "<skill-name>"
    version = "0.1.0"
+
+   [triggers]
    keywords = ["trigger", "words"]
    ```
 3. Add `system_prompt.md` with the skill's system prompt
@@ -294,3 +296,4 @@ Skills are loaded at runtime from this generated constant — no filesystem acce
    - `MIKA_RELAY_IDENTITY` (1 skill) — only `permission-policy`; rarely needs new skills
    - `MIKA_ARCH` uses a computed identity via `build_mika_arch_identity()` (3 skills) — read-only review skills only
 5. Build — the skill is automatically discovered and available
+6. **Verify structure** — run `make verify-bundled-skills` (mika#1575). This pre-merge gate (the structural counterpart to mika#1326 AC2) asserts the new bundle is complete: required files present, manifest parses, handlers resolve, `required_tools` tokens consistent, and identity allowlists coherent. CI runs it on every PR. See `docs/architecture/bundled-skill-verification.md`.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INSTALL_DIR ?= $(HOME)/.local/bin
 BINARIES := mika mika-spirit mika-gateway
 
-.PHONY: build build-dashboard deploy stop restart install test test-async-db-saturation lint fmt check check-ngrok deploy-info clean help calibrate-mika-dev calibrate-mika-arch
+.PHONY: build build-dashboard deploy stop restart install test test-async-db-saturation test-dispatch-symmetry verify-bundled-skills lint fmt check check-ngrok deploy-info clean help calibrate-mika-dev calibrate-mika-arch
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -96,6 +96,9 @@ test-async-db-saturation: ## Run async DB channel saturation regression test (mi
 
 test-dispatch-symmetry: ## Verify dev-pilot and dev-groom handlers are structurally symmetric (mika#893 R5)
 	@bash scripts/test-dispatch-symmetry.sh
+
+verify-bundled-skills: ## Verify structural invariants on bundled skills — pre-merge counterpart to AC2 (mika#1575)
+	cargo run -q --bin verify-bundled-skills
 
 lint: ## Run clippy
 	cargo clippy

--- a/crates/mika-agent/Cargo.toml
+++ b/crates/mika-agent/Cargo.toml
@@ -24,6 +24,10 @@ path = "src/bin/calibrate.rs"
 name = "eval-diff"
 path = "src/bin/eval-diff.rs"
 
+[[bin]]
+name = "verify-bundled-skills"
+path = "src/bin/verify_bundled_skills.rs"
+
 [features]
 telemetry = ["mika-common/telemetry"]
 

--- a/crates/mika-agent/src/bin/verify_bundled_skills.rs
+++ b/crates/mika-agent/src/bin/verify_bundled_skills.rs
@@ -1,0 +1,1037 @@
+//! `verify-bundled-skills` — structural-invariants gate for the engine-coupled
+//! bundled skills under `skills/bundled/` (mika#1575).
+//!
+//! This is the **pre-merge structural counterpart to mika#1326 AC2**. AC2
+//! (`test_bundled_skills_no_cross_skill_tool_name_collision`) catches cross-skill
+//! tool-name *collisions* at build-test time. This gate catches *incomplete
+//! skill-adds* — the gap between "skill bundle files exist" and "skill bundle works
+//! in production" — at pre-merge time, so the operator's review of a mika#1282
+//! dirty-worktree-rescued draft PR is reduced from "verify structure" to "verify
+//! content".
+//!
+//! Five checks (see `docs/architecture/bundled-skill-verification.md`):
+//!   1. Bundle completeness — `skill.toml` + `system_prompt.md` present.
+//!   2. Manifest parses + minimum fields.
+//!   3. Tool handler resolution (builtin function known; exec command file exists + executable).
+//!   4. `required_tools` token consistency (allowlist-unaware — token exists in the bundled surface).
+//!   5. Identity allowlist coherence (allowlist names exist; tokens reachable through the allowlist).
+//!
+//! Fire-disposition (mika#1575 F2): all five checks ship GREEN against the current
+//! source tree; `KNOWN_EXCEPTIONS` ships EMPTY. The binary exits non-zero on any
+//! unallowlisted failure or any stale exception; CI blocks merge on non-zero exit.
+//!
+//! Check-1 predicate per mika-arch third-pass ratification (session d8b4c839,
+//! Decision A): `skill.toml` + `system_prompt.md` presence only — the
+//! `required_tools ⇒ tools.json` coupling was dropped as unsound (a `required_tools`
+//! token may resolve via a builtin or another skill, so its presence cannot proxy
+//! "this skill ships its own tools.json"). Token validity is owned by Check 4.
+
+use std::collections::{HashMap, HashSet};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use mika_agent::bundled_skills::{
+    all_bundled_tool_names, bundled_skill_tool_map, is_bundled_skill,
+};
+use mika_agent::skills::builtin_handlers::KNOWN_BUILTINS;
+use mika_agent::tools::BUILTIN_TOOL_NAMES;
+use mika_agent::well_known_agents::well_known_skill_allowlists;
+
+// Reuse the canonical on-disk skill walker (shared with build.rs + integration tests).
+#[path = "../../build_support/bundled_skills_discover.rs"]
+mod discover;
+
+/// A known, deliberately-allowed pre-existing check failure.
+///
+/// Mirrors `KNOWN_PRE_EXISTING_COLLISIONS` in `bundled_skills.rs` (mika#1326 AC2):
+/// each entry names the check, the skill, a substring the failure reason must
+/// contain, and the follow-up ticket that will resolve it. **Self-cleaning**: the
+/// binary (and a test) fail when an entry no longer matches a real failure, forcing
+/// removal of stale exceptions.
+///
+/// Per mika#1575 F2 this ships **EMPTY**. A non-empty entry MUST be enumerated in
+/// the PR description with its resolution ticket.
+struct KnownException {
+    check: u8,
+    skill: &'static str,
+    reason_substr: &'static str,
+    #[allow(dead_code)]
+    ticket: &'static str,
+}
+
+const KNOWN_EXCEPTIONS: &[KnownException] = &[];
+
+/// A single structural-invariant violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Failure {
+    check: u8,
+    skill: String,
+    reason: String,
+}
+
+impl Failure {
+    fn new(check: u8, skill: impl Into<String>, reason: impl Into<String>) -> Self {
+        Failure {
+            check,
+            skill: skill.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Parsed `skill.toml` fields the checks care about.
+struct Manifest {
+    name: Option<String>,
+    version: Option<String>,
+    always_on: bool,
+    /// Whether `[triggers].keywords` is *declared* (as an array). Per the issue's
+    /// Check 2 ("contains [triggers] keywords") this is field-presence, NOT
+    /// non-emptiness: `skill-review` deliberately declares `keywords = []` (it is a
+    /// programmatically-invoked handler skill, inert-by-keyword on purpose, #265).
+    keywords_present: bool,
+    required_tools: Vec<String>,
+}
+
+/// One tool declaration from a skill's `tools.json`.
+struct ToolDecl {
+    name: Option<String>,
+    handler_type: Option<String>,
+    function: Option<String>,
+    command: Option<String>,
+}
+
+/// A parsed view of one engine-coupled bundled skill (`skills/bundled/<name>/`).
+struct SkillView {
+    name: String,
+    /// Absolute skill directory — used by Check 3 to stat exec handler files.
+    dir: PathBuf,
+    /// Relative paths of files present in the skill directory.
+    rel_files: HashSet<String>,
+    /// Parsed `skill.toml`, or the parse error message.
+    manifest: Result<Manifest, String>,
+    /// Parsed `tools.json` (empty when absent), or the parse error message.
+    tools: Result<Vec<ToolDecl>, String>,
+}
+
+fn parse_manifest(content: &str) -> Result<Manifest, String> {
+    let value: toml::Value = toml::from_str(content).map_err(|e| e.to_string())?;
+    let str_at = |a: &str, b: &str| -> Option<String> {
+        value
+            .get(a)
+            .and_then(|t| t.get(b))
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    };
+    let arr_at = |a: &str, b: &str| -> Vec<String> {
+        value
+            .get(a)
+            .and_then(|t| t.get(b))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| e.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    Ok(Manifest {
+        name: str_at("skill", "name"),
+        version: str_at("skill", "version"),
+        always_on: value
+            .get("skill")
+            .and_then(|s| s.get("always_on"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        keywords_present: value
+            .get("triggers")
+            .and_then(|t| t.get("keywords"))
+            .and_then(|v| v.as_array())
+            .is_some(),
+        required_tools: arr_at("constraints", "required_tools"),
+    })
+}
+
+fn parse_tools(content: &str) -> Result<Vec<ToolDecl>, String> {
+    let arr: Vec<serde_json::Value> = serde_json::from_str(content).map_err(|e| e.to_string())?;
+    Ok(arr
+        .iter()
+        .map(|t| ToolDecl {
+            name: t.get("name").and_then(|v| v.as_str()).map(str::to_string),
+            handler_type: t
+                .get("handler")
+                .and_then(|h| h.get("type"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            function: t
+                .get("handler")
+                .and_then(|h| h.get("function"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            command: t
+                .get("handler")
+                .and_then(|h| h.get("command"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        })
+        .collect())
+}
+
+/// Build `SkillView`s from the on-disk `skills/bundled/` tree via the shared walker.
+fn load_skill_views(base: &Path) -> Vec<SkillView> {
+    discover::discover_bundled_skills(base)
+        .into_iter()
+        .map(|d| {
+            let rel_files: HashSet<String> = d.files.iter().map(|f| f.rel_path.clone()).collect();
+            let read = |rel: &str| -> Option<String> {
+                d.files
+                    .iter()
+                    .find(|f| f.rel_path == rel)
+                    .and_then(|f| std::fs::read_to_string(&f.abs_path).ok())
+            };
+            let manifest = match read("skill.toml") {
+                Some(c) => parse_manifest(&c),
+                None => Err("skill.toml not present".to_string()),
+            };
+            let tools = match read("tools.json") {
+                Some(c) => parse_tools(&c),
+                None => Ok(Vec::new()),
+            };
+            SkillView {
+                name: d.name,
+                dir: d.abs_dir,
+                rel_files,
+                manifest,
+                tools,
+            }
+        })
+        .collect()
+}
+
+// ---- Checks -------------------------------------------------------------------
+
+/// Check 1 — bundle completeness. `skill.toml` + `system_prompt.md` always required.
+/// (Per mika-arch session d8b4c839 Decision A, the `required_tools ⇒ tools.json`
+/// coupling is intentionally NOT enforced here — Check 4 owns token validity.)
+fn check1_completeness(skills: &[SkillView]) -> Vec<Failure> {
+    let mut out = Vec::new();
+    for s in skills {
+        if !s.rel_files.contains("skill.toml") {
+            out.push(Failure::new(1, &s.name, "missing required file skill.toml"));
+        }
+        if !s.rel_files.contains("system_prompt.md") {
+            out.push(Failure::new(
+                1,
+                &s.name,
+                "missing required file system_prompt.md",
+            ));
+        }
+    }
+    out
+}
+
+/// Check 1 (orphan-directory arm) — flag skill-shaped directories under
+/// `skills/bundled/` that lack `skill.toml` entirely.
+///
+/// The shared walker (`discover_bundled_skills`) only returns a directory once it
+/// already contains a real `skill.toml`, so a forgotten manifest is invisible to
+/// [`check1_completeness`] (its `SkillView` is never built). That is exactly the
+/// incomplete-skill-add class this gate exists to catch (a `skills/bundled/<name>/`
+/// with `system_prompt.md` / `tools.json` but no manifest), so it is checked here
+/// against the raw directory listing.
+fn check1_missing_manifest(base: &Path) -> Vec<Failure> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return out; // missing base dir is surfaced elsewhere; nothing to flag here
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_symlink() || !ft.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Excludes `_shared`, dotfiles — same predicate the walker uses.
+        if !discover::is_bundled_skill_dir(&name) {
+            continue;
+        }
+        // `symlink_metadata` so a symlinked `skill.toml` doesn't count (mirrors the walker).
+        let toml = entry.path().join("skill.toml");
+        let is_real = std::fs::symlink_metadata(&toml)
+            .map(|m| m.file_type().is_file())
+            .unwrap_or(false);
+        if !is_real {
+            out.push(Failure::new(1, name, "missing required file skill.toml"));
+        }
+    }
+    out
+}
+
+/// Check 2 — manifest parses + minimum fields.
+fn check2_manifest(skills: &[SkillView]) -> Vec<Failure> {
+    let mut out = Vec::new();
+    for s in skills {
+        let m = match &s.manifest {
+            Ok(m) => m,
+            Err(e) => {
+                out.push(Failure::new(
+                    2,
+                    &s.name,
+                    format!("skill.toml does not parse: {e}"),
+                ));
+                continue;
+            }
+        };
+        if m.name.as_deref().unwrap_or("").is_empty() {
+            out.push(Failure::new(2, &s.name, "skill.toml missing [skill].name"));
+        }
+        if m.version.as_deref().unwrap_or("").is_empty() {
+            out.push(Failure::new(
+                2,
+                &s.name,
+                "skill.toml missing [skill].version",
+            ));
+        }
+        if !m.always_on && !m.keywords_present {
+            out.push(Failure::new(
+                2,
+                &s.name,
+                "skill.toml missing [triggers].keywords field (required unless always_on = true)",
+            ));
+        }
+    }
+    out
+}
+
+/// Check 3 — tool handler resolution.
+/// `builtin` → `handler.function` must be a known builtin *handler* function.
+/// `exec` → `handler.command` file must exist at the skill dir and be executable.
+fn check3_handler_resolution(skills: &[SkillView], known_builtins: &HashSet<&str>) -> Vec<Failure> {
+    let mut out = Vec::new();
+    for s in skills {
+        let tools = match &s.tools {
+            Ok(t) => t,
+            Err(e) => {
+                out.push(Failure::new(
+                    3,
+                    &s.name,
+                    format!("tools.json does not parse: {e}"),
+                ));
+                continue;
+            }
+        };
+        for tool in tools {
+            let tool_name = tool.name.as_deref().unwrap_or("<unnamed>");
+            match tool.handler_type.as_deref() {
+                Some("builtin") => match &tool.function {
+                    Some(f) if known_builtins.contains(f.as_str()) => {}
+                    Some(f) => out.push(Failure::new(
+                        3,
+                        &s.name,
+                        format!("tool '{tool_name}' builtin handler function '{f}' is not a registered builtin"),
+                    )),
+                    None => out.push(Failure::new(
+                        3,
+                        &s.name,
+                        format!("tool '{tool_name}' has builtin handler with no 'function'"),
+                    )),
+                },
+                Some("exec") => match &tool.command {
+                    Some(cmd) => {
+                        let path = s.dir.join(cmd);
+                        match std::fs::metadata(&path) {
+                            Ok(meta) if meta.is_file() => {
+                                if meta.permissions().mode() & 0o111 == 0 {
+                                    out.push(Failure::new(
+                                        3,
+                                        &s.name,
+                                        format!("tool '{tool_name}' exec command '{cmd}' is not executable"),
+                                    ));
+                                }
+                            }
+                            _ => out.push(Failure::new(
+                                3,
+                                &s.name,
+                                format!("tool '{tool_name}' exec command file '{cmd}' does not exist"),
+                            )),
+                        }
+                    }
+                    None => out.push(Failure::new(
+                        3,
+                        &s.name,
+                        format!("tool '{tool_name}' has exec handler with no 'command'"),
+                    )),
+                },
+                // `http` is a deliberately out-of-scope handler type (runtime-resolved).
+                Some("http") => {}
+                // A missing or unrecognized handler.type is an incomplete declaration
+                // the runtime would skip — flag it pre-merge rather than passing silently.
+                Some(other) => out.push(Failure::new(
+                    3,
+                    &s.name,
+                    format!("tool '{tool_name}' has unrecognized handler.type '{other}'"),
+                )),
+                None => out.push(Failure::new(
+                    3,
+                    &s.name,
+                    format!("tool '{tool_name}' has no handler.type"),
+                )),
+            }
+        }
+    }
+    out
+}
+
+/// Check 4 — `required_tools` token consistency (allowlist-unaware, per mika#1575 F1).
+/// Each token must exist somewhere in the bundled surface: a builtin tool name OR a
+/// tool declared in any bundled skill's `tools.json`.
+fn check4_token_consistency(skills: &[SkillView], known_tools: &HashSet<String>) -> Vec<Failure> {
+    let mut out = Vec::new();
+    for s in skills {
+        let Ok(m) = &s.manifest else { continue };
+        for token in &m.required_tools {
+            if !known_tools.contains(token) {
+                out.push(Failure::new(
+                    4,
+                    &s.name,
+                    format!(
+                        "required_tools token '{token}' resolves to no builtin and no bundled skill's tools.json"
+                    ),
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Check 5 — identity allowlist coherence (allowlist-scoped, per mika#1575 F1).
+/// For each well-known agent allowlist: every allowlisted name exists as a bundled
+/// skill, and every `required_tools` token of allowlisted *engine-coupled* skills is
+/// reachable through the allowlist (a builtin, or a tool declared by a skill IN that
+/// allowlist).
+fn check5_identity_coherence(
+    skills: &[SkillView],
+    allowlists: &[(&'static str, Vec<String>)],
+    builtin_tools: &HashSet<String>,
+    skill_tool_map: &HashMap<String, Vec<String>>,
+) -> Vec<Failure> {
+    let mut out = Vec::new();
+    let view_by_name: HashMap<&str, &SkillView> =
+        skills.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    for (agent, allowlist) in allowlists {
+        // (a) every allowlisted name must be a bundled skill.
+        for name in allowlist {
+            if !is_bundled_skill(name) {
+                out.push(Failure::new(
+                    5,
+                    *agent,
+                    format!("allowlist references '{name}' which is not a bundled skill"),
+                ));
+            }
+        }
+
+        // Reachable tool set = builtins ∪ tools declared by skills IN this allowlist.
+        let mut reachable: HashSet<String> = builtin_tools.clone();
+        for name in allowlist {
+            if let Some(tools) = skill_tool_map.get(name) {
+                reachable.extend(tools.iter().cloned());
+            }
+        }
+
+        // (b) every required_tools token of an allowlisted engine-coupled skill must
+        //     be reachable through this allowlist.
+        for name in allowlist {
+            let Some(view) = view_by_name.get(name.as_str()) else {
+                continue; // community skill (not in skills/bundled/) — token-bearing engine skills only
+            };
+            let Ok(m) = &view.manifest else { continue };
+            for token in &m.required_tools {
+                if !reachable.contains(token) {
+                    out.push(Failure::new(
+                        5,
+                        *agent,
+                        format!(
+                            "skill '{name}' requires tool '{token}', not reachable through {agent}'s allowlist"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+// ---- Aggregation + entrypoint -------------------------------------------------
+
+fn run_all_checks(base: &Path) -> Vec<Failure> {
+    let skills = load_skill_views(base);
+    let known_builtins: HashSet<&str> = KNOWN_BUILTINS.iter().copied().collect();
+    let mut known_tools: HashSet<String> =
+        BUILTIN_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
+    known_tools.extend(all_bundled_tool_names());
+    let skill_tool_map = bundled_skill_tool_map();
+    let allowlists = well_known_skill_allowlists();
+
+    let mut failures = Vec::new();
+    failures.extend(check1_completeness(&skills));
+    failures.extend(check1_missing_manifest(base));
+    failures.extend(check2_manifest(&skills));
+    failures.extend(check3_handler_resolution(&skills, &known_builtins));
+    failures.extend(check4_token_consistency(&skills, &known_tools));
+    failures.extend(check5_identity_coherence(
+        &skills,
+        &allowlists,
+        &known_tools_builtins_only(),
+        &skill_tool_map,
+    ));
+    failures
+}
+
+/// The builtin-only tool set used for Check 5 reachability (allowlist-scoped):
+/// builtins are reachable by every agent regardless of allowlist; skill-provided
+/// tools are added per-allowlist inside the check.
+fn known_tools_builtins_only() -> HashSet<String> {
+    BUILTIN_TOOL_NAMES.iter().map(|s| s.to_string()).collect()
+}
+
+/// Does a failure match a known exception entry?
+fn matches_exception(f: &Failure, e: &KnownException) -> bool {
+    e.check == f.check && e.skill == f.skill && f.reason.contains(e.reason_substr)
+}
+
+fn main() -> ExitCode {
+    // skills/bundled/ lives at <repo-root>/skills/bundled. CARGO_MANIFEST_DIR is
+    // <repo-root>/crates/mika-agent at compile time — robust regardless of runtime CWD.
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../skills/bundled")
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../skills/bundled"));
+
+    println!("verify-bundled-skills: scanning {}", base.display());
+
+    let failures = run_all_checks(&base);
+
+    // Partition failures into allowlisted vs reportable.
+    let mut reportable: Vec<&Failure> = Vec::new();
+    for f in &failures {
+        if !KNOWN_EXCEPTIONS.iter().any(|e| matches_exception(f, e)) {
+            reportable.push(f);
+        }
+    }
+
+    // Self-cleaning: any KNOWN_EXCEPTIONS entry that matches no real failure is stale.
+    let stale: Vec<&KnownException> = KNOWN_EXCEPTIONS
+        .iter()
+        .filter(|e| !failures.iter().any(|f| matches_exception(f, e)))
+        .collect();
+
+    for f in &reportable {
+        println!("CHECK {} FAIL: {} — {}", f.check, f.skill, f.reason);
+    }
+    for e in &stale {
+        println!(
+            "STALE EXCEPTION: check {} / skill '{}' / ticket {} no longer matches any failure — remove it",
+            e.check, e.skill, e.ticket
+        );
+    }
+
+    if reportable.is_empty() && stale.is_empty() {
+        println!(
+            "OK — all 5 structural checks pass for skills/bundled/ ({} reportable failures).",
+            reportable.len()
+        );
+        ExitCode::SUCCESS
+    } else {
+        println!(
+            "\nFAILED — {} reportable failure(s), {} stale exception(s).",
+            reportable.len(),
+            stale.len()
+        );
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(
+        name: Option<&str>,
+        version: Option<&str>,
+        always_on: bool,
+        keywords: &[&str],
+        required_tools: &[&str],
+    ) -> Manifest {
+        // In tests, a non-empty keyword slice models a declared `[triggers].keywords`;
+        // an empty slice models an ABSENT field. The present-but-empty case
+        // (`keywords = []`, e.g. skill-review) is exercised by the real-tree test.
+        Manifest {
+            name: name.map(str::to_string),
+            version: version.map(str::to_string),
+            always_on,
+            keywords_present: !keywords.is_empty(),
+            required_tools: required_tools.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn view(
+        name: &str,
+        rel_files: &[&str],
+        manifest: Result<Manifest, String>,
+        tools: Result<Vec<ToolDecl>, String>,
+    ) -> SkillView {
+        SkillView {
+            name: name.to_string(),
+            dir: PathBuf::from("/nonexistent"),
+            rel_files: rel_files.iter().map(|s| s.to_string()).collect(),
+            manifest,
+            tools,
+        }
+    }
+
+    // ---- Check 1 ----
+    #[test]
+    fn check1_pass_prompt_only_skill() {
+        let s = view(
+            "prompt-only",
+            &["skill.toml", "system_prompt.md"],
+            Ok(manifest(
+                Some("prompt-only"),
+                Some("0.1.0"),
+                false,
+                &["kw"],
+                &[],
+            )),
+            Ok(vec![]),
+        );
+        assert!(check1_completeness(&[s]).is_empty());
+    }
+
+    #[test]
+    fn check1_pass_required_tools_without_tools_json() {
+        // OD-1 ratified shape: required_tools + no tools.json is VALID at Check 1.
+        let s = view(
+            "self-dev-like",
+            &["skill.toml", "system_prompt.md"],
+            Ok(manifest(
+                Some("self-dev-like"),
+                Some("0.1.0"),
+                false,
+                &["kw"],
+                &["run_claude_pilot"],
+            )),
+            Ok(vec![]),
+        );
+        assert!(check1_completeness(&[s]).is_empty());
+    }
+
+    #[test]
+    fn check1_fail_missing_system_prompt() {
+        let s = view(
+            "broken",
+            &["skill.toml"],
+            Ok(manifest(Some("broken"), Some("0.1.0"), false, &["kw"], &[])),
+            Ok(vec![]),
+        );
+        let f = check1_completeness(&[s]);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].reason.contains("system_prompt.md"));
+    }
+
+    #[test]
+    fn check1_fail_missing_skill_toml() {
+        let s = view(
+            "broken",
+            &["system_prompt.md"],
+            Err("skill.toml not present".to_string()),
+            Ok(vec![]),
+        );
+        let f = check1_completeness(&[s]);
+        assert!(f.iter().any(|x| x.reason.contains("skill.toml")));
+    }
+
+    // ---- Check 2 ----
+    #[test]
+    fn check2_pass_keyworded_and_always_on() {
+        let kw = view(
+            "kw",
+            &["skill.toml", "system_prompt.md"],
+            Ok(manifest(Some("kw"), Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![]),
+        );
+        let ao = view(
+            "ao",
+            &["skill.toml", "system_prompt.md"],
+            Ok(manifest(Some("ao"), Some("0.1.0"), true, &[], &[])),
+            Ok(vec![]),
+        );
+        assert!(check2_manifest(&[kw, ao]).is_empty());
+    }
+
+    #[test]
+    fn check2_fail_unparseable_missing_fields_and_keywords() {
+        let bad_parse = view("bad", &["skill.toml"], Err("boom".to_string()), Ok(vec![]));
+        let no_name = view(
+            "noname",
+            &["skill.toml"],
+            Ok(manifest(None, Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![]),
+        );
+        let no_ver = view(
+            "nover",
+            &["skill.toml"],
+            Ok(manifest(Some("nover"), None, false, &["x"], &[])),
+            Ok(vec![]),
+        );
+        let no_kw = view(
+            "nokw",
+            &["skill.toml"],
+            Ok(manifest(Some("nokw"), Some("0.1.0"), false, &[], &[])),
+            Ok(vec![]),
+        );
+        let f = check2_manifest(&[bad_parse, no_name, no_ver, no_kw]);
+        assert!(
+            f.iter()
+                .any(|x| x.skill == "bad" && x.reason.contains("does not parse"))
+        );
+        assert!(
+            f.iter()
+                .any(|x| x.skill == "noname" && x.reason.contains("name"))
+        );
+        assert!(
+            f.iter()
+                .any(|x| x.skill == "nover" && x.reason.contains("version"))
+        );
+        assert!(
+            f.iter()
+                .any(|x| x.skill == "nokw" && x.reason.contains("keywords"))
+        );
+    }
+
+    // ---- Check 3 ----
+    fn known_builtins_fixture() -> HashSet<&'static str> {
+        ["gh_read", "run_gh"].into_iter().collect()
+    }
+
+    #[test]
+    fn check3_pass_builtin_and_fail_unknown_builtin() {
+        let good = view(
+            "good",
+            &["skill.toml", "tools.json"],
+            Ok(manifest(Some("good"), Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![ToolDecl {
+                name: Some("gh_read".into()),
+                handler_type: Some("builtin".into()),
+                function: Some("gh_read".into()),
+                command: None,
+            }]),
+        );
+        assert!(check3_handler_resolution(&[good], &known_builtins_fixture()).is_empty());
+
+        let bad = view(
+            "bad",
+            &["skill.toml", "tools.json"],
+            Ok(manifest(Some("bad"), Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![ToolDecl {
+                name: Some("mystery".into()),
+                handler_type: Some("builtin".into()),
+                function: Some("nonexistent_fn".into()),
+                command: None,
+            }]),
+        );
+        let f = check3_handler_resolution(&[bad], &known_builtins_fixture());
+        assert_eq!(f.len(), 1);
+        assert!(f[0].reason.contains("nonexistent_fn"));
+    }
+
+    #[test]
+    fn check3_exec_missing_and_nonexecutable() {
+        let dir = tempfile::tempdir().unwrap();
+        // Missing command file.
+        let missing = SkillView {
+            name: "missing".into(),
+            dir: dir.path().to_path_buf(),
+            rel_files: ["skill.toml", "tools.json"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            manifest: Ok(manifest(Some("missing"), Some("0.1.0"), false, &["x"], &[])),
+            tools: Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: Some("exec".into()),
+                function: None,
+                command: Some("handlers/run.sh".into()),
+            }]),
+        };
+        let f = check3_handler_resolution(&[missing], &known_builtins_fixture());
+        assert!(f.iter().any(|x| x.reason.contains("does not exist")));
+
+        // Present but non-executable.
+        let handlers = dir.path().join("handlers");
+        std::fs::create_dir_all(&handlers).unwrap();
+        let script = handlers.join("run.sh");
+        std::fs::write(&script, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let nonexec = SkillView {
+            name: "nonexec".into(),
+            dir: dir.path().to_path_buf(),
+            rel_files: ["skill.toml", "tools.json"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            manifest: Ok(manifest(Some("nonexec"), Some("0.1.0"), false, &["x"], &[])),
+            tools: Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: Some("exec".into()),
+                function: None,
+                command: Some("handlers/run.sh".into()),
+            }]),
+        };
+        let f = check3_handler_resolution(&[nonexec], &known_builtins_fixture());
+        assert!(f.iter().any(|x| x.reason.contains("not executable")));
+
+        // Present and executable → pass.
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let exec = SkillView {
+            name: "exec".into(),
+            dir: dir.path().to_path_buf(),
+            rel_files: ["skill.toml", "tools.json"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            manifest: Ok(manifest(Some("exec"), Some("0.1.0"), false, &["x"], &[])),
+            tools: Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: Some("exec".into()),
+                function: None,
+                command: Some("handlers/run.sh".into()),
+            }]),
+        };
+        assert!(check3_handler_resolution(&[exec], &known_builtins_fixture()).is_empty());
+    }
+
+    // ---- Check 4 ----
+    #[test]
+    fn check4_pass_builtin_own_and_crossskill_fail_nonexistent() {
+        let mut known: HashSet<String> =
+            ["write_agent_file"].iter().map(|s| s.to_string()).collect();
+        known.insert("run_claude_pilot".into()); // cross-skill (option c)
+        known.insert("qa_pr_view".into()); // own (option b)
+
+        let ok = view(
+            "ok",
+            &["skill.toml"],
+            Ok(manifest(
+                Some("ok"),
+                Some("0.1.0"),
+                false,
+                &["x"],
+                &["write_agent_file", "run_claude_pilot", "qa_pr_view"],
+            )),
+            Ok(vec![]),
+        );
+        assert!(check4_token_consistency(&[ok], &known).is_empty());
+
+        let bad = view(
+            "bad",
+            &["skill.toml"],
+            Ok(manifest(
+                Some("bad"),
+                Some("0.1.0"),
+                false,
+                &["x"],
+                &["nonexistent_tool"],
+            )),
+            Ok(vec![]),
+        );
+        let f = check4_token_consistency(&[bad], &known);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].reason.contains("nonexistent_tool"));
+    }
+
+    // ---- Check 5 ----
+    #[test]
+    fn check5_pass_and_fail_cases() {
+        let builtins: HashSet<String> = ["run_gh"].iter().map(|s| s.to_string()).collect();
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        map.insert("provider".into(), vec!["the_tool".into()]);
+        map.insert("consumer".into(), vec![]);
+
+        // consumer requires the_tool, provided by provider. Both names must be
+        // is_bundled_skill — so for this synthetic test we cannot rely on is_bundled_skill.
+        // Instead validate the reachability arm with names that won't trip arm (a):
+        // we only assert arm (b) here by using the real allowlist test below for arm (a).
+        let consumer = view(
+            "consumer",
+            &["skill.toml"],
+            Ok(manifest(
+                Some("consumer"),
+                Some("0.1.0"),
+                false,
+                &["x"],
+                &["the_tool"],
+            )),
+            Ok(vec![]),
+        );
+        // Allowlist includes provider → the_tool reachable.
+        let reachable_ok = check5_identity_coherence(
+            &[consumer],
+            &[("agentX", vec!["consumer".into(), "provider".into()])],
+            &builtins,
+            &map,
+        );
+        // arm (b) must NOT fire for the_tool (reachable via provider in the allowlist).
+        assert!(
+            !reachable_ok
+                .iter()
+                .any(|f| f.reason.contains("not reachable")),
+            "the_tool should be reachable via provider in the allowlist: {reachable_ok:?}"
+        );
+        // arm (a) MUST fire: "consumer"/"provider" are not real bundled skills.
+        assert!(
+            reachable_ok
+                .iter()
+                .any(|f| f.reason.contains("not a bundled skill")),
+            "arm (a) should flag non-bundled allowlist names: {reachable_ok:?}"
+        );
+
+        // Remove provider from allowlist → the_tool not reachable.
+        let consumer2 = view(
+            "consumer",
+            &["skill.toml"],
+            Ok(manifest(
+                Some("consumer"),
+                Some("0.1.0"),
+                false,
+                &["x"],
+                &["the_tool"],
+            )),
+            Ok(vec![]),
+        );
+        let unreachable = check5_identity_coherence(
+            &[consumer2],
+            &[("agentY", vec!["consumer".into()])],
+            &builtins,
+            &map,
+        );
+        assert!(
+            unreachable
+                .iter()
+                .any(|f| f.reason.contains("not reachable"))
+        );
+    }
+
+    // ---- Check 3 unknown/missing handler.type ----
+    #[test]
+    fn check3_unknown_and_missing_handler_type() {
+        let unknown = view(
+            "unknown",
+            &["skill.toml", "tools.json"],
+            Ok(manifest(Some("unknown"), Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: Some("mystery".into()),
+                function: None,
+                command: None,
+            }]),
+        );
+        let f = check3_handler_resolution(&[unknown], &known_builtins_fixture());
+        assert!(
+            f.iter()
+                .any(|x| x.reason.contains("unrecognized handler.type"))
+        );
+
+        let missing = view(
+            "missing-type",
+            &["skill.toml", "tools.json"],
+            Ok(manifest(
+                Some("missing-type"),
+                Some("0.1.0"),
+                false,
+                &["x"],
+                &[],
+            )),
+            Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: None,
+                function: None,
+                command: None,
+            }]),
+        );
+        let f = check3_handler_resolution(&[missing], &known_builtins_fixture());
+        assert!(f.iter().any(|x| x.reason.contains("no handler.type")));
+
+        // `http` is deliberately out of scope — must NOT fail.
+        let http = view(
+            "http",
+            &["skill.toml", "tools.json"],
+            Ok(manifest(Some("http"), Some("0.1.0"), false, &["x"], &[])),
+            Ok(vec![ToolDecl {
+                name: Some("t".into()),
+                handler_type: Some("http".into()),
+                function: None,
+                command: None,
+            }]),
+        );
+        assert!(check3_handler_resolution(&[http], &known_builtins_fixture()).is_empty());
+    }
+
+    // ---- Check 1 orphan-directory (missing skill.toml) ----
+    #[test]
+    fn check1_missing_manifest_flags_dir_without_skill_toml() {
+        let base = tempfile::tempdir().unwrap();
+        // A skill-shaped dir with system_prompt.md but NO skill.toml (incomplete add).
+        let incomplete = base.path().join("incomplete-skill");
+        std::fs::create_dir_all(&incomplete).unwrap();
+        std::fs::write(incomplete.join("system_prompt.md"), "prompt").unwrap();
+        // A complete dir with skill.toml → must not be flagged.
+        let complete = base.path().join("complete-skill");
+        std::fs::create_dir_all(&complete).unwrap();
+        std::fs::write(complete.join("skill.toml"), "[skill]\nname=\"x\"\n").unwrap();
+        // A support dir (`_shared`) → must be skipped.
+        let shared = base.path().join("_shared");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("lib.sh"), "#!/bin/sh\n").unwrap();
+
+        let f = check1_missing_manifest(base.path());
+        assert_eq!(
+            f.len(),
+            1,
+            "exactly the incomplete dir should be flagged: {f:?}"
+        );
+        assert_eq!(f[0].skill, "incomplete-skill");
+        assert!(f[0].reason.contains("skill.toml"));
+    }
+
+    // ---- KNOWN_EXCEPTIONS hygiene + full-tree green ----
+    #[test]
+    fn known_exceptions_ship_empty() {
+        // mika#1575 F2: KNOWN_EXCEPTIONS ships empty. If you add an entry, the PR
+        // description MUST enumerate it with its resolution ticket.
+        assert!(
+            KNOWN_EXCEPTIONS.is_empty(),
+            "KNOWN_EXCEPTIONS must ship empty (mika#1575 F2)"
+        );
+    }
+
+    #[test]
+    fn real_bundled_tree_passes_green() {
+        // mika#1575 F2 + mika-arch #1576 F3 (first-deploy fire-disposition): the
+        // detector MUST pass green against the current source tree on first run.
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../skills/bundled");
+        let failures = run_all_checks(&base);
+        let reportable: Vec<&Failure> = failures
+            .iter()
+            .filter(|f| !KNOWN_EXCEPTIONS.iter().any(|e| matches_exception(f, e)))
+            .collect();
+        assert!(
+            reportable.is_empty(),
+            "skills/bundled/ has structural failures (mika#1575 must ship green):\n{}",
+            reportable
+                .iter()
+                .map(|f| format!("  CHECK {} {} — {}", f.check, f.skill, f.reason))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+}

--- a/crates/mika-agent/src/bundled_skills.rs
+++ b/crates/mika-agent/src/bundled_skills.rs
@@ -242,6 +242,52 @@ pub fn all_bundled_skill_names() -> Vec<&'static str> {
     all_bundled_skills().iter().map(|s| s.name).collect()
 }
 
+/// Returns the set of every tool `name` declared in any bundled skill's
+/// `tools.json` — across BOTH the legacy hardcoded community skills and the
+/// directory-sourced engine-coupled skills.
+///
+/// This is the canonical "any bundled skill's tools.json" universe for the
+/// `verify-bundled-skills` gate (mika#1575, Check 4 option (c) — allowlist-unaware
+/// token resolution). It must consult the same dual source as [`all_bundled_skills`]
+/// so a `required_tools` token provided by a community skill (e.g. `run_shell` from
+/// `shell-exec`) resolves correctly and does not false-fail the gate.
+///
+/// Malformed `tools.json` content is skipped silently here — manifest validity is
+/// the responsibility of other checks, not this accessor.
+pub fn all_bundled_tool_names() -> std::collections::HashSet<String> {
+    bundled_skill_tool_map().into_values().flatten().collect()
+}
+
+/// Returns `skill_name -> [tool names it declares in its tools.json]` across BOTH
+/// the legacy hardcoded community skills and the directory-sourced engine-coupled
+/// skills.
+///
+/// Used by the `verify-bundled-skills` gate (mika#1575, Check 5 — identity allowlist
+/// coherence) to compute an agent's *allowlist-scoped* reachable tool set: a token is
+/// reachable through an allowlist only if a builtin provides it OR a skill IN THAT
+/// ALLOWLIST declares it. Per-skill attribution (not just the flat
+/// [`all_bundled_tool_names`] set) is required to distinguish "exists somewhere in the
+/// bundled surface" (Check 4) from "reachable through this specific allowlist" (Check 5).
+///
+/// Skills with no `tools.json` or unparseable content map to an empty list.
+pub fn bundled_skill_tool_map() -> std::collections::HashMap<String, Vec<String>> {
+    let mut map = std::collections::HashMap::new();
+    for skill in all_bundled_skills() {
+        let mut names = Vec::new();
+        if let Some(tools_file) = skill.files.iter().find(|f| f.path == "tools.json")
+            && let Ok(tools) = serde_json::from_str::<Vec<serde_json::Value>>(tools_file.content)
+        {
+            for tool in &tools {
+                if let Some(name) = tool.get("name").and_then(|n| n.as_str()) {
+                    names.push(name.to_string());
+                }
+            }
+        }
+        map.insert(skill.name.to_string(), names);
+    }
+    map
+}
+
 /// Trust-critical bundled skills whose prompts must NOT be reviewed or adapted.
 ///
 /// These skills govern the agent's self-awareness, security posture, or ability

--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -291,6 +291,16 @@ pub const MIKA_ARCH_DISABLED_TOOLS: &[&str] = &[
     "remove_team_member",
 ];
 
+/// mika-arch's static skill allowlist. Held as a `pub const` (rather than only
+/// inline in `build_mika_arch_identity`) so the `verify-bundled-skills` gate
+/// (mika#1575) can read it without constructing a full `Settings` — mika-arch's
+/// identity is `Computed`, but its allowlist does not depend on `Settings`.
+pub const MIKA_ARCH_SKILL_ALLOWLIST: &[&str] = &[
+    "mika-arch-groom-ticket",
+    "mika-arch-groom-milestone",
+    "mika-arch-second-review",
+];
+
 /// Build mika-arch's identity.toml with absolute `[kg].docs_roots` paths
 /// derived from `Settings.kg_docs_roots`.
 ///
@@ -328,6 +338,12 @@ fn build_mika_arch_identity(settings: &Settings) -> Result<String, String> {
     }
     tools_block.push(']');
 
+    let allowlist_block = MIKA_ARCH_SKILL_ALLOWLIST
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+
     Ok(format!(
         r#"name = "Architect"
 emoji = "🏛"
@@ -341,7 +357,7 @@ docs_roots = [
 inject = false
 
 [skills]
-allowlist = ["mika-arch-groom-ticket", "mika-arch-groom-milestone", "mika-arch-second-review"]
+allowlist = [{allowlist_block}]
 
 [tools]
 {tools_block}
@@ -351,6 +367,56 @@ allowlist = ["mika-arch-groom-ticket", "mika-arch-groom-milestone", "mika-arch-s
 
 /// All well-known agents.
 pub static WELL_KNOWN_AGENTS: &[&WellKnownAgent] = &[&MIKA_DEV, &MIKA_TEST, &MIKA_QA, &MIKA_ARCH];
+
+/// Returns `(agent_name, skill_allowlist)` for every well-known agent that
+/// declares a `[skills].allowlist`, for the `verify-bundled-skills` gate
+/// (mika#1575, Check 5 — identity allowlist coherence).
+///
+/// Resolution rules:
+/// - `IdentitySource::Static(s)` — parse `[skills].allowlist` from the identity TOML.
+/// - `IdentitySource::Computed` — only mika-arch is computed; its allowlist is
+///   static and read from [`MIKA_ARCH_SKILL_ALLOWLIST`] (no `Settings` needed).
+/// - Sentinel tokens (`__mika_test_no_skills__`, `__fail_closed_no_skills__`, or
+///   any `__…__` form) are filtered out — they intentionally match no real skill.
+/// - Agents with no `[skills].allowlist` (or an allowlist that is only sentinels)
+///   are omitted entirely.
+pub fn well_known_skill_allowlists() -> Vec<(&'static str, Vec<String>)> {
+    fn is_sentinel(name: &str) -> bool {
+        name.starts_with("__") && name.ends_with("__")
+    }
+
+    let mut out = Vec::new();
+    for spec in WELL_KNOWN_AGENTS {
+        let names: Vec<String> = match spec.identity_source {
+            Some(IdentitySource::Static(s)) => toml::from_str::<toml::Value>(s)
+                .ok()
+                .and_then(|v| {
+                    v.get("skills")
+                        .and_then(|sk| sk.get("allowlist"))
+                        .and_then(|al| al.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|e| e.as_str().map(str::to_string))
+                                .collect()
+                        })
+                })
+                .unwrap_or_default(),
+            Some(IdentitySource::Computed(_)) if spec.name == "mika-arch" => {
+                MIKA_ARCH_SKILL_ALLOWLIST
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            _ => Vec::new(),
+        };
+
+        let filtered: Vec<String> = names.into_iter().filter(|n| !is_sentinel(n)).collect();
+        if !filtered.is_empty() {
+            out.push((spec.name, filtered));
+        }
+    }
+    out
+}
 
 /// Identity-toml section paths that the reconciler owns from the static spec.
 ///

--- a/docs/architecture/bundled-skill-verification.md
+++ b/docs/architecture/bundled-skill-verification.md
@@ -1,0 +1,100 @@
+# Bundled-skill structural verification (`make verify-bundled-skills`)
+
+**Status:** active · **Introduced:** mika#1575 · **Counterpart to:** mika#1326 AC2
+
+`make verify-bundled-skills` is a build-time / pre-merge gate that asserts structural
+invariants on the engine-coupled bundled skills under `skills/bundled/`. It is the
+**structural counterpart to mika#1326 AC2**: AC2 catches cross-skill tool-name
+*collisions*; this gate catches *incomplete skill-adds* — the gap between "the skill
+bundle's files exist" and "the skill bundle works in production".
+
+## Why it exists
+
+mika#1282's post-flight dirty-worktree recovery rescues uncommitted skill-add content
+into a draft PR marked `PIPELINE_INCOMPLETE`. The operator then had to **hand-verify**
+that the rescued skill bundle was structurally complete — files present, manifest parses,
+handlers wire up, `required_tools` tokens consistent, identity allowlist coherent. Peer
+review on mika#1326/#1569/#1570 named that precisely:
+
+> "operator reads diff for completeness puts a human on a mechanizable, silent-failure
+> check — which is precisely why AC2 is a test and not a code-review guideline."
+
+This gate mechanizes that review. After it lands, the operator's task on a rescued draft
+PR shrinks from "verify structure" to "verify content" — the structure is machine-checked.
+
+## Where it sits in the silent-failure defense
+
+Four layers cover the same invariant class at different times:
+
+| Layer | When | Catches |
+|-------|------|---------|
+| mika#1326 AC2 (`test_bundled_skills_no_cross_skill_tool_name_collision`) | build-test | cross-skill tool-name collisions |
+| **`verify-bundled-skills` (this gate)** | **build-time / pre-merge** | **incomplete skill-adds (missing files, unresolvable `required_tools`, allowlist incoherence)** |
+| mika#1576 `apply_load_safety_check` coherence guard | runtime (load) | allowlist ↔ `required_tools` coherence at the layer where both are visible |
+| mika#516 availability filter | runtime (per-turn) | a `required_tool` not in the resolved surface at call time |
+
+## The five checks
+
+Run against the on-disk `skills/bundled/` tree (the source files a PR changes), reusing
+the canonical walker `crates/mika-agent/build_support/bundled_skills_discover.rs`.
+
+1. **Bundle completeness.** Every skill directory (excluding `_shared/` and dotfiles) has
+   `skill.toml` **and** `system_prompt.md`.
+   - *Predicate note (mika-arch session `d8b4c839`, Decision A):* the `required_tools ⇒
+     tools.json` coupling proposed in the original ticket text was **dropped as unsound** —
+     a `required_tools` token may legitimately resolve via a builtin or another skill
+     (see Check 4), so its presence cannot proxy "this skill ships its own `tools.json`".
+     Token validity is owned by Check 4, not Check 1. (`self-dev` and `dev-handsoff` both
+     declare `required_tools` with no `tools.json` and are correct designs.)
+
+2. **Manifest parses + minimum fields.** `skill.toml` is valid TOML and declares
+   `[skill].name`, `[skill].version`, and — unless `always_on = true` — a `[triggers].keywords`
+   **field** (presence, not non-emptiness: `skill-review` deliberately declares
+   `keywords = []` as a programmatically-invoked handler skill, #265).
+
+3. **Tool handler resolution.** For each `tools.json` tool: a `builtin` handler's `function`
+   is one of `skills::builtin_handlers::KNOWN_BUILTINS` (the handler-dispatch set); an
+   `exec` handler's `command` file exists under the skill directory and is executable on disk.
+
+4. **`required_tools` token consistency (allowlist-unaware).** Each `[constraints].required_tools`
+   token resolves to *something real somewhere* in the bundled surface: a builtin tool name
+   (`tools::BUILTIN_TOOL_NAMES`) **or** a tool declared in **any** bundled skill's `tools.json`
+   (`bundled_skills::all_bundled_tool_names()`, which spans both community and engine-coupled
+   skills — so e.g. `qa-review`'s `run_shell`, provided by the community `shell-exec` skill,
+   resolves). Catches typos and references to nonexistent tools.
+
+5. **Identity allowlist coherence (allowlist-scoped).** For each well-known agent's
+   `[skills].allowlist` (`well_known_agents::well_known_skill_allowlists()`): every allowlisted
+   name is a bundled skill (`is_bundled_skill`), and every `required_tools` token of an
+   allowlisted engine-coupled skill is *reachable through that allowlist* — a builtin, or a
+   tool declared by a skill **in the same allowlist**. This is the allowlist-scoped reachability
+   Check 4 deliberately defers: Check 4 says "exists somewhere"; Check 5 says "reachable here".
+
+## Fire-disposition and `KNOWN_EXCEPTIONS`
+
+Per mika#1575 F2, all five checks ship **green** against the current source tree, and the
+`KNOWN_EXCEPTIONS` constant ships **empty**. `KNOWN_EXCEPTIONS` mirrors
+`KNOWN_PRE_EXISTING_COLLISIONS` (bundled_skills.rs, mika#1326 AC2): each entry names the
+check, skill, a substring of the failure reason, and a resolution ticket. It is
+**self-cleaning** — the binary and a test fail if an entry no longer matches a real failure,
+forcing removal of stale exceptions. A non-empty `KNOWN_EXCEPTIONS` MUST be enumerated in the
+PR description with each entry's resolution ticket.
+
+## Running it
+
+```bash
+make verify-bundled-skills          # human-readable gate; exit 0 = green, non-zero = fail
+cargo test --bin verify-bundled-skills   # unit + real-tree green test
+```
+
+CI runs `make verify-bundled-skills` as a step in the `check` job on every PR; a non-zero
+exit blocks merge. The real-tree invariant is *also* enforced by the
+`real_bundled_tree_passes_green` test inside `cargo test`, so the gate has two independent
+CI entry points.
+
+## Out of scope
+
+Runtime invariants (`apply_load_safety_check`, mika#1576), marketplace skill verification
+(bundled only), `tools.json` schema validation against the canonical tool schema, and the
+optional checks 6–8 (prompt-size limits, keyword-overlap detection, schema validation) are
+deferred follow-ups.

--- a/docs/plans/2026-06-26-006-feat-1575-verify-bundled-skills-plan.md
+++ b/docs/plans/2026-06-26-006-feat-1575-verify-bundled-skills-plan.md
@@ -38,7 +38,7 @@ is precisely why AC2 is a test and not a code-review guideline."* The durable an
 
 ---
 
-## Requirements traceability
+## Acceptance criteria
 
 | AC | Requirement | Unit |
 |----|-------------|------|

--- a/docs/plans/2026-06-26-006-feat-1575-verify-bundled-skills-plan.md
+++ b/docs/plans/2026-06-26-006-feat-1575-verify-bundled-skills-plan.md
@@ -1,0 +1,290 @@
+---
+title: "feat(ci,skills): make verify-bundled-skills target — structural counterpart to AC2"
+date: 2026-06-26
+type: feat
+issue: mika#1575
+branch: feat/1575/ci-skills-make-verify-bundled-skills
+groomed_by: mika-arch session 1874bb55 (F1/F2/F3 govern)
+status: check-1 predicate pending mika-arch third-pass ratification (see Open Decisions)
+---
+
+# feat(ci,skills): `make verify-bundled-skills` — structural counterpart to AC2
+
+## Summary
+
+Add a `verify-bundled-skills` binary + `make verify-bundled-skills` target + a CI gate that
+asserts structural invariants on the engine-coupled bundled skills under `skills/bundled/`. This is
+the **pre-merge structural counterpart to mika#1326 AC2**: AC2 catches cross-skill tool-name
+collisions at build-test time; this gate catches *incomplete skill-adds* (missing bundle files,
+unresolvable `required_tools` tokens, identity-allowlist incoherence) at pre-merge time, so the
+operator's "review the rescued draft PR for completeness" task (mika#1282 dirty-worktree recovery)
+becomes "review for content correctness" — structure is already machine-verified.
+
+Five checks (1–5). The binary fails non-zero with explicit per-failure errors; CI blocks merge on
+failure. Per F2, all five checks ship **green on current data** and `KNOWN_EXCEPTIONS` ships
+**empty**.
+
+---
+
+## Problem Frame
+
+mika#1282's post-flight dirty-worktree recovery rescues uncommitted skill-add content into a draft
+PR marked PIPELINE_INCOMPLETE. The operator must then hand-verify that the rescued skill bundle is
+structurally complete (files present, manifest parses, handlers wire up, `required_tools` tokens
+consistent, identity allowlist coherent). Peer review on mika#1326/#1569/#1570 named this precisely:
+*"operator reads diff for completeness puts a human on a mechanizable, silent-failure check — which
+is precisely why AC2 is a test and not a code-review guideline."* The durable answer is a build-time
+/ pre-merge structural gate — this ticket.
+
+---
+
+## Requirements traceability
+
+| AC | Requirement | Unit |
+|----|-------------|------|
+| AC1 | `make verify-bundled-skills` target runs the check binary | U4 |
+| AC2 | `verify-bundled-skills` binary at `crates/mika-agent/src/bin/verify_bundled_skills.rs` implementing checks 1–5 | U1, U2, U3 |
+| AC3 | CI gate in `.github/workflows/ci.yml` runs the target on every PR; failure blocks merge | U5 |
+| AC4 | Tests for the verify binary — fixtures covering each PASS/FAIL case for checks 1–5 | U6 |
+| AC5 | Documentation at `docs/architecture/` describing the verify target as the structural counterpart to AC2 | U7 |
+
+---
+
+## Open Decisions
+
+**OD-1 — RESOLVED 2026-06-26 (mika-arch third-pass session `d8b4c839`): Decision (A) RATIFIED.**
+Drop the `required_tools ⇒ tools.json` coupling. **Check 1 = `skill.toml` + `system_prompt.md`
+presence only.** OD-2 (check-4 option (a) union) explicitly approved ("no architect objection").
+Routing chain: Mika Prime (session `0000…`) ruled this architect-scope and routed to mika-arch with
+the recommendation below, which mika-arch ratified. U1 is now unblocked.
+
+**OD-1 (original framing) — Check 1 `required_tools ⇒ tools.json` coupling.**
+Grounding against real data found a forced contradiction: F3 check-1 ("`required_tools` present +
+no `tools.json` → FAIL") fires on `self-dev` (`required_tools = ["run_claude_pilot"]`, no
+`tools.json`) and `dev-handsoff` (`required_tools = ["write_agent_file"]`, no `tools.json`), which
+violates F2 ("all five green on first run"). The only literal fix (add a `tools.json` declaring
+those tools) re-declares `run_claude_pilot` (already in `dev-pilot/tools.json`) → trips mika#1326
+AC2 collision. `KNOWN_EXCEPTIONS` is semantically wrong (these are correct design, not bugs; the
+self-cleaning assertion would pin them forever). Mika Prime ruled this **architect-scope** (it
+overturns a ratified F3 predicate) and routed it to mika-arch with the recommendation below.
+
+- **Recommended (pending ratification):** Check 1 validates `skill.toml` + `system_prompt.md`
+  presence ONLY; drop the `required_tools ⇒ tools.json` coupling. Tool-reference validity is owned
+  entirely by Check 4 (F1's allowlist-unaware resolution). Rationale: F1 permits `required_tools` to
+  resolve via a builtin or *any other* bundled skill's `tools.json`, so `required_tools` presence
+  cannot validly proxy "this skill ships its own `tools.json`" — the proxy is circular.
+- **U1 (Check 1) MUST NOT be implemented until mika-arch ratifies.** Build U2/U3/U4/U5/U6(2-5)/U7
+  first. When the ruling lands, implement U1 per the ratified predicate and the matching tests.
+
+**OD-2 — Check 4 option (a) breadth (carried on implementer warrant — Prime ruled spec-completion).**
+F1 option (a) names "a builtin handler registered in `builtin_handlers.rs`" but core `ToolRegistry`
+builtins (e.g. `write_agent_file`) live in a different registry and are not in
+`builtin_handlers.rs`'s 7-fn dispatch (`KNOWN_BUILTINS`). Broaden option (a) to the **union of
+`builtin_handlers::KNOWN_BUILTINS` + the core `ToolRegistry` default tool-name set**. This completes
+F1's plain intent ("validate the token resolves to something real") without changing it. No
+ratification required; flagged to mika-arch as FYI.
+
+---
+
+## Key Technical Decisions
+
+**KTD-1 — Source of truth: walk the real source tree, not the compile-time snapshot.**
+The verify binary walks `skills/bundled/` **on disk** (the actual source files a PR changes), reusing
+the canonical discovery helper `crates/mika-agent/build_support/bundled_skills_discover.rs` via a
+`#[path = ...]` mod attribute (the same pattern `build.rs` and the integration tests use). Rationale:
+(a) a pre-merge gate should assert against the files on disk, not a `BUNDLED_SKILL_MANIFESTS` snapshot
+that only updates on rebuild; (b) Check 3's Exec executable-bit check needs `std::fs` metadata on the
+real handler file; (c) avoids widening the crate's `pub` surface (`all_bundled_skills()`,
+`SkillFile`, `BundledSkill` are private). The binary reads `skill.toml` (via the `toml` crate),
+`tools.json` (via `serde_json`), and file metadata directly.
+
+**KTD-2 — Builtin name resolution set.** Check 3 (Builtin handler resolution) and Check 4 option (a)
+resolve against `builtin_handlers::KNOWN_BUILTINS` (already `pub`). For the *core ToolRegistry*
+builtin set (OD-2), expose a `pub` accessor returning the default tool names (or reuse an existing
+one if present) — scoped to this need, not a general API. Resolve the exact accessor during
+implementation with compiler feedback.
+
+**KTD-3 — Identity allowlist access for Check 5.** Check 5 reads each well-known agent's
+`[skills].allowlist` from `well_known_agents.rs` (`MIKA_DEV_IDENTITY`, `MIKA_QA_IDENTITY`,
+`MIKA_RELAY_IDENTITY`, and the computed `build_mika_arch_identity()`). These consts are private; add a
+`pub` accessor that returns the per-agent allowlist skill-name set (parsed from the identity TOML, or
+a structured getter). The binary then asserts: every allowlisted name exists as a bundled skill, and
+every `required_tools` token of every allowlisted skill is transitively resolvable through the
+allowlist's skills + builtins.
+
+**KTD-4 — `KNOWN_EXCEPTIONS` self-cleaning pattern.** Mirror `bundled_skills.rs:1563`
+`KNOWN_PRE_EXISTING_COLLISIONS` exactly: a `const KNOWN_EXCEPTIONS: &[(…, &str /*ticket*/)]` plus a
+test that fails when an entry no longer matches an actual failure ("stale exception, remove it").
+Ships **empty** (per F2). If a future skill-add needs an exception too large to fix in-PR, the entry
+cites its resolution ticket and the PR body enumerates it.
+
+**KTD-5 — Output + exit semantics.** The binary prints one human-readable line per failure
+(`CHECK n FAIL: <skill> — <reason>`), a summary, and exits `0` (all pass) / `1` (any unallowlisted
+failure). Designed to read well in CI logs, mirroring the existing `byte-slice-lint` /
+`loop-select-lint` script gates.
+
+---
+
+## High-Level Technical Design
+
+```
+verify_bundled_skills (bin)
+   │
+   ├─ discover()  ──────────────►  build_support/bundled_skills_discover.rs  (#[path], real dir walk)
+   │      └─ Vec<DiscoveredSkill { name, dir, has_skill_toml, has_system_prompt, has_tools_json,
+   │                               skill_toml: toml::Value, tools: Vec<ToolDef> }>
+   │
+   ├─ builtin_name_set()  ──────►  builtin_handlers::KNOWN_BUILTINS  ∪  core ToolRegistry names
+   ├─ identity_allowlists() ────►  well_known_agents:: pub accessor (DEV/QA/RELAY/ARCH)
+   │
+   ├─ check1_completeness()   (skill.toml + system_prompt.md ; tools.json per ratified OD-1)
+   ├─ check2_manifest()       (valid TOML; [skill] name+version; [triggers] keywords unless always_on)
+   ├─ check3_handler_res()    (Builtin{function} ∈ builtin set ; Exec{command} file exists + +x)
+   ├─ check4_token_consistency() (each required_tools token ∈ builtin set ∪ own tools ∪ any skill's tools)
+   ├─ check5_identity_coherence() (allowlist names exist ; tokens transitively resolvable in allowlist)
+   │
+   └─ KNOWN_EXCEPTIONS (empty) + self-cleaning assertion → aggregate → exit 0|1
+```
+
+Grounded facts (verified against the worktree, HEAD `f15c2839`):
+- `skill.toml` schema: `keywords` live under **`[triggers]`** (e.g. `gh-read-only`), `required_tools`
+  under **`[constraints]`**. `always_on` under `[skill]`.
+- `tools.json`: array of `{name, description, input_schema, handler}`; `handler.type ∈
+  {"builtin","exec"}`; builtin → `handler.function`; exec → `handler.command` (e.g.
+  `"handlers/run.sh"`).
+- Skills with `[constraints] required_tools`: `gh-read-only`, `mika-arch-groom-milestone`,
+  `qa-review`, `mika-arch-groom-ticket`, `skill-review`, `mika-arch-second-review`, `dev-groom`,
+  `dev-handsoff`, `self-dev`. Of these, `dev-handsoff` and `self-dev` have **no** `tools.json` (OD-1).
+
+---
+
+## Implementation Units
+
+### U1. Check 1 — bundle completeness  **(BLOCKED on OD-1 / mika-arch third-pass)**
+
+- **Goal:** Assert every skill dir under `skills/bundled/` (excluding `_shared/` and dotfiles) has the
+  required files, per the ratified Check-1 predicate.
+- **Dependencies:** OD-1 ruling; U2's discovery scaffold.
+- **Files:** `crates/mika-agent/src/bin/verify_bundled_skills.rs` (check1 fn + tests).
+- **Approach:** Implement per ratified predicate. Recommended shape: `skill.toml` + `system_prompt.md`
+  always required; `tools.json` coupling DROPPED. If mika-arch ratifies (B) instead, implement the
+  coupling + the named AC2-safe resolution for self-dev/dev-handsoff.
+- **Test scenarios:** PASS — prompt-only skill (no tools.json, no required_tools); skill with all
+  three files. FAIL — dir missing `skill.toml`; dir missing `system_prompt.md`. (If coupling kept:
+  required_tools + no tools.json → FAIL.) Plus: the real `skills/bundled/` tree passes green.
+- **Execution note:** Do not author until OD-1 is ratified — building the recommended drop
+  pre-ratification constructs an overturn of a ratified architect resolution (Prime ruling).
+
+### U2. Binary scaffold + discovery + checks 2 & 3
+
+- **Goal:** The binary entrypoint, source-tree discovery (KTD-1), and Checks 2 (manifest parses +
+  minimum fields) and 3 (handler resolution).
+- **Dependencies:** none (KTD-1, KTD-2).
+- **Files:** `crates/mika-agent/src/bin/verify_bundled_skills.rs`; `Cargo.toml` (`[[bin]]` entry if
+  the bin isn't auto-discovered — `src/bin/` is auto-discovered, so likely none).
+- **Approach:** Walk `skills/bundled/` via the shared discovery helper; for each skill parse
+  `skill.toml` (toml), `tools.json` (serde_json). Check 2: valid TOML, `[skill].name`,
+  `[skill].version`, `[triggers].keywords` non-empty unless `[skill].always_on = true`. Check 3: for
+  each tool, `builtin` → `handler.function ∈ KNOWN_BUILTINS`; `exec` → handler file exists at
+  `<skill_dir>/<handler.command>` and is executable (`std::fs` mode `& 0o111 != 0`).
+- **Patterns to follow:** `bundled_skills.rs` AC2 test (iteration over skills, tools.json parse,
+  aggregate-then-assert); existing `scripts/check-*.sh` CLI-gate ergonomics.
+- **Test scenarios:** Check 2 PASS — valid manifest; always_on skill without keywords. FAIL —
+  malformed TOML; missing name; missing version; non-always_on missing keywords. Check 3 PASS —
+  `gh_read` builtin resolves; `dev-pilot` exec `handlers/run.sh` exists+executable. FAIL — builtin
+  `function` not in set; exec command file missing; exec command file not executable.
+
+### U3. Check 4 (token consistency) + Check 5 (identity coherence) + builtin/allowlist accessors
+
+- **Goal:** Checks 4 and 5, plus the `pub` accessors they need (KTD-2 core tool names, KTD-3 identity
+  allowlists).
+- **Dependencies:** U2.
+- **Files:** `crates/mika-agent/src/bin/verify_bundled_skills.rs`;
+  `crates/mika-agent/src/skills/builtin_handlers.rs` or a tool-registry module (pub core-tool-name
+  accessor, OD-2/KTD-2); `crates/mika-agent/src/well_known_agents.rs` (pub allowlist accessor, KTD-3).
+- **Approach:** Build `builtin_name_set = KNOWN_BUILTINS ∪ core_tool_names`. Check 4: for each skill
+  with `required_tools`, each token ∈ `builtin_name_set` OR declared in own `tools.json` OR in ANY
+  skill's `tools.json` (allowlist-unaware, per F1). Check 5: for each well-known agent allowlist,
+  every name is a bundled skill, and every `required_tools` token of allowlisted skills is resolvable
+  via `builtin_name_set` ∪ tools declared by skills *in that allowlist* (allowlist-scoped — the
+  reachability F1 defers here).
+- **Test scenarios:** Check 4 PASS — `gh_read` (builtin); `run_claude_pilot` (cross-skill, in
+  dev-pilot); `write_agent_file` (core builtin). FAIL — `required_tools = ["nonexistent_tool"]`. Check
+  5 PASS — real DEV/QA/RELAY/ARCH allowlists cohere. FAIL — allowlist names a non-bundled skill;
+  allowlist skill's token unreachable within the allowlist's skill set + builtins.
+
+### U4. Makefile target (AC1)
+
+- **Goal:** `make verify-bundled-skills` builds and runs the binary.
+- **Dependencies:** U2 (binary must exist to run).
+- **Files:** `Makefile`.
+- **Approach:** Add a `.PHONY` target mirroring existing structural-gate targets (`test-dispatch-symmetry`):
+  `cargo run -q --bin verify-bundled-skills` (or `cargo run -p mika-agent --bin verify_bundled_skills`).
+  Confirm the bin name the cargo manifest exposes.
+- **Test scenarios:** Test expectation: none — Makefile wiring; behavior covered by U6 + CI (U5).
+
+### U5. CI gate (AC3)
+
+- **Goal:** A new, additive job/step in `.github/workflows/ci.yml` running `make verify-bundled-skills`
+  on every PR; failure blocks merge.
+- **Dependencies:** U4.
+- **Files:** `.github/workflows/ci.yml`.
+- **Approach:** Mirror the existing `byte-slice-lint` / `loop-select-lint` job shape (checkout +
+  toolchain + run). Additive — does not modify existing jobs.
+- **Test scenarios:** Test expectation: none — CI config; validated by the job running green on this PR.
+
+### U6. Tests / fixtures for checks (AC4)
+
+- **Goal:** Inline `#[cfg(test)]` tests covering each PASS/FAIL case for checks 2–5 now, and check 1
+  once U1 lands; plus the `KNOWN_EXCEPTIONS` self-cleaning assertion (KTD-4); plus a "real tree passes
+  green" test.
+- **Dependencies:** U2, U3 (U1 portion gated on OD-1).
+- **Files:** `crates/mika-agent/src/bin/verify_bundled_skills.rs` (`#[cfg(test)] mod tests`); synthetic
+  in-memory skill fixtures (build `DiscoveredSkill` values in-test rather than temp dirs where
+  possible; use a `tempfile` dir only for the executable-bit Exec case).
+- **Approach:** Pure-function checks take a `&[DiscoveredSkill]` + the builtin/allowlist sets so tests
+  pass synthetic fixtures without touching the real FS (except the one exec-bit case). Add the
+  self-cleaning `KNOWN_EXCEPTIONS` test mirroring `bundled_skills.rs:1579`.
+- **Test scenarios:** Enumerated per-check under U1/U2/U3; plus `KNOWN_EXCEPTIONS` empty-by-default
+  asserted; plus stale-exception self-clean assertion fires when an entry doesn't match a real failure.
+
+### U7. Documentation (AC5)
+
+- **Goal:** `docs/architecture/` doc describing the verify target as the structural counterpart to AC2.
+- **Dependencies:** none (can write in parallel; finalize check-1 prose after OD-1).
+- **Files:** `docs/architecture/bundled-skill-verification.md` (new). Update root `CLAUDE.md` §"Adding
+  a New Bundled Skill" to reference the gate. Note doc-sync: if the doc must be readable from the crate
+  (it's architecture, not `docs/solutions/`), confirm whether `scripts/sync-agent-docs.sh` / the
+  `docs-sync` CI job scopes it — `docs/architecture/` is not currently synced into the crate, so a new
+  file there should not trip docs-sync; verify during implementation.
+- **Approach:** Describe the three-layer silent-failure defense (AC2 collision test @ build-test;
+  this gate @ pre-merge; #516 availability filter @ runtime), the five checks, the `KNOWN_EXCEPTIONS`
+  mechanism, and the OD-1 reconciliation outcome.
+- **Test scenarios:** Test expectation: none — documentation.
+
+---
+
+## Scope Boundaries
+
+**In scope:** checks 1–5 on `skills/bundled/`; Makefile target; CI gate; tests; `docs/architecture/`
+doc; the OD-2 check-4 broadening; pub accessors needed by checks 3/4/5.
+
+**Out of scope:** runtime invariants (`apply_load_safety_check`); marketplace skill verification
+(bundled only); `tools.json` schema validation against the canonical tool schema; optional checks
+6–8 (prompt-size limits, keyword-overlap, schema validation).
+
+### Deferred to Follow-Up Work
+- Optional checks 6–8 (file a follow-up if/when needed).
+- If mika-arch rules (B) on OD-1, the self-dev/dev-handsoff skill changes it mandates may warrant a
+  companion ticket.
+
+---
+
+## Risks & Dependencies
+
+- **OD-1 ratification is on the critical path for U1 only.** All other units proceed independently.
+- **Pub-surface additions (KTD-2/KTD-3):** keep minimal and single-purpose; a reviewer may prefer an
+  existing accessor — resolve with compiler feedback, don't speculatively widen the API.
+- **CI cost:** one extra `cargo run` of a tiny binary — negligible next to existing build/test jobs.
+- **Composition with mika#1326 AC2 / mika#516:** this gate must not duplicate or contradict AC2's
+  collision check; it targets the orthogonal completeness class.

--- a/docs/solutions/best-practices/detector-built-on-filtered-set-is-blind-to-the-filter.md
+++ b/docs/solutions/best-practices/detector-built-on-filtered-set-is-blind-to-the-filter.md
@@ -1,0 +1,98 @@
+---
+module: skills
+tags: [detector, structural-gate, discovery, false-negative, verify-bundled-skills, builtin-tools]
+problem_type: bug-class-prevention
+category: best-practices
+---
+
+# A detector built on a filtered set is blind to what the filter drops
+
+## Context
+
+mika#1575 added `make verify-bundled-skills` — a pre-merge structural gate that asserts
+invariants on the engine-coupled skills under `skills/bundled/` (the structural counterpart
+to mika#1326 AC2). Its job is to catch *incomplete skill-adds*: a skill bundle that is
+missing a required file, has an unresolvable `required_tools` token, etc.
+
+The first implementation enumerated its subjects by calling the shared walker
+`discover_bundled_skills()` and building a `SkillView` per result. Code review (cross-
+corroborated by two independent reviewers) caught that **the walker only returns a
+directory once it already contains a real `skill.toml`** (`build_support/bundled_skills_discover.rs`
+skips any dir whose `skill.toml` is absent or a symlink). So a skill-add that *forgot
+`skill.toml` entirely* produces zero `SkillView`s — and the gate passes **green** on the
+exact failure class it exists to catch. The `if !rel_files.contains("skill.toml")` branch
+was dead code against the real tree; only the synthetic unit test ever exercised it.
+
+## Guidance
+
+When a detector's input set is produced by a filter that **presupposes the invariant you
+are checking**, the detector structurally cannot see the invariant's violation. Before
+trusting "iterate the discovered set and check each one," ask: *what does the discovery
+step silently drop, and is any dropped item a violation I am responsible for flagging?*
+
+The fix is to check the **raw, unfiltered surface** for the existence class, separately from
+the per-item checks on the discovered set:
+
+```rust
+// WRONG: every SkillView already has skill.toml (the walker guaranteed it),
+// so this branch can never fire against the real tree.
+for s in &skill_views {
+    if !s.rel_files.contains("skill.toml") { flag(...); }
+}
+
+// RIGHT: scan the raw directory listing for skill-shaped dirs the walker dropped.
+fn check1_missing_manifest(base: &Path) -> Vec<Failure> {
+    for entry in std::fs::read_dir(base)?.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !discover::is_bundled_skill_dir(&name) { continue; } // skip _shared, dotfiles
+        let toml = entry.path().join("skill.toml");
+        let is_real = std::fs::symlink_metadata(&toml)
+            .map(|m| m.file_type().is_file()).unwrap_or(false);
+        if !is_real { flag(name, "missing required file skill.toml"); }
+    }
+}
+```
+
+Test the gate against the **pipeline** (discovery → check), not just synthetic fixtures —
+a synthetic `SkillView` with a missing file passes the unit test while masking that the real
+pipeline never produces such a view. mika#1575's `real_bundled_tree_passes_green` test plus
+a tempdir test that creates a manifest-less dir cover both directions.
+
+### Companion fact — two distinct builtin-name registries in mika-agent
+
+Resolving "is this tool name real?" in the skills layer requires knowing which registry to
+consult — they are not interchangeable:
+
+- **`skills::builtin_handlers::KNOWN_BUILTINS`** (7 entries) — the skill-handler *dispatch*
+  functions. Use this to validate a `tools.json` declaration whose `handler.type = "builtin"`
+  (its `function` must be one of these 7). A handler function not in this set is unroutable.
+- **`tools::BUILTIN_TOOL_NAMES`** (~55 entries, kept complete by the mika#1217 F4 sync test) —
+  every engine-registered builtin *tool*. `KNOWN_BUILTINS` is a strict subset. Use this to
+  resolve a `[constraints] required_tools` token (e.g. `write_agent_file`, `update_task_status`).
+
+Conflating them causes false-positives: validating a `required_tools` token against the
+7-entry `KNOWN_BUILTINS` rejects legitimate core builtins. Prior art for the correct choice:
+`skills/index.rs` already resolves `required_tools` against `BUILTIN_TOOL_NAMES`.
+
+## Why This Matters
+
+A detector that silently passes on the failure it was built to catch is worse than no
+detector — it manufactures false confidence. The operator stops hand-checking ("the gate
+covers it") precisely where the gate is blind. The cost of the gap is paid later, in
+production, by whoever debugs the skill that never loaded.
+
+This is a general shape, not specific to skills: any lint/gate/audit whose candidate set
+comes from a parser, loader, or walker that *requires the thing being validated* inherits the
+blind spot. Schema validators that only see rows the ORM could hydrate, link-checkers that
+only see pages the router could resolve, and dependency auditors that only see packages the
+resolver could install all have the same failure mode.
+
+## When to Apply
+
+- Building any structural gate, lint, or audit that iterates a "discovered" / "loaded" /
+  "parsed" set and asserts properties per item.
+- Reviewing a detector PR: explicitly ask what the discovery step drops and whether any
+  dropped item is in the detector's mandate. Demand a test that exercises the full
+  discovery→check pipeline, not only synthetic per-item fixtures.
+- Resolving tool/handler names anywhere in the mika skills layer: pick `KNOWN_BUILTINS`
+  (handler dispatch) vs `BUILTIN_TOOL_NAMES` (full builtin tool surface) deliberately.


### PR DESCRIPTION
## Why

mika#1282's dirty-worktree recovery rescues uncommitted skill-add content into a draft PR marked PIPELINE_INCOMPLETE; the operator then hand-verifies structural completeness — a mechanizable, silent-failure check. Peer review on mika#1326/#1569/#1570: *"operator reads diff for completeness puts a human on a mechanizable, silent-failure check — which is precisely why AC2 is a test and not a code-review guideline."* This gate mechanizes that review.

## What

`make verify-bundled-skills` + a `verify-bundled-skills` binary (`crates/mika-agent/src/bin/verify_bundled_skills.rs`) + a CI gate, asserting five structural invariants on `skills/bundled/`. The **pre-merge counterpart to mika#1326 AC2** (AC2 catches collisions; this catches incomplete skill-adds). Three layers now cover the silent-failure class: AC2 (build-test) → this gate (pre-merge) → mika#516 availability filter (runtime).

**Five checks** (all GREEN on the current tree; `KNOWN_EXCEPTIONS` ships EMPTY per F2):
1. **Bundle completeness** — `skill.toml` + `system_prompt.md` present (incl. a raw-directory scan that flags skill-shaped dirs the walker drops because they lack `skill.toml` — the exact incomplete-add class the gate targets).
2. **Manifest parses + minimum fields** — valid TOML, `[skill].name`/`.version`, `[triggers].keywords` *field-presence* unless `always_on` (`skill-review` legitimately declares `keywords = []`).
3. **Tool handler resolution** — builtin `function` ∈ `KNOWN_BUILTINS`; exec `command` file exists + executable; unknown/missing `handler.type` flagged.
4. **`required_tools` token consistency** (allowlist-unaware, F1) — token ∈ `BUILTIN_TOOL_NAMES` ∪ any bundled skill's `tools.json` (spans community + engine skills, so e.g. qa-review's `run_shell` from `shell-exec` resolves).
5. **Identity allowlist coherence** (allowlist-scoped, F1) — every allowlisted name is a bundled skill; every token of an allowlisted engine skill is reachable through that allowlist.

## Contract reconciliation (Check 1)

Grounding the GROOMED F1/F2/F3 resolutions against real data surfaced an internal contradiction: F3's Check-1 `required_tools ⇒ tools.json` coupling fires on `self-dev`/`dev-handsoff` (which correctly declare `required_tools` with no `tools.json`), violating F2 ("all checks green"); the literal fix (add `tools.json`) re-declares `run_claude_pilot`/`write_agent_file` → trips **mika#1326 AC2**. Routed via **Mika Prime** (ruled architect-scope) → **mika-arch third-pass (session `d8b4c839`)**, which **ratified Decision A**: drop the coupling — **Check 1 = `skill.toml` + `system_prompt.md` presence only**; token validity is owned by Check 4. Check-4 option (a) was broadened to the full `BUILTIN_TOOL_NAMES` surface (completes F1's intent; mika-arch: no objection).

## Surface

- New binary + `[[bin]]` entry; Makefile target; additive CI step in the `check` job (failure blocks merge).
- New pub accessors: `bundled_skills::{all_bundled_tool_names, bundled_skill_tool_map}`, `well_known_agents::{well_known_skill_allowlists, MIKA_ARCH_SKILL_ALLOWLIST}`.
- Docs: `docs/architecture/bundled-skill-verification.md` + CLAUDE.md skill-add checklist (also corrected its stale `[skill].keywords` example to `[triggers].keywords`).
- 14 unit tests (PASS/FAIL fixtures for checks 1–5 + a real-tree green test + `KNOWN_EXCEPTIONS` self-cleaning).

## Verification

`make verify-bundled-skills` → green (exit 0); `cargo test --bin verify-bundled-skills` → 14 pass; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean. Code-reviewed (correctness + standards); review findings (Check-1 manifest-less-dir false-negative, Check-3 unknown-handler-type, orphaned doc comment, doc schema drift, Check-5 arm-a test) all resolved.

Plan: `docs/plans/2026-06-26-006-feat-1575-verify-bundled-skills-plan.md`

Closes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)