### PR TITLE
fix(gateway): build global Telegram client on token presence, not mode flag (#1590)

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -80,10 +80,10 @@ API keys are SHA-256 hashed and stored in Postgres `a2a_api_keys` table (migrati
 ## Gateway Environment Variables
 
 - `MIKA_DATABASE_URL` — Postgres connection string
-- `MIKA_TELEGRAM_BOT_TOKEN` — Telegram Bot API token. Required only in single-bot mode.
-- `MIKA_TELEGRAM_WEBHOOK_SECRET` — 64-char hex secret for webhook validation. Required only in single-bot mode.
-- `MIKA_TELEGRAM_WEBHOOK_URL` — Public HTTPS URL for Telegram webhook delivery. Required only in single-bot mode.
-- `MIKA_TELEGRAM_SINGLE_BOT_MODE` — When `1` or `true`, the gateway uses the global `MIKA_TELEGRAM_BOT_TOKEN` for all customers (legacy single-bot behavior). Requires `MIKA_TELEGRAM_BOT_TOKEN`, `MIKA_TELEGRAM_WEBHOOK_SECRET`, and `MIKA_TELEGRAM_WEBHOOK_URL` to be set. Default: off (per-customer bot mode).
+- `MIKA_TELEGRAM_BOT_TOKEN` — Telegram Bot API token. When configured, the gateway builds the global `TelegramClient` for outbound delivery via `/send` (operator agents without `customer_id`), independent of `MIKA_TELEGRAM_SINGLE_BOT_MODE`. Required in single-bot mode; optional but enables outbound-only delivery in per-customer mode (mika#1590).
+- `MIKA_TELEGRAM_WEBHOOK_SECRET` — 64-char hex secret for inbound webhook validation. Required only in single-bot mode (inbound registration).
+- `MIKA_TELEGRAM_WEBHOOK_URL` — Public HTTPS URL for inbound Telegram webhook delivery. Required only in single-bot mode (inbound registration).
+- `MIKA_TELEGRAM_SINGLE_BOT_MODE` — Exclusively controls **inbound global webhook registration**. When `1` or `true`, the gateway registers the global webhook with Telegram for inbound messages (requires all three: `MIKA_TELEGRAM_BOT_TOKEN`, `MIKA_TELEGRAM_WEBHOOK_SECRET`, `MIKA_TELEGRAM_WEBHOOK_URL`). Default: off (per-customer inbound mode). **Semantic narrowing (mika#1590):** pre-fix, this flag gated both inbound webhook registration and outbound client construction; post-fix, it gates inbound registration only — the global outbound client is built whenever `MIKA_TELEGRAM_BOT_TOKEN` is configured.
 - `MIKA_INTERNAL_TOKEN` — Shared 64-char hex bearer token
 - `MIKA_AGENTS_NAMESPACE` — K8s namespace where agent pods run (default: `mika-agents`). Used for FQDN construction in cross-namespace DNS resolution (`http://mika-{id}.{ns}.svc.cluster.local:8080`). Override for environment-scoped namespaces (e.g. `mika-agents-prd`).
 - `MIKA_GITHUB_WEBHOOK_SECRET` — Secret for validating inbound GitHub App webhooks via HMAC-SHA256. Arbitrary string (not hex-constrained like Telegram). When absent, `POST /webhook/github` returns 404.

--- a/crates/mika-gateway/src/main.rs
+++ b/crates/mika-gateway/src/main.rs
@@ -84,35 +84,40 @@ async fn main() -> Result<()> {
         .pool_idle_timeout(std::time::Duration::from_secs(90))
         .build()?;
 
-    // Create Telegram client (only in single-bot mode)
+    // Build global Telegram client whenever a bot token is configured (outbound delivery).
+    // The MIKA_TELEGRAM_SINGLE_BOT_MODE flag gates only inbound webhook registration,
+    // not client construction — operator agents need the global client for /send even
+    // in per-customer mode (mika#1590).
     let single_bot_mode =
         settings::telegram_single_bot_mode_is_enabled(settings.telegram_single_bot_mode.as_deref());
-    let telegram = if single_bot_mode {
-        let bot_token = settings
-            .telegram_bot_token
-            .clone()
-            .expect("validated in GatewaySettings::load");
+    let telegram = if let Some(bot_token) = settings.telegram_bot_token.clone() {
         let tg = TelegramClient::new(http_client.clone(), bot_token);
 
-        // Register webhook with Telegram (idempotent)
-        let webhook_url = settings
-            .telegram_webhook_url
-            .as_ref()
-            .expect("validated in GatewaySettings::load");
-        tg.set_webhook(
-            webhook_url,
-            settings
-                .telegram_webhook_secret
+        if single_bot_mode {
+            // Register inbound webhook with Telegram (idempotent)
+            let webhook_url = settings
+                .telegram_webhook_url
                 .as_ref()
-                .expect("validated in GatewaySettings::load")
-                .expose_secret(),
-        )
-        .await?;
-        info!(url = %webhook_url, "telegram webhook registered (single-bot mode)");
+                .expect("validated in GatewaySettings::load");
+            tg.set_webhook(
+                webhook_url,
+                settings
+                    .telegram_webhook_secret
+                    .as_ref()
+                    .expect("validated in GatewaySettings::load")
+                    .expose_secret(),
+            )
+            .await?;
+            info!(url = %webhook_url, "telegram webhook registered (single-bot mode)");
+        } else {
+            info!(
+                "global Telegram client built for outbound delivery — inbound webhook registration skipped (per-customer mode)"
+            );
+        }
 
         Some(tg)
     } else {
-        info!("per-customer Telegram bot mode — global webhook registration skipped");
+        info!("no MIKA_TELEGRAM_BOT_TOKEN configured — global Telegram client not built");
         None
     };
 

--- a/crates/mika-gateway/src/routes.rs
+++ b/crates/mika-gateway/src/routes.rs
@@ -85,8 +85,9 @@ pub(crate) async fn handle_version() -> Json<VersionInfo> {
 #[derive(Clone)]
 pub struct AppState {
     pub pool: PgPool,
-    /// Global Telegram client — populated only in single-bot mode
-    /// (`MIKA_TELEGRAM_SINGLE_BOT_MODE=1`). `None` in per-customer mode.
+    /// Global Telegram client — populated when `MIKA_TELEGRAM_BOT_TOKEN` is configured.
+    /// Used for outbound delivery via `/send` (operator agents without `customer_id`).
+    /// `None` only when no bot token is set.
     pub telegram: Option<TelegramClient>,
     pub http_client: reqwest::Client,
     pub internal_token: SecretString,
@@ -1098,6 +1099,12 @@ pub(crate) async fn handle_send(
                 CustomerTelegramClient::new(state.http_client.clone(), global_tg.bot_token_cloned())
             }
             None => {
+                warn!(
+                    agent_name = ?payload.agent_name,
+                    chat_id = payload.chat_id,
+                    request_id = ?payload.request_id,
+                    "send failed: no customer_id provided and no global Telegram client configured"
+                );
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({"error": "no customer_id provided and gateway is not in single-bot mode"})),

--- a/crates/mika-gateway/src/settings.rs
+++ b/crates/mika-gateway/src/settings.rs
@@ -8,7 +8,8 @@ pub struct GatewaySettings {
     /// Postgres connection string
     pub database_url: SecretString,
 
-    /// Telegram Bot API token (required only in single-bot mode)
+    /// Telegram Bot API token. When set, the global outbound client is built
+    /// regardless of single-bot mode (mika#1590).
     #[serde(default)]
     pub telegram_bot_token: Option<SecretString>,
 
@@ -118,45 +119,53 @@ impl GatewaySettings {
                 )
             })?;
 
+        settings.validate()?;
+        Ok(settings)
+    }
+
+    /// Validate settings constraints. Extracted from `load()` for testability.
+    fn validate(&self) -> anyhow::Result<()> {
         // Validate internal token
-        validate_hex_token(&settings.internal_token, "MIKA_INTERNAL_TOKEN")?;
+        validate_hex_token(&self.internal_token, "MIKA_INTERNAL_TOKEN")?;
 
         // Single-bot mode requires bot token, webhook secret, and webhook URL
-        if telegram_single_bot_mode_is_enabled(settings.telegram_single_bot_mode.as_deref()) {
-            if settings.telegram_bot_token.is_none() {
+        // for inbound webhook registration. When single-bot mode is off,
+        // bot_token alone is sufficient for outbound delivery (mika#1590).
+        if telegram_single_bot_mode_is_enabled(self.telegram_single_bot_mode.as_deref()) {
+            if self.telegram_bot_token.is_none() {
                 anyhow::bail!(
                     "MIKA_TELEGRAM_SINGLE_BOT_MODE is enabled but MIKA_TELEGRAM_BOT_TOKEN is not set"
                 );
             }
-            if settings.telegram_webhook_secret.is_none() {
+            if self.telegram_webhook_secret.is_none() {
                 anyhow::bail!(
                     "MIKA_TELEGRAM_SINGLE_BOT_MODE is enabled but MIKA_TELEGRAM_WEBHOOK_SECRET is not set"
                 );
             }
-            if settings.telegram_webhook_url.is_none() {
+            if self.telegram_webhook_url.is_none() {
                 anyhow::bail!(
                     "MIKA_TELEGRAM_SINGLE_BOT_MODE is enabled but MIKA_TELEGRAM_WEBHOOK_URL is not set"
                 );
             }
 
             // Validate webhook URL is well-formed
-            reqwest::Url::parse(settings.telegram_webhook_url.as_ref().unwrap()).map_err(|e| {
+            reqwest::Url::parse(self.telegram_webhook_url.as_ref().unwrap()).map_err(|e| {
                 anyhow::anyhow!("MIKA_TELEGRAM_WEBHOOK_URL is not a valid URL: {e}")
             })?;
 
             // Validate webhook secret format
             validate_hex_token(
-                settings.telegram_webhook_secret.as_ref().unwrap(),
+                self.telegram_webhook_secret.as_ref().unwrap(),
                 "MIKA_TELEGRAM_WEBHOOK_SECRET",
             )?;
         }
 
         // Validate agent_base_url scheme when set (dev-only override)
-        if let Some(ref url_str) = settings.agent_base_url {
+        if let Some(ref url_str) = self.agent_base_url {
             validate_agent_base_url(url_str)?;
         }
 
-        Ok(settings)
+        Ok(())
     }
 }
 
@@ -407,5 +416,69 @@ mod tests {
     fn test_single_bot_mode_handles_whitespace() {
         assert!(telegram_single_bot_mode_is_enabled(Some(" 1 ")));
         assert!(telegram_single_bot_mode_is_enabled(Some("\ttrue\n")));
+    }
+
+    // -- validation contract tests (mika#1590) --
+
+    /// Helper to build a GatewaySettings with sensible defaults for validation tests.
+    fn test_settings() -> GatewaySettings {
+        GatewaySettings {
+            database_url: SecretString::from("postgres://localhost/test"),
+            telegram_bot_token: None,
+            telegram_webhook_secret: None,
+            telegram_webhook_url: None,
+            telegram_single_bot_mode: None,
+            internal_token: SecretString::from("a".repeat(64)),
+            gateway_port: 8080,
+            log_level: "info".to_string(),
+            log_format: "json".to_string(),
+            agent_base_url: None,
+            gateway_log_file: None,
+            agents_namespace: "mika-agents".to_string(),
+            github_webhook_secret: None,
+            github_app_id: None,
+            github_app_private_key: None,
+            github_app_installation_id: None,
+            orchestrator_inbox_enabled: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_token_only_mode_off_succeeds() {
+        // AC7: bot token alone is sufficient when single-bot mode is off
+        let mut s = test_settings();
+        s.telegram_bot_token = Some(SecretString::from("123:ABC"));
+        assert!(s.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_token_only_mode_on_fails() {
+        // AC7: token-only with single-bot mode on → validation error
+        let mut s = test_settings();
+        s.telegram_bot_token = Some(SecretString::from("123:ABC"));
+        s.telegram_single_bot_mode = Some("1".to_string());
+        let err = s.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("MIKA_TELEGRAM_WEBHOOK_SECRET"),
+            "expected error about missing webhook secret, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_all_three_mode_on_succeeds() {
+        // AC7: all three vars + mode on → success
+        let mut s = test_settings();
+        s.telegram_bot_token = Some(SecretString::from("123:ABC"));
+        s.telegram_webhook_secret = Some(SecretString::from("b".repeat(64)));
+        s.telegram_webhook_url = Some("https://example.com/webhook".to_string());
+        s.telegram_single_bot_mode = Some("1".to_string());
+        assert!(s.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_no_token_no_mode_succeeds() {
+        // No Telegram config at all — valid (Telegram features simply disabled)
+        let s = test_settings();
+        assert!(s.validate().is_ok());
     }
 }

--- a/docs/plans/2026-06-27-002-fix-gateway-operator-send-no-route-plan.md
+++ b/docs/plans/2026-06-27-002-fix-gateway-operator-send-no-route-plan.md
@@ -1,0 +1,221 @@
+---
+title: "fix: Build global Telegram client on token presence — operator-agent /send route in multi-bot mode"
+date: 2026-06-27
+type: fix
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+issue: 1590
+---
+
+# fix: Build global Telegram client on token presence — operator-agent /send route in multi-bot mode
+
+## Goal Capsule
+
+Fix the half-migrated contract where operator agents (mika-dev, mika-arch, mika-qa) cannot deliver messages via the gateway `/send` endpoint in multi-bot mode because the global `TelegramClient` is only built when `MIKA_TELEGRAM_SINGLE_BOT_MODE` is enabled. Decouple outbound client construction from inbound webhook registration so a bot token alone is sufficient for outbound delivery. Add structured logging to the silent 400 arm.
+
+---
+
+## Problem Frame
+
+Since the multi-bot migration (mika#1454), the gateway conditionally builds the global `TelegramClient` only when `MIKA_TELEGRAM_SINGLE_BOT_MODE` is enabled (`main.rs:90-117`). In the default per-customer mode, `state.telegram = None`. Operator agents send messages via `/send` with `{chat_id, text, agent_name}` but no `customer_id` — they're not customer-scoped. The `/send` handler's fallback branch (`routes.rs:1100-1106`) returns 400 when `state.telegram` is `None`, silently dropping all operator notifications.
+
+Secondary defect: the 400 arm emits no structured log, making this failure class invisible gateway-side.
+
+---
+
+## Requirements
+
+- R1. The gateway builds the global `TelegramClient` whenever `MIKA_TELEGRAM_BOT_TOKEN` is configured, regardless of `MIKA_TELEGRAM_SINGLE_BOT_MODE`.
+- R2. `MIKA_TELEGRAM_SINGLE_BOT_MODE` exclusively controls inbound global webhook registration — it no longer gates outbound client construction.
+- R3. When `MIKA_TELEGRAM_SINGLE_BOT_MODE` is off, `MIKA_TELEGRAM_BOT_TOKEN` alone is sufficient — `MIKA_TELEGRAM_WEBHOOK_SECRET` and `MIKA_TELEGRAM_WEBHOOK_URL` are not required.
+- R4. When `MIKA_TELEGRAM_SINGLE_BOT_MODE` is on, all three (token + secret + URL) remain required for inbound webhook registration.
+- R5. The 400 "no customer_id" arm emits a structured `warn!` with `agent_name`, `chat_id`, and `request_id`.
+- R6. Per-customer bot lookup (with `customer_id` present) is unaffected.
+- R7. Documentation reflects the semantic narrowing of `MIKA_TELEGRAM_SINGLE_BOT_MODE`.
+
+---
+
+## Key Technical Decisions
+
+**KTD1. Two-phase client construction in `main.rs`.**
+Build the global `TelegramClient` in an early phase (token presence only), then conditionally register the webhook in a second phase (single-bot mode). This keeps the existing `TelegramClient` struct unchanged and only restructures the conditional in `main.rs`. The `state.telegram` field becomes `Some` whenever a bot token exists, which is exactly what the `/send` fallback branch checks.
+
+**KTD2. Validation split in `settings.rs`.**
+The existing validation block (`settings.rs:124-152`) requires all three Telegram vars when single-bot mode is on. The fix leaves this block unchanged but does NOT add any new validation for the token-only case — if `MIKA_TELEGRAM_BOT_TOKEN` is set without single-bot mode, the token is simply used for outbound. No webhook secret/URL validation runs because those are inbound-only concerns.
+
+**KTD3. `warn!` over `error!` for the 400 arm.**
+The 400 arm in `/send` means "no global client AND no customer_id" — a misconfiguration or caller error, not an internal failure. `warn!` is the right severity. The response body already carries the error message for the caller.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+- `main.rs` — restructure global client construction
+- `settings.rs` — no code change needed (existing validation is already correct — it only fires when single-bot mode is on)
+- `routes.rs` — add structured logging to the 400 arm
+- `CLAUDE.md` — document the semantic narrowing
+- Unit tests for settings validation and /send behavior
+
+### Out of Scope
+- Agent-side changes (the agent payload is already correct)
+- Operator bot token provisioning (operator-host work, documented in the issue)
+- Per-customer Telegram migration paths
+
+### Deferred to Follow-Up Work
+- None identified
+
+---
+
+## Implementation Units
+
+### U1. Restructure global TelegramClient construction in main.rs
+
+**Goal:** Build the global `TelegramClient` whenever `MIKA_TELEGRAM_BOT_TOKEN` is configured, independent of `MIKA_TELEGRAM_SINGLE_BOT_MODE`. The mode flag gates only the webhook registration call.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- `crates/mika-gateway/src/main.rs`
+
+**Approach:**
+Replace the single `if single_bot_mode { ... } else { None }` block (lines 90-117) with two phases:
+1. Build `TelegramClient` from `settings.telegram_bot_token` when present (no mode check). Store as `Option<TelegramClient>`.
+2. If `single_bot_mode` is true AND the client was built, register the webhook using `tg.set_webhook(...)`. The webhook registration still requires `telegram_webhook_url` and `telegram_webhook_secret` (validated by settings when single-bot mode is on).
+
+Update the `AppState` doc comment on the `telegram` field from "populated only in single-bot mode" to "populated when `MIKA_TELEGRAM_BOT_TOKEN` is configured".
+
+**Patterns to follow:** The existing two-phase pattern used for `github_app` construction in the same file — build from credentials, then use conditionally.
+
+**Test scenarios:**
+- With `MIKA_TELEGRAM_BOT_TOKEN` set and `MIKA_TELEGRAM_SINGLE_BOT_MODE` unset: `state.telegram` is `Some` (global client built for outbound), no webhook registration occurs.
+- With both token and single-bot mode enabled: `state.telegram` is `Some` AND webhook registration runs.
+- With no bot token set: `state.telegram` is `None` regardless of mode flag.
+
+**Verification:** `cargo build -p mika-gateway` succeeds. The info log changes from "per-customer Telegram bot mode — global webhook registration skipped" to a message reflecting that the global client is built but webhook registration is skipped.
+
+---
+
+### U2. Add structured logging to the /send 400 arm
+
+**Goal:** Make the "no customer_id and no global client" failure visible in gateway logs.
+
+**Requirements:** R5
+
+**Dependencies:** None (can be done in parallel with U1)
+
+**Files:**
+- `crates/mika-gateway/src/routes.rs`
+
+**Approach:**
+In the `None` arm of `state.telegram.as_ref()` (around line 1100), add a `warn!` before returning the 400 response:
+```
+warn!(
+    agent_name = ?payload.agent_name,
+    chat_id = payload.chat_id,
+    request_id = ?payload.request_id,
+    "send failed: no customer_id provided and no global Telegram client configured"
+);
+```
+
+**Patterns to follow:** The existing `error!` pattern at line 1093 (`customer lookup failed for /send`) which uses structured fields.
+
+**Test scenarios:**
+- `/send` with no `customer_id` and `state.telegram = None` → 400 response AND warn log emitted with `agent_name`, `chat_id`, `request_id` fields.
+
+**Verification:** The log line appears in structured JSON output when the 400 path is hit.
+
+---
+
+### U3. Unit tests for settings validation contract
+
+**Goal:** Verify that `MIKA_TELEGRAM_BOT_TOKEN` alone is sufficient when single-bot mode is off, and all three vars are required when single-bot mode is on.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- `crates/mika-gateway/src/settings.rs`
+
+**Approach:**
+The existing `GatewaySettings::load()` validation already only fires when `telegram_single_bot_mode_is_enabled()` returns true. The token-only case needs no code change — it already works because no validation runs for non-single-bot-mode. Add tests that construct `GatewaySettings` directly and call the validation path to confirm:
+1. Token-only + mode-off → success (no validation error).
+2. Token-only + mode-on → validation error naming missing `MIKA_TELEGRAM_WEBHOOK_SECRET`.
+3. All three + mode-on → success.
+
+Since `GatewaySettings::load()` reads from env vars via `config-rs`, the cleanest approach is to test the validation logic extracted into a helper, or test via the existing `load()` with env var overrides. Follow the existing test pattern in settings.rs which tests individual helper functions.
+
+**Patterns to follow:** Existing `test_single_bot_mode_*` and `test_orchestrator_inbox_*` test patterns in `settings.rs`.
+
+**Test scenarios:**
+- Load settings with `telegram_bot_token = Some(...)`, `telegram_single_bot_mode = None` → no validation error.
+- Load settings with `telegram_bot_token = Some(...)`, `telegram_single_bot_mode = Some("1")`, `telegram_webhook_secret = None` → validation error containing "MIKA_TELEGRAM_WEBHOOK_SECRET".
+- Load settings with all three Telegram vars set + `telegram_single_bot_mode = Some("1")` → success.
+
+**Verification:** `cargo test -p mika-gateway` passes with new tests.
+
+---
+
+### U4. Update CLAUDE.md documentation
+
+**Goal:** Document the semantic narrowing of `MIKA_TELEGRAM_SINGLE_BOT_MODE` and the global outbound client behavior.
+
+**Requirements:** R7
+
+**Dependencies:** U1
+
+**Files:**
+- `crates/mika-gateway/CLAUDE.md`
+
+**Approach:**
+Update the environment variables section:
+1. `MIKA_TELEGRAM_BOT_TOKEN` — change from "Required only in single-bot mode" to document that it's used for the global outbound client whenever configured, independent of single-bot mode.
+2. `MIKA_TELEGRAM_WEBHOOK_SECRET` — keep "Required only in single-bot mode" (unchanged, inbound-only).
+3. `MIKA_TELEGRAM_WEBHOOK_URL` — keep "Required only in single-bot mode" (unchanged, inbound-only).
+4. `MIKA_TELEGRAM_SINGLE_BOT_MODE` — update description to state it exclusively controls inbound global webhook registration. Document the semantic narrowing: pre-fix it gated both inbound registration and outbound client construction; post-fix it gates inbound only.
+
+Also update the `AppState` doc comment reference if the CLAUDE.md mentions it.
+
+**Patterns to follow:** Existing env var documentation style in the file.
+
+**Test scenarios:**
+- Test expectation: none — documentation-only change.
+
+**Verification:** CLAUDE.md accurately reflects the new behavior. The three env vars have consistent documentation.
+
+---
+
+## Verification Contract
+
+1. `cargo build -p mika-gateway` — compiles without warnings.
+2. `cargo test -p mika-gateway` — all existing and new tests pass.
+3. `cargo clippy -p mika-gateway` — no new warnings.
+4. Manual verification scenario: with `MIKA_TELEGRAM_BOT_TOKEN` set and `MIKA_TELEGRAM_SINGLE_BOT_MODE` unset, the gateway startup log shows the global client was built but webhook registration was skipped.
+
+---
+
+## Definition of Done
+
+- [ ] Global `TelegramClient` is built on token presence, not mode flag
+- [ ] `MIKA_TELEGRAM_SINGLE_BOT_MODE` only gates inbound webhook registration
+- [ ] 400 arm in `/send` emits structured `warn!` with agent_name/chat_id/request_id
+- [ ] Settings validation: token-only + mode-off succeeds; token-only + mode-on fails
+- [ ] Unit tests cover the settings validation contract
+- [ ] CLAUDE.md documents the semantic narrowing
+- [ ] `cargo build && cargo test && cargo clippy` all pass for mika-gateway
+
+---
+
+## Sources & Research
+
+- Issue: senara-solutions/mika#1590
+- Multi-bot migration: mika#1454 / PR #1455 (commit `ac53b73d`)
+- `crates/mika-gateway/src/main.rs:87-117` — current conditional client construction
+- `crates/mika-gateway/src/routes.rs:1061-1108` — /send handler fallback branch
+- `crates/mika-gateway/src/settings.rs:124-152` — single-bot mode validation
+- `crates/mika-gateway/src/telegram.rs:557-596` — TelegramClient struct

--- a/docs/plans/2026-06-27-002-fix-gateway-operator-send-no-route-plan.md
+++ b/docs/plans/2026-06-27-002-fix-gateway-operator-send-no-route-plan.md
@@ -199,7 +199,7 @@ Also update the `AppState` doc comment reference if the CLAUDE.md mentions it.
 
 ---
 
-## Definition of Done
+## Acceptance criteria
 
 - [ ] Global `TelegramClient` is built on token presence, not mode flag
 - [ ] `MIKA_TELEGRAM_SINGLE_BOT_MODE` only gates inbound webhook registration


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: commit-pushed-no-pr)

This PR was created by dispatch-lib's git-workflow recovery.

The dev-pilot session committed and pushed the implementation but `gh pr create` failed (typically a transient AxiosError 5000ms timeout from claude-cli's internal HTTP relay). Branch is on origin with the impl commit; only the final PR-creation step needed recovery.

**This is a draft PR — operator should verify pilot's pipeline (/ce:work, /ce:review, /ce:compound) completed before marking ready.** The recovery path is uniform with mika#1282's draft-PR pattern for audit consistency.

### Recovery metadata
- Recovery class: `commit-pushed-no-pr`
- Pilot session: `b222d097-e371-432e-822a-29abac3b0687`
- Turns: 48
- Cost: $3.49738845

Closes #1590