### PR TITLE
fix(engine): auto-fire-after-groom (mika#1289) becomes engine-side deterministic (mika#1614)

### DIFF
--- a/crates/mika-agent/src/task_engine/dispatcher.rs
+++ b/crates/mika-agent/src/task_engine/dispatcher.rs
@@ -25,6 +25,7 @@ use crate::async_db::AsyncDatabase;
 use crate::db::Task;
 use crate::messaging::MessageSender;
 use crate::skills::SkillRegistry;
+use crate::skills::manifest::ToolHandler;
 use crate::tools::ToolRegistry;
 
 use super::types::action_type;
@@ -419,15 +420,20 @@ impl TaskDispatcher {
             // depending on the LLM to fire the transition. Coupled pair with
             // `reap_orphaned_parent_tasks` (failure path).
             try_complete_parent_on_callback_success(&self.db, task).await;
-            // mika#1289: structural counterpart to the prompt-level groom-
-            // success handler in self-dev-callback (PR #1291). When a groom
-            // callback delivers with `Outcome: PLAN_GROOMED`, re-add the
-            // `ready` label so the ready-label webhook handler dispatches
-            // dev-pilot — engine-side, not LLM-mediated, so it fires every
-            // time. Prompt-level path remains as defense-in-depth
-            // (idempotent — re-adding an already-present label is a no-op).
-            try_dispatch_pilot_after_groom_success(&self.db, task, self.github_token.as_deref())
-                .await;
+            // mika#1289 / mika#1614: structural counterpart to the prompt-level
+            // groom-success handler in self-dev-callback (PR #1291). When a groom
+            // callback delivers with `Outcome: PLAN_GROOMED`, the engine spawns the
+            // implement-class dev-pilot dispatch DIRECTLY (mirroring the
+            // ready_label_handler engine-side path, mika#1572) — no `gh` label
+            // round-trip, no LLM-mediated turn, so it fires every time. The
+            // prompt-level path in self-dev-callback remains as defense-in-depth.
+            try_dispatch_pilot_after_groom_success(
+                &self.db,
+                task,
+                self.github_token.as_deref(),
+                &self.skills,
+            )
+            .await;
         }
 
         // Suppress user-facing notifications for team-child callbacks.
@@ -1778,13 +1784,29 @@ fn is_team_child_callback(task: &Task) -> bool {
 ///   - parent task has a parseable `reference_url` of shape
 ///     `https://github.com/<owner>/<repo>/issues/<n>`
 ///
-/// `gh` subprocess uses the resolved GitHub token from `github_token` (already
-/// scrubbed-and-re-injected pattern from `run_gh`). Audit event written under
-/// `tool_name='task_engine_groom_pilot_dispatcher'` for traceability.
+/// Dispatch is **engine-side and direct** (mika#1614): the function resolves the
+/// `run_claude_pilot` tool from the `SkillRegistry`, **reuses the groom parent
+/// task** by flipping its `dispatch_class` groom→implement (mika#996 task-reuse
+/// pattern — NOT a new parent, which would collide with the groom parent on the
+/// `reference_url` unique index while it is still `in_progress`), validates
+/// dispatch readiness, and spawns the claude-pilot subprocess via
+/// `spawn_long_running_exec` — mirroring `ready_label_handler`'s steps 9a–9i
+/// (mika#1572). This replaces the prior `gh issue edit --add-label ready` →
+/// webhook round-trip → LLM-mediated turn chain, which was vulnerable to LLM
+/// fabrication (an "auto-fired dispatch" log line with no actual subprocess
+/// spawn — observed on mika#1609, 2026-06-28).
+///
+/// Fire-and-forget: on ANY precondition failure (tool not in registry, readiness
+/// rejection, handler missing) the function logs a WARN and returns. The
+/// prompt-level path in `self-dev-callback` remains as defense-in-depth.
+///
+/// Audit event written under `tool_name='task_engine_groom_pilot_dispatcher'`
+/// with `after_value='implement_dispatched'` for traceability.
 async fn try_dispatch_pilot_after_groom_success(
     db: &AsyncDatabase,
     task: &Task,
     github_token: Option<&str>,
+    skills: &SkillRegistry,
 ) {
     // 1. Groom-class callbacks only.
     if task.dispatch_class.as_deref() != Some("groom") {
@@ -1792,8 +1814,8 @@ async fn try_dispatch_pilot_after_groom_success(
     }
 
     // 2. Canonical success marker in callback result text.
-    let result = match &task.result {
-        Some(r) if r.contains("Outcome: PLAN_GROOMED") => r,
+    match &task.result {
+        Some(r) if r.contains("Outcome: PLAN_GROOMED") => {}
         _ => return,
     };
 
@@ -1807,94 +1829,234 @@ async fn try_dispatch_pilot_after_groom_success(
         _ => return,
     };
     let reference_url = match parent.reference_url.as_deref() {
-        Some(url) => url,
+        Some(url) => url.to_string(),
         None => return,
     };
-    let (repo, issue_num) = match parse_repo_issue_from_url(reference_url) {
+    let (repo, issue_num) = match parse_repo_issue_from_url(&reference_url) {
         Some(parsed) => parsed,
         None => return,
     };
 
-    // 4. GitHub token required.
-    let token = match github_token {
-        Some(t) if !t.is_empty() => t,
-        _ => {
+    // 4. GitHub token required (the grooming-marker readiness check fetches the
+    //    issue body; without a token it fails-open, but the dispatch is
+    //    meaningless without GitHub access — keep the original precondition).
+    if github_token.is_none_or(str::is_empty) {
+        warn!(
+            groom_parent_task_id = %parent_id,
+            callback_task_id = %task.id,
+            "engine: groom-pilot auto-fire skipped — no GitHub token configured"
+        );
+        return;
+    }
+
+    // 5. Engine-side direct dispatch (mika#1614, mirrors ready_label_handler
+    //    steps 9a–9i / mika#1572). Grooming just succeeded, so the follow-up is
+    //    always the implement-class dev-pilot run.
+    //
+    //    CRITICAL — task REUSE, not a new parent (mika#996 pattern). The groom
+    //    parent is still `in_progress` here (groom callbacks carry no `pr_url`,
+    //    so the earlier `try_complete_parent_on_callback_success` is a no-op for
+    //    them). Creating a *separate* implement parent with the same
+    //    `reference_url` would collide with the partial-unique index
+    //    `idx_tasks_manual_active_ref_url` (active manual tasks, per agent+url) —
+    //    `create_task` would error and the dispatch would silently never fire,
+    //    re-introducing the very bug this fixes. Instead we flip the groom
+    //    parent's `dispatch_class` groom→implement and reuse it as the implement
+    //    parent (one task identity per issue, no leak — it completes normally
+    //    when the pilot delivers a `pr_url`).
+    let system_session = format!("system-{}", parent.agent_id);
+    let trace_id = mika_common::trace::generate_trace_id();
+
+    // 5a. Resolve the dev-pilot dispatch tool from the agent's SkillRegistry.
+    let skill_tool = match skills.resolve_tool_by_name("run_claude_pilot") {
+        Some(t) => t,
+        None => {
             warn!(
                 parent_task_id = %parent_id,
                 callback_task_id = %task.id,
-                "engine: groom-pilot auto-fire skipped — no GitHub token configured"
+                "engine: groom-pilot auto-fire skipped — run_claude_pilot not in \
+                 SkillRegistry (prompt-level path remains as fallback)"
             );
             return;
         }
     };
 
-    // 5. Spawn `gh issue edit <n> --repo senara-solutions/<repo> --add-label ready`.
-    //    Idempotent: re-adding an already-present label is a no-op on GitHub.
-    let mut cmd = tokio::process::Command::new("gh");
-    cmd.args([
-        "issue",
-        "edit",
-        &issue_num.to_string(),
-        "--repo",
-        &format!("senara-solutions/{repo}"),
-        "--add-label",
-        "ready",
-    ]);
-    cmd.env("GH_TOKEN", token);
-    cmd.env("GH_PROMPT_DISABLED", "1");
-
-    match cmd.output().await {
-        Ok(out) if out.status.success() => {
-            info!(
-                parent_task_id = %parent_id,
-                callback_task_id = %task.id,
-                repo = %repo,
-                issue = issue_num,
-                _result_len = result.len(),
-                "engine: auto-fired dev-pilot dispatch after groom success (mika#1289 — re-added ready label)"
-            );
-            let system_session = format!("system-{}", parent.agent_id);
-            let trace_id = mika_common::trace::generate_trace_id();
-            let reason = format!("groom_pilot_dispatch_fired (issue: {repo}#{issue_num})");
-            if let Err(e) = db
-                .log_audit_event(
-                    &system_session,
-                    "task_engine_groom_pilot_dispatcher",
-                    &parent_id,
-                    Some("groom_delivered"),
-                    Some("ready_label_re_added"),
-                    Some(&reason),
-                    Some(&trace_id),
-                )
-                .await
-            {
-                warn!(
-                    parent_task_id = %parent_id,
-                    error = %e,
-                    "engine: failed to write groom-pilot-dispatcher audit event"
-                );
-            }
-        }
-        Ok(out) => {
-            let stderr = String::from_utf8_lossy(&out.stderr);
+    // 5b. Resolve the long-running exec command + estimated duration from the
+    //     tool handler (binds the callback timeout to the same value the LLM
+    //     tool-call path uses; dev-pilot declares estimated_duration_secs).
+    let (command, estimated_duration_secs) = match &skill_tool.handler {
+        ToolHandler::Exec {
+            command,
+            long_running: true,
+            estimated_duration_secs,
+        } => (command.clone(), *estimated_duration_secs),
+        _ => {
             warn!(
                 parent_task_id = %parent_id,
                 callback_task_id = %task.id,
-                repo = %repo,
-                issue = issue_num,
-                exit_code = ?out.status.code(),
-                stderr = %stderr,
-                "engine: groom-pilot auto-fire failed — gh issue edit returned non-zero"
+                "engine: groom-pilot auto-fire skipped — run_claude_pilot is not a \
+                 long-running exec handler"
             );
+            return;
+        }
+    };
+
+    // 5c. Flip the groom parent's dispatch_class groom→implement BEFORE the
+    //     readiness check, so the per-class slot guard (#1001) scopes to the
+    //     `implement` slot (not the now-vacated `groom` slot). On failure, abort
+    //     before any dispatch state is created.
+    match db.update_task_dispatch_class(&parent_id, "implement").await {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(
+                parent_task_id = %parent_id,
+                "engine: groom-pilot auto-fire skipped — groom parent not found for \
+                 dispatch_class flip"
+            );
+            return;
         }
         Err(e) => {
             warn!(
                 parent_task_id = %parent_id,
-                callback_task_id = %task.id,
                 error = %e,
-                "engine: groom-pilot auto-fire failed — could not spawn gh subprocess"
+                "engine: groom-pilot auto-fire failed — could not flip dispatch_class"
             );
+            return;
         }
+    }
+
+    // 5d. The dispatch input the LLM would have provided. `prompt` is the bare
+    //     `<repo>#<num>` reference (dispatch-lib's worktree-setup parser requires
+    //     the bare form, mika#1593). `task_id` is the reused (now implement)
+    //     parent.
+    let dispatch_input = serde_json::json!({
+        "skill": "dev-pilot",
+        "prompt": format!("{repo}#{issue_num}"),
+        "task_id": parent_id,
+    });
+
+    // 5e. Re-use the dispatch-readiness gate (slot availability, grooming
+    //     markers, blockedBy). `originating_message = None` — this is an engine
+    //     callback, not a webhook fallthrough event, so guard (0) is a no-op. On
+    //     rejection (e.g. slot occupied), the rejection JSON is written to the
+    //     task's `result` by `validate_dispatch_readiness` itself (operator-
+    //     visible); the prompt-level path remains as defense-in-depth.
+    if let Err(rejection) = crate::skills::executor::validate_dispatch_readiness(
+        db,
+        &parent_id,
+        github_token,
+        Some(&dispatch_input),
+        None,
+    )
+    .await
+    {
+        warn!(
+            parent_task_id = %parent_id,
+            rejection = %rejection,
+            "engine: groom-pilot auto-fire skipped — dispatch readiness check failed"
+        );
+        return;
+    }
+
+    // 5f. Create the callback child task (same shape + timeout as the LLM
+    //     tool-call path via the shared `build_callback_task` helper).
+    let timeout_secs = (estimated_duration_secs.unwrap_or(3600) * 3).clamp(600, 7_776_000);
+    let callback_task = crate::skills::executor::build_callback_task(
+        parent.agent_id.clone(),
+        Some(parent_id.clone()),
+        "run_claude_pilot",
+        &dispatch_input,
+        timeout_secs,
+        &system_session,
+        &trace_id,
+    );
+    let callback_task_id = match db.create_task(callback_task).await {
+        Ok(id) => id,
+        Err(e) => {
+            warn!(
+                parent_task_id = %parent_id,
+                error = %e,
+                "engine: groom-pilot auto-fire failed — could not create callback child"
+            );
+            return;
+        }
+    };
+
+    // 5g. Verify the handler script exists before committing to the spawn. If
+    //     missing, mark the callback child failed so it does not dangle.
+    let cmd_path = skill_tool.skill_dir.join(&command);
+    if !cmd_path.exists() {
+        warn!(
+            parent_task_id = %parent_id,
+            callback_task_id = %callback_task_id,
+            cmd_path = %cmd_path.display(),
+            "engine: groom-pilot auto-fire failed — dispatch handler script not found"
+        );
+        let _ = db
+            .update_task_failed(
+                &callback_task_id,
+                &format!("handler not found: {}", cmd_path.display()),
+            )
+            .await;
+        return;
+    }
+
+    // 5h. The reused parent is already `in_progress` (it was the groom parent),
+    //     so no status transition is needed — execute_long_running's #525
+    //     pending→in_progress transition does not apply to task reuse.
+
+    // 5i. Inject subprocess metadata, mirroring execute_long_running:
+    //     `__mika_task_id` is the callback child (delivery target), `__mika_agent`
+    //     is this agent.
+    let mut enriched_input = dispatch_input.clone();
+    if let serde_json::Value::Object(ref mut map) = enriched_input {
+        map.insert(
+            "__mika_task_id".to_string(),
+            serde_json::Value::String(callback_task_id.clone()),
+        );
+        map.insert(
+            "__mika_agent".to_string(),
+            serde_json::Value::String(parent.agent_id.clone()),
+        );
+    }
+
+    // 5j. Spawn the detached subprocess. No webhook round-trip, no LLM turn.
+    crate::skills::executor::spawn_long_running_exec(
+        cmd_path,
+        skill_tool.skill_dir.clone(),
+        enriched_input,
+        callback_task_id.clone(),
+        db.clone(),
+        github_token.map(|s| s.to_string()),
+    );
+
+    info!(
+        parent_task_id = %parent_id,
+        callback_task_id = %callback_task_id,
+        repo = %repo,
+        issue = issue_num,
+        "engine: auto-fired dev-pilot dispatch after groom success \
+         (mika#1614 — engine-side direct spawn, task reuse, no webhook round-trip)"
+    );
+
+    let reason = format!("groom_pilot_dispatch_fired (issue: {repo}#{issue_num})");
+    if let Err(e) = db
+        .log_audit_event(
+            &system_session,
+            "task_engine_groom_pilot_dispatcher",
+            &parent_id,
+            Some("groom_delivered"),
+            Some("implement_dispatched"),
+            Some(&reason),
+            Some(&trace_id),
+        )
+        .await
+    {
+        warn!(
+            parent_task_id = %parent_id,
+            error = %e,
+            "engine: failed to write groom-pilot-dispatcher audit event"
+        );
     }
 }
 
@@ -3654,5 +3816,306 @@ mod tests {
             parent.status, "in_progress",
             "non-self_dev parent must not be auto-completed"
         );
+    }
+
+    // ---- mika#1614: engine-side auto-fire-after-groom ----
+
+    /// Create a groom-class parent + groom-class callback child. The callback's
+    /// result text controls whether `Outcome: PLAN_GROOMED` is present; the
+    /// parent carries the GitHub issue reference_url.
+    async fn create_groom_callback_pair(
+        db: &AsyncDatabase,
+        plan_groomed: bool,
+        reference_url: Option<&str>,
+    ) -> (String, String) {
+        let parent = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "ready-label: senara-solutions/mika#1614".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: reference_url.map(|s| s.to_string()),
+            source: Some("self_dev".to_string()),
+            metadata: None,
+            r#type: Some("issue".to_string()),
+            dispatch_class: Some("groom".to_string()),
+        };
+        let parent_id = db.create_task(parent).await.unwrap();
+        db.update_task_status(&parent_id, "in_progress")
+            .await
+            .unwrap();
+
+        let callback = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.clone()),
+            depth: 1,
+            label: "long_running:run_claude_pilot_groom".to_string(),
+            trigger_type: "callback".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "resume_agent".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: Some("groom".to_string()),
+        };
+        let callback_id = db.create_task(callback).await.unwrap();
+        let body = if plan_groomed {
+            "claude-pilot completed (status: done).\nOutcome: PLAN_GROOMED\nSession: sess-1614"
+        } else {
+            "claude-pilot completed (status: done).\nOutcome: PLAN_ITERATE\nSession: sess-1614"
+        };
+        db.update_task_completed(&callback_id, Some(body))
+            .await
+            .unwrap();
+        (parent_id, callback_id)
+    }
+
+    /// Read the current dispatch_class of a task (None → "<none>").
+    async fn dispatch_class_of(db: &AsyncDatabase, task_id: &str) -> String {
+        db.get_task_unscoped(task_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .dispatch_class
+            .unwrap_or_else(|| "<none>".to_string())
+    }
+
+    /// Count active (non-terminal) manual tasks with the given reference_url —
+    /// the population the `idx_tasks_manual_active_ref_url` unique index covers.
+    async fn count_active_manual_with_ref(db: &AsyncDatabase, reference_url: &str) -> usize {
+        db.list_manual_tasks(None, None, true)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|(t, _)| {
+                t.reference_url.as_deref() == Some(reference_url)
+                    && !matches!(
+                        t.status.as_str(),
+                        "completed" | "cancelled" | "failed" | "delivered"
+                    )
+            })
+            .count()
+    }
+
+    const TEST_ISSUE_URL: &str = "https://github.com/senara-solutions/mika/issues/1614";
+
+    #[tokio::test]
+    async fn test_auto_fire_skips_non_groom_class() {
+        let db = test_db();
+        let (parent_id, callback_id) =
+            create_groom_callback_pair(&db, true, Some(TEST_ISSUE_URL)).await;
+        // Flip the callback to implement-class → precondition 1 returns early.
+        db.update_task_dispatch_class(&callback_id, "implement")
+            .await
+            .unwrap();
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+
+        try_dispatch_pilot_after_groom_success(
+            &db,
+            &task,
+            Some("ghp_token"),
+            &crate::skills::SkillRegistry::empty(),
+        )
+        .await;
+
+        assert_eq!(
+            dispatch_class_of(&db, &parent_id).await,
+            "groom",
+            "non-groom callback must not flip the parent's dispatch_class"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_fire_skips_without_plan_groomed_marker() {
+        let db = test_db();
+        let (parent_id, callback_id) =
+            create_groom_callback_pair(&db, false, Some(TEST_ISSUE_URL)).await;
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+
+        try_dispatch_pilot_after_groom_success(
+            &db,
+            &task,
+            Some("ghp_token"),
+            &crate::skills::SkillRegistry::empty(),
+        )
+        .await;
+
+        assert_eq!(
+            dispatch_class_of(&db, &parent_id).await,
+            "groom",
+            "groom callback without PLAN_GROOMED must not dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_fire_skips_without_github_token() {
+        let db = test_db();
+        let (parent_id, callback_id) =
+            create_groom_callback_pair(&db, true, Some(TEST_ISSUE_URL)).await;
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+
+        // No token → precondition 4 returns before any dispatch state changes.
+        try_dispatch_pilot_after_groom_success(
+            &db,
+            &task,
+            None,
+            &crate::skills::SkillRegistry::empty(),
+        )
+        .await;
+
+        assert_eq!(
+            dispatch_class_of(&db, &parent_id).await,
+            "groom",
+            "no github token must short-circuit before the dispatch_class flip"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_fire_skips_when_tool_not_in_registry() {
+        let db = test_db();
+        let (parent_id, callback_id) =
+            create_groom_callback_pair(&db, true, Some(TEST_ISSUE_URL)).await;
+        let task = db.get_task_unscoped(&callback_id).await.unwrap().unwrap();
+
+        // Token + PLAN_GROOMED present, but empty registry has no run_claude_pilot
+        // tool → step 5a returns BEFORE the dispatch_class flip (5c).
+        try_dispatch_pilot_after_groom_success(
+            &db,
+            &task,
+            Some("ghp_token"),
+            &crate::skills::SkillRegistry::empty(),
+        )
+        .await;
+
+        assert_eq!(
+            dispatch_class_of(&db, &parent_id).await,
+            "groom",
+            "missing run_claude_pilot tool must not flip the parent before bailing"
+        );
+    }
+
+    /// Regression guard for the mika#1614 design decision: the engine MUST reuse
+    /// the groom parent (flip its dispatch_class), NOT create a new implement
+    /// parent. A new parent would reuse the groom parent's reference_url while the
+    /// groom parent is still `in_progress`, colliding with the partial-unique
+    /// index `idx_tasks_manual_active_ref_url` — `create_task` errors and the
+    /// dispatch silently never fires. This test pins that collision so a future
+    /// refactor back to "new parent" fails loudly here.
+    #[tokio::test]
+    async fn test_new_parent_would_collide_on_active_groom_ref_url() {
+        let db = test_db();
+        let (_groom_parent, _cb) =
+            create_groom_callback_pair(&db, true, Some(TEST_ISSUE_URL)).await;
+
+        // Simulate the rejected "new parent" approach: a second active manual
+        // task with the SAME reference_url while the groom parent is in_progress.
+        let dup = NewTask {
+            agent_id: "mika".to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "auto-fire: mika#1614".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: Some(TEST_ISSUE_URL.to_string()),
+            source: Some("self_dev".to_string()),
+            metadata: None,
+            r#type: Some("issue".to_string()),
+            dispatch_class: Some("implement".to_string()),
+        };
+        let res = db.create_task(dup).await;
+        assert!(
+            res.is_err(),
+            "EXPECTED COLLISION on idx_tasks_manual_active_ref_url — a new implement \
+             parent cannot coexist with the active groom parent; the engine must REUSE \
+             the groom parent instead. got Ok({res:?})"
+        );
+    }
+
+    /// The chosen fix mechanism: flipping the groom parent's dispatch_class
+    /// groom→implement succeeds in-place, keeps a single active task on the issue
+    /// URL (no collision, no leak), and the reused parent accepts an
+    /// implement-class callback child.
+    #[tokio::test]
+    async fn test_reuse_flips_groom_parent_in_place_without_collision() {
+        let db = test_db();
+        let (parent_id, _cb) = create_groom_callback_pair(&db, true, Some(TEST_ISSUE_URL)).await;
+
+        // Exactly one active manual task on the issue URL before the flip.
+        assert_eq!(count_active_manual_with_ref(&db, TEST_ISSUE_URL).await, 1);
+
+        let flipped = db
+            .update_task_dispatch_class(&parent_id, "implement")
+            .await
+            .unwrap();
+        assert!(flipped, "flip must report the row was updated");
+        assert_eq!(
+            dispatch_class_of(&db, &parent_id).await,
+            "implement",
+            "groom parent is reused as the implement parent"
+        );
+        // Still exactly one active manual task — reuse, not duplication.
+        assert_eq!(
+            count_active_manual_with_ref(&db, TEST_ISSUE_URL).await,
+            1,
+            "reuse must not create a second active task on the same reference_url"
+        );
+
+        // The reused parent accepts an implement callback child (the dispatch
+        // slot the engine then validates + spawns against).
+        let dispatch_input = serde_json::json!({
+            "skill": "dev-pilot",
+            "prompt": "mika#1614",
+            "task_id": parent_id,
+        });
+        let callback = crate::skills::executor::build_callback_task(
+            "mika".to_string(),
+            Some(parent_id.clone()),
+            "run_claude_pilot",
+            &dispatch_input,
+            7200,
+            "system-mika",
+            "trace-xyz",
+        );
+        let cb_id = db
+            .create_task(callback)
+            .await
+            .expect("implement callback child must be creatable on the reused parent");
+        let cb = db.get_task_unscoped(&cb_id).await.unwrap().unwrap();
+        assert_eq!(cb.dispatch_class.as_deref(), Some("implement"));
+        assert_eq!(cb.parent_task_id.as_deref(), Some(parent_id.as_str()));
     }
 }

--- a/docs/plans/2026-06-28-003-fix-engine-auto-fire-after-groom-plan.md
+++ b/docs/plans/2026-06-28-003-fix-engine-auto-fire-after-groom-plan.md
@@ -1,0 +1,143 @@
+# Plan: fix(engine): auto-fire-after-groom deterministic dispatch (mika#1614)
+
+## Problem
+
+`try_dispatch_pilot_after_groom_success()` (dispatcher.rs:1784) fires after a groom callback delivers with `Outcome: PLAN_GROOMED`. Its current mechanism is **indirect**: it runs `gh issue edit --add-label ready` to re-add the `ready` label, then relies on:
+
+1. GitHub webhook round-trip back to the server
+2. `try_handle_ready_label_dispatch()` intercepting the webhook
+3. That handler spawning the dev-pilot subprocess
+
+This indirection is vulnerable to **fabrication**: the LLM in the silent callback turn can emit a log line claiming dispatch fired without the `gh issue edit` tool ever running. Observed on mika#1609 (2026-06-28 at 11:57:09Z) — the engine logged "auto-fired dev-pilot dispatch" but no claude-pilot task was created. Recovery required manual ready-label re-toggle.
+
+## Root cause
+
+The `gh issue edit --add-label ready` command runs from within the engine's `try_dispatch_pilot_after_groom_success()` function, which is correct (engine-side, not LLM-mediated). However, the actual dev-pilot subprocess spawn depends on the GitHub webhook round-trip completing successfully and the server receiving it. The observed failure mode on mika#1609 suggests either the `gh` subprocess failed silently, the webhook was lost/delayed, or the label was already present (GitHub doesn't re-fire a webhook for a no-op label add).
+
+## Proposed fix
+
+Replace the indirect `gh issue edit --add-label ready` → webhook round-trip → `ready_label_handler` chain with a **direct engine-side subprocess spawn** — the same `spawn_long_running_exec("run_claude_pilot", ...)` path that `ready_label_handler` step 9 (lines 235–432) already uses for the initial dispatch.
+
+The auto-fire function becomes a self-contained dispatcher: it creates the parent task, the callback child task, and spawns the subprocess — all within the same synchronous engine call. No GitHub API call, no webhook dependency, no round-trip.
+
+## Scope
+
+### In scope
+
+- Rewrite `try_dispatch_pilot_after_groom_success()` to spawn dev-pilot directly
+- Expand function signature to accept `skills: &SkillRegistry` (already on `TaskDispatcher`)
+- Add dispatch-readiness validation (reuse `validate_dispatch_readiness`)
+- Add audit events for the direct dispatch path
+
+### Out of scope
+
+- `ready_label_handler` itself (already deterministic per mika#1572)
+- The LLM-mediated prompt-level path in `self-dev-callback` (defense-in-depth, unchanged)
+- Deferred dispatch registration (if slot is occupied, the direct spawn should fail gracefully and the existing prompt-level path or next heartbeat picks it up)
+
+## Implementation
+
+### Step 1: Expand `try_dispatch_pilot_after_groom_success` signature
+
+**File:** `crates/mika-agent/src/task_engine/dispatcher.rs`
+
+Add `skills: &SkillRegistry` parameter to the function signature. The caller at line 429 already has access to `self.skills` on `TaskDispatcher`.
+
+### Step 2: Rewrite function body — direct subprocess spawn
+
+Replace the `gh issue edit --add-label ready` mechanism (lines 1831–1898) with a direct dispatch path mirroring `ready_label_handler` steps 9a–9i:
+
+1. **Keep existing preconditions** (lines 1790–1829): dispatch_class == "groom", result contains "Outcome: PLAN_GROOMED", parent has parseable reference_url, GitHub token present. These remain the trigger gate.
+
+2. **Resolve dispatch target** (new): Since we know grooming succeeded, the target is always `("run_claude_pilot", "dev-pilot", "implement")` — the implement-class dispatch. No need to re-check grooming state.
+
+3. **Resolve tool from SkillRegistry** (mirror 9a): `skills.resolve_tool_by_name("run_claude_pilot")`. On failure, log WARN and return (fire-and-forget — the prompt-level path remains as defense-in-depth).
+
+4. **Extract command + estimated_duration** (mirror 9b): Match `ToolHandler::Exec { long_running: true, .. }`. On mismatch, log WARN and return.
+
+5. **Build dispatch input** (mirror 9c):
+   ```rust
+   let dispatch_input = serde_json::json!({
+       "skill": "dev-pilot",
+       "prompt": format!("{}#{}", repo, issue_num),
+       "task_id": parent_task_id,  // reuse the existing parent task
+   });
+   ```
+
+6. **Create implement-class parent task** (new): Create a new `NewTask` with `dispatch_class: Some("implement")`, `trigger_type: "manual"`, `source: Some("self_dev")`, `reference_url` from the parent's reference_url. This is a new parent task for the implement dispatch (the groom parent task is already completed/completing). Use label format: `"auto-fire: {repo}#{issue_num}"`.
+
+7. **Validate dispatch readiness** (mirror 9d): Call `validate_dispatch_readiness()` with the new parent task ID. On rejection, log WARN and return. This catches slot contention, active callbacks, and blockedBy issues. The grooming-marker check (#919) will pass because the groom just completed successfully.
+
+8. **Create callback child task** (mirror 9e): Use `build_callback_task()` with `tool_name = "run_claude_pilot"`, `parent_task_id = new_parent_id`. Timeout from estimated_duration_secs.
+
+9. **Verify handler script exists** (mirror 9f): Check `cmd_path.exists()`. On failure, mark callback failed and return.
+
+10. **Auto-transition parent to in_progress** (mirror 9g).
+
+11. **Inject subprocess metadata** (mirror 9h): `__mika_task_id`, `__mika_agent`.
+
+12. **Spawn subprocess** (mirror 9i): `spawn_long_running_exec(...)`.
+
+13. **Audit event**: Write `tool_name = "task_engine_groom_pilot_dispatcher"` with `before_value = "groom_delivered"`, `after_value = "implement_dispatched"` (distinguish from the old `ready_label_re_added`).
+
+### Step 3: Update caller
+
+**File:** `crates/mika-agent/src/task_engine/dispatcher.rs`
+
+Update the call site at line 429 to pass `&self.skills`:
+
+```rust
+try_dispatch_pilot_after_groom_success(
+    &self.db,
+    task,
+    self.github_token.as_deref(),
+    &self.skills,  // new
+).await;
+```
+
+### Step 4: Handle task reuse vs. new task creation
+
+The groom callback's parent task has `dispatch_class: Some("groom")`. For the implement dispatch, we need a new parent task with `dispatch_class: Some("implement")`. This matches the existing pattern where `ready_label_handler` creates a fresh parent task for each dispatch.
+
+Key detail: use the same `reference_url` from the groom parent so the grooming-marker check (#919) in `validate_dispatch_readiness` can fetch the issue body and verify the Plan callout is present.
+
+### Step 5: Add/update tests
+
+**File:** `crates/mika-agent/src/task_engine/dispatcher.rs` (inline `#[cfg(test)]` module)
+
+1. **Test: auto-fire creates implement-class parent + callback and would spawn subprocess** — mock the SkillRegistry to return a dev-pilot tool, verify task creation with correct dispatch_class.
+
+2. **Test: auto-fire skips when dispatch slot is occupied** — verify WARN log and graceful return when `validate_dispatch_readiness` rejects.
+
+3. **Test: auto-fire skips for non-groom callbacks** — existing test coverage, verify it still passes.
+
+4. **Test: auto-fire skips when result doesn't contain PLAN_GROOMED** — existing test coverage.
+
+5. **Remove or update existing test that verifies `gh issue edit --add-label ready`** — the old mechanism is replaced.
+
+## Signal verification
+
+After deploy, verify with:
+
+```bash
+# New signal: direct dispatch after groom success
+grep "engine: auto-fired dev-pilot dispatch after groom success" server.log | jq 'select(.after_value == "implement_dispatched")'
+
+# Confirm no webhook round-trip needed
+grep "ready_label_engine_dispatched" server.log  # Should NOT appear for auto-fire cases (only for webhook-triggered dispatches)
+```
+
+## Risk assessment
+
+- **Low risk**: The `ready_label_handler` dispatch path (steps 9a–9i) is battle-tested — this change mirrors it exactly.
+- **Defense-in-depth preserved**: The prompt-level `self-dev-callback` path still runs and can re-add the ready label as a fallback. The `ready_label_handler` still handles manual ready-label additions.
+- **Rollback**: If the direct spawn has issues, the old `gh issue edit --add-label ready` mechanism can be restored by reverting this change. The webhook path will continue to work.
+
+## Acceptance criteria
+
+1. After a successful groom callback (`Outcome: PLAN_GROOMED`), the engine spawns `run_claude_pilot` directly — no `gh issue edit` call, no webhook round-trip
+2. The spawned subprocess creates a real claude-pilot task (verifiable via `list_tasks` or dashboard)
+3. Dispatch-readiness checks (slot availability, grooming markers, blockedBy) are respected
+4. When the dispatch slot is occupied, the auto-fire logs a WARN and returns gracefully (deferred dispatch or prompt-level path picks it up)
+5. Existing tests pass; new tests cover the direct dispatch path
+6. `cargo clippy` and `cargo test` pass


### PR DESCRIPTION
## Summary

When a dev-groom callback delivers `Outcome: PLAN_GROOMED`, the engine now spawns the implement-class dev-pilot dispatch **directly** (engine-side `spawn_long_running_exec`), instead of re-adding the `ready` label and relying on a GitHub webhook round-trip + an LLM-mediated turn to call `run_claude_pilot`.

The old path was vulnerable to LLM fabrication: the silent callback turn could emit an "auto-fired dispatch" log line without the tool ever running — no claude-pilot task, no worktree, no PR. Observed on mika#1609 (2026-06-28 11:57:09Z): engine logged the dispatch but no task materialized; recovery required a manual `ready`-label re-toggle. Same shape stalled #1612/#1613/#1614 tonight. This mirrors the deterministic engine-side dispatch `ready_label_handler` already uses (mika#1572).

Closes #1614

## Changes

- `crates/mika-agent/src/task_engine/dispatcher.rs` — rewrote `try_dispatch_pilot_after_groom_success`:
  - Resolve `run_claude_pilot` from the `SkillRegistry`; extract the long-running exec command + estimated duration.
  - **Reuse the groom parent task** by flipping its `dispatch_class` groom→implement (the mika#996 task-reuse pattern), then validate dispatch readiness, create the callback child, and spawn the subprocess — all engine-side, no webhook, no LLM turn.
  - Audit `after_value` moves from `ready_label_re_added` → `implement_dispatched`.
  - Function signature gains `skills: &SkillRegistry`; caller passes `&self.skills`.

## ⚠️ Divergence from the groomed plan (architect attention)

The plan (`docs/plans/2026-06-28-003-...`, architect-pending) specified creating a **new** implement-class parent task. That approach is **not viable** and I corrected it to **task reuse**. Reason, with hard evidence:

- A new implement parent reuses the groom parent's `reference_url`. At this point in the callback path the groom parent is still `in_progress` — groom callbacks carry no `pr_url`, so the earlier `try_complete_parent_on_callback_success` is a no-op for them.
- The partial-unique index `idx_tasks_manual_active_ref_url` (active manual tasks, per `agent_id + reference_url`) then rejects the insert. `create_task` is a plain `INSERT` (no `ON CONFLICT`) → returns `Err` → dispatch silently never fires, **re-introducing the exact bug #1614 fixes**.
- It would also leak the groom parent (reaped to `failed` after 600s while a duplicate implement parent shows `completed` for the same issue).

This is pinned by a regression test (`test_new_parent_would_collide_on_active_groom_ref_url`). The reuse approach keeps one task identity per issue (the loop's existing contract), no collision, no leak. The plan's *intent* — engine-side deterministic implement dispatch after groom — is preserved; only the task-lifecycle mechanism changed.

## Acceptance criteria (from #1614)

- [x] After a successful groom callback, the engine spawns `run_claude_pilot` directly — no `gh issue edit`, no webhook round-trip.
- [x] Dispatch-readiness checks (slot availability, grooming markers, blockedBy) are respected (reused `validate_dispatch_readiness`).
- [x] On slot-occupied / precondition failure, logs a WARN and returns gracefully; rejection JSON is written to the task `result` by the readiness gate (operator-visible). Prompt-level path remains as defense-in-depth.
- [x] Existing tests pass; new tests added.

## Verification

- `cargo build --bin mika-spirit` — clean
- `cargo test -p mika-agent --lib task_engine::` — 90 passed
- `cargo clippy -p mika-agent --all-targets -- -D warnings` — clean
- `cargo fmt -p mika-agent -- --check` — clean

New tests (`dispatcher::tests`):
- 4 precondition skip-path tests (non-groom class / missing `PLAN_GROOMED` / no token / tool not in registry) assert the groom parent is **not** flipped when the function bails.
- `test_new_parent_would_collide_on_active_groom_ref_url` — regression guard for the design decision (collision proof).
- `test_reuse_flips_groom_parent_in_place_without_collision` — the chosen mechanism: flip succeeds in place, one active task on the issue URL, reused parent accepts an implement callback child.

The full 5c→5j subprocess-spawn body is not unit-tested in isolation (it requires a live `gh` + handler script), matching `ready_label_handler`'s test philosophy; runtime validation is via the post-deploy `implement_dispatched` audit signal.

## Out of scope

- `ready_label_handler` (already deterministic, mika#1572).
- The defense-in-depth prompt-level path in `self-dev-callback` (unchanged).