### PR TITLE
fix(skills): relax cross-skill collision test to AC2's handler-type spec

### DIFF
--- a/crates/mika-agent/src/bin/verify_bundled_skills.rs
+++ b/crates/mika-agent/src/bin/verify_bundled_skills.rs
@@ -44,11 +44,14 @@ mod discover;
 
 /// A known, deliberately-allowed pre-existing check failure.
 ///
-/// Mirrors `KNOWN_PRE_EXISTING_COLLISIONS` in `bundled_skills.rs` (mika#1326 AC2):
-/// each entry names the check, the skill, a substring the failure reason must
-/// contain, and the follow-up ticket that will resolve it. **Self-cleaning**: the
-/// binary (and a test) fail when an entry no longer matches a real failure, forcing
-/// removal of stale exceptions.
+/// Uses the same self-cleaning-exception discipline the mika#1326 AC2 collision
+/// test (`test_bundled_skills_no_cross_skill_tool_name_collision`) once applied
+/// via its own allowlist: each entry names the check, the skill, a substring the
+/// failure reason must contain, and the follow-up ticket that will resolve it.
+/// **Self-cleaning**: the binary (and a test) fail when an entry no longer
+/// matches a real failure, forcing removal of stale exceptions. (That AC2 test
+/// has since been relaxed to flag only divergent handler types and no longer
+/// needs an allowlist — mika#1573; this gate's pattern is unchanged.)
 ///
 /// Per mika#1575 F2 this ships **EMPTY**. A non-empty entry MUST be enumerated in
 /// the PR description with its resolution ticket.

--- a/crates/mika-agent/src/bundled_skills.rs
+++ b/crates/mika-agent/src/bundled_skills.rs
@@ -1589,144 +1589,172 @@ mod tests {
         );
     }
 
-    /// Allowlist of known cross-skill tool name declarations that are
-    /// benign (same name, same handler — skill-scoped tool surface model).
+    /// Detect cross-skill tool-name collisions where the same tool name is
+    /// declared with **different handler types** across bundled skills
+    /// (mika#1326 AC2, relaxed to spec per mika#1573).
     ///
-    /// Each entry: `(tool_name, sorted_skill_names_csv, follow_up_ticket)`.
-    /// The sorted-CSV form means `(skill_a, skill_b)` and `(skill_b, skill_a)`
-    /// produce the same key; we sort owners before comparison.
+    /// Returns one formatted line per divergent collision. Same-name +
+    /// **same**-handler-type declarations are intentionally NOT reported: that
+    /// is the skill-scoped tool surface model working as designed (every value
+    /// identical → no HashMap last-write-wins risk, e.g. the architect skills +
+    /// gh-read-only each declaring `gh_read` with an identical Builtin handler).
+    /// Only handler-type *divergence* — the class behind the 2026-05-28
+    /// `run_gh` Builtin-vs-Exec incident — is flagged.
     ///
