### PR TITLE
fix(skills): apply_load_safety_check coherence guard — allowlist ↔ required_tools

### DIFF
--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -419,6 +419,10 @@ async fn init_agent(
         skill_registry.apply_overrides(&overrides);
     }
     skill_registry.apply_load_safety_check();
+    // Runtime allowlist↔required_tools coherence guard (mika#1576). Runs after
+    // identity allowlist + DB overrides + safety check — the one point where both
+    // the allowlist and each skill's required_tools are simultaneously visible.
+    skill_registry.apply_required_tools_coherence_check(agent_name);
     skill_registry.log_summary();
     let skill_registry = Arc::new(skill_registry);
 

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -17,6 +17,42 @@ use self::index::{DisabledSkill, SkillEntry, SkillValidationWarning, SkippedSkil
 use crate::async_db::AsyncDatabase;
 use crate::db::{Database, SkillOverride};
 
+/// The effective tool surface for `[constraints] required_tools` coherence checking
+/// (mika#1576): engine builtins (`tools::BUILTIN_TOOL_NAMES`, which subsumes
+/// `builtin_handlers::KNOWN_BUILTINS` via the mika#1217 parity test — the same builtin
+/// set mika#1575's build-time check uses) ∪ the tool names declared by `skills`'
+/// `tools.json`. The **full** `BUILTIN_TOOL_NAMES` (including conditionally-injected
+/// management tools) is used, mirroring mika#1575 and avoiding false-positive fires.
+///
+/// Shared by the runtime check (`SkillRegistry::apply_required_tools_coherence_check`,
+/// allowlist-aware — pass the loaded skill set) and the `mika skills validate` CLI
+/// diagnostic (allowlist-unaware — pass all installed skills). The allowlist-aware vs
+/// -unaware difference lives at the call site (*which* skills are passed); centralizing
+/// the surface primitive keeps the two from drifting.
+pub fn effective_tool_surface(skills: &[SkillEntry]) -> std::collections::HashSet<String> {
+    let mut surface: std::collections::HashSet<String> = crate::tools::BUILTIN_TOOL_NAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    for entry in skills {
+        for tool in &entry.skill_tools {
+            surface.insert(tool.definition.name.clone());
+        }
+    }
+    surface
+}
+
+/// Whether a `[constraints] required_tools` token resolves against `surface`.
+///
+/// `mcp__*` tokens always resolve — they are provided by the MCP client at startup,
+/// not the builtin/skill surface, so firing on them would wrongly skip a skill that
+/// can in fact call the tool (mirrors `validate_skill` step 5b's leniency). Shared by
+/// the runtime coherence check and the CLI diagnostic so the exemption rule cannot
+/// drift between them (mika#1576).
+pub fn required_tool_resolves(token: &str, surface: &std::collections::HashSet<String>) -> bool {
+    token.starts_with("mcp__") || surface.contains(token)
+}
+
 /// Migrate `.disabled` marker files to DB `skill_overrides` rows.
 ///
 /// Scans all skill directories under `skills_dir`. For each skill that has a
@@ -428,18 +464,26 @@ impl SkillRegistry {
     /// `required_tools` are simultaneously visible, and catches the incoherence at
     /// startup instead.
     ///
-    /// Effective surface = engine builtins (`tools::BUILTIN_TOOL_NAMES`, which
-    /// subsumes `builtin_handlers::KNOWN_BUILTINS` via the mika#1217 parity test)
-    /// ∪ the tool names declared by the agent's *loaded* skills' tools.json. The
-    /// builtin half is the same set mika#1575's build-time check consumes, so the
-    /// load-time and build-time checks never disagree about what counts as a
-    /// builtin. The **full** `BUILTIN_TOOL_NAMES` — including the conditionally
-    /// injected management tools — is treated as builtin, mirroring mika#1575 and
-    /// avoiding false-positive fires for agents where those tools are present.
+    /// **Scope is deliberately broader than the #516/#463 runtime *enforcement*
+    /// scope.** #463 declines to *enforce* `required_tools` on always-on-only
+    /// (non-keyword-matched) skills — it won't force a tool call. This guard is about
+    /// a different invariant: whether a *held* skill is internally coherent with the
+    /// agent's tool surface. An always-on skill whose prompt presumes a tool the
+    /// agent can't call is incoherent regardless of whether #516 would force the
+    /// call — and the motivating mika#1406 case (Prime's always-on bearing skill) is
+    /// exactly that shape. So every loaded skill is checked, keyword-matched or not.
     ///
-    /// Unlike mika#1575's allowlist-unaware build-time check 4, this surface is
-    /// allowlist-aware (only loaded skills contribute), making it the runtime
-    /// sibling of mika#1575's check 5 (identity coherence).
+    /// Effective surface = engine builtins ∪ tools declared by *loaded* skills'
+    /// tools.json (see [`effective_tool_surface`]). Unlike mika#1575's allowlist-
+    /// unaware build-time check 4, this surface is allowlist-aware (only loaded skills
+    /// contribute), making it the runtime sibling of mika#1575's check 5.
+    ///
+    /// **Fixpoint.** Evicting a skill removes its declared tools from the surface,
+    /// which can make a *consumer* skill's cross-skill `required_tool` newly
+    /// unresolvable. The scan therefore repeats until a round evicts nothing —
+    /// `self.skills` strictly shrinks each round, so it terminates. (A single pass
+    /// would leave a consumer loaded while its provider was coherence-evicted in the
+    /// same pass — exactly the silent hold-a-tool-you-can't-call state this guards.)
     ///
     /// On fire: the offending skill is skipped (evicted into `self.skipped`) and an
     /// error-level `required_tool_unresolvable` event is emitted. The agent starts
@@ -452,56 +496,46 @@ impl SkillRegistry {
     /// Must run **after** `apply_load_safety_check()` so the effective surface
     /// reflects only skills that survived structural validation.
     pub fn apply_required_tools_coherence_check(&mut self, agent_id: &str) {
-        // Effective tool surface: engine builtins ∪ tools declared by loaded skills.
-        let mut effective: std::collections::HashSet<String> = crate::tools::BUILTIN_TOOL_NAMES
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        for entry in &self.skills {
-            for tool in &entry.skill_tools {
-                effective.insert(tool.definition.name.clone());
+        loop {
+            let effective = effective_tool_surface(&self.skills);
+
+            // Collect coherence violations without mutating self.skills.
+            let mut to_skip: Vec<SkippedSkill> = Vec::new();
+            let mut skip_names: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+
+            for entry in &self.skills {
+                let skill_name = &entry.manifest.skill.name;
+                // First unresolvable token is enough to skip the skill.
+                if let Some(token) = entry
+                    .manifest
+                    .constraints
+                    .required_tools
+                    .iter()
+                    .find(|t| !required_tool_resolves(t.as_str(), &effective))
+                {
+                    tracing::error!(
+                        agent_id = %agent_id,
+                        skill = %skill_name,
+                        unresolvable_token = %token,
+                        available_tool_count = effective.len(),
+                        event = "required_tool_unresolvable",
+                        "skill required_tools references a tool absent from the agent's effective \
+                         surface — skipping skill; run `mika skills validate` for diagnostics",
+                    );
+                    skip_names.insert(skill_name.clone());
+                    to_skip.push(SkippedSkill {
+                        name: skill_name.clone(),
+                        reason: format!(
+                            "coherence: required_tool '{token}' unresolvable in effective surface"
+                        ),
+                    });
+                }
             }
-        }
 
-        // Phase 1: collect coherence violations without mutating self.skills.
-        let mut to_skip: Vec<SkippedSkill> = Vec::new();
-        let mut skip_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-
-        for entry in &self.skills {
-            let skill_name = &entry.manifest.skill.name;
-            // First unresolvable token is enough to skip the skill. MCP tools
-            // (`mcp__{server}__{tool}`) are exempt — they resolve through the MCP
-            // client at startup, not the builtin/skill surface, so firing on them
-            // would wrongly skip a skill that can in fact call the tool. Mirrors
-            // the same leniency in `validate_skill`'s step 5b (mika#1217 F4).
-            if let Some(token) = entry
-                .manifest
-                .constraints
-                .required_tools
-                .iter()
-                .find(|t| !t.starts_with("mcp__") && !effective.contains(t.as_str()))
-            {
-                tracing::error!(
-                    agent_id = %agent_id,
-                    skill = %skill_name,
-                    unresolvable_token = %token,
-                    available_tool_count = effective.len(),
-                    event = "required_tool_unresolvable",
-                    "skill required_tools references a tool absent from the agent's effective \
-                     surface — skipping skill; run `mika skills validate` for diagnostics",
-                );
-                skip_names.insert(skill_name.clone());
-                to_skip.push(SkippedSkill {
-                    name: skill_name.clone(),
-                    reason: format!(
-                        "coherence: required_tool '{token}' unresolvable in effective surface"
-                    ),
-                });
+            if to_skip.is_empty() {
+                break;
             }
-        }
-
-        // Phase 2: evict violating skills.
-        if !to_skip.is_empty() {
             self.skills
                 .retain(|e| !skip_names.contains(&e.manifest.skill.name));
             self.skipped.extend(to_skip);
@@ -1355,6 +1389,67 @@ mod tests {
         assert_eq!(registry.skills[0].manifest.skill.name, "good");
         assert_eq!(registry.skipped.len(), 1);
         assert_eq!(registry.skipped[0].name, "bad");
+    }
+
+    #[test]
+    fn test_coherence_mcp_token_is_exempt() {
+        // `mcp__*` tokens resolve via the MCP client at startup, not the builtin/skill
+        // surface — they must NOT fire even when nothing in the surface provides them.
+        let mut registry = registry_of(vec![entry_with_required_tools(
+            "uses-mcp",
+            &["mcp__server__tool"],
+        )]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 1, "mcp__ token must be exempt");
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_coherence_fixpoint_evicts_consumer_after_provider() {
+        // Cascade: consumer requires a tool only the provider declares, but the
+        // provider has its OWN unresolvable token. Round 1 evicts the provider;
+        // round 2 sees the consumer's tool is now gone and evicts it too. A single
+        // pass would wrongly leave the consumer holding an uncallable tool.
+        let mut registry = registry_of(vec![
+            entry_with_required_tools("consumer", &["tool_from_provider"]),
+            entry_requiring_and_providing(
+                "provider",
+                &["totally_unresolvable_tool"],
+                &["tool_from_provider"],
+            ),
+        ]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert!(
+            registry.skills.is_empty(),
+            "both provider (own bad token) and consumer (cascade) should be evicted"
+        );
+        let skipped: Vec<&str> = registry.skipped.iter().map(|s| s.name.as_str()).collect();
+        assert!(skipped.contains(&"provider"));
+        assert!(skipped.contains(&"consumer"));
+    }
+
+    #[test]
+    fn test_required_tool_resolves_helper() {
+        let surface: std::collections::HashSet<String> =
+            ["search_memory".to_string(), "tool_x".to_string()]
+                .into_iter()
+                .collect();
+        assert!(required_tool_resolves("search_memory", &surface)); // builtin/in-surface
+        assert!(required_tool_resolves("tool_x", &surface)); // skill-provided
+        assert!(required_tool_resolves("mcp__srv__t", &surface)); // mcp exempt
+        assert!(!required_tool_resolves("nope", &surface)); // genuinely unresolvable
+    }
+
+    #[test]
+    fn test_effective_tool_surface_includes_builtins_and_skill_tools() {
+        let surface =
+            effective_tool_surface(&[entry_requiring_and_providing("p", &[], &["custom_tool"])]);
+        assert!(
+            surface.contains("custom_tool"),
+            "skill-declared tool present"
+        );
+        assert!(surface.contains("search_memory"), "engine builtin present");
+        assert!(surface.contains("run_gh"), "KNOWN_BUILTINS member present");
     }
 
     #[test]

--- a/crates/mika-agent/src/skills/mod.rs
+++ b/crates/mika-agent/src/skills/mod.rs
@@ -416,6 +416,98 @@ impl SkillRegistry {
         self.validated_warnings = to_warn;
     }
 
+    /// Runtime coherence check: every loaded skill's `[constraints] required_tools`
+    /// token must resolve to a tool in the agent's effective tool surface (mika#1576).
+    ///
+    /// Closes the silent vacuous-pass risk: the per-turn required_tools gate (#516)
+    /// only fires for keyword-matched skills when the LLM is actually asked to call
+    /// the tool, so a structurally-broken allowlist↔required_tools pairing surfaces
+    /// only mid-work — when the agent reaches for a tool that isn't there. This
+    /// load-time check runs after `apply_identity_allowlist` + `apply_overrides` +
+    /// transient overrides, the one point where both the allowlist and each skill's
+    /// `required_tools` are simultaneously visible, and catches the incoherence at
+    /// startup instead.
+    ///
+    /// Effective surface = engine builtins (`tools::BUILTIN_TOOL_NAMES`, which
+    /// subsumes `builtin_handlers::KNOWN_BUILTINS` via the mika#1217 parity test)
+    /// ∪ the tool names declared by the agent's *loaded* skills' tools.json. The
+    /// builtin half is the same set mika#1575's build-time check consumes, so the
+    /// load-time and build-time checks never disagree about what counts as a
+    /// builtin. The **full** `BUILTIN_TOOL_NAMES` — including the conditionally
+    /// injected management tools — is treated as builtin, mirroring mika#1575 and
+    /// avoiding false-positive fires for agents where those tools are present.
+    ///
+    /// Unlike mika#1575's allowlist-unaware build-time check 4, this surface is
+    /// allowlist-aware (only loaded skills contribute), making it the runtime
+    /// sibling of mika#1575's check 5 (identity coherence).
+    ///
+    /// On fire: the offending skill is skipped (evicted into `self.skipped`) and an
+    /// error-level `required_tool_unresolvable` event is emitted. The agent starts
+    /// degraded — the broken skill stays unavailable until the operator fixes the
+    /// coherence violation (adds the providing skill to the allowlist, or removes
+    /// the dangling token) and restarts. This is the established
+    /// `apply_load_safety_check` "load with warning + skip the broken skill"
+    /// pattern, not refuse-to-start.
+    ///
+    /// Must run **after** `apply_load_safety_check()` so the effective surface
+    /// reflects only skills that survived structural validation.
+    pub fn apply_required_tools_coherence_check(&mut self, agent_id: &str) {
+        // Effective tool surface: engine builtins ∪ tools declared by loaded skills.
+        let mut effective: std::collections::HashSet<String> = crate::tools::BUILTIN_TOOL_NAMES
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        for entry in &self.skills {
+            for tool in &entry.skill_tools {
+                effective.insert(tool.definition.name.clone());
+            }
+        }
+
+        // Phase 1: collect coherence violations without mutating self.skills.
+        let mut to_skip: Vec<SkippedSkill> = Vec::new();
+        let mut skip_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for entry in &self.skills {
+            let skill_name = &entry.manifest.skill.name;
+            // First unresolvable token is enough to skip the skill. MCP tools
+            // (`mcp__{server}__{tool}`) are exempt — they resolve through the MCP
+            // client at startup, not the builtin/skill surface, so firing on them
+            // would wrongly skip a skill that can in fact call the tool. Mirrors
+            // the same leniency in `validate_skill`'s step 5b (mika#1217 F4).
+            if let Some(token) = entry
+                .manifest
+                .constraints
+                .required_tools
+                .iter()
+                .find(|t| !t.starts_with("mcp__") && !effective.contains(t.as_str()))
+            {
+                tracing::error!(
+                    agent_id = %agent_id,
+                    skill = %skill_name,
+                    unresolvable_token = %token,
+                    available_tool_count = effective.len(),
+                    event = "required_tool_unresolvable",
+                    "skill required_tools references a tool absent from the agent's effective \
+                     surface — skipping skill; run `mika skills validate` for diagnostics",
+                );
+                skip_names.insert(skill_name.clone());
+                to_skip.push(SkippedSkill {
+                    name: skill_name.clone(),
+                    reason: format!(
+                        "coherence: required_tool '{token}' unresolvable in effective surface"
+                    ),
+                });
+            }
+        }
+
+        // Phase 2: evict violating skills.
+        if !to_skip.is_empty() {
+            self.skills
+                .retain(|e| !skip_names.contains(&e.manifest.skill.name));
+            self.skipped.extend(to_skip);
+        }
+    }
+
     /// Match skills against a user message.
     /// Only returns enabled skills, annotated with match reason.
     pub fn match_message(&self, user_message: &str) -> Vec<matcher::MatchedSkill<'_>> {
@@ -1132,6 +1224,137 @@ mod tests {
     fn test_safe_always_on_skills_empty() {
         let registry = SkillRegistry::empty();
         assert!(registry.safe_always_on_skills().is_empty());
+    }
+
+    // ── apply_required_tools_coherence_check tests (mika#1576) ──
+
+    fn entry_with_required_tools(name: &str, required: &[&str]) -> SkillEntry {
+        let mut e = make_entry(name, false, true);
+        e.manifest.constraints.required_tools = required.iter().map(|s| s.to_string()).collect();
+        e
+    }
+
+    /// A skill that both requires `required` and provides `provides` via its own tools.json.
+    fn entry_requiring_and_providing(
+        name: &str,
+        required: &[&str],
+        provides: &[&str],
+    ) -> SkillEntry {
+        use crate::skills::index::ResolvedSkillTool;
+        use crate::skills::manifest::ToolHandler;
+        use mika_common::claude::ToolDefinition;
+
+        let mut e = entry_with_required_tools(name, required);
+        e.skill_tools = provides
+            .iter()
+            .map(|tool_name| ResolvedSkillTool {
+                definition: ToolDefinition {
+                    name: tool_name.to_string(),
+                    description: "tool".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                },
+                handler: ToolHandler::Builtin {
+                    function: tool_name.to_string(),
+                },
+                skill_dir: PathBuf::from(format!("/skills/{name}")),
+            })
+            .collect();
+        e
+    }
+
+    fn registry_of(skills: Vec<SkillEntry>) -> SkillRegistry {
+        SkillRegistry {
+            skipped: Vec::new(),
+            disabled: Vec::new(),
+            validated_warnings: Vec::new(),
+            skills,
+        }
+    }
+
+    #[test]
+    fn test_coherence_pass_builtin_and_cross_skill() {
+        // "search_memory" is a builtin (BUILTIN_TOOL_NAMES); "tool_from_b" is
+        // provided by a co-loaded skill. Both resolve → no fire.
+        let mut registry = registry_of(vec![
+            entry_with_required_tools("skill-a", &["search_memory", "tool_from_b"]),
+            entry_requiring_and_providing("skill-b", &[], &["tool_from_b"]),
+        ]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 2);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_coherence_fail_synthetic_unresolvable_token() {
+        // A token that exists nowhere → the skill is evicted.
+        let mut registry = registry_of(vec![entry_with_required_tools(
+            "broken",
+            &["totally_unresolvable_tool"],
+        )]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert!(registry.skills.is_empty());
+        assert_eq!(registry.skipped.len(), 1);
+        assert_eq!(registry.skipped[0].name, "broken");
+        assert!(
+            registry.skipped[0]
+                .reason
+                .contains("totally_unresolvable_tool")
+        );
+    }
+
+    #[test]
+    fn test_coherence_fail_realistic_allowlist_exclusion() {
+        // skill-a requires a tool only skill-b provides, but skill-b is NOT loaded
+        // (simulating allowlist exclusion — the mika#1406 motivating scenario).
+        let mut registry =
+            registry_of(vec![entry_with_required_tools("skill-a", &["tool_from_b"])]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert!(registry.skills.is_empty(), "skill-a should be evicted");
+        assert_eq!(registry.skipped.len(), 1);
+        assert_eq!(registry.skipped[0].name, "skill-a");
+
+        // With skill-b loaded, the same required_tool resolves → no fire.
+        let mut registry = registry_of(vec![
+            entry_with_required_tools("skill-a", &["tool_from_b"]),
+            entry_requiring_and_providing("skill-b", &[], &["tool_from_b"]),
+        ]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 2);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_coherence_edge_builtin_always_resolves() {
+        // "run_gh" ∈ KNOWN_BUILTINS ⊂ BUILTIN_TOOL_NAMES, so it resolves as a
+        // builtin even when no loaded skill declares it. (This is why mika#1576's
+        // AC3 literal `run_gh` FAIL example was inconsistent with F1 — run_gh can
+        // never fire; see plan KTD-4.)
+        let mut registry = registry_of(vec![entry_with_required_tools("uses-gh", &["run_gh"])]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 1);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_coherence_edge_empty_required_tools() {
+        let mut registry = registry_of(vec![make_entry("no-constraints", false, true)]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 1);
+        assert!(registry.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_coherence_skips_only_offending_skill() {
+        // One broken skill is evicted; a coherent sibling survives.
+        let mut registry = registry_of(vec![
+            entry_with_required_tools("good", &["search_memory"]),
+            entry_with_required_tools("bad", &["totally_unresolvable_tool"]),
+        ]);
+        registry.apply_required_tools_coherence_check("test-agent");
+        assert_eq!(registry.skills.len(), 1);
+        assert_eq!(registry.skills[0].manifest.skill.name, "good");
+        assert_eq!(registry.skipped.len(), 1);
+        assert_eq!(registry.skipped[0].name, "bad");
     }
 
     #[test]

--- a/crates/mika-agent/src/tools/list_skills.rs
+++ b/crates/mika-agent/src/tools/list_skills.rs
@@ -57,6 +57,9 @@ impl Tool for ListSkillsTool {
         // Run load-time crash-protection to promote broken-handler/tools.json skills to skipped,
         // matching the startup paths (chat.rs, ask.rs, server/mod.rs).
         registry.apply_load_safety_check();
+        // Runtime allowlist↔required_tools coherence guard (mika#1576) — keep the
+        // listing in parity with the startup paths (chat.rs, ask.rs, server/mod.rs).
+        registry.apply_required_tools_coherence_check(ctx.db.agent_id());
         registry.log_summary();
 
         let entries = registry.skills();

--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -1322,6 +1322,48 @@ mod tests {
         assert_eq!(find_well_known_agent("mika-qa").unwrap().name, "mika-qa");
     }
 
+    /// mika#1576 F2 verification gate: every well-known agent's identity allowlist
+    /// must pass the runtime `required_tools` coherence check with zero fires.
+    ///
+    /// A fire here means a pre-existing allowlist↔required_tools incoherence — the
+    /// detector did its job, and the violation must be fixed in the same PR (either
+    /// add the providing skill to the allowlist, or drop the dangling token). This
+    /// mirrors mika#1575's fire-disposition contract and is the runtime sibling of
+    /// `verify_bundled_skills`'s build-time check 5 (identity coherence).
+    #[test]
+    fn test_well_known_agents_pass_required_tools_coherence() {
+        use crate::bundled_skills::seed_bundled_skills;
+        use crate::skills::SkillRegistry;
+
+        // Seed the full bundled skill library (community + engine-coupled) into a
+        // temp dir so the effective tool surface matches the real per-agent startup
+        // set — required_tools tokens like `run_shell` are provided by community
+        // skills (shell-exec), not just engine-coupled ones.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        seed_bundled_skills(tmp.path());
+
+        for (agent, allowlist) in well_known_skill_allowlists() {
+            let mut registry = SkillRegistry::from_dir(tmp.path());
+            registry.apply_identity_allowlist(&allowlist);
+            registry.apply_load_safety_check();
+            registry.apply_required_tools_coherence_check(agent);
+
+            let coherence_fires: Vec<&str> = registry
+                .skipped()
+                .iter()
+                .filter(|s| s.reason.starts_with("coherence:"))
+                .map(|s| s.name.as_str())
+                .collect();
+
+            assert!(
+                coherence_fires.is_empty(),
+                "well-known agent '{agent}' has required_tools coherence fires: \
+                 {coherence_fires:?} — fix the allowlist↔required_tools incoherence in \
+                 this PR (mika#1576 F2 gate)"
+            );
+        }
+    }
+
     #[test]
     fn test_find_well_known_agent_not_found() {
         assert!(find_well_known_agent("mika").is_none());

--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -328,6 +328,9 @@ pub async fn run(
         }
     }
     skill_registry.apply_load_safety_check();
+    // Runtime allowlist↔required_tools coherence guard (mika#1576). Runs after
+    // safety check so the effective surface reflects only surviving skills.
+    skill_registry.apply_required_tools_coherence_check(agent_name);
     skill_registry.log_summary();
 
     // Surface validation warnings on stderr (Unit 4: #530)

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -126,6 +126,8 @@ async fn spawn_agent_worker(
         skill_registry.apply_overrides(&overrides);
     }
     skill_registry.apply_load_safety_check();
+    // Runtime allowlist↔required_tools coherence guard (mika#1576).
+    skill_registry.apply_required_tools_coherence_check(ctx.async_db.agent_id());
     skill_registry.log_summary();
     let skill_registry = Arc::new(skill_registry);
     let skills_dirty = Arc::new(AtomicBool::new(false));

--- a/crates/mika-cli/src/commands/skills.rs
+++ b/crates/mika-cli/src/commands/skills.rs
@@ -7,7 +7,9 @@ use mika_agent::skills::index::{
 };
 use mika_agent::skills::install;
 use mika_agent::skills::marketplace;
-use mika_agent::skills::{SkillListFilter, SkillRegistry, SkillSource};
+use mika_agent::skills::{
+    SkillListFilter, SkillRegistry, SkillSource, effective_tool_surface, required_tool_resolves,
+};
 use mika_agent::tools::create_skill::validate_skill_name;
 use mika_common::home;
 use std::io::IsTerminal;
@@ -1572,16 +1574,7 @@ fn validate_skills(
     // (`SkillRegistry::apply_required_tools_coherence_check`) is the allowlist-aware
     // authority that catches tokens unresolvable under a specific agent's allowlist.
     let coherence_registry = SkillRegistry::from_dir(skills_dir);
-    let mut coherence_surface: std::collections::HashSet<String> =
-        mika_agent::tools::BUILTIN_TOOL_NAMES
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-    for entry in coherence_registry.skills() {
-        for tool in &entry.skill_tools {
-            coherence_surface.insert(tool.definition.name.clone());
-        }
-    }
+    let coherence_surface = effective_tool_surface(coherence_registry.skills());
     let coherence_required: std::collections::HashMap<String, Vec<String>> = coherence_registry
         .skills()
         .iter()
@@ -1603,16 +1596,21 @@ fn validate_skills(
     for (dir_name, dir_path) in &dirs {
         let mut diags = validate_skill(dir_path);
         // mika#1576 coherence diagnostics: flag required_tools tokens that don't
-        // resolve to a builtin or any installed skill's declared tool.
+        // resolve to a builtin or any installed skill's declared tool. Emitted as
+        // **Warn**, not Fail — this is the allowlist-unaware disk-surface view (a
+        // dependency may be installed at runtime but absent in a standalone validate
+        // tree), so it must not break `mika skills validate`'s exit code. Matches the
+        // Warn severity of validate_skill step 5b and verify_bundled_skills check 4
+        // for the same allowlist-unaware class; the allowlist-aware runtime guard
+        // (apply_required_tools_coherence_check) is the authority that hard-skips.
         if let Some(required) = coherence_required.get(dir_name) {
             for token in required {
-                // MCP tools (`mcp__{server}__{tool}`) resolve via the MCP client at
-                // startup, not the disk surface — exempt them (mirrors validate_skill 5b).
-                if !token.starts_with("mcp__") && !coherence_surface.contains(token) {
-                    diags.push(SkillDiagnostic::fail(format!(
-                        "required_tool '{token}' is unresolvable — not a builtin and not declared \
-                         by any installed skill's tools.json (allowlist-unaware disk view; \
-                         per-agent coherence is enforced at load time, mika#1576)"
+                if !required_tool_resolves(token, &coherence_surface) {
+                    diags.push(SkillDiagnostic::warn(format!(
+                        "required_tool '{token}' is unresolvable in the installed-skill surface — \
+                         not a builtin and not declared by any installed skill's tools.json. OK if \
+                         provided by a not-yet-installed dependency or an MCP server; the per-agent \
+                         load-time coherence guard is the authority (mika#1576)"
                     )));
                 }
             }
@@ -1709,14 +1707,17 @@ mod coherence_tests {
     }
 
     #[test]
-    fn test_validate_flags_unresolvable_required_tool() {
+    fn test_validate_warns_not_hardfails_on_unresolvable_required_tool() {
         let tmp = tempfile::tempdir().unwrap();
         write_skill(tmp.path(), "coh-broken", &["totally_unresolvable_xyz"]);
-        // A truly-unresolvable token is a Fail → validate_skills bails.
-        let err = validate_skills(tmp.path(), None, &crate::cli::OutputFormat::Json).unwrap_err();
+        // The coherence diagnostic is a Warn (allowlist-unaware disk view), NOT a
+        // Fail — so `mika skills validate` must NOT exit non-zero on it (adversarial
+        // P2-B regression: a dependency-provided tool absent from a standalone tree
+        // must not break community-skill CI). It returns Ok with a warning emitted.
+        let res = validate_skills(tmp.path(), None, &crate::cli::OutputFormat::Json);
         assert!(
-            err.to_string().contains("validation failed"),
-            "expected validation failure, got: {err}"
+            res.is_ok(),
+            "unresolvable required_tool must warn, not hard-fail validate: {res:?}"
         );
     }
 

--- a/crates/mika-cli/src/commands/skills.rs
+++ b/crates/mika-cli/src/commands/skills.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result, bail};
 use mika_agent::bundled_skills;
 use mika_agent::skills::executor;
 use mika_agent::skills::git;
-use mika_agent::skills::index::{DiagnosticLevel, scan_skills_dir, validate_skill};
+use mika_agent::skills::index::{
+    DiagnosticLevel, SkillDiagnostic, scan_skills_dir, validate_skill,
+};
 use mika_agent::skills::install;
 use mika_agent::skills::marketplace;
 use mika_agent::skills::{SkillListFilter, SkillRegistry, SkillSource};
@@ -1562,12 +1564,59 @@ fn validate_skills(
     let mut total_errors = 0;
     let mut total_warnings = 0;
 
+    // mika#1576: build the cross-skill effective tool surface (engine builtins ∪
+    // tools declared by all installed skills) once, so `validate` can flag
+    // `required_tools` tokens that resolve to nothing on disk. This is the
+    // allowlist-UNAWARE disk-surface view — it catches the structural class
+    // (a token resolving to nothing anywhere). The per-agent runtime check
+    // (`SkillRegistry::apply_required_tools_coherence_check`) is the allowlist-aware
+    // authority that catches tokens unresolvable under a specific agent's allowlist.
+    let coherence_registry = SkillRegistry::from_dir(skills_dir);
+    let mut coherence_surface: std::collections::HashSet<String> =
+        mika_agent::tools::BUILTIN_TOOL_NAMES
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+    for entry in coherence_registry.skills() {
+        for tool in &entry.skill_tools {
+            coherence_surface.insert(tool.definition.name.clone());
+        }
+    }
+    let coherence_required: std::collections::HashMap<String, Vec<String>> = coherence_registry
+        .skills()
+        .iter()
+        .map(|e| {
+            let key = e
+                .dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(e.manifest.skill.name.as_str())
+                .to_string();
+            (key, e.manifest.constraints.required_tools.clone())
+        })
+        .collect();
+
     if matches!(format, crate::cli::OutputFormat::Text) {
         println!();
     }
 
     for (dir_name, dir_path) in &dirs {
-        let diags = validate_skill(dir_path);
+        let mut diags = validate_skill(dir_path);
+        // mika#1576 coherence diagnostics: flag required_tools tokens that don't
+        // resolve to a builtin or any installed skill's declared tool.
+        if let Some(required) = coherence_required.get(dir_name) {
+            for token in required {
+                // MCP tools (`mcp__{server}__{tool}`) resolve via the MCP client at
+                // startup, not the disk surface — exempt them (mirrors validate_skill 5b).
+                if !token.starts_with("mcp__") && !coherence_surface.contains(token) {
+                    diags.push(SkillDiagnostic::fail(format!(
+                        "required_tool '{token}' is unresolvable — not a builtin and not declared \
+                         by any installed skill's tools.json (allowlist-unaware disk view; \
+                         per-agent coherence is enforced at load time, mika#1576)"
+                    )));
+                }
+            }
+        }
         let has_errors = diags.iter().any(|d| d.level == DiagnosticLevel::Fail);
         let has_warnings = diags.iter().any(|d| d.level == DiagnosticLevel::Warn);
 
@@ -1633,4 +1682,78 @@ fn validate_skills(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod coherence_tests {
+    //! mika#1576: `mika skills validate` cross-skill required_tools coherence.
+    use super::*;
+    use std::fs;
+
+    /// Write a minimal valid skill into `skills_dir/<name>/` with the given
+    /// `required_tools`. tools.json is empty (skill declares no tools of its own).
+    fn write_skill(skills_dir: &std::path::Path, name: &str, required_tools: &[&str]) {
+        let dir = skills_dir.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        let required = required_tools
+            .iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let toml = format!(
+            "[skill]\nname = \"{name}\"\ndescription = \"coherence test skill\"\nversion = \"0.1.0\"\n\n[triggers]\nkeywords = [\"cohtest\"]\n\n[constraints]\nrequired_tools = [{required}]\n"
+        );
+        fs::write(dir.join("skill.toml"), toml).unwrap();
+        fs::write(dir.join("system_prompt.md"), "test prompt").unwrap();
+        fs::write(dir.join("tools.json"), "[]").unwrap();
+    }
+
+    #[test]
+    fn test_validate_flags_unresolvable_required_tool() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_skill(tmp.path(), "coh-broken", &["totally_unresolvable_xyz"]);
+        // A truly-unresolvable token is a Fail → validate_skills bails.
+        let err = validate_skills(tmp.path(), None, &crate::cli::OutputFormat::Json).unwrap_err();
+        assert!(
+            err.to_string().contains("validation failed"),
+            "expected validation failure, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_passes_builtin_required_tool() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `search_memory` is an engine builtin (BUILTIN_TOOL_NAMES) → resolves, no fire.
+        write_skill(tmp.path(), "coh-ok", &["search_memory"]);
+        let res = validate_skills(tmp.path(), None, &crate::cli::OutputFormat::Json);
+        assert!(
+            res.is_ok(),
+            "builtin required_tool should not fail validation: {res:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_resolves_cross_skill_provided_tool() {
+        let tmp = tempfile::tempdir().unwrap();
+        // skill-a requires a tool provided by skill-b's tools.json → resolves cross-skill.
+        write_skill(tmp.path(), "coh-consumer", &["tool_from_provider"]);
+        let provider = tmp.path().join("coh-provider");
+        fs::create_dir_all(&provider).unwrap();
+        fs::write(
+            provider.join("skill.toml"),
+            "[skill]\nname = \"coh-provider\"\ndescription = \"provider\"\nversion = \"0.1.0\"\n\n[triggers]\nkeywords = [\"prov\"]\n",
+        )
+        .unwrap();
+        fs::write(provider.join("system_prompt.md"), "p").unwrap();
+        fs::write(
+            provider.join("tools.json"),
+            "[{\"name\": \"tool_from_provider\", \"description\": \"d\", \"input_schema\": {\"type\": \"object\"}, \"handler\": {\"type\": \"builtin\", \"function\": \"run_gh\"}}]",
+        )
+        .unwrap();
+        let res = validate_skills(tmp.path(), None, &crate::cli::OutputFormat::Json);
+        assert!(
+            res.is_ok(),
+            "cross-skill-provided required_tool should resolve: {res:?}"
+        );
+    }
 }

--- a/docs/architecture/bundled-skill-verification.md
+++ b/docs/architecture/bundled-skill-verification.md
@@ -143,10 +143,13 @@ clean. The regression test `well_known_agents::tests::test_well_known_agents_pas
 seeds the full bundled library, applies each well-known allowlist, and asserts zero coherence
 fires — the runtime sibling of Check 5's build-time guarantee.
 
-**CLI surface.** `mika skills validate` reports a `[FAIL]` coherence diagnostic for any
-`required_tools` token that resolves to nothing on disk. The CLI view is allowlist-*unaware*
-(disk-surface, like Check 4) since it has no specific agent's allowlist; the per-agent runtime
-guard above is the allowlist-aware authority.
+**CLI surface.** `mika skills validate` reports a `[WARN]` coherence diagnostic for any
+`required_tools` token that resolves to nothing in the installed-skill surface. The CLI view is
+allowlist-*unaware* (disk-surface, like Check 4), so it emits **Warn, not Fail** — a token may
+be provided by a dependency that isn't installed in a standalone validate tree (e.g. community-
+skill CI) yet resolves fine at runtime; hard-failing there would break that CI. This matches
+the Warn severity of `validate_skill` step 5b and Check 4 for the same allowlist-unaware class.
+The per-agent runtime guard above is the allowlist-aware authority that hard-skips.
 
 ## Out of scope
 

--- a/docs/architecture/bundled-skill-verification.md
+++ b/docs/architecture/bundled-skill-verification.md
@@ -92,9 +92,64 @@ exit blocks merge. The real-tree invariant is *also* enforced by the
 `real_bundled_tree_passes_green` test inside `cargo test`, so the gate has two independent
 CI entry points.
 
+## Runtime sibling: the load-time coherence guard (mika#1576)
+
+The build-time gate above proves the *source tree* is coherent. It cannot prove a *running
+agent* is coherent, because the effective skill set is computed at startup from the agent's
+`identity.toml [skills].allowlist` plus DB and transient overrides — state the build-time
+gate never sees. `SkillRegistry::apply_required_tools_coherence_check(agent_id)` closes that
+gap.
+
+**The invariant:** an agent must not hold a loaded skill that requires a tool it can't call.
+
+**Why a separate layer is needed.** The per-turn `required_tools` gate (mika#516) is
+keyword-scoped — it only fires when a skill keyword-matches *and* the LLM is asked to use the
+tool. A structurally-broken allowlist↔`required_tools` pairing (e.g. a skill requiring a tool
+provided by a skill the allowlist swap removed — the mika#1406 `github`→`gh-read-only`
+scenario) passes every existing check *vacuously* and surfaces only mid-work, when the agent
+reaches for a tool that isn't there. Counter: `invariant-enforced-at-dispatch-layer-not-load-layer`.
+
+**Where it runs.** Immediately after `apply_load_safety_check()` at every registry-finalize
+site (`crates/mika-cli/src/commands/{ask,chat}.rs`, `crates/mika-agent/src/server/mod.rs`,
+and the `list_skills` tool). This is the one point in the load chain where both operands —
+the allowlist (already applied) and each surviving skill's `required_tools` — are
+simultaneously visible.
+
+**The rule.** For each loaded skill, every `[constraints].required_tools` token must resolve to:
+
+- a builtin tool name — the **full** `tools::BUILTIN_TOOL_NAMES` (which subsumes
+  `builtin_handlers::KNOWN_BUILTINS` via the mika#1217 parity test); **the same builtin set
+  Check 4 / Check 5 use**, so the load-time and build-time checks never disagree about what
+  counts as a builtin; or
+- a tool declared in the `tools.json` of some **loaded** skill (allowlist-aware — only
+  surviving skills contribute). This makes it the runtime sibling of **Check 5**, not Check 4:
+  Check 4 is allowlist-unaware ("exists somewhere"); Check 5 and this guard are allowlist-aware
+  ("reachable here").
+
+`mcp__{server}__{tool}` tokens are exempt — they resolve through the MCP client at startup,
+not the builtin/skill surface, so firing on them would wrongly skip a skill that can in fact
+call the tool (mirrors `validate_skill` step 5b's leniency).
+
+**Fire disposition.** On a fire, the offending skill is **skipped** (evicted, recorded in
+`SkillRegistry::skipped()`) and an error-level `required_tool_unresolvable` structured event
+is emitted with fields `agent_id`, `skill`, `unresolvable_token`, `available_tool_count`. The
+agent starts **degraded** — the broken skill is unavailable until the operator fixes the
+coherence violation (adds the providing skill to the allowlist, or drops the dangling token)
+and restarts. This is the established `apply_load_safety_check` "load with warning + skip the
+broken skill" pattern, **not** refuse-to-start.
+
+**First-deploy expectation (mika#1576 F2).** All existing well-known agent configurations pass
+clean. The regression test `well_known_agents::tests::test_well_known_agents_pass_required_tools_coherence`
+seeds the full bundled library, applies each well-known allowlist, and asserts zero coherence
+fires — the runtime sibling of Check 5's build-time guarantee.
+
+**CLI surface.** `mika skills validate` reports a `[FAIL]` coherence diagnostic for any
+`required_tools` token that resolves to nothing on disk. The CLI view is allowlist-*unaware*
+(disk-surface, like Check 4) since it has no specific agent's allowlist; the per-agent runtime
+guard above is the allowlist-aware authority.
+
 ## Out of scope
 
-Runtime invariants (`apply_load_safety_check`, mika#1576), marketplace skill verification
-(bundled only), `tools.json` schema validation against the canonical tool schema, and the
-optional checks 6–8 (prompt-size limits, keyword-overlap detection, schema validation) are
-deferred follow-ups.
+Marketplace skill verification (bundled only), `tools.json` schema validation against the
+canonical tool schema, and the optional checks 6–8 (prompt-size limits, keyword-overlap
+detection, schema validation) are deferred follow-ups.

--- a/docs/plans/2026-06-27-003-fix-apply-load-safety-check-coherence-guard-plan.md
+++ b/docs/plans/2026-06-27-003-fix-apply-load-safety-check-coherence-guard-plan.md
@@ -1,0 +1,309 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+title: "fix(skills): apply_load_safety_check coherence guard — allowlist ↔ required_tools"
+plan_type: fix
+date: 2026-06-27
+issue: senara-solutions/mika#1576
+branch: fix/1576/skills-apply-load-safety-check-coherence
+product_contract_source: ce-plan-bootstrap
+origin: "GitHub issue mika#1576 (architect-groomed, session f6971f73, second-pass Verdict: GROOMED)"
+---
+
+# fix(skills): apply_load_safety_check coherence guard — allowlist ↔ required_tools
+
+> **Product Contract preservation:** This plan is sourced from an architect-groomed GitHub issue (mika#1576), not a ce-brainstorm requirements doc. The issue body (with architect Resolutions F1 + F2) is the contract. Scope is preserved verbatim; the only enrichment below is HOW (real code grounding from repo research). One **carried correction** to F1's illustrative tool-name list is documented in Key Technical Decisions — it completes F1's plain intent (which explicitly delegated exact names to code investigation) and does not overturn its design.
+
+---
+
+## Summary
+
+Add a **runtime, load-time coherence check** to the mika-agent skill registry: after an agent's identity allowlist and DB/transient overrides have been applied, verify that every `[constraints] required_tools` token in every loaded skill resolves to a tool that is actually in the agent's effective tool surface (engine builtins + tools declared by the agent's *loaded* skills). A token that resolves to nothing is a **silent vacuous pass** today — the existing `required_tools` enforcement (mika#516, per-turn, keyword-scoped) only fires when the skill keyword-matches *and* the LLM is asked to use the tool, so a structurally-broken allowlist↔required_tools pairing surfaces only mid-work when the agent reaches for a tool that isn't there.
+
+On a fire: **skip the broken skill** with an error-level structured log event `required_tool_unresolvable`, surface it in `mika skills validate`, and let the agent start degraded (the established `apply_load_safety_check` "load with warning + skip broken skill" pattern — **not** refuse-to-start). The check closes the silent-pass risk at the one layer where both operands (the allowlist and the skill's `required_tools`) are simultaneously visible — the load/apply path.
+
+This is the runtime sibling of mika#1575's build-time check 5 (identity coherence). It shares the same builtin-tool-name surface (`BUILTIN_TOOL_NAMES ∪ KNOWN_BUILTINS`) so the two checks never disagree about what counts as a builtin.
+
+---
+
+## Problem Frame
+
+**The invariant:** an agent must not hold a loaded skill that requires a tool the agent cannot call.
+
+**The current gap (counter `invariant-enforced-at-dispatch-layer-not-load-layer n=1`):** the coherence between two pieces of config — the agent's `identity.toml [skills].allowlist` and a skill's `skill.toml [constraints] required_tools` — is only checked where one operand is visible at a time:
+
+- `collect_required_tools()` (`crates/mika-agent/src/agent_loop/mod.rs:4581–4615`) gathers `required_tools` from **keyword-matched skills only** (`MatchReason::Keyword`), per turn.
+- The EndTurn post-condition (mika#516) checks the agent actually *called* each required tool — but it allows a vacuous pass when a terminal tool error is detected, and it never fires at all for a skill that is loaded-but-not-keyword-matched this turn.
+
+**Motivating incident (mika#1406 / PR #1570):** Prime's allowlist swap `github` → `gh-read-only` removes the `github` skill that *provides* the `run_gh` skill-tool binding to a given agent. A loaded skill whose `required_tools` references the (now-absent) provider would pass every existing check vacuously and fail silently only when the agent reaches for the tool. Per Mika Prime's bearing-read: *"A silent failure gated on a human remembering a PR-body note is precisely the shape structural enforcement exists for."*
+
+**Where the fix belongs:** the load/apply path (`SkillRegistry::apply_load_safety_check`), which runs *after* allowlist + overrides and therefore sees both operands at once.
+
+---
+
+## Requirements
+
+Traced from mika#1576 body (acceptance criteria) + architect Resolutions F1/F2.
+
+- **R1** — Extend the canonical load-time safety check (`SkillRegistry::apply_load_safety_check` in `crates/mika-agent/src/skills/mod.rs`) with the allowlist↔required_tools coherence rule. (AC1)
+- **R2** — Emit an error-level structured log event `required_tool_unresolvable` when the check fires, with fields `agent_id`, `skill`, `unresolvable_token`, `available_tool_count`. (AC2)
+- **R3** — On fire: skip the offending skill (evict from loaded set, record in `skipped`), agent continues to start degraded. Load-with-warning, **not** refuse-to-start. (AC2, F2)
+- **R4** — Tests covering: PASS (all tokens resolve, no fire), FAIL (a genuinely-unresolvable token fires → skill skipped + event), edge (builtin tokens always resolve with no skill declaration needed). (AC3)
+- **R5** — `mika skills validate` reports the coherence diagnostic when it would fire. (AC4)
+- **R6** — Documentation describing the coherence invariant and how it composes with the other layers (mika#516 / #1326 / #1575). (AC5)
+- **R7 (F1)** — "Builtin tool name" = the union of `KNOWN_BUILTINS` (`builtin_handlers.rs`) and the engine-default `ToolRegistry` tool names — **the same set mika#1575's check uses**. Sourced from real code, not the contract's illustrative list.
+- **R8 (F2, verification gate)** — Before opening the PR, run the coherence check against **all** well-known agent identity templates (mika-dev, mika-qa, mika-relay, mika-arch) and confirm **zero fires**. Any fire is a pre-existing bug surfaced by the detector and is fixed **in this PR**, not deferred.
+
+---
+
+## Key Technical Decisions
+
+### KTD-1 — Builtin surface = `BUILTIN_TOOL_NAMES ∪ KNOWN_BUILTINS` (carried correction to F1)
+
+F1's prose lists an illustrative `KNOWN_BUILTIN_FUNCTIONS` of 7 names (`run_shell, web_search, get_documentation, run_claude_pilot, run_claude_pilot_groom, run_gh, run_mcp_tool`). **Repo research found this list is factually wrong against HEAD:**
+
+- The real const is `KNOWN_BUILTINS` (`crates/mika-agent/src/skills/builtin_handlers.rs:39–47`) = `["get_documentation", "gh_read", "git_ops", "review_skill", "run_gh", "run_gws", "web_search"]`.
+- The authoritative engine-tool surface is `BUILTIN_TOOL_NAMES` (`crates/mika-agent/src/tools/mod.rs:716–775`), 46 names = `default_tools()` ∪ `management_tools_if_needed()` ∪ `KNOWN_BUILTINS`. The `test_builtin_tool_names_parity` test (mika#1217 F4) guards that this const stays in sync.
+- Names from F1's list like `run_shell`, `run_claude_pilot`, `run_claude_pilot_groom`, `run_mcp_tool` are **skill-provided** tools (declared in a skill's `tools.json`), not engine builtins.
+
+**Decision:** the coherence check's builtin base = `BUILTIN_TOOL_NAMES` (which already subsumes `KNOWN_BUILTINS` via the parity test). This is *exactly* the set mika#1575's build-time check consumes, satisfying F1's binding requirement ("the same set"). Using the real constants **completes** F1's plain intent — F1 explicitly instructed "investigate the actual code… do not assume the lists above are exhaustive" and pinned the definition to "mika#1575 check 4 option (a)". This is a carry-not-route call per the implementer-contradiction doctrine: it finishes a resolution's stated intent rather than overturning its design.
+
+Include the **full** `BUILTIN_TOOL_NAMES` (including the conditionally-injected management tools) in the builtin base. The static mika#1575 checks do the same, and treating conditional management tools as always-builtin avoids false-positive fires for agents where those tools are conditionally present. Document this choice inline.
+
+### KTD-2 — Effective surface is allowlist-AWARE (runtime sibling of #1575 check 5, not check 4)
+
+The check runs over `self.skills` *after* `apply_identity_allowlist` + `apply_overrides` + transient overrides. The effective tool surface = `BUILTIN_TOOL_NAMES` ∪ { every tool name declared in the `tools.json` of each **loaded** skill }. This is allowlist-aware (only loaded skills contribute), mirroring mika#1575's check 5 (`known_tools_builtins_only()` + reachable-through-allowlist), **not** check 4 (which is allowlist-unaware and adds `all_bundled_tool_names()`). The shared piece between #1576 and #1575 is the *builtin* base (KTD-1); the skill-provided augmentation differs by design (runtime = loaded skills only).
+
+### KTD-3 — Placement and signature
+
+Implement as a distinct pass invoked immediately after `apply_load_safety_check()` in the call sequence (`crates/mika-cli/src/commands/ask.rs` and any other call site that builds a registry for a specific agent). Either (a) add a new method `SkillRegistry::apply_required_tools_coherence_check(&mut self, agent_id: &str)`, or (b) extend `apply_load_safety_check` to take `agent_id` and fold the rule in as a new phase. **Prefer (a)** — a separate, single-purpose method keeps `apply_load_safety_check`'s existing signature stable, is independently testable, and reads as its own concern. The new method needs `agent_id` for the log event (R2); `apply_load_safety_check` is currently `&mut self` with no agent_id in scope, so the call site must thread it through. Use the same Phase-1-collect / Phase-2-evict structure already used in `apply_load_safety_check` (lines 342–417) so eviction during iteration is safe.
+
+### KTD-4 — FAIL-case token must be genuinely unresolvable (AC3 example correction)
+
+AC3's literal FAIL example is `required_tools = ["run_gh"]` "fires because no allowlisted skill provides run_gh." But under KTD-1, `run_gh ∈ KNOWN_BUILTINS ⊂ BUILTIN_TOOL_NAMES`, so `run_gh` **always** resolves as a builtin and can never fire. The example token is inconsistent with F1's builtin definition. **Decision:** honor F1 (the BLOCKING, code-grounded resolution) over AC3's illustrative token. The FAIL-case test uses a token that is genuinely outside the effective surface — both (i) a synthetic non-existent token (`totally_unresolvable_tool`) for the pure unit test, and (ii) the realistic shape: a skill whose `required_tools` names a *skill-provided* tool whose providing skill is **excluded from the allowlist** (the actual mika#1406 motivating scenario, and the case mika#516's per-turn check misses). This completes AC3's plain intent (an unresolvable token fires) without contradicting F1.
+
+### KTD-5 — Reuse the const directly; no new shared abstraction (KISS)
+
+`BUILTIN_TOOL_NAMES` is already `pub` and parity-test-guarded. Both the runtime check (this ticket) and the build-time `verify_bundled_skills` binary reference the *same* const, so "use the same set" is satisfied without extracting a new helper. Do not introduce a shared `builtin_tool_surface()` function unless implementation reveals the assembly logic genuinely duplicates (it is a one-liner: collect the const into a set). Keep it simple.
+
+---
+
+## High-Level Technical Design
+
+Load/apply sequence (call site: `crates/mika-cli/src/commands/ask.rs`), with the new pass appended:
+
+```
+SkillRegistry built from scan
+        │
+        ▼
+apply_identity_allowlist(allowlist)   // Phase -1: evict non-allowlisted skills   (mod.rs:472–508)
+        │
+        ▼
+apply_overrides(&overrides)           // Phase 0/1: evict DB-disabled, apply always_on/LLM (mod.rs:518–595)
+        │
+        ▼
+apply_transient_disable / always_on   // Phase 1.5: CLI enable/disable
+        │
+        ▼
+apply_load_safety_check()             // existing: skip broken handlers / tools.json / manifest (mod.rs:338–417)
+        │
+        ▼
+apply_required_tools_coherence_check(agent_id)   // NEW (this ticket)
+        │   ┌─────────────────────────────────────────────────────────────┐
+        │   │ effective = BUILTIN_TOOL_NAMES ∪ {tool.name for each loaded   │
+        │   │             skill's tools.json}                               │
+        │   │ for each loaded skill S:                                      │
+        │   │   for each token T in S.manifest.required_tools:             │
+        │   │     if T ∉ effective:                                         │
+        │   │        tracing::error!(required_tool_unresolvable, …)         │
+        │   │        mark S for eviction → self.skipped                     │
+        │   └─────────────────────────────────────────────────────────────┘
+        ▼
+log_summary()
+```
+
+Coherence rule (per loaded skill, after allowlist + overrides):
+
+```
+resolvable(token) ⟺ token ∈ BUILTIN_TOOL_NAMES
+                  ∨ ∃ loaded skill L : token ∈ names(L.tools.json)
+```
+
+---
+
+## Implementation Units
+
+### U1. Add the coherence-check pass to `SkillRegistry`
+
+**Goal:** implement `apply_required_tools_coherence_check(&mut self, agent_id: &str)` (KTD-3) that evicts loaded skills whose `required_tools` contain an unresolvable token, emitting `required_tool_unresolvable` per fire.
+
+**Requirements:** R1, R2, R3, R7.
+
+**Dependencies:** none.
+
+**Files:**
+- `crates/mika-agent/src/skills/mod.rs` — new method on `SkillRegistry` (place adjacent to `apply_load_safety_check`, ~line 417). Import `crate::tools::BUILTIN_TOOL_NAMES`.
+
+**Approach:**
+- Build `effective: HashSet<&str>` = `BUILTIN_TOOL_NAMES` collected, then extend with every tool name declared by each currently-loaded skill (read from the parsed `tools.json` / `skill_tools` on each `SkillEntry` — confirm the exact field name during implementation; research indicates `SkillEntry` carries resolved skill tools). Include the skill's own declared tools so a skill that both declares and requires a tool resolves.
+- Two-phase like `apply_load_safety_check`: Phase 1 collect `(skill_name, unresolvable_token)` violations without mutating; Phase 2 `tracing::error!` each + `retain()` out the violating skills + push to `self.skipped`.
+- Log fields exactly: `agent_id = %agent_id, skill = %skill_name, unresolvable_token = %token, available_tool_count = effective.len()`, message e.g. `"skill required_tools references a tool absent from the agent's effective surface — skipping skill"`. Match the house style in `skills/mod.rs:380–401` (snake_case fields, `%` display formatter, guidance to `mika skills validate`).
+- Comment inline why the full `BUILTIN_TOOL_NAMES` (incl. conditional management tools) is used as the builtin base (KTD-1).
+
+**Patterns to follow:** existing skip/evict + `tracing::warn!` block in `apply_load_safety_check` (`skills/mod.rs:380–417`); the two-phase collect-then-apply structure already there.
+
+**Test scenarios** (inline `#[cfg(test)] mod tests` in `skills/mod.rs`, using `make_entry` / `SkillRegistry { … }` helpers at lines 833–871 / 1114–1119):
+- **PASS:** a loaded skill with `required_tools = ["search_memory"]` (a builtin) and another with a token provided by a co-loaded skill's tools.json → no fire, both skills remain in `self.skills`, `self.skipped` empty.
+- **FAIL (synthetic):** a loaded skill with `required_tools = ["totally_unresolvable_tool"]` and no skill providing it → skill evicted into `self.skipped`, exactly one violation. (KTD-4)
+- **FAIL (realistic allowlist exclusion):** skill A requires a tool that only skill B's tools.json provides, but skill B is absent from the loaded set (simulating it being excluded by the allowlist) → A is evicted. Mirrors the mika#1406 scenario. (KTD-4)
+- **Edge (builtin always resolves):** a loaded skill with `required_tools = ["run_gh"]` (∈ KNOWN_BUILTINS ⊂ BUILTIN_TOOL_NAMES) and **no** skill declaring `run_gh` → no fire. Directly asserts AC3's edge case and demonstrates why AC3's literal `run_gh` FAIL example was inconsistent. (R4)
+- **Edge (empty required_tools):** loaded skill with `required_tools = []` → no fire.
+- Assert the log event is emitted on fire (capture via `tracing-test` / `tracing_subscriber` if the crate already uses one for log assertions; otherwise assert on the `self.skipped` outcome + reason string, matching how existing skip tests verify behavior).
+
+**Verification:** `cargo test -p mika-agent skills::` passes; new tests cover all four AC3 categories.
+
+### U2. Thread `agent_id` into the call site(s)
+
+**Goal:** invoke `apply_required_tools_coherence_check(agent_id)` immediately after `apply_load_safety_check()` wherever a registry is finalized for a specific agent.
+
+**Requirements:** R1, R2.
+
+**Dependencies:** U1.
+
+**Files:**
+- `crates/mika-cli/src/commands/ask.rs` — add the call after `apply_load_safety_check()` in the documented sequence.
+- Any other registry-finalize site (grep for `apply_load_safety_check(` across the crate; the agent server startup path in `crates/mika-agent/src/server/` or `agent_loop` may build registries too). **Add the new call at every site that already calls `apply_load_safety_check`** so server-launched agents (mika-spirit) get the check, not just CLI.
+
+**Approach:** `agent_id` is in scope at these call sites (the registry is being built *for* a named agent). Pass it through. If a call site builds a registry without a concrete agent (e.g., a generic validation context), pass the best-available identifier or a sentinel and note it — but prefer the real agent id everywhere an agent is being provisioned/loaded.
+
+**Patterns to follow:** the existing ordering and call style at the `ask.rs` sequence (`apply_identity_allowlist` → `apply_overrides` → … → `apply_load_safety_check` → `log_summary`).
+
+**Test scenarios:** `Test expectation: none — wiring only; behavior is covered by U1 unit tests and U4's well-known-agent integration test.` (If a call site is missed, U4's per-agent gate would not catch a runtime-only miss; manually confirm via grep that every `apply_load_safety_check` call has a sibling coherence call.)
+
+**Verification:** `grep -rn "apply_load_safety_check(" crates/` — every hit has an adjacent `apply_required_tools_coherence_check(` call; `cargo build` clean.
+
+### U3. Surface the diagnostic in `mika skills validate`
+
+**Goal:** `mika skills validate` reports a coherence diagnostic when a skill's `required_tools` token would be unresolvable.
+
+**Requirements:** R5.
+
+**Dependencies:** U1.
+
+**Files:**
+- `crates/mika-cli/src/commands/skills.rs` — `validate_skills` (lines 1481–1636); add a diagnostic pass after the per-skill structural validation loop (~line 1569) and before the summary (~line 1616).
+
+**Approach:**
+- `mika skills validate` validates skills on disk (the bundled/installed surface) and is **not** inherently scoped to a single agent's allowlist. Scope the coherence diagnostic to what `validate` can know: resolve each skill's `required_tools` against `BUILTIN_TOOL_NAMES ∪ all-validated-skills' declared tools`. This is the build-time-style (allowlist-unaware) view appropriate for the CLI surface — it catches the structural class (a token resolving to *nothing anywhere*) even if it can't reproduce a specific agent's allowlist. State this scoping in the diagnostic message so the operator understands it is the disk-surface view, and that the per-agent runtime check (U1) is the allowlist-aware authority.
+- Emit a `DiagnosticLevel::Fail` (or `Warn` — match the severity the existing `required_tools` structural diagnostics use; prefer `Fail` to align with mika#1575's pre-merge stance) entry per unresolvable token, rendered in all three output formats (Text / JSON / YAML) the command already supports (lines 1582–1615).
+
+**Patterns to follow:** the existing diagnostic collection + `DiagnosticLevel` rendering in `validate_skills`; the diagnostic struct shape `{skill, level, message}`.
+
+**Test scenarios:**
+- A skill (in a temp skills dir) with `required_tools = ["totally_unresolvable_tool"]` → `validate` reports a Fail/Warn diagnostic naming the token; exit status reflects it (1 if Fail).
+- A skill with only builtin / co-resolvable tokens → no coherence diagnostic.
+- JSON output includes the diagnostic entry with the token in the message.
+
+**Verification:** `cargo test -p mika-cli` passes; manual `cargo run --bin mika -- skills validate` on a crafted broken skill shows the line.
+
+### U4. F2 verification gate — well-known agents pass clean (+ integration test)
+
+**Goal:** prove (and lock in) that **all** well-known agent identity templates pass the coherence check with zero fires (R8). This is both the F2 implementer gate and a regression test.
+
+**Requirements:** R8, R4.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- `crates/mika-agent/src/well_known_agents.rs` (test module) **or** an integration test under `crates/mika-agent/tests/` — for each well-known agent (mika-dev: 26 skills @ lines 134–160; mika-qa: 17 @ 192–211; mika-relay: 1 `permission-policy`; mika-arch: 3 @ 298–302 via `build_mika_arch_identity`), build a `SkillRegistry` from the bundled skills, apply that agent's allowlist, run `apply_load_safety_check` + `apply_required_tools_coherence_check`, and assert `self.skipped` contains **no** coherence-class evictions.
+
+**Approach:**
+- Use the bundled skill manifests (`BUNDLED_SKILL_MANIFESTS`) as the source registry so the test reflects the real shipped surface.
+- mika-arch's identity is computed via `build_mika_arch_identity()` and requires `MIKA_KG_DOCS_ROOTS`; in the test, supply a dummy value or construct the allowlist directly from `MIKA_ARCH_SKILL_ALLOWLIST` (lines 298–302) to avoid the env dependency — the allowlist is what the check consumes.
+- **If any agent fires:** that is a pre-existing coherence bug surfaced by the detector. Per F2, fix it in this PR — either add the providing skill to the agent's allowlist or remove the dangling `required_tools` token from the offending skill. Document any such fix in the PR body. (Architect verified zero fires at grooming HEAD; this gate re-confirms at PR HEAD.)
+- Watch specifically: `qa-review` (always_on) declares `required_tools = ["qa_pr_view", "run_gh", "run_shell", "build_mika"]` — `run_gh` is a builtin; `run_shell`, `build_mika`, `qa_pr_view` must be provided by co-allowlisted skills (`shell-exec`, `build-mika`, and qa-review's own tools.json). mika-qa allowlists `build-mika` and `shell-exec`, so these should resolve; the gate confirms it.
+
+**Test scenarios:**
+- `test_well_known_agents_pass_coherence_check` — parametrized over the four agents; asserts zero coherence evictions for each.
+- (If a fire is found and fixed) a focused test documenting the corrected pairing.
+
+**Verification:** `cargo test -p mika-agent well_known` (or the integration test) passes for all four agents.
+
+### U5. Documentation of the coherence invariant
+
+**Goal:** document the invariant, the runtime check, and how it composes with the other three layers.
+
+**Requirements:** R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- `docs/architecture/bundled-skill-verification.md` — extend (this is mika#1575's home and the natural place for the build-time↔runtime composition story), **or** a new `docs/solutions/best-practices/required-tools-coherence-runtime-check-2026-06-27.md` with YAML frontmatter (`module`, `tags`, `problem_type`, `category`). Prefer extending `bundled-skill-verification.md` so the four-layer composition lives in one place; cross-link from a short solutions entry if the doc-audit step wants a searchable record.
+- `crates/mika-agent/docs/` fallback copy if the doc lives under `docs/` and is `include_str!`-synced — run `scripts/sync-agent-docs.sh` if applicable (CI `docs-sync` job enforces this for `docs/` changes consumed by `build.rs`).
+
+**Approach:** describe the invariant ("an agent must not hold a loaded skill requiring a tool it can't call"), the builtin definition (KTD-1, shared with mika#1575), the allowlist-aware effective surface (KTD-2), the fire disposition (skip + log + degraded start), and the four-layer composition table:
+
+| Layer | When | Scope | Ticket |
+|-------|------|-------|--------|
+| Availability filter | runtime, per-turn | LLM-call time | mika#516 |
+| Cross-skill name collisions | build-time test | bundled surface | mika#1326 AC2 |
+| `make verify-bundled-skills` | build-time / pre-merge | structural, allowlist-aware (check 5) | mika#1575 |
+| **required_tools coherence** | **runtime, load-time** | **per-agent effective surface** | **mika#1576 (this)** |
+
+**Test scenarios:** `Test expectation: none — documentation.` Doc-sync verified by CI if applicable.
+
+**Verification:** doc renders; if synced, `scripts/sync-agent-docs.sh` leaves no diff; CI `docs-sync` green.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the runtime load-time coherence check, its log event, CLI surface, tests, the F2 well-known-agent gate (including fixing any pre-existing fire it surfaces), and documentation.
+
+### Deferred to Follow-Up Work
+- Refactoring `required_tools` to be data-driven from the skill registry instead of declared per-skill (out of scope per issue body).
+- Cross-agent coherence (each agent's check is independent — per issue body).
+
+### Outside this change's identity
+- Backfilling existing skill prompts to fix coherence violations **other than** any fire surfaced by the U4 verification gate. The gate-surfaced fire is fixed here (F2); speculative/other violations are per-incident follow-ups.
+- Changing mika#516 / #1326 / #1575 behavior. Those layers stay exactly as-is; this adds a fourth.
+- Any operator action on Prime's allowlist swap (`github` → `gh-read-only`). This ticket *unblocks* that action structurally; performing it is a separate operator-gated step (issue body § Sequencing).
+
+---
+
+## Risks & Dependencies
+
+- **False-positive fire skipping a legitimate skill.** Mitigation: builtin base is the full parity-guarded `BUILTIN_TOOL_NAMES` (KTD-1); effective surface includes the skill's own declared tools; U4 proves all four shipped agents pass clean before merge.
+- **Missed call site** (a registry finalized without the new pass → no runtime coverage for that path). Mitigation: U2's grep verification; add the call at *every* `apply_load_safety_check` site.
+- **`SkillEntry` tool-name field uncertainty.** The exact field exposing a loaded skill's declared tool names (`skill_tools` vs parsed `tools.json`) must be confirmed in code during U1 — research indicates `SkillEntry` carries resolved skill tools but the precise accessor needs verification.
+- **Severity choice in `mika skills validate`** (Fail vs Warn) — align with the existing `required_tools` structural diagnostic severity; prefer Fail to match mika#1575's pre-merge stance.
+- **Dependency:** none blocking. The substrate bug that wedged the autonomous dev-groom for this ticket (#1593) is being fixed in parallel; this plan is dispatched via direct-implementation mode and does not depend on #1593.
+
+---
+
+## Definition of Done
+
+- All of R1–R8 satisfied.
+- `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt --check` clean.
+- `cargo run --bin verify-bundled-skills` still passes (this ticket adds a runtime check; it must not break the build-time one).
+- U4 gate green: all four well-known agents pass the coherence check with zero fires (or any surfaced fire is fixed in this PR and documented).
+- Every `apply_load_safety_check` call site has an adjacent coherence-check call (U2 grep).
+- Documentation merged (and doc-synced if applicable).
+- PR body documents the F1 carried correction (KTD-1) and the AC3 token correction (KTD-4), and `Closes #1576`.
+
+---
+
+## Sources & Research
+
+- **Issue contract:** mika#1576 body + comment `mika-arch second-pass (GROOMED)` session `f6971f73-4e24-4743-bc75-9c50ea58181e` (Resolutions F1, F2).
+- **`apply_load_safety_check`** — `crates/mika-agent/src/skills/mod.rs:338–417`; `apply_identity_allowlist` 472–508; `apply_overrides` 518–595; call sequence in `crates/mika-cli/src/commands/ask.rs`.
+- **Builtin surface (KTD-1)** — `KNOWN_BUILTINS` `crates/mika-agent/src/skills/builtin_handlers.rs:39–47`; `BUILTIN_TOOL_NAMES` `crates/mika-agent/src/tools/mod.rs:716–775`; parity test `test_builtin_tool_names_parity` (mika#1217 F4).
+- **Existing enforcement** — `collect_required_tools()` `crates/mika-agent/src/agent_loop/mod.rs:4581–4615` (keyword-scoped, per-turn); EndTurn post-condition + terminal-failure bypass (mika#516).
+- **`required_tools` manifest field** — `crates/mika-agent/src/skills/manifest.rs:101` (`[constraints]`).
+- **`tools.json`** — parsed via `ToolDecl` in `crates/mika-agent/src/skills/index.rs`; example `skills/bundled/dev-groom/tools.json`; `qa-review` `required_tools` example `skills/bundled/qa-review/skill.toml`.
+- **mika#1575** — `crates/mika-agent/src/bin/verify_bundled_skills.rs` (check 4 builtin assembly lines 468–475; check 5 builtin-only set lines 490–495); `docs/architecture/bundled-skill-verification.md`; CI `make verify-bundled-skills`.
+- **Well-known agents** — `crates/mika-agent/src/well_known_agents.rs` (mika-dev 134–160, mika-qa 192–211, mika-arch allowlist 298–302, `build_mika_arch_identity` 310–366).
+- **CLI** — `mika skills validate` `crates/mika-cli/src/commands/skills.rs:1481–1636`.
+- **Logging house style** — `crates/mika-agent/src/skills/mod.rs:57–61, 380–401`.
+- **Test harness** — `crates/mika-agent/src/skills/mod.rs` test module 827–1149 (`make_entry` 833–871; registry construction 1114–1119).

--- a/docs/plans/2026-06-27-003-fix-apply-load-safety-check-coherence-guard-plan.md
+++ b/docs/plans/2026-06-27-003-fix-apply-load-safety-check-coherence-guard-plan.md
@@ -282,7 +282,7 @@ resolvable(token) ⟺ token ∈ BUILTIN_TOOL_NAMES
 
 ---
 
-## Definition of Done
+## Acceptance criteria
 
 - All of R1–R8 satisfied.
 - `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt --check` clean.

--- a/docs/plans/2026-06-27-004-fix-apply-load-safety-check-coherence-guard-plan.md
+++ b/docs/plans/2026-06-27-004-fix-apply-load-safety-check-coherence-guard-plan.md
@@ -284,13 +284,14 @@ resolvable(token) ⟺ token ∈ BUILTIN_TOOL_NAMES
 
 ## Acceptance criteria
 
-- All of R1–R8 satisfied.
-- `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt --check` clean.
-- `cargo run --bin verify-bundled-skills` still passes (this ticket adds a runtime check; it must not break the build-time one).
-- U4 gate green: all four well-known agents pass the coherence check with zero fires (or any surfaced fire is fixed in this PR and documented).
-- Every `apply_load_safety_check` call site has an adjacent coherence-check call (U2 grep).
-- Documentation merged (and doc-synced if applicable).
-- PR body documents the F1 carried correction (KTD-1) and the AC3 token correction (KTD-4), and `Closes #1576`.
+- [ ] **AC1** — `SkillRegistry::apply_load_safety_check` (or a dedicated sibling method) includes the allowlist↔required_tools coherence rule, running after identity allowlist + DB/transient overrides have been applied. (R1)
+- [ ] **AC2** — On fire: emit an error-level structured log event `required_tool_unresolvable` (fields: `agent_id`, `skill`, `unresolvable_token`, `available_tool_count`) and skip the offending skill (evict from loaded set, agent starts degraded — load-with-warning, **not** refuse-to-start). (R2, R3)
+- [ ] **AC3** — Tests covering: PASS (all tokens resolve), FAIL (genuinely-unresolvable token → skill skipped + event), edge (builtin tokens always resolve with no skill declaration needed). (R4)
+- [ ] **AC4** — `mika skills validate` reports the coherence diagnostic when it would fire. (R5)
+- [ ] **AC5** — Documentation describing the coherence invariant and how it composes with mika#516 / #1326 / #1575. (R6)
+- [ ] **AC6** — "Builtin tool name" = `BUILTIN_TOOL_NAMES ∪ KNOWN_BUILTINS` — the same set mika#1575's check uses. (R7 / F1)
+- [ ] **AC7** — F2 verification gate: before opening the PR, run the coherence check against all well-known agent identity templates (mika-dev, mika-qa, mika-relay, mika-arch) and confirm zero fires. Any fire is fixed in this PR, not deferred. (R8)
+- [ ] **AC8** — `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt --check` clean; `cargo run --bin verify-bundled-skills` still passes; every `apply_load_safety_check` call site has an adjacent coherence-check call; PR body documents the F1 carried correction (KTD-1) and the AC3 token correction (KTD-4), and `Closes #1576`.
 
 ---
 

--- a/docs/solutions/architecture-patterns/asymmetric-perimeter-predicate-drift.md
+++ b/docs/solutions/architecture-patterns/asymmetric-perimeter-predicate-drift.md
@@ -75,6 +75,10 @@ Two predicates encoding "does this task have an active callback child?":
 
 These two perimeters answer overlapping questions and have evolved independently across multiple tickets (mika#525, mika#549, mika#1058). They have not yet drifted into a bug, but the structural shape is the same as #910 and #1163 — two perimeters, separate predicates, no shared function or parity test. Worth tracking as a pre-incident risk.
 
+### 4. mika#1576 — required_tools coherence across N layers (generalization to >2 perimeters)
+
+The same concept ("does this `required_tools` token resolve to a real tool?") is enforced at four layers: build-time `verify_bundled_skills` checks 4/5, the per-turn `#516` gate, and the new load-time `apply_required_tools_coherence_check`. The first review pass copied the surface-builder and the `mcp__` exemption predicate verbatim into both the runtime check and the `mika skills validate` CLI — the same drift seed, caught before merge. Fix: extract `effective_tool_surface` + `required_tool_resolves` (one home for the predicate); reuse the parity-guarded `BUILTIN_TOOL_NAMES` constant. This instance generalizes the two-perimeter pattern to N layers and adds three sub-rules (vantage-dependent severity, fixpoint eviction, coherence-scope ≠ enforcement-scope) — see `docs/solutions/architecture-patterns/multi-layer-structural-invariant-shared-primitive-2026-06-27.md`.
+
 ## The pattern
 
 ```

--- a/docs/solutions/architecture-patterns/multi-layer-structural-invariant-shared-primitive-2026-06-27.md
+++ b/docs/solutions/architecture-patterns/multi-layer-structural-invariant-shared-primitive-2026-06-27.md
@@ -1,0 +1,101 @@
+---
+title: "Multi-layer structural invariants must share one primitive — and the four sub-rules for adding a layer"
+date: 2026-06-27
+category: architecture-patterns
+module: agent-loop
+problem_type: best_practice
+component: skills
+severity: medium
+applies_when:
+  - Adding a new enforcement layer for an invariant already checked elsewhere (build-time, load-time, per-turn)
+  - The invariant is "a config token must resolve to a real X" (a tool name, a skill name, an agent id, an event class)
+  - Two or more checks each compute "what counts as a valid X" independently
+  - A new check evicts/skips items, and one eviction can invalidate another item
+  - A check runs at a different vantage point (whole-disk vs per-agent) than an existing sibling
+tags:
+  - structural-invariant
+  - predicate-sharing
+  - shared-primitive
+  - drift
+  - required_tools
+  - coherence-check
+  - fixpoint
+  - allowlist-aware
+  - mika-1576
+---
+
+# Multi-layer structural invariants must share one primitive
+
+## Context
+
+mika#1576 added a fourth enforcement layer for one invariant: **an agent must not hold a loaded skill that requires a tool it can't call** (`[constraints] required_tools` ↔ the agent's tool surface). The same invariant was already enforced at three other layers:
+
+- **build-time** — `verify_bundled_skills` check 4 (allowlist-unaware) + check 5 (allowlist-aware), mika#1575
+- **per-turn** — the `#516` required-tools gate (keyword-matched skills only)
+- and now **load-time** — `SkillRegistry::apply_required_tools_coherence_check` (allowlist-aware, all loaded skills)
+
+Each layer must answer the sub-question "does token T resolve to a real tool?" — and "real tool" means the same thing (`BUILTIN_TOOL_NAMES ∪ KNOWN_BUILTINS`, plus the `mcp__*` exemption). This is a concrete instance of the [asymmetric-perimeter-predicate-drift](asymmetric-perimeter-predicate-drift.md) pattern (same concept, multiple consumers, diverging sets), generalized from two perimeters to N layers. The first review pass shipped the new layer with the surface-builder and the `mcp__` predicate **copied verbatim** into both the runtime check and the CLI — exactly the drift seed the parent pattern warns about.
+
+## Guidance
+
+When you add the Nth check of an invariant the codebase already enforces, four rules apply. They are independent — a layer can satisfy three and violate the fourth.
+
+### 1. Share the primitive, not the policy
+
+Extract the *definition* of "valid X" into one named function and call it from every layer. Do **not** re-implement it per call site, even when the surrounding policy differs.
+
+```rust
+// crates/mika-agent/src/skills/mod.rs — one home for "what resolves"
+pub fn effective_tool_surface(skills: &[SkillEntry]) -> HashSet<String> { /* builtins ∪ skill tools */ }
+pub fn required_tool_resolves(token: &str, surface: &HashSet<String>) -> bool {
+    token.starts_with("mcp__") || surface.contains(token)   // the mcp__ exemption lives here, once
+}
+```
+
+The runtime check and the `mika skills validate` CLI now call the *same* `required_tool_resolves`; if the exemption grows another prefix, both update together. The builtin set itself (`BUILTIN_TOOL_NAMES`) is already parity-test-guarded (mika#1217 F4) — reuse the guarded constant rather than re-listing names. What differs between layers is **which skills feed the surface** (the policy), and that stays at the call site.
+
+### 2. Severity follows vantage point: hard-fail only where you have full information
+
+The **same finding** warrants different severity at different vantage points:
+
+| Vantage | Information | Disposition |
+|---|---|---|
+| Per-agent runtime (load-time) | Knows the agent's exact loaded skill set (allowlist-aware) | **Hard-skip** the incoherent skill |
+| Whole-disk CLI (`mika skills validate`) | Allowlist-unaware; a provider may be an uninstalled dependency | **Warn only** — never exit-1 |
+
+The CLI emitting `Fail`/exit-1 on a token a dependency would provide at runtime breaks standalone CI (e.g. a community-skill repo whose deps aren't co-installed). Match the severity to what the layer can actually prove. This mirrors `validate_skill` step 5b and check 4, which are also Warn for the allowlist-unaware class.
+
+### 3. Eviction-based checks must reach a fixpoint
+
+If your check *removes* items (skip/evict), removing one item can make a second item newly invalid — a consumer skill whose required tool was provided by a skill you just evicted. A single pass leaves the consumer holding an uncallable tool: precisely the state the check exists to forbid. Loop until a pass changes nothing (the set strictly shrinks, so it terminates):
+
+```rust
+loop {
+    let effective = effective_tool_surface(&self.skills);
+    let to_skip = /* skills with an unresolvable required_tool */;
+    if to_skip.is_empty() { break; }
+    self.skills.retain(|e| !to_skip.contains(&e.name));
+}
+```
+
+### 4. Coherence scope ≠ enforcement scope
+
+"Is this held skill internally consistent?" is a different question from "will this constraint be enforced this turn?". The `#516`/#463 per-turn gate deliberately does **not** enforce `required_tools` on always-on-only (non-keyword-matched) skills — it won't force a tool call (see [conditional-required-tools-enforcement-via-match-reason](conditional-required-tools-enforcement-via-match-reason.md)). The load-time coherence check is deliberately **broader**: it checks *every* loaded skill, because an always-on skill whose prompt presumes an uncallable tool is incoherent regardless of whether the constraint would fire. (The motivating mika#1406 case — Prime's always-on bearing skill — is exactly that shape.) When you reuse an existing scoping rule for a new check, confirm the scope matches the *new* question, not the old one.
+
+## Why This Matters
+
+The four layers exist to make the invariant impossible to violate silently. They only deliver that if they agree. Independent re-implementation (rule 1) makes them silently disagree; wrong severity (rule 2) turns a correct check into a CI outage; a non-fixpoint eviction (rule 3) leaves the exact hole the check advertises closing; borrowing the wrong scope (rule 4) either misses the target case or evicts working skills. Each rule failed silently — every per-layer test still passed. The drift is only visible from the cross-layer seat, which is why it belongs in a learning, not a single test.
+
+## When to Apply
+
+Reach for this checklist whenever you add a structural guard/gate/check for an invariant the codebase already enforces elsewhere — `required_tools`, identity allowlists, dispatch authorization, event-class routing, schema coherence. Before shipping: (1) did you call a shared primitive or copy one? (2) is your severity honest about what your vantage can prove? (3) if you evict, do you re-scan to a fixpoint? (4) does the scope you borrowed answer your check's question?
+
+## Examples
+
+mika#1576 review caught all four in one PR: the surface-build + `mcp__` predicate were duplicated (rule 1 → extracted `effective_tool_surface`/`required_tool_resolves`); the CLI emitted `Fail` (rule 2 → downgraded to `Warn`); the check was single-pass (rule 3 → wrapped in a fixpoint loop with a cascade regression test); and the broad load-time scope vs #463's keyword-only enforcement scope was undocumented (rule 4 → documented as deliberate). The F2 verification gate (`test_well_known_agents_pass_required_tools_coherence`) is the runtime sibling of check 5, asserting all shipped agents pass the new layer clean. See `docs/architecture/bundled-skill-verification.md` for the four-layer composition table.
+
+## Related
+
+- [asymmetric-perimeter-predicate-drift](asymmetric-perimeter-predicate-drift.md) — the parent pattern (two perimeters → N layers here)
+- [intent-guard-predicate-sharing-2026-05-14](intent-guard-predicate-sharing-2026-05-14.md) — predicate-sharing instance in the dispatch-guard family
+- [conditional-required-tools-enforcement-via-match-reason](conditional-required-tools-enforcement-via-match-reason.md) — the #463 keyword-only *enforcement* scope (rule 4's contrast)


### PR DESCRIPTION
## Why

A coherence invariant between two pieces of config — an agent's `identity.toml [skills].allowlist` and a loaded skill's `skill.toml [constraints] required_tools` — was enforced only where one operand is visible at a time. The **silent vacuous-pass** risk: a loaded skill's `required_tools` references a tool (e.g. `run_gh`) that resolves to nothing in the agent's effective surface, so the existing checks pass vacuously and the failure surfaces only mid-work when the agent reaches for the tool. Motivating incident: mika#1406 / PR #1570 — Prime's `github` → `gh-read-only` allowlist swap removes the skill that provides `run_gh` to the agent. Per Mika Prime: *"a silent failure gated on a human remembering a PR-body note is precisely the shape structural enforcement exists for."* Counter: `invariant-enforced-at-dispatch-layer-not-load-layer`.

Groomed by mika-arch (session `f6971f73`, second-pass **GROOMED**, F1 + F2 resolved). Plan: `docs/plans/2026-06-27-003-fix-apply-load-safety-check-coherence-guard-plan.md`.

## What

A runtime **load-time coherence check** (`SkillRegistry::apply_required_tools_coherence_check`) that runs after `apply_identity_allowlist` + `apply_overrides` + `apply_load_safety_check` — the one point where both operands are visible. For each loaded skill, every `required_tools` token must resolve to a builtin (`BUILTIN_TOOL_NAMES ∪ KNOWN_BUILTINS`) or a tool declared by a loaded skill's `tools.json`; `mcp__*` tokens are exempt (resolved by the MCP client). On a fire: skip the skill + emit error-level `required_tool_unresolvable` (`{agent_id, skill, unresolvable_token, available_tool_count}`) — load-with-warning, **not** refuse-to-start. Wired into all four registry-finalize sites (`ask`/`chat`/`server`/`list_skills`). Surfaced in `mika skills validate`. Documented in `docs/architecture/bundled-skill-verification.md` (four-layer composition: #516 per-turn · #1326 AC2 · #1575 build-time · this load-time).

It is the runtime sibling of mika#1575's build-time check 5 and shares the parity-guarded `BUILTIN_TOOL_NAMES` so the layers never disagree.

### Carried corrections (documented, per implementer-contradiction doctrine)
- **F1 builtin definition:** the contract's illustrative `KNOWN_BUILTIN_FUNCTIONS` list was factually wrong vs HEAD. F1 explicitly delegated the exact names to code investigation ("investigate the actual code … same set as #1575 check 4"). Implemented against the real `KNOWN_BUILTINS` (`builtin_handlers.rs`) + `BUILTIN_TOOL_NAMES` (`tools/mod.rs`) — **completes** F1's intent, does not overturn it.
- **AC3 FAIL example:** AC3's literal `required_tools=["run_gh"]` can't fire because `run_gh` is a builtin. Tests use a genuinely-unresolvable token + the realistic allowlist-exclusion shape instead.

## F2 verification gate
`test_well_known_agents_pass_required_tools_coherence` seeds the full bundled library, applies each well-known agent's allowlist, and asserts **zero** coherence fires — confirmed green for mika-dev / mika-qa / mika-relay / mika-arch. `make verify-bundled-skills` (build-time check 5) still passes.

## Review fixes (3 reviewers, no P0/P1)
- Extracted shared `effective_tool_surface` + `required_tool_resolves` (kills DRY/drift between runtime check and CLI).
- Runtime check is a **fixpoint** — evicting a provider can invalidate a consumer; re-scan until stable (closes a cascade false-negative; regression test added).
- CLI diagnostic downgraded **Fail → Warn** (allowlist-unaware disk view must not break standalone community-skill CI; matches `validate_skill` 5b / check-4 severity).
- Documented the deliberate broad load-time scope vs #516/#463's keyword-only enforcement scope.
- Added `mcp__` exemption + cascade + helper tests.

## Testing
`cargo build` / `clippy` / `fmt` clean; new coherence unit tests + F2 gate + CLI tests pass; full `skills::` (868) and `well_known_agents::` (58) suites green; `verify-bundled-skills` green.

Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)