### PR TITLE
fix(agent): thread customer_id from MIKA_CUSTOMER_ID into /send payload (#1607)

### DIFF
--- a/crates/mika-agent/src/messaging.rs
+++ b/crates/mika-agent/src/messaging.rs
@@ -58,9 +58,20 @@ pub struct GatewayMessageSender {
     /// Used by delegated agents whose agent-scoped `customer_config` doesn't
     /// contain the chat_id (it's stored under the orchestrator's agent_id).
     chat_id: Option<i64>,
+    /// Per-customer identifier (from `MIKA_CUSTOMER_ID` → `Settings.customer_id`).
+    /// When `Some`, included in the `/send` payload so the gateway can resolve
+    /// the per-customer bot token in multi-bot mode (#1607). When `None`
+    /// (CLI/dev, single-bot deployments), the field is omitted and the gateway
+    /// falls back to its global single-bot path — no behavioral change.
+    customer_id: Option<String>,
 }
 
 impl GatewayMessageSender {
+    // Constructor threads transport config + routing identity (request_id,
+    // agent_name, chat_id override, customer_id) through positionally. The arg
+    // count is inherent to the sender's responsibilities, not accidental
+    // complexity; a builder would add ceremony without clarifying intent.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         gateway_url: String,
         internal_token: SecretString,
@@ -69,6 +80,7 @@ impl GatewayMessageSender {
         request_id: Option<String>,
         agent_name: Option<String>,
         chat_id: Option<i64>,
+        customer_id: Option<String>,
     ) -> Self {
         Self {
             client,
@@ -78,6 +90,7 @@ impl GatewayMessageSender {
             request_id,
             agent_name,
             chat_id,
+            customer_id,
         }
     }
 
@@ -92,6 +105,27 @@ impl GatewayMessageSender {
                 .parse::<i64>()
                 .map_err(|e| anyhow!("invalid chat_id: {e}")),
         }
+    }
+
+    /// Build the `/send` request payload. In multi-bot gateway mode (`customer_id`
+    /// is `Some`), the `customer_id` field is included so the gateway can resolve
+    /// the per-customer bot token (#1607). In single-bot/CLI mode (`None`), the
+    /// field is omitted — the gateway's `SendPayload.customer_id` defaults to
+    /// `None` and it falls back to its global single-bot path. Extracted from
+    /// `send()` so the payload contract is unit-testable without an HTTP round-trip.
+    fn build_payload(&self, chat_id: i64, text: &str) -> serde_json::Value {
+        let mut payload = serde_json::json!({
+            "chat_id": chat_id,
+            "text": text,
+            "request_id": self.request_id,
+            "agent_name": self.agent_name,
+        });
+
+        if let Some(customer_id) = &self.customer_id {
+            payload["customer_id"] = serde_json::json!(customer_id);
+        }
+
+        payload
     }
 
     async fn try_send(&self, payload: &serde_json::Value) -> Result<()> {
@@ -164,12 +198,7 @@ impl MessageSender for GatewayMessageSender {
             "GatewayMessageSender: sending outbound message"
         );
 
-        let payload = serde_json::json!({
-            "chat_id": chat_id,
-            "text": text,
-            "request_id": self.request_id,
-            "agent_name": self.agent_name,
-        });
+        let payload = self.build_payload(chat_id, text);
 
         // First attempt
         match self.try_send(&payload).await {
@@ -237,6 +266,7 @@ mod tests {
             None,
             Some("delegate-agent".to_string()),
             Some(12345),
+            None,
         );
 
         let chat_id = sender.resolve_chat_id().await.unwrap();
@@ -260,6 +290,7 @@ mod tests {
             None,
             Some("mika".to_string()),
             None,
+            None,
         );
 
         let chat_id = sender.resolve_chat_id().await.unwrap();
@@ -277,6 +308,7 @@ mod tests {
             reqwest::Client::new(),
             None,
             Some("delegate-agent".to_string()),
+            None,
             None,
         );
 
@@ -315,6 +347,7 @@ mod tests {
             None,
             Some("mika".to_string()),
             None,
+            None,
         );
 
         let chat_id = sender.resolve_chat_id().await.unwrap();
@@ -345,6 +378,7 @@ mod tests {
             None,
             Some("mika".to_string()),
             None,
+            None,
         );
 
         let chat_id = sender.resolve_chat_id().await.unwrap();
@@ -366,6 +400,7 @@ mod tests {
             None,
             Some("test-agent".to_string()),
             Some(0), // explicit chat_id override of 0
+            None,
         );
 
         let outcome = sender.send("hello").await.unwrap();
@@ -394,6 +429,7 @@ mod tests {
             None,
             Some("mika".to_string()),
             None, // no explicit override — falls back to DB
+            None,
         );
 
         let outcome = sender.send("hello").await.unwrap();
@@ -424,6 +460,7 @@ mod tests {
             None,
             Some("no-chat-agent".to_string()),
             None, // no explicit override, no DB entry
+            None,
         );
 
         let result = sender.send("hello").await;
@@ -438,6 +475,69 @@ mod tests {
                 .contains("chat_id not configured"),
             "error should mention chat_id not configured"
         );
+    }
+
+    // --- customer_id payload tests (mika#1607) ---
+
+    /// Multi-bot mode: when `customer_id` is `Some`, the `/send` payload includes
+    /// it so the gateway can resolve the per-customer bot token. The fixture uses a
+    /// real UUID string because that is the production wire shape — the gateway's
+    /// `SendPayload.customer_id: Option<Uuid>` deserializes the JSON string back
+    /// into a `Uuid` (see mika-gateway `test_send_payload_with_customer_id`).
+    #[tokio::test]
+    async fn test_send_payload_includes_customer_id() {
+        let customer_uuid = "12345678-1234-1234-1234-123456789abc";
+        let harness = TestHarness::with_agent("customer-agent");
+        let sender = GatewayMessageSender::new(
+            "http://localhost:9999".to_string(),
+            SecretString::from("test-token"),
+            harness.db.clone(),
+            reqwest::Client::new(),
+            None,
+            Some("customer-agent".to_string()),
+            Some(12345),
+            Some(customer_uuid.to_string()),
+        );
+
+        let payload = sender.build_payload(12345, "hello");
+        assert_eq!(
+            payload["customer_id"],
+            serde_json::json!(customer_uuid),
+            "multi-bot payload must carry customer_id"
+        );
+        // The emitted value must parse as a Uuid — the gateway deserializes the
+        // JSON string into Option<Uuid>, so a non-UUID would 400 at the gateway.
+        assert!(
+            uuid::Uuid::parse_str(payload["customer_id"].as_str().unwrap()).is_ok(),
+            "customer_id must be a valid UUID on the wire"
+        );
+        assert_eq!(payload["chat_id"], serde_json::json!(12345));
+        assert_eq!(payload["text"], serde_json::json!("hello"));
+    }
+
+    /// Backward compatibility: when `customer_id` is `None` (single-bot/CLI), the
+    /// payload omits the key entirely — the gateway falls back to single-bot mode.
+    #[tokio::test]
+    async fn test_send_payload_omits_customer_id_when_none() {
+        let harness = TestHarness::with_agent("single-bot-agent");
+        let sender = GatewayMessageSender::new(
+            "http://localhost:9999".to_string(),
+            SecretString::from("test-token"),
+            harness.db.clone(),
+            reqwest::Client::new(),
+            None,
+            Some("single-bot-agent".to_string()),
+            Some(12345),
+            None,
+        );
+
+        let payload = sender.build_payload(12345, "hello");
+        assert!(
+            payload.get("customer_id").is_none(),
+            "single-bot payload must NOT include customer_id key"
+        );
+        assert_eq!(payload["chat_id"], serde_json::json!(12345));
+        assert_eq!(payload["text"], serde_json::json!("hello"));
     }
 
     // --- truncate_for_log tests (mika#1090) ---

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -756,6 +756,7 @@ async fn run_agent_for_message(
         Some(req.request_id.clone()),
         Some(a.db.agent_id().to_string()),
         None,
+        a.settings.customer_id.clone(),
     );
     let sender_arc: Arc<dyn MessageSender> = Arc::new(sender);
 
@@ -1006,6 +1007,7 @@ async fn flush_failed_sends(state: &AppState, agent_state: &AgentState) {
         None,
         Some(agent_state.db.agent_id().to_string()),
         None,
+        agent_state.settings.customer_id.clone(),
     );
 
     for send in sends {

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -434,6 +434,7 @@ async fn init_agent(
         None,
         Some(agent_name.to_string()),
         None,
+        agent_settings.customer_id.clone(),
     );
     let engine_sender: Arc<dyn MessageSender> = Arc::new(engine_sender);
 

--- a/crates/mika-agent/src/tools/delegate_task.rs
+++ b/crates/mika-agent/src/tools/delegate_task.rs
@@ -225,6 +225,7 @@ impl Tool for DelegateTaskTool {
                     None,
                     Some(agent_name.to_string()),
                     chat_id,
+                    self.settings.customer_id.clone(),
                 )))
             } else {
                 tracing::warn!(

--- a/crates/mika-cli/src/init.rs
+++ b/crates/mika-cli/src/init.rs
@@ -268,6 +268,7 @@ pub fn make_message_sender(
         None,
         Some(agent_name.to_string()),
         None,
+        settings.customer_id.clone(),
     );
     Some(Arc::new(sender))
 }

--- a/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
+++ b/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
@@ -1,5 +1,7 @@
 # Plan: Fix per-customer outbound delivery (mika#1607)
 
+**Issue:** mika#1607
+
 ## Problem
 
 Per-customer agents cannot deliver outbound Telegram replies in multi-bot gateway mode. The agent's `GatewayMessageSender` builds the `/send` payload without `customer_id`, so the gateway cannot resolve the per-customer bot token and returns 400.

--- a/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
+++ b/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
@@ -1,0 +1,77 @@
+# Plan: Fix per-customer outbound delivery (mika#1607)
+
+## Problem
+
+Per-customer agents cannot deliver outbound Telegram replies in multi-bot gateway mode. The agent's `GatewayMessageSender` builds the `/send` payload without `customer_id`, so the gateway cannot resolve the per-customer bot token and returns 400.
+
+The gateway already supports `customer_id` in the `SendPayload` (`routes.rs:1173`). The agent already has the value available via `MIKA_CUSTOMER_ID` → `Settings.customer_id: Option<String>`. The code just never threads it through to the outbound payload.
+
+## Fix shape
+
+Agent-side only. Three construction sites for `GatewayMessageSender` need `customer_id` threaded through. Gateway code is untouched.
+
+## Steps
+
+### 1. Add `customer_id` field to `GatewayMessageSender`
+
+**File:** `crates/mika-agent/src/messaging.rs`
+
+- Add `customer_id: Option<String>` field to the `GatewayMessageSender` struct (line 50-61).
+- Add `customer_id: Option<String>` parameter to `GatewayMessageSender::new()` (line 64-82).
+- In `MessageSender::send()` impl (line 167), conditionally include `"customer_id"` in the JSON payload when `self.customer_id` is `Some`. Use `serde_json::json!` conditional inclusion or build the payload with `if let Some(cid) = &self.customer_id { payload["customer_id"] = json!(cid); }`.
+
+### 2. Thread `customer_id` from `Settings` at all construction sites
+
+There are four construction sites for `GatewayMessageSender::new()`:
+
+#### 2a. Engine sender (`server/mod.rs:429`)
+
+Pass `settings.customer_id.clone()` as the new parameter. `settings` (the agent-scoped `Settings`) is already in scope at line 429.
+
+#### 2b. Request handler sender (`server/handlers.rs:751`)
+
+Pass `state.settings.customer_id.clone()` (or `a.settings.customer_id.clone()` — the `AgentState.settings` is the per-agent settings loaded at init). The `AgentState` `a` is resolved at line 726.
+
+#### 2c. Failed-sends flush sender (`server/handlers.rs:1001`)
+
+Same pattern: `state.settings.customer_id.clone()` or `agent_state.settings.customer_id.clone()`.
+
+#### 2d. Delegate task sender (`tools/delegate_task.rs:220`)
+
+Pass `self.settings.customer_id.clone()`. The delegate runs in the same container as the orchestrator, so it shares the same `MIKA_CUSTOMER_ID`. `self.settings` is available (the `DelegateTask` struct holds a `Settings` reference).
+
+### 3. Add test
+
+**File:** `crates/mika-agent/src/messaging.rs` (in `#[cfg(test)] mod tests`)
+
+Add a test `test_send_payload_includes_customer_id` that:
+1. Creates a `GatewayMessageSender` with `customer_id: Some("test-customer-uuid".to_string())`.
+2. Verifies the struct holds the `customer_id` field.
+3. Optionally: use a local HTTP mock (or just verify the payload construction) to assert `customer_id` appears in the outbound JSON.
+
+A simpler approach: extract the payload-building logic into a helper method and test that directly, or add a unit test that checks the `serde_json::json!` payload includes the field.
+
+Also add a test `test_send_payload_omits_customer_id_when_none` confirming backward compatibility — when `customer_id` is `None`, the payload does not include the key.
+
+### 4. Update existing tests
+
+All existing tests in `messaging.rs` construct `GatewayMessageSender::new()` with 7 arguments. Add the 8th argument `None` (no `customer_id`) to each call site to maintain backward compatibility. There are 10 test call sites.
+
+## Backward compatibility
+
+When `customer_id` is `None` (CLI/dev mode, no `MIKA_CUSTOMER_ID` set), the payload omits the field entirely. The gateway's `SendPayload.customer_id` is `Option<Uuid>` with `#[serde(default)]`, so an absent field deserializes to `None` and the gateway falls back to its global single-bot path. No behavioral change for existing single-bot deployments.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/messaging.rs` | Add `customer_id` field, thread through constructor and payload |
+| `crates/mika-agent/src/server/mod.rs` | Pass `customer_id` at engine sender construction |
+| `crates/mika-agent/src/server/handlers.rs` | Pass `customer_id` at request handler and flush sender construction |
+| `crates/mika-agent/src/tools/delegate_task.rs` | Pass `customer_id` at delegate sender construction |
+
+## Acceptance
+
+- Per-customer agent (provisioned with `MIKA_CUSTOMER_ID`) delivers outbound reply through gateway in multi-bot mode — no 400, no `failed_sends` entry.
+- Single-bot mode (no `MIKA_CUSTOMER_ID`) continues to work unchanged.
+- `cargo test -p mika-agent` passes including the new payload tests.

--- a/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
+++ b/docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md
@@ -72,8 +72,8 @@ When `customer_id` is `None` (CLI/dev mode, no `MIKA_CUSTOMER_ID` set), the payl
 | `crates/mika-agent/src/server/handlers.rs` | Pass `customer_id` at request handler and flush sender construction |
 | `crates/mika-agent/src/tools/delegate_task.rs` | Pass `customer_id` at delegate sender construction |
 
-## Acceptance
+## Acceptance criteria
 
-- Per-customer agent (provisioned with `MIKA_CUSTOMER_ID`) delivers outbound reply through gateway in multi-bot mode — no 400, no `failed_sends` entry.
-- Single-bot mode (no `MIKA_CUSTOMER_ID`) continues to work unchanged.
-- `cargo test -p mika-agent` passes including the new payload tests.
+- [ ] Per-customer agent (provisioned with `MIKA_CUSTOMER_ID`) includes `customer_id` in the `/send` payload so the gateway resolves the per-customer bot token in multi-bot mode — no 400, no `failed_sends` entry.
+- [ ] Single-bot mode (no `MIKA_CUSTOMER_ID`) continues to work unchanged — `customer_id` key omitted.
+- [ ] `cargo test -p mika-agent` passes including the new payload tests.

--- a/docs/solutions/best-practices/json-uuid-fields-cross-the-wire-as-strings-2026-06-28.md
+++ b/docs/solutions/best-practices/json-uuid-fields-cross-the-wire-as-strings-2026-06-28.md
@@ -1,0 +1,60 @@
+---
+title: JSON UUID fields cross the wire as strings — Option<String> sender + Option<Uuid> receiver is correct, not a mismatch
+date: 2026-06-28
+category: best-practices
+module: mika-agent
+problem_type: best_practice
+component: messaging
+severity: low
+applies_when:
+  - Reviewing a serde boundary where one side serializes a String and the other deserializes a Uuid (or other newtype with a string Serialize impl)
+  - Threading an identifier from an env var / config String into a JSON payload consumed by a typed receiver
+  - A code review flags a "type mismatch" between producer and consumer of a JSON field
+tags:
+  - serde
+  - uuid
+  - json-contract
+  - code-review
+  - false-positive
+  - gateway
+---
+
+# JSON UUID fields cross the wire as strings
+
+## Context
+
+mika#1607 threaded `customer_id` from `MIKA_CUSTOMER_ID` (`Settings.customer_id: Option<String>`)
+through `GatewayMessageSender` into the gateway `/send` JSON payload. The agent serializes the
+value as a JSON string; the gateway's `SendPayload.customer_id` is `Option<Uuid>`.
+
+A code-review pass flagged this as a **P1 "type mismatch — String vs Uuid causes deserialization
+failure."** It is not. JSON has no native UUID type: a `Uuid` always travels as a string, and
+`serde` with the `uuid` crate's `serde` feature parses a valid UUID string straight back into a
+`Uuid`. The producer emitting a JSON string and the consumer deserializing `Option<Uuid>` is the
+**standard, correct contract** — the same shape already exercised by the gateway's own
+`test_send_payload_with_customer_id` (`crates/mika-gateway/src/routes.rs`), which round-trips
+`{"customer_id": "12345678-..."}` into `Some(Uuid)`.
+
+## Guidance
+
+- Do **not** treat a `String`-serializer / `Uuid`-deserializer pair across a JSON boundary as a
+  type mismatch. Over JSON the wire type is *string* on both sides. Confirm by checking whether the
+  receiver's deserialize already round-trips a string (an existing serde round-trip test is decisive
+  evidence — look for one before escalating).
+- The real, narrower risk is **validity, not type**: if the source `String` is not a well-formed
+  UUID, the typed receiver rejects the whole payload (HTTP 400). Mitigate where the value is most
+  authoritatively known — validate/parse at config load, or rely on the value being a UUID by
+  construction (in mika, `customer_id` is a `Uuid` system-wide: the inbound
+  `/webhook/telegram/{customer_id}` route is already `Path<Uuid>`, and provisioning sets
+  `MIKA_CUSTOMER_ID` to the customer UUID). This is a hardening follow-up, not a blocker for a
+  deployment that provisions real UUIDs.
+- When writing a unit test for the producer side, use a **real UUID** as the fixture value, not a
+  placeholder like `"test-customer-uuid"`. A non-UUID fixture passes the agent-side
+  `build_payload` assertion (which never parses) while misrepresenting the production wire shape and
+  inviting exactly this false-positive review finding. Assert `Uuid::parse_str(...).is_ok()` on the
+  emitted value to lock the wire contract.
+
+## Evidence
+
+- `crates/mika-gateway/src/routes.rs` — `SendPayload.customer_id: Option<Uuid>` with `#[serde(default)]`; `test_send_payload_with_customer_id` round-trips a JSON string into `Some(Uuid)`.
+- `crates/mika-agent/src/messaging.rs` — `GatewayMessageSender::build_payload` includes `customer_id` only when `Some`; `test_send_payload_includes_customer_id` asserts the emitted value parses as a UUID.


### PR DESCRIPTION
## Summary

Per-customer agents could not deliver outbound Telegram replies in **multi-bot gateway mode**: `GatewayMessageSender` built the `/send` payload without `customer_id`, so the gateway could not resolve the per-customer bot token and returned **400**. Family-rollout blocker.

The gateway already supports it — `SendPayload.customer_id: Option<Uuid>` with `#[serde(default)]` (`crates/mika-gateway/src/routes.rs:1163`). The agent side was the only missing link.

## Changes

- Add `customer_id: Option<String>` field + constructor param to `GatewayMessageSender`.
- Thread `settings.customer_id` (sourced from `MIKA_CUSTOMER_ID`) through all **5** construction sites: `server/mod.rs`, `server/handlers.rs` (×2), `tools/delegate_task.rs`, and `mika-cli/init.rs`.
- Extract payload construction into `build_payload()` and include `customer_id` only when `Some`.
- Two unit tests for the include/omit contract (real-UUID fixture; asserts the emitted value parses as a `Uuid`).
- Compound doc: *JSON UUID fields cross the wire as strings* (`docs/solutions/best-practices/`).

## Backward compatibility

When `customer_id` is `None` (CLI/dev, single-bot deployments), the key is **omitted** from the payload. The gateway's `#[serde(default)]` deserializes the absent field to `None` and falls back to its global single-bot path — **no behavioral change** for existing single-bot deployments.

## Acceptance criteria

- [x] Per-customer agent (provisioned with `MIKA_CUSTOMER_ID`) includes `customer_id` in the `/send` payload so the gateway resolves the per-customer bot token in multi-bot mode — no 400, no `failed_sends` entry.
- [x] Single-bot mode (no `MIKA_CUSTOMER_ID`) continues to work unchanged — `customer_id` key omitted.
- [x] `cargo test -p mika-agent` passes including the new payload tests.

## Verification

- `cargo build -p mika-agent -p mika-cli` — clean
- `cargo test -p mika-agent --lib` — 3226 passed (3224 pre-existing + 2 new); `mika-cli` tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

## Review note

A review pass flagged a "P1 String-vs-Uuid type mismatch." Assessed as a **false positive**: JSON has no native UUID type, so a `Uuid` always travels as a string and serde parses valid UUID strings back into `Uuid` — proven by the gateway's existing round-trip test `test_send_payload_with_customer_id` (`routes.rs:1606`). The narrow residual is robustness only (a non-UUID `MIKA_CUSTOMER_ID` would 400); `customer_id` is a `Uuid` by construction system-wide (the inbound `/webhook/telegram/{customer_id}` route is already `Path<Uuid>`), so this is a pre-existing hardening follow-up, not a blocker.

Plan: `docs/plans/2026-06-28-001-fix-per-customer-outbound-delivery-plan.md`

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)