-    /// **Self-cleaning contract:** the test below asserts each allowlist
-    /// entry STILL collides at the named owner set. When the follow-up
-    /// ticket's resolution removes the collision, this test fails with
-    /// "stale allowlist entry, remove it" — preventing the bounded hole
-    /// from rotting into permanence.
-    ///
-    /// **Scope discipline:** entries live inside `#[cfg(test)] mod tests`
-    /// so the production skill loader cannot consult them at runtime.
-    /// Adding a `mod-scope` re-export would breach the additions-only
-    /// scope reservation that mika#1326's freeze-safe subset honors.
-    const KNOWN_PRE_EXISTING_COLLISIONS: &[(&str, &str, &str)] = &[
-        // Four skills legitimately declare gh_read with identical Builtin
-        // handlers — same skill-scoped tool surface model used by each skill
-        // independently. Three are the architect skills (mika-arch-groom-
-        // milestone/groom-ticket/second-review); the fourth is gh-read-only
-        // (mika#1406, Mika Prime's read-only GitHub access). Not a true
-        // collision (same name + same handler = no last-write-wins risk),
-        // but the strict test flags it. See mika#1573 for the test-relaxation
-        // decision.
-        (
-            "gh_read",
-            "gh-read-only,mika-arch-groom-milestone,mika-arch-groom-ticket,mika-arch-second-review",
-            "mika#1573",
-        ),
-    ];
+    /// Factored out so the invariant test and the mika#1573 AC3 regression
+    /// fixture exercise the same detection path. Lives in `#[cfg(test)]` so the
+    /// production skill loader cannot consult it at runtime (preserving
+    /// mika#1326's additions-only scope reservation).
+    fn detect_divergent_handler_collisions(skills: &[&BundledSkill]) -> Vec<String> {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        // tool_name -> handler_type -> sorted set of declaring skills. A
+        // missing/unparseable handler.type maps to a stable sentinel so two
+        // handler-less declarations are treated as same (not a divergence),
+        // while a missing-vs-present pairing is flagged conservatively.
+        let mut by_tool: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> = BTreeMap::new();
+
+        for skill in skills {
+            let Some(tools_json) = skill.files.iter().find(|f| f.path == "tools.json") else {
+                continue;
+            };
+            let tool_defs: Vec<serde_json::Value> = match serde_json::from_str(tools_json.content) {
+                Ok(t) => t,
+                Err(_) => continue, // malformed tools.json caught by other tests
+            };
+            for tool_def in &tool_defs {
+                let Some(name) = tool_def.get("name").and_then(|n| n.as_str()) else {
+                    continue;
+                };
+                let handler_type = tool_def
+                    .get("handler")
+                    .and_then(|h| h.get("type"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("(no handler.type)");
+                by_tool
+                    .entry(name.to_string())
+                    .or_default()
+                    .entry(handler_type.to_string())
+                    .or_default()
+                    .insert(skill.name.to_string());
+            }
+        }
+
+        by_tool
+            .into_iter()
+            .filter(|(_, by_handler)| by_handler.len() > 1)
+            .map(|(tool, by_handler)| {
+                let detail = by_handler
+                    .iter()
+                    .map(|(ht, owners)| {
+                        format!(
+                            "{ht} [{}]",
+                            owners.iter().cloned().collect::<Vec<_>>().join(", ")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" vs ");
+                format!("  tool '{tool}' declared with divergent handler types: {detail}")
+            })
+            .collect()
+    }
 
     #[test]
     fn test_bundled_skills_no_cross_skill_tool_name_collision() {
-        // AC2: No two bundled skills may declare the same tool name.
-        // This catches collisions at compile-test time, before they reach
-        // production as silent last-write-wins shadows (mika#1326).
+        // AC2 (mika#1326), relaxed to spec per mika#1573: no two bundled skills
+        // may declare the same tool name with DIFFERENT handler types. This
+        // catches the production-risk class — divergent handlers silently
+        // shadowing each other via HashMap last-write-wins (the 2026-05-28
+        // run_gh Builtin-vs-Exec incident) — at compile-test time.
         //
-        // Intentionally stricter than AC2's "different handler types"
-        // criterion: we flag ALL same-name declarations regardless of
-        // handler type. Rationale: even same-handler-type collisions
-        // indicate a manifest hygiene issue (redundant declarations),
-        // and the cost of flagging them is zero (fix is to remove the
-        // duplicate).
-        //
-        // **Known pre-existing exceptions** are allowlisted via
-        // `KNOWN_PRE_EXISTING_COLLISIONS`. Each entry names the colliding
-        // tool, the exact (sorted) skill-name set, and a follow-up ticket
-        // for resolution. The test asserts each allowlist entry STILL
-        // collides at the named owner set — so when the follow-up ticket
-        // lands and the collision is resolved, this test fails with
-        // "stale allowlist entry, remove it." Self-cleaning, not silent.
-
-        use std::collections::HashMap;
+        // Same-name + same-handler-type declarations are NOT flagged: that is
+        // the skill-scoped tool surface model working as designed (e.g. the
+        // architect skills + gh-read-only each declaring `gh_read` with an
+        // identical Builtin handler — every value identical, no last-write-wins
+        // risk). The original AC2 impl was stricter (flagged ALL same-name
+        // declarations) and false-positived on that benign case; mika#1573
+        // relaxed it to the handler-type-divergence spec AC2 actually named.
 
         let all_skills = all_bundled_skills();
-        let mut tool_owners: HashMap<String, Vec<String>> = HashMap::new();
-
-        for skill in &all_skills {
-            let tools_json = skill.files.iter().find(|f| f.path == "tools.json");
-            let Some(tools_json) = tools_json else {
-                continue;
-            };
-
-            let tool_defs: Vec<serde_json::Value> = match serde_json::from_str(tools_json.content) {
-                Ok(t) => t,
-                Err(_) => continue, // Malformed tools.json caught by other tests
-            };
-
-            for tool_def in &tool_defs {
-                if let Some(name) = tool_def.get("name").and_then(|n| n.as_str()) {
-                    tool_owners
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(skill.name.to_string());
-                }
-            }
-        }
-
-        // Build the actual-collision set: (tool_name, sorted owners csv).
-        let mut actual_collisions: HashMap<String, String> = HashMap::new();
-        for (tool, owners) in tool_owners.iter() {
-            if owners.len() > 1 {
-                let mut sorted_owners = owners.clone();
-                sorted_owners.sort();
-                actual_collisions.insert(tool.clone(), sorted_owners.join(","));
-            }
-        }
-
-        // Self-cleaning assertion: each allowlist entry must STILL collide
-        // at the exact owner set named. If the follow-up ticket lands and
-        // resolves the collision, this fires — telling the next engineer
-        // to remove the now-stale allowlist entry.
-        for (tool, expected_owners_csv, follow_up) in KNOWN_PRE_EXISTING_COLLISIONS {
-            match actual_collisions.get(*tool) {
-                Some(actual_owners_csv) if actual_owners_csv == expected_owners_csv => {
-                    // Allowlist entry is still valid — collision still exists.
-                }
-                Some(actual_owners_csv) => {
-                    panic!(
-                        "STALE allowlist entry for tool '{tool}' (mika#1326 / {follow_up}): \
-                         expected collision owners '{expected_owners_csv}' but found \
-                         '{actual_owners_csv}'. The follow-up resolved part of the collision \
-                         — update or remove the allowlist entry to match the new state."
-                    );
-                }
-                None => {
-                    panic!(
-                        "STALE allowlist entry for tool '{tool}' (mika#1326 / {follow_up}): \
-                         no collision found at all. The follow-up resolved the collision — \
-                         remove this allowlist entry."
-                    );
-                }
-            }
-        }
-
-        // Now report any UNALLOWLISTED collisions.
-        let unallowlisted: Vec<(String, String)> = actual_collisions
-            .iter()
-            .filter(|(tool, owners_csv)| {
-                !KNOWN_PRE_EXISTING_COLLISIONS
-                    .iter()
-                    .any(|(allowed_tool, allowed_owners, _)| {
-                        allowed_tool == tool && allowed_owners == &owners_csv.as_str()
-                    })
-            })
-            .map(|(t, o)| (t.clone(), o.clone()))
-            .collect();
+        let collisions = detect_divergent_handler_collisions(&all_skills);
 
         assert!(
-            unallowlisted.is_empty(),
-            "Bundled skill tool name collisions detected (mika#1326):\n{}",
-            unallowlisted
-                .iter()
-                .map(|(tool, owners_csv)| format!("  tool '{tool}' declared by: {owners_csv}"))
-                .collect::<Vec<_>>()
-                .join("\n")
+            collisions.is_empty(),
+            "Bundled skill tool-name collisions with DIVERGENT handler types \
+             detected (mika#1326 / mika#1573):\n{}\n\n\
+             The same tool name declared with different handler types risks \
+             silent last-write-wins shadowing in the skill loader. Consolidate \
+             to a single handler type.",
+            collisions.join("\n")
+        );
+    }
+
+    #[test]
+    fn test_collision_detector_catches_divergent_run_gh_handlers() {
+        // mika#1573 AC3 regression guard: the relaxed AC2 detector MUST still
+        // catch the original mika#1326 incident class — two skills declaring
+        // the same tool name with DIFFERENT handler types (Builtin vs Exec).
+        // This reproduces the 2026-05-28 run_gh Builtin-vs-Exec production bug
+        // as a fixture so the mika#1573 relaxation can't silently drop coverage
+        // of the class it was scoped to keep.
+        static RUN_GH_BUILTIN_FILES: &[SkillFile] = &[SkillFile {
+            path: "tools.json",
+            content: r#"[{"name": "run_gh", "handler": {"type": "builtin", "function": "run_gh"}}]"#,
+            executable: false,
+        }];
+        static RUN_GH_EXEC_FILES: &[SkillFile] = &[SkillFile {
+            path: "tools.json",
+            content: r#"[{"name": "run_gh", "handler": {"type": "exec", "command": "handlers/run.sh"}}]"#,
+            executable: false,
+        }];
+        static RUN_GH_BUILTIN_SKILL: BundledSkill = BundledSkill {
+            name: "skill-run-gh-builtin",
+            files: RUN_GH_BUILTIN_FILES,
+            content_hash: "",
+        };
+        static RUN_GH_EXEC_SKILL: BundledSkill = BundledSkill {
+            name: "skill-run-gh-exec",
+            files: RUN_GH_EXEC_FILES,
+            content_hash: "",
+        };
+
+        let divergent: &[&BundledSkill] = &[&RUN_GH_BUILTIN_SKILL, &RUN_GH_EXEC_SKILL];
+        let collisions = detect_divergent_handler_collisions(divergent);
+        assert_eq!(
+            collisions.len(),
+            1,
+            "run_gh Builtin-vs-Exec divergence must be flagged, got: {collisions:?}"
+        );
+        assert!(
+            collisions[0].contains("run_gh"),
+            "collision report must name the run_gh tool: {collisions:?}"
+        );
+
+        // Negative companion: same name + SAME handler type is the benign
+        // skill-scoped tool surface model (the gh_read false-positive that
+        // motivated mika#1573) and must NOT be flagged.
+        static GH_READ_BUILTIN_FILES: &[SkillFile] = &[SkillFile {
+            path: "tools.json",
+            content: r#"[{"name": "gh_read", "handler": {"type": "builtin", "function": "gh_read"}}]"#,
+            executable: false,
+        }];
+        static GH_READ_SKILL_A: BundledSkill = BundledSkill {
+            name: "skill-gh-read-a",
+            files: GH_READ_BUILTIN_FILES,
+            content_hash: "",
+        };
+        static GH_READ_SKILL_B: BundledSkill = BundledSkill {
+            name: "skill-gh-read-b",
+            files: GH_READ_BUILTIN_FILES,
+            content_hash: "",
+        };
+
+        let benign: &[&BundledSkill] = &[&GH_READ_SKILL_A, &GH_READ_SKILL_B];
+        let benign_collisions = detect_divergent_handler_collisions(benign);
+        assert!(
+            benign_collisions.is_empty(),
+            "same-handler-type gh_read declarations must NOT be flagged \
+             (skill-scoped tool surface model): {benign_collisions:?}"
         );
     }
 

--- a/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
+++ b/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
@@ -1,0 +1,105 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+origin: senara-solutions/mika#1573
+plan_depth: lightweight
+created: 2026-06-27
+---
+
+# fix: Relax `test_bundled_skills_no_cross_skill_tool_name_collision` to AC2's spec
+
+> **Target repo:** mika · **Issue:** senara-solutions/mika#1573 · **Branch:** `fix/1573/skills-relax-test-bundled-skills-no`
+
+## Summary
+
+`mika#1569` (AC2 of `mika#1326`) added `test_bundled_skills_no_cross_skill_tool_name_collision` — a build-time invariant test guarding against cross-skill tool-name collisions in bundled-skill `tools.json` declarations. The dispatched author wrote it **stricter than AC2 specified**: it flags ALL same-name declarations regardless of handler type, where AC2 named only the "different handler types" class (the production-risk class — divergent handlers silently shadowing each other via `HashMap` last-write-wins, e.g. the 2026-05-28 `run_gh` Builtin-vs-Exec incident).
+
+That over-strict framing false-positives on four bundled skills (`gh-read-only`, `mika-arch-groom-ticket`, `mika-arch-groom-milestone`, `mika-arch-second-review`) that each legitimately declare `gh_read` with an **identical** Builtin handler — the skill-scoped tool surface model working as designed (same name + same handler = no last-write-wins risk). `mika#1569` papered over this with a `KNOWN_PRE_EXISTING_COLLISIONS` allowlist. This plan removes that allowlist and relaxes the test to AC2's actual spec.
+
+This is a **test-only** change in `crates/mika-agent/` — no production behavior changes.
+
+## Problem Frame
+
+- **What's wrong:** The collision test flags benign same-handler-type declarations, requiring an allowlist to stay green. Allowlists rot; the underlying test contract is wrong relative to AC2.
+- **Why it matters:** AC2 was scoped to catch the divergent-handler class (real last-write-wins shadowing). Flagging same-handler redundancy is coverage AC2 never required and produces false-positives on the intended skill-scoped tool surface model.
+- **Scope boundary:** Relax the test to flag only divergent-handler-type collisions; remove the allowlist; prove the original `mika#1326` incident class still trips. No skill-loader changes (Path A is explicitly out of scope per the issue body). No AC3–AC5 of `mika#1326`.
+
+## Requirements
+
+- **R1** — Remove the `KNOWN_PRE_EXISTING_COLLISIONS` allowlist (and its self-cleaning + unallowlisted-filter logic). The four `gh_read` declarations are no longer flagged. *(issue AC1)*
+- **R2** — `test_bundled_skills_no_cross_skill_tool_name_collision` flags **only** same-name declarations with **different handler types** (`handler.type`). Same-name + same-handler-type is not reported. *(issue AC2)*
+- **R3** — A fixture-based regression test asserts the relaxed detector still catches the `mika#1326` incident class: two skills declaring `run_gh` with Builtin vs Exec handlers trips the detector. *(issue AC3)*
+- **R4** — No dangling reference to the deleted `KNOWN_PRE_EXISTING_COLLISIONS` symbol remains in the codebase (doc-comment in `verify_bundled_skills.rs`).
+
+## Key Technical Decisions
+
+- **KTD-1 — Factor a pure, testable helper.** Extract the collision logic into `detect_divergent_handler_collisions(skills: &[&BundledSkill]) -> Vec<String>` so both the real invariant test (over `all_bundled_skills()`) and the AC3 fixture test exercise the **same** detection code path. This is what makes AC3 a genuine regression guard rather than a parallel re-implementation. Helper lives inside `#[cfg(test)] mod tests` (the scope-reservation discipline from `mika#1326` keeps collision logic out of the production loader).
+- **KTD-2 — Group by `(tool_name → set of handler types)`; report when the set size > 1.** Handler type is read from `tool_def["handler"]["type"]`. A missing/unparseable `handler.type` maps to a stable sentinel string so two declarations that both lack a handler type are treated as same (not a divergence) and a missing-vs-present pairing is flagged conservatively. Malformed `tools.json` is skipped (other tests own that failure).
+- **KTD-3 — No allowlist in the relaxed test.** Divergent-handler-type collisions are always bugs (never benign), so the relaxed test needs no exception mechanism. Removing `KNOWN_PRE_EXISTING_COLLISIONS` is a net deletion, not a replacement.
+
+## Implementation Units
+
+### U1. Relax the collision test + factor the detection helper
+
+- **Goal:** Replace the strict same-name detection with divergent-handler-type detection, behind a reusable helper. Satisfies R1 + R2.
+- **Requirements:** R1, R2
+- **Dependencies:** none
+- **Files:**
+  - `crates/mika-agent/src/bundled_skills.rs` (modify — the `#[cfg(test)] mod tests` block, ~lines 1592–1731)
+- **Approach:**
+  - Delete the `KNOWN_PRE_EXISTING_COLLISIONS` const and the two blocks that consume it (the self-cleaning per-entry assertion loop and the `unallowlisted` filter).
+  - Add `fn detect_divergent_handler_collisions(skills: &[&BundledSkill]) -> Vec<String>`: for each skill, find the `tools.json` file, parse it (skip on parse error), and for each tool record `tool_name → handler_type` into a `BTreeMap<String, BTreeMap<String, BTreeSet<String>>>` (tool → handler_type → declaring skills). Emit one formatted line per tool whose handler-type map has > 1 entry, naming the tool and the divergent `handler_type [skills...]` groups. Use `BTree*` for deterministic output ordering.
+  - Rewrite the test body to call the helper over `all_bundled_skills()` and assert the result is empty, with a message that names the divergent collisions and explains the last-write-wins risk + the relaxation provenance (`mika#1326` / `mika#1573`).
+  - Update the test's leading doc comment to state the relaxed contract (different-handler-types only) and why same-handler-type is benign.
+- **Patterns to follow:** existing `serde_json::from_str::<Vec<serde_json::Value>>(tools_json.content)` parse pattern already in the test; `tool_def.get("handler").and_then(|h| h.get("type")).and_then(|t| t.as_str())` extraction (mirrors `verify_bundled_skills.rs::parse_tools`).
+- **Test scenarios:**
+  - `test_bundled_skills_no_cross_skill_tool_name_collision` runs over the real bundle and passes green (the four `gh_read` Builtin declarations are not flagged — verified there are zero divergent-handler collisions in the tree today).
+  - *Covers R2:* the helper does not report a tool name shared across skills when every declaration has the same `handler.type`.
+- **Verification:** `cargo test -p mika-agent test_bundled_skills_no_cross_skill_tool_name_collision` passes; no reference to `KNOWN_PRE_EXISTING_COLLISIONS` remains in `bundled_skills.rs`.
+
+### U2. Add the AC3 fixture regression test
+
+- **Goal:** Prove the relaxed detector still catches the original `mika#1326` incident class. Satisfies R3.
+- **Requirements:** R3
+- **Dependencies:** U1 (uses `detect_divergent_handler_collisions`)
+- **Files:**
+  - `crates/mika-agent/src/bundled_skills.rs` (modify — add a `#[test]` in the same tests module)
+- **Approach:** Build `static` `BundledSkill` fixtures with inline `tools.json` content (mirroring the existing `MERGE_TEST_*` static-fixture pattern, since `BundledSkill` fields are `&'static`). Positive case: two skills declaring `run_gh` with `{"type":"builtin",...}` vs `{"type":"exec",...}` → assert exactly one collision reported, naming `run_gh`. Negative companion: two skills both declaring `gh_read` with identical `{"type":"builtin",...}` → assert empty (the false-positive that motivated `mika#1573`).
+- **Patterns to follow:** `MERGE_TEST_LEGACY_FILES` / `MERGE_TEST_LEGACY_ALPHA` static-fixture construction already in the tests module; `r#"..."#` raw-string JSON for `tools.json` content.
+- **Test scenarios:**
+  - *Covers R3 (positive):* `run_gh` Builtin-vs-Exec across two fixture skills → detector returns one collision containing `"run_gh"`.
+  - *Covers R2 (negative):* `gh_read` Builtin-vs-Builtin across two fixture skills → detector returns empty.
+- **Verification:** the new test passes; deliberately divergent fixture trips the detector (proven by the positive assertion).
+
+### U3. De-reference the deleted symbol in the verify-gate doc comment
+
+- **Goal:** Keep the `make verify-bundled-skills` binary's doc comment accurate after `KNOWN_PRE_EXISTING_COLLISIONS` is deleted. Satisfies R4.
+- **Requirements:** R4
+- **Dependencies:** U1
+- **Files:**
+  - `crates/mika-agent/src/bin/verify_bundled_skills.rs` (modify — doc comment at ~line 47)
+- **Approach:** The comment currently says the binary's `KNOWN_EXCEPTIONS` "Mirrors `KNOWN_PRE_EXISTING_COLLISIONS` in `bundled_skills.rs`". Rewrite to describe the self-cleaning-allowlist *pattern* it mirrors without naming the now-deleted constant (e.g., reference the self-cleaning exception discipline and note the AC2 collision test was relaxed to handler-type divergence per `mika#1573`). `verify_bundled_skills.rs` performs no collision detection itself — this is a documentation-only touch; its five structural checks are unchanged.
+- **Test scenarios:** `Test expectation: none -- doc-comment-only change, no behavior.`
+- **Verification:** `grep -rn KNOWN_PRE_EXISTING_COLLISIONS crates/` returns no matches; `cargo build -p mika-agent --bin verify-bundled-skills` succeeds; `make verify-bundled-skills` still passes green.
+
+## Verification Contract
+
+- `cargo test -p mika-agent bundled_skills` — both the relaxed invariant test and the new AC3 fixture test pass.
+- `cargo build -p mika-agent` and `cargo clippy -p mika-agent` — clean.
+- `grep -rn KNOWN_PRE_EXISTING_COLLISIONS crates/` — zero matches (R1 + R4 complete).
+- `make verify-bundled-skills` — green (unaffected; confirms no collateral).
+
+## Definition of Done
+
+All three issue ACs satisfied: allowlist removed (AC1/R1), test flags only divergent handler types (AC2/R2), fixture regression test guards the `run_gh` Builtin-vs-Exec class (AC3/R3); no dangling symbol reference (R4); crate builds + lints clean; PR opened with `Closes #1573`.
+
+## Scope Boundaries
+
+**In scope:** Relaxing the collision test, removing the allowlist, the AC3 fixture test, the verify-gate doc-comment touch.
+
+### Deferred / Out of scope (per issue body)
+
+- **Path A** — consolidating the `gh_read` declarations behind a shared-declaration loader mechanism. Rejected in grooming as architectural complexity to "fix" a non-bug.
+- **AC3–AC5 of `mika#1326`** — registry-drift detection, mtime-based reload trigger, recovery-without-restart. Reserved in `mika#1326`'s scope.

--- a/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
+++ b/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
@@ -91,7 +91,7 @@ This is a **test-only** change in `crates/mika-agent/` — no production behavio
 - `grep -rn KNOWN_PRE_EXISTING_COLLISIONS crates/` — zero matches (R1 + R4 complete).
 - `make verify-bundled-skills` — green (unaffected; confirms no collateral).
 
-## Definition of Done
+## Acceptance criteria
 
 All three issue ACs satisfied: allowlist removed (AC1/R1), test flags only divergent handler types (AC2/R2), fixture regression test guards the `run_gh` Builtin-vs-Exec class (AC3/R3); no dangling symbol reference (R4); crate builds + lints clean; PR opened with `Closes #1573`.
 

--- a/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
+++ b/docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md
@@ -93,7 +93,12 @@ This is a **test-only** change in `crates/mika-agent/` — no production behavio
 
 ## Acceptance criteria
 
-All three issue ACs satisfied: allowlist removed (AC1/R1), test flags only divergent handler types (AC2/R2), fixture regression test guards the `run_gh` Builtin-vs-Exec class (AC3/R3); no dangling symbol reference (R4); crate builds + lints clean; PR opened with `Closes #1573`.
+- [ ] **AC1 (R1):** `KNOWN_PRE_EXISTING_COLLISIONS` allowlist and its self-cleaning + unallowlisted-filter logic are deleted. The four `gh_read` Builtin declarations are no longer flagged.
+- [ ] **AC2 (R2):** `test_bundled_skills_no_cross_skill_tool_name_collision` flags only same-name declarations with **different** `handler.type` values. Same-name + same-handler-type is not reported.
+- [ ] **AC3 (R3):** A fixture-based regression test asserts the relaxed detector catches the `mika#1326` incident class (two skills declaring `run_gh` with Builtin vs Exec handlers trips the detector).
+- [ ] **AC4 (R4):** No dangling reference to `KNOWN_PRE_EXISTING_COLLISIONS` remains in the codebase.
+- [ ] **Verify:** `grep -rn KNOWN_PRE_EXISTING_COLLISIONS crates/` → zero matches.
+- [ ] **Verify:** `cargo test -p mika-agent bundled_skills` passes.
 
 ## Scope Boundaries
 

--- a/docs/solutions/best-practices/invariant-test-stricter-than-spec-needs-an-allowlist-2026-06-27.md
+++ b/docs/solutions/best-practices/invariant-test-stricter-than-spec-needs-an-allowlist-2026-06-27.md
@@ -1,0 +1,79 @@
+---
+module: skills
+tags: [invariant-test, allowlist, scope-discipline, false-positive, collision-detection, handler-type, bundled-skills]
+problem_type: bug-class-prevention
+category: best-practices
+---
+
+# An invariant test authored stricter than its spec needs a suppression allowlist — relax the test, don't grow the allowlist
+
+## Context
+
+mika#1326 AC2 specified a build-time invariant: no two bundled skills may declare the same
+tool name with **different handler types** — the production-risk class where divergent
+handlers silently shadow each other via `HashMap` last-write-wins (the 2026-05-28
+`run_gh` Builtin-vs-Exec incident).
+
+The dispatched implementer of mika#1569 wrote `test_bundled_skills_no_cross_skill_tool_name_collision`
+**stricter than the spec**: it flagged ALL same-name declarations regardless of handler
+type, with the rationale "even same-handler-type collisions indicate manifest hygiene."
+That stricter framing immediately false-positived on four skills (`gh-read-only` plus the
+three `mika-arch-*` skills) that each legitimately declare `gh_read` with an **identical**
+Builtin handler — the skill-scoped tool surface model working as designed (same name +
+same handler = no last-write-wins risk). To ship mika#1569 green, the author added a
+`KNOWN_PRE_EXISTING_COLLISIONS` allowlist with a self-cleaning assertion to suppress the
+false-positive, and filed mika#1573 to resolve it.
+
+mika#1573 deleted the allowlist and relaxed the test to AC2's actual spec: group
+declarations by `tool_name -> handler_type -> {skills}` and report only tool names with
+more than one distinct handler type. A fixture regression test (`run_gh` Builtin-vs-Exec)
+proves the original incident class still trips after the relaxation.
+
+## Guidance
+
+**The suppression allowlist was the smell, not the fix.** When a freshly-authored invariant
+test needs an allowlist of "known benign exceptions" to pass on the *current, healthy*
+tree, the test is almost always stricter than the invariant it was scoped to enforce. The
+allowlist is suppressing the test's own over-reach, not a real pre-existing defect. The
+correct move is to relax the test to its spec — not to institutionalize the over-strict
+version behind a curated exception list that future engineers must maintain.
+
+Diagnostics that distinguish "test is too strict" from "real exception":
+
+- **The exception is the design working as intended.** Four skills sharing an identical
+  Builtin `gh_read` handler is the skill-scoped tool surface model, not a bug. If the
+  "violation" is a pattern the system *wants*, the test contract is wrong.
+- **The allowlist appears in the same PR that introduces the test.** A genuine
+  pre-existing exception predates the gate. An exception born alongside the gate is the
+  gate mis-scoped on day one.
+- **The spec named a narrower class than the test enforces.** AC2 said "different handler
+  types"; the test flagged "all same names." Re-read the AC: enforce what it specified,
+  not a superset the implementer rationalized as "free extra coverage."
+
+**When you do relax, prove the spec'd class still trips.** Relaxing a too-strict test
+risks over-correcting into a vacuous one. Factor the detection into a pure helper
+(`detect_divergent_handler_collisions(&[&BundledSkill]) -> Vec<String>`) and add a
+fixture-based regression test that feeds it the original incident class (two skills, same
+tool name, Builtin vs Exec handlers) and asserts it still fires — plus a negative
+companion asserting the benign same-handler case does not. The helper makes the real
+invariant test and the regression fixture exercise the *same* code path, so the regression
+test is a genuine guard rather than a parallel re-implementation that can drift.
+
+**Keep the detection logic in `#[cfg(test)]`.** mika#1326's freeze-safe subset reserved an
+additions-only scope; the collision helper lives inside `#[cfg(test)] mod tests` so the
+production skill loader cannot consult it at runtime. Relaxing the test must not leak a
+mod-scope re-export.
+
+## Evidence
+
+- `crates/mika-agent/src/bundled_skills.rs` — `test_bundled_skills_no_cross_skill_tool_name_collision`
+  + `detect_divergent_handler_collisions` helper + `test_collision_detector_catches_divergent_run_gh_handlers`.
+- mika#1573 (this fix); mika#1569 (introduced the over-strict test + allowlist);
+  mika#1326 AC2 (the spec); the 2026-05-28 `run_gh` Builtin-vs-Exec incident (the class
+  the invariant exists to catch).
+
+## Related
+
+- `detector-built-on-filtered-set-is-blind-to-the-filter.md` — sibling failure mode on the
+  same mika#1326/mika#1575 invariant surface (a detector that *under*-fires because its
+  input set presupposes the invariant). This doc is the *over*-fires counterpart.


### PR DESCRIPTION
## Why

mika#1569's `test_bundled_skills_no_cross_skill_tool_name_collision` (AC2 of mika#1326) was authored **stricter than AC2 specified** — it flagged ALL same-name tool declarations regardless of handler type, where AC2 named only the **"different handler types"** class: divergent handlers silently shadowing each other via `HashMap` last-write-wins (the 2026-05-28 `run_gh` Builtin-vs-Exec incident).

That over-strict framing false-positived on four bundled skills (`gh-read-only` + `mika-arch-groom-ticket` / `mika-arch-groom-milestone` / `mika-arch-second-review`) that each legitimately declare `gh_read` with an **identical** Builtin handler — the skill-scoped tool surface model working as designed (same name + same handler = no last-write-wins risk). mika#1569 papered over it with a `KNOWN_PRE_EXISTING_COLLISIONS` allowlist; this PR removes that allowlist and relaxes the test to AC2's actual spec.

## What

- **AC1** — Remove `KNOWN_PRE_EXISTING_COLLISIONS` and its self-cleaning + unallowlisted-filter logic. The four `gh_read` declarations are no longer flagged.
- **AC2** — Factor a pure helper `detect_divergent_handler_collisions(&[&BundledSkill]) -> Vec<String>` that groups declarations by `tool_name → handler_type → {skills}` and reports only tool names with **>1 distinct handler type**. The invariant test now calls it.
- **AC3** — Add `test_collision_detector_catches_divergent_run_gh_handlers`: a positive fixture (two skills declaring `run_gh` with Builtin vs Exec handlers) trips the detector; a negative companion (two skills declaring `gh_read` with identical Builtin handlers) does not. Reproduces the original mika#1326 incident class so the relaxation can't silently drop coverage.
- De-reference the now-deleted `KNOWN_PRE_EXISTING_COLLISIONS` symbol in `verify_bundled_skills.rs`'s doc comment (that gate does no collision detection itself; its five structural checks are unchanged).

## Scope / risk

Test-only change in `mika-agent` — **no production behavior changes**. The real bundle has zero divergent-handler collisions today, so the relaxed test is green; `make verify-bundled-skills` stays green. Path A (consolidating the `gh_read` declarations behind a shared-declaration loader mechanism) and AC3–AC5 of mika#1326 are explicitly out of scope per the issue body.

## Verification

- `cargo test -p mika-agent --lib bundled_skills` — relaxed invariant test + new AC3 fixture both pass.
- `cargo clippy -p mika-agent` / `cargo fmt` — clean (pre-commit hooks green).
- `cargo run -p mika-agent --bin verify-bundled-skills` — `OK — all 5 structural checks pass`.
- `grep -rn KNOWN_PRE_EXISTING_COLLISIONS crates/` — zero matches.

Plan: `docs/plans/2026-06-27-003-fix-relax-cross-skill-collision-test-plan.md`
Compound: `docs/solutions/best-practices/invariant-test-stricter-than-spec-needs-an-allowlist-2026-06-27.md`

Closes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)