### PR TITLE
fix: Plan: fix(verdict-handler): block[ac]/block[ci] verdicts don't re-dispatch when slot frees (mika#1630)

### DIFF
--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -778,6 +778,7 @@ async fn run_agent_for_message(
             Some(&sender_arc),
             &session_id,
             &req.request_id,
+            &skills,
         )
         .await;
         match action {
@@ -790,8 +791,10 @@ async fn run_agent_for_message(
                 req.text = format!("{e}{}", req.text);
             }
             VerdictAction::Passthrough { enrichment: None } => {}
-            // Only the ready-label handler returns Dispatched (mika#1572).
-            VerdictAction::Dispatched { .. } => {}
+            // Engine-side dispatch fired (mika#1572 ready-label, mika#1630 verdict).
+            VerdictAction::Dispatched { pre_digest, .. } => {
+                req.text = pre_digest;
+            }
         }
 
         // Structural CI success handler: intercept check_suite.completed(success)

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -3879,6 +3879,147 @@ mod tests {
         assert!(!has_pending_deferred_child(&db, &parent_id).await);
     }
 
+    /// AC1 + AC4: When a block[ac] verdict arrives and the global dispatch slot
+    /// is busy (another active callback occupies it), the handler calls
+    /// `register_deferred_callback` which creates a deferred child task, and
+    /// emits the `verdict_redispatch_deferred` audit event.
+    #[tokio::test]
+    async fn block_ac_registers_deferred_when_slot_busy() {
+        use crate::skills::index::{ResolvedSkillTool, SkillEntry};
+        use crate::skills::manifest::ToolHandler;
+        use mika_common::claude::ToolDefinition;
+
+        let db = cb_test_db().await;
+
+        // 1. Create the task that will receive the block[ac] verdict.
+        let pr_url = "https://github.com/senara-solutions/mika/pull/1630";
+        let task_id = create_task_with_pr_url(&db, pr_url, "in_progress").await;
+
+        // 2. Create a DIFFERENT task with an active (non-deferred) callback child
+        //    to occupy the global implement dispatch slot.
+        let blocker_pr = "https://github.com/senara-solutions/mika/pull/9999";
+        let blocker_id = create_task_with_pr_url(&db, blocker_pr, "in_progress").await;
+        create_callback_child(
+            &db,
+            &blocker_id,
+            "long_running:run_claude_pilot",
+            "in_progress",
+        )
+        .await;
+
+        // 3. Build a SkillRegistry with a resolvable `run_claude_pilot` tool so
+        //    the handler reaches `validate_dispatch_readiness` instead of falling
+        //    back immediately.
+        let tmp = tempfile::tempdir().unwrap();
+        let handler_path = tmp.path().join("run.sh");
+        std::fs::write(&handler_path, "#!/bin/sh\nexit 0").unwrap();
+
+        let mut dev_pilot = {
+            use crate::skills::manifest::{SkillInfo, SkillManifest, Triggers};
+            SkillEntry {
+                manifest: SkillManifest {
+                    skill: SkillInfo {
+                        name: "dev-pilot".to_string(),
+                        description: "dev-pilot skill".to_string(),
+                        version: String::new(),
+                        always_on: false,
+                        timeout_secs: 30,
+                        dependencies: vec![],
+                        max_prompt_size: None,
+                    },
+                    triggers: Triggers { keywords: vec![] },
+                    llm: Default::default(),
+                    constraints: Default::default(),
+                    output: Default::default(),
+                    context: std::collections::HashMap::new(),
+                    variants: Default::default(),
+                },
+                dir: tmp.path().to_path_buf(),
+                keywords_lower: vec![],
+                prompt_snippet: String::new(),
+                skill_tools: vec![],
+                enabled: true,
+                has_override: false,
+                provider_overrides: std::collections::HashMap::new(),
+                prompt_sources: SkillEntry::empty_prompt_sources(),
+                model_overrides: std::collections::HashMap::new(),
+            }
+        };
+        dev_pilot.skill_tools = vec![ResolvedSkillTool {
+            definition: ToolDefinition {
+                name: "run_claude_pilot".to_string(),
+                description: "dispatch".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            handler: ToolHandler::Exec {
+                command: "run.sh".to_string(),
+                long_running: true,
+                estimated_duration_secs: Some(600),
+            },
+            skill_dir: tmp.path().to_path_buf(),
+        }];
+        let skills = SkillRegistry::from_test_entries(vec![dev_pilot]);
+
+        // 4. Send the block[ac] verdict through handle_block_ac.
+        let event = PrReviewEvent {
+            state: "commented".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 1630,
+            title: "fix: verdict handler".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/1630#pullrequestreview-1"
+                .to_string(),
+            body: "PLAN-AC VERIFICATION:\n\
+                   - [❌] unsatisfied: AC1 missing test\n\n\
+                   VERDICT: block[ac]\n\
+                   REASON: AC1 unsatisfied."
+                .to_string(),
+        };
+
+        let session_id = "cb-test-session";
+        let trace_id = "trace-deferred-1";
+        let action = handle_block_ac(&event, &db, None, None, session_id, trace_id, &skills).await;
+
+        // 5. Assert VerdictAction::Handled with deferred mention in pre-digest.
+        match &action {
+            VerdictAction::Handled { pre_digest } => {
+                assert!(
+                    pre_digest.contains("deferred") || pre_digest.contains("queued"),
+                    "Expected deferred/queued in pre-digest, got: {pre_digest}"
+                );
+            }
+            other => {
+                panic!("Expected VerdictAction::Handled for slot-busy deferred path, got {other:?}")
+            }
+        }
+
+        // 6. Assert a deferred child task was created in the DB.
+        let children = db.get_child_tasks(&task_id).await.unwrap();
+        let deferred_child = children
+            .iter()
+            .find(|c| c.label == crate::agent::DEFERRED_DISPATCH_LABEL && c.status == "pending");
+        assert!(
+            deferred_child.is_some(),
+            "Expected a pending deferred child task (label = '{}'), children: {:?}",
+            crate::agent::DEFERRED_DISPATCH_LABEL,
+            children
+                .iter()
+                .map(|c| (&c.label, &c.status))
+                .collect::<Vec<_>>()
+        );
+
+        // 7. AC4: Assert `verdict_redispatch_deferred` audit event was emitted.
+        let events = db.get_audit_events(session_id).await.unwrap();
+        let has_deferred_event = events
+            .iter()
+            .any(|e| e.tool_name == "verdict_redispatch_deferred");
+        assert!(
+            has_deferred_event,
+            "Expected verdict_redispatch_deferred audit event, found: {:?}",
+            events.iter().map(|e| &e.tool_name).collect::<Vec<_>>()
+        );
+    }
+
     #[tokio::test]
     async fn block_ci_fallback_to_llm_when_tool_not_found() {
         // Mirror of block_ac_fallback test for block[ci].

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -27,6 +27,7 @@ use tracing::{info, warn};
 
 use crate::async_db::AsyncDatabase;
 use crate::messaging::MessageSender;
+use crate::skills::SkillRegistry;
 use crate::task_state::merge_metadata;
 use crate::tools::pr_merge_with_gate::{
     CheckClassification, classify_checks, is_behind_main, run_gh_checks, run_gh_merge,
@@ -117,6 +118,7 @@ pub async fn try_handle_pr_review_verdict(
     message_sender: Option<&Arc<dyn MessageSender>>,
     session_id: &str,
     trace_id: &str,
+    skills: &SkillRegistry,
 ) -> VerdictAction {
     // 1. Parse the PR review event from formatted text
     let event = match parse_pr_review_event(text) {
@@ -196,6 +198,7 @@ pub async fn try_handle_pr_review_verdict(
                     message_sender,
                     session_id,
                     trace_id,
+                    skills,
                 )
                 .await
             }
@@ -207,6 +210,7 @@ pub async fn try_handle_pr_review_verdict(
                     message_sender,
                     session_id,
                     trace_id,
+                    skills,
                 )
                 .await
             }
@@ -538,6 +542,217 @@ async fn handle_pass_verdict(
 }
 
 // ---------------------------------------------------------------------------
+// Engine-side dispatch helper (mika#1630)
+// ---------------------------------------------------------------------------
+
+/// Result of an engine-side dispatch attempt from the verdict handler.
+enum EngineDispatchResult {
+    /// Subprocess spawned; return Dispatched to the LLM.
+    Spawned { callback_task_id: String },
+    /// Slot busy; deferred callback registered engine-side.
+    Deferred { deferred_task_id: String },
+    /// Dispatch readiness failed for a non-slot reason; fall back to LLM-mediated.
+    Fallback { reason: String },
+}
+
+/// Attempt engine-side dispatch following the ready-label handler pattern (mika#1572).
+///
+/// Eliminates the LLM-dependency gap for block[ac]/block[ci] verdicts:
+/// 1. Resolves the dispatch tool from SkillRegistry
+/// 2. Validates dispatch readiness
+/// 3. On slot-busy (`global_dispatch_active`), registers a deferred callback
+/// 4. On other failures, falls back to LLM-mediated dispatch
+#[allow(clippy::too_many_arguments)]
+async fn try_engine_dispatch(
+    db: &AsyncDatabase,
+    skills: &SkillRegistry,
+    task_id: &str,
+    github_token: Option<&str>,
+    event: &PrReviewEvent,
+    target_skill: &str,
+    target_tool: &str,
+    iteration_context: &str,
+    session_id: &str,
+    trace_id: &str,
+) -> EngineDispatchResult {
+    use crate::skills::manifest::ToolHandler;
+
+    // 1. Resolve the dispatch tool from the agent's loaded SkillRegistry.
+    let skill_tool = match skills.resolve_tool_by_name(target_tool) {
+        Some(t) => t,
+        None => {
+            return EngineDispatchResult::Fallback {
+                reason: format!("dispatch tool '{target_tool}' not in SkillRegistry"),
+            };
+        }
+    };
+
+    // 2. Resolve long-running exec command + estimated duration.
+    let (command, estimated_duration_secs) = match &skill_tool.handler {
+        ToolHandler::Exec {
+            command,
+            long_running: true,
+            estimated_duration_secs,
+        } => (command.clone(), *estimated_duration_secs),
+        _ => {
+            return EngineDispatchResult::Fallback {
+                reason: format!("dispatch tool '{target_tool}' is not a long-running exec handler"),
+            };
+        }
+    };
+
+    // 3. Build dispatch input. `prompt` uses bare `<repo>#<pr_number>` form
+    //    (not owner-qualified — dispatch-lib only accepts bare form, per mika#1593).
+    let repo_name = event.repo.rsplit('/').next().unwrap_or(&event.repo);
+    let dispatch_input = serde_json::json!({
+        "skill": target_skill,
+        "prompt": format!("{repo_name}#{}", event.pr_number),
+        "task_id": task_id,
+        "iteration_context": iteration_context,
+    });
+
+    // 4. Validate dispatch readiness. `originating_message = None` because
+    //    the dispatch is engine-authorized by the verdict handler's own
+    //    event-type gate — the webhook already passed the PR review parse.
+    //    Passing `None` skips guard (0) (unauthorized_webhook_dispatch),
+    //    which is correct: the verdict handler already validated the event type.
+    if let Err(rejection) = crate::skills::executor::validate_dispatch_readiness(
+        db,
+        task_id,
+        github_token,
+        Some(&dispatch_input),
+        None,
+    )
+    .await
+    {
+        // 5. Check if the rejection is slot-busy (global_dispatch_active).
+        if let Ok(rejection_json) = serde_json::from_str::<serde_json::Value>(&rejection)
+            && rejection_json.get("error").and_then(|e| e.as_str())
+                == Some("global_dispatch_active")
+        {
+            // Register deferred callback engine-side (AC2).
+            if crate::skills::executor::register_deferred_callback(db, task_id, &dispatch_input)
+                .await
+            {
+                // Find the deferred task ID for observability.
+                let deferred_task_id = match db.get_child_tasks(task_id).await {
+                    Ok(children) => children
+                        .iter()
+                        .rev()
+                        .find(|c| {
+                            c.label == crate::agent::DEFERRED_DISPATCH_LABEL
+                                && c.status == "pending"
+                        })
+                        .map(|c| c.id.clone())
+                        .unwrap_or_default(),
+                    Err(_) => String::new(),
+                };
+                return EngineDispatchResult::Deferred { deferred_task_id };
+            }
+            // Registration failed (cap exceeded or DB error) — fall back.
+            return EngineDispatchResult::Fallback {
+                reason: "deferred callback registration failed (cap exceeded or DB error)"
+                    .to_string(),
+            };
+        }
+        // Non-slot rejection — fall back to LLM-mediated.
+        return EngineDispatchResult::Fallback {
+            reason: format!("dispatch readiness check failed: {rejection}"),
+        };
+    }
+
+    // 6. Dispatch readiness passed — create callback child task and spawn.
+    let timeout_secs = (estimated_duration_secs.unwrap_or(3600) * 3).clamp(600, 7_776_000);
+    let callback_task = crate::skills::executor::build_callback_task(
+        db.agent_id().to_string(),
+        Some(task_id.to_string()),
+        target_tool,
+        &dispatch_input,
+        timeout_secs,
+        session_id,
+        trace_id,
+    );
+    let callback_task_id = match db.create_task(callback_task).await {
+        Ok(id) => id,
+        Err(e) => {
+            return EngineDispatchResult::Fallback {
+                reason: format!("failed to create callback child: {e}"),
+            };
+        }
+    };
+
+    // Resolve and verify handler script exists.
+    let cmd_path = skill_tool.skill_dir.join(&command);
+    if !cmd_path.exists() {
+        let _ = db
+            .update_task_failed(
+                &callback_task_id,
+                &format!("handler not found: {}", cmd_path.display()),
+            )
+            .await;
+        return EngineDispatchResult::Fallback {
+            reason: format!("handler script not found: {}", cmd_path.display()),
+        };
+    }
+
+    // Auto-transition parent task to in_progress (mirrors execute_long_running #525).
+    if let Err(e) = db.update_manual_task_status(task_id, "in_progress").await {
+        warn!(
+            task_id = %task_id,
+            error = %e,
+            "verdict engine-dispatch: failed to auto-transition parent to in_progress"
+        );
+    }
+
+    // Inject subprocess metadata (__mika_task_id, __mika_agent).
+    let mut enriched_input = dispatch_input.clone();
+    if let serde_json::Value::Object(ref mut map) = enriched_input {
+        map.insert(
+            "__mika_task_id".to_string(),
+            serde_json::Value::String(callback_task_id.clone()),
+        );
+        map.insert(
+            "__mika_agent".to_string(),
+            serde_json::Value::String(db.agent_id().to_string()),
+        );
+    }
+
+    // Spawn the detached subprocess.
+    crate::skills::executor::spawn_long_running_exec(
+        cmd_path,
+        skill_tool.skill_dir.clone(),
+        enriched_input,
+        callback_task_id.clone(),
+        db.clone(),
+        github_token.map(|s| s.to_string()),
+    );
+
+    info!(
+        event = "verdict_engine_dispatched",
+        repo = %event.repo,
+        pr_number = event.pr_number,
+        target_tool,
+        target_skill,
+        task_id = %task_id,
+        callback_task_id = %callback_task_id,
+        "verdict handler: engine-side dispatch spawned"
+    );
+
+    EngineDispatchResult::Spawned { callback_task_id }
+}
+
+/// Check if a task has a pending deferred-dispatch child (`:deferred` label suffix).
+async fn has_pending_deferred_child(db: &AsyncDatabase, task_id: &str) -> bool {
+    match db.get_child_tasks(task_id).await {
+        Ok(children) => children.iter().any(|c| {
+            c.label == crate::agent::DEFERRED_DISPATCH_LABEL
+                && matches!(c.status.as_str(), "pending")
+        }),
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Block[ac] handler (#889)
 // ---------------------------------------------------------------------------
 
@@ -550,6 +765,7 @@ async fn handle_block_ac(
     message_sender: Option<&Arc<dyn MessageSender>>,
     session_id: &str,
     trace_id: &str,
+    skills: &SkillRegistry,
 ) -> VerdictAction {
     let pr_url = event.pr_url();
 
@@ -569,20 +785,33 @@ async fn handle_block_ac(
 
     let task_id = task.id.clone();
 
-    // Check if fix is already in-flight
+    // Check if fix is already in-flight or queued (AC3 — idempotent collapse)
     if has_active_callback_child(db, &task_id).await {
+        let is_deferred = has_pending_deferred_child(db, &task_id).await;
+        let (status_msg, action_msg) = if is_deferred {
+            (
+                "a fix is queued (deferred — waiting for dispatch slot)",
+                "Do NOT dispatch run_claude_pilot — a deferred callback will auto-fire when the slot frees.",
+            )
+        } else {
+            (
+                "a fix is already in-flight",
+                "Do NOT dispatch run_claude_pilot — a session is already running.",
+            )
+        };
         info!(
             task_id = %task_id,
             pr_number = event.pr_number,
-            "block[ac] but fix already in-flight — enriching passthrough"
+            is_deferred,
+            "block[ac] but {status_msg} — suppressing duplicate dispatch"
         );
         return VerdictAction::Handled {
             pre_digest: format!(
                 "<verdict_handler>\n\
                  [GitHub] PR review ({}) on {}#{} by @{}\n\
-                 VERDICT: block[ac] — but a fix is already in-flight for task {task_id}.\n\n\
+                 VERDICT: block[ac] — but {status_msg} for task {task_id}.\n\n\
                  Wait for the active callback to finish before taking further action.\n\
-                 Do NOT dispatch run_claude_pilot — a session is already running.\n\
+                 {action_msg}\n\
                  </verdict_handler>",
                 event.state, event.repo, event.pr_number, event.reviewer
             ),
@@ -749,6 +978,68 @@ async fn handle_block_ac(
         "Structural verdict handler: block[ac] — AC-fix dispatch preparing"
     );
 
+    // Engine-side dispatch (mika#1630) — eliminate LLM-dependency gap.
+    match try_engine_dispatch(
+        db,
+        skills,
+        &task_id,
+        github_token,
+        event,
+        "dev-pilot",
+        "run_claude_pilot",
+        &ac_summary,
+        session_id,
+        trace_id,
+    )
+    .await
+    {
+        EngineDispatchResult::Spawned { callback_task_id } => {
+            return VerdictAction::Dispatched {
+                pre_digest: format_block_ac_dispatched_pre_digest(
+                    event,
+                    &ac_summary,
+                    &task_id,
+                    new_count,
+                    &callback_task_id,
+                ),
+                task_id: task_id.clone(),
+            };
+        }
+        EngineDispatchResult::Deferred { deferred_task_id } => {
+            // Emit audit event (AC4).
+            let _ = db
+                .log_audit_event(
+                    session_id,
+                    "verdict_redispatch_deferred",
+                    &format!("task:{task_id}"),
+                    None,
+                    Some("deferred"),
+                    Some(&format!(
+                        "verdict=block[ac] deferred_id={deferred_task_id} pr_url={}",
+                        pr_url
+                    )),
+                    Some(trace_id),
+                )
+                .await;
+            return VerdictAction::Handled {
+                pre_digest: format_block_ac_deferred_pre_digest(
+                    event,
+                    &ac_summary,
+                    &task_id,
+                    new_count,
+                ),
+            };
+        }
+        EngineDispatchResult::Fallback { reason } => {
+            warn!(
+                task_id = %task_id,
+                reason = %reason,
+                "verdict engine-dispatch fallback — LLM-mediated path"
+            );
+        }
+    }
+
+    // Existing code: return prescriptive pre-digest for LLM-mediated dispatch
     VerdictAction::Handled {
         pre_digest: format_block_ac_pre_digest(event, &ac_summary, &task_id, new_count),
     }
@@ -768,6 +1059,7 @@ async fn handle_block_ci(
     message_sender: Option<&Arc<dyn MessageSender>>,
     session_id: &str,
     trace_id: &str,
+    skills: &SkillRegistry,
 ) -> VerdictAction {
     let pr_url = event.pr_url();
 
@@ -786,19 +1078,33 @@ async fn handle_block_ci(
 
     let task_id = task.id.clone();
 
+    // Check if fix is already in-flight or queued (AC3 — idempotent collapse)
     if has_active_callback_child(db, &task_id).await {
+        let is_deferred = has_pending_deferred_child(db, &task_id).await;
+        let (status_msg, action_msg) = if is_deferred {
+            (
+                "a fix is queued (deferred — waiting for dispatch slot)",
+                "Do NOT dispatch run_claude_pilot — a deferred callback will auto-fire when the slot frees.",
+            )
+        } else {
+            (
+                "a fix is already in-flight",
+                "Do NOT dispatch run_claude_pilot — a session is already running.",
+            )
+        };
         info!(
             task_id = %task_id,
             pr_number = event.pr_number,
-            "block[ci] but fix already in-flight — enriching passthrough"
+            is_deferred,
+            "block[ci] but {status_msg} — suppressing duplicate dispatch"
         );
         return VerdictAction::Handled {
             pre_digest: format!(
                 "<verdict_handler>\n\
                  [GitHub] PR review ({}) on {}#{} by @{}\n\
-                 VERDICT: block[ci] — but a fix is already in-flight for task {task_id}.\n\n\
+                 VERDICT: block[ci] — but {status_msg} for task {task_id}.\n\n\
                  Wait for the active callback to finish before taking further action.\n\
-                 Do NOT dispatch run_claude_pilot — a session is already running.\n\
+                 {action_msg}\n\
                  </verdict_handler>",
                 event.state, event.repo, event.pr_number, event.reviewer
             ),
@@ -940,13 +1246,71 @@ async fn handle_block_ci(
         "Structural verdict handler: block[ci] — CI-fix dispatch preparing"
     );
 
+    // Engine-side dispatch (mika#1630) — eliminate LLM-dependency gap.
+    let ci_context = truncate_body(&event.body);
+    match try_engine_dispatch(
+        db,
+        skills,
+        &task_id,
+        github_token,
+        event,
+        "dev-pilot",
+        "run_claude_pilot",
+        &ci_context,
+        session_id,
+        trace_id,
+    )
+    .await
+    {
+        EngineDispatchResult::Spawned { callback_task_id } => {
+            return VerdictAction::Dispatched {
+                pre_digest: format_block_ci_dispatched_pre_digest(
+                    event,
+                    &ci_context,
+                    &task_id,
+                    new_count,
+                    &callback_task_id,
+                ),
+                task_id: task_id.clone(),
+            };
+        }
+        EngineDispatchResult::Deferred { deferred_task_id } => {
+            // Emit audit event (AC4).
+            let _ = db
+                .log_audit_event(
+                    session_id,
+                    "verdict_redispatch_deferred",
+                    &format!("task:{task_id}"),
+                    None,
+                    Some("deferred"),
+                    Some(&format!(
+                        "verdict=block[ci] deferred_id={deferred_task_id} pr_url={}",
+                        pr_url
+                    )),
+                    Some(trace_id),
+                )
+                .await;
+            return VerdictAction::Handled {
+                pre_digest: format_block_ci_deferred_pre_digest(
+                    event,
+                    &ci_context,
+                    &task_id,
+                    new_count,
+                ),
+            };
+        }
+        EngineDispatchResult::Fallback { reason } => {
+            warn!(
+                task_id = %task_id,
+                reason = %reason,
+                "verdict engine-dispatch fallback — LLM-mediated path"
+            );
+        }
+    }
+
+    // Existing code: return prescriptive pre-digest for LLM-mediated dispatch
     VerdictAction::Handled {
-        pre_digest: format_block_ci_pre_digest(
-            event,
-            &truncate_body(&event.body),
-            &task_id,
-            new_count,
-        ),
+        pre_digest: format_block_ci_pre_digest(event, &ci_context, &task_id, new_count),
     }
 }
 
@@ -2097,6 +2461,104 @@ fn format_block_ci_limit_pre_digest(event: &PrReviewEvent, task_id: &str) -> Str
     )
 }
 
+/// Format pre-digest for block[ac] engine-side dispatch succeeded (mika#1630).
+fn format_block_ac_dispatched_pre_digest(
+    event: &PrReviewEvent,
+    ac_summary: &str,
+    task_id: &str,
+    retry_count: u32,
+    callback_task_id: &str,
+) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review ({}) on {}#{} by @{}\n\
+         VERDICT: block[ac] — engine-side AC-fix dispatch fired.\n\n\
+         {ac_summary}\n\n\
+         Task: {task_id}\n\
+         Retry: {retry_count}/{BLOCK_AC_MAX_RETRIES}\n\
+         Callback: {callback_task_id}\n\
+         Review: {}\n\n\
+         The AC-fix dispatch has already been spawned engine-side.\n\
+         Do NOT dispatch run_claude_pilot — the subprocess is already running.\n\
+         Do NOT re-increment the retry counter — the structural handler already updated it.\n\
+         </verdict_handler>",
+        event.state, event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
+/// Format pre-digest for block[ac] slot busy, deferred callback registered (mika#1630).
+fn format_block_ac_deferred_pre_digest(
+    event: &PrReviewEvent,
+    ac_summary: &str,
+    task_id: &str,
+    retry_count: u32,
+) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review ({}) on {}#{} by @{}\n\
+         VERDICT: block[ac] — dispatch slot busy; AC-fix queued (deferred).\n\n\
+         {ac_summary}\n\n\
+         Task: {task_id}\n\
+         Retry: {retry_count}/{BLOCK_AC_MAX_RETRIES}\n\
+         Review: {}\n\n\
+         The dispatch slot is currently occupied. A deferred callback has been registered \
+         engine-side and will auto-fire when the slot frees.\n\
+         Do NOT dispatch run_claude_pilot — the deferred wrapper handles it.\n\
+         Do NOT re-increment the retry counter — the structural handler already updated it.\n\
+         </verdict_handler>",
+        event.state, event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
+/// Format pre-digest for block[ci] engine-side dispatch succeeded (mika#1630).
+fn format_block_ci_dispatched_pre_digest(
+    event: &PrReviewEvent,
+    ci_context: &str,
+    task_id: &str,
+    retry_count: u32,
+    callback_task_id: &str,
+) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review ({}) on {}#{} by @{}\n\
+         VERDICT: block[ci] — engine-side CI-fix dispatch fired.\n\n\
+         CI failure context:\n{ci_context}\n\n\
+         Task: {task_id}\n\
+         Retry: {retry_count}/{BLOCK_CI_MAX_RETRIES}\n\
+         Callback: {callback_task_id}\n\
+         Review: {}\n\n\
+         The CI-fix dispatch has already been spawned engine-side.\n\
+         Do NOT dispatch run_claude_pilot — the subprocess is already running.\n\
+         Do NOT re-increment the retry counter — the structural handler already updated it.\n\
+         </verdict_handler>",
+        event.state, event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
+/// Format pre-digest for block[ci] slot busy, deferred callback registered (mika#1630).
+fn format_block_ci_deferred_pre_digest(
+    event: &PrReviewEvent,
+    ci_context: &str,
+    task_id: &str,
+    retry_count: u32,
+) -> String {
+    format!(
+        "<verdict_handler>\n\
+         [GitHub] PR review ({}) on {}#{} by @{}\n\
+         VERDICT: block[ci] — dispatch slot busy; CI-fix queued (deferred).\n\n\
+         CI failure context:\n{ci_context}\n\n\
+         Task: {task_id}\n\
+         Retry: {retry_count}/{BLOCK_CI_MAX_RETRIES}\n\
+         Review: {}\n\n\
+         The dispatch slot is currently occupied. A deferred callback has been registered \
+         engine-side and will auto-fire when the slot frees.\n\
+         Do NOT dispatch run_claude_pilot — the deferred wrapper handles it.\n\
+         Do NOT re-increment the retry counter — the structural handler already updated it.\n\
+         </verdict_handler>",
+        event.state, event.repo, event.pr_number, event.reviewer, event.review_url
+    )
+}
+
 /// Format pre-digest for block[security] / block[pipeline] escalation.
 fn format_escalate_pre_digest(event: &PrReviewEvent, reason: &str, task_id: &str) -> String {
     format!(
@@ -3048,6 +3510,413 @@ mod tests {
         assert!(
             text.contains("Rebase"),
             "Behind-main enrichment should instruct rebase: {text}"
+        );
+    }
+
+    // ---- Engine-side dispatch pre-digest tests (mika#1630) ----
+
+    #[test]
+    fn block_ac_dispatched_pre_digest_avoids_completion_claim_words() {
+        let event = sample_event_commented();
+        let text = format_block_ac_dispatched_pre_digest(
+            &event,
+            "2 unsatisfied AC(s):\n  1. Unit 1\n  2. Unit 3",
+            "task-456",
+            1,
+            "callback-789",
+        );
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "block[ac] dispatched pre-digest contains completion-claim trigger word: {text}"
+        );
+        assert!(text.starts_with("<verdict_handler>"));
+        assert!(text.contains("engine-side"));
+        assert!(text.contains("Do NOT dispatch run_claude_pilot"));
+        assert!(text.contains("callback-789"));
+    }
+
+    #[test]
+    fn block_ac_deferred_pre_digest_avoids_completion_claim_words() {
+        let event = sample_event_commented();
+        let text = format_block_ac_deferred_pre_digest(
+            &event,
+            "2 unsatisfied AC(s):\n  1. Unit 1",
+            "task-456",
+            1,
+        );
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "block[ac] deferred pre-digest contains completion-claim trigger word: {text}"
+        );
+        assert!(text.starts_with("<verdict_handler>"));
+        assert!(text.contains("deferred"));
+        assert!(text.contains("Do NOT dispatch run_claude_pilot"));
+    }
+
+    #[test]
+    fn block_ci_dispatched_pre_digest_avoids_completion_claim_words() {
+        let mut event = sample_event_commented();
+        event.body = "VERDICT: block[ci]\nREASON: CI failing.".to_string();
+        let text = format_block_ci_dispatched_pre_digest(
+            &event,
+            "CI checks failing",
+            "task-789",
+            1,
+            "callback-101",
+        );
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "block[ci] dispatched pre-digest contains completion-claim trigger word: {text}"
+        );
+        assert!(text.starts_with("<verdict_handler>"));
+        assert!(text.contains("engine-side"));
+        assert!(text.contains("Do NOT dispatch run_claude_pilot"));
+    }
+
+    #[test]
+    fn block_ci_deferred_pre_digest_avoids_completion_claim_words() {
+        let mut event = sample_event_commented();
+        event.body = "VERDICT: block[ci]\nREASON: CI failing.".to_string();
+        let text = format_block_ci_deferred_pre_digest(&event, "CI checks failing", "task-789", 1);
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "block[ci] deferred pre-digest contains completion-claim trigger word: {text}"
+        );
+        assert!(text.starts_with("<verdict_handler>"));
+        assert!(text.contains("deferred"));
+        assert!(text.contains("Do NOT dispatch run_claude_pilot"));
+    }
+
+    // ---- Engine dispatch fallback test (mika#1630) ----
+
+    /// Create a task with pr_url metadata that `find_active_task_by_pr_url` can find.
+    async fn create_task_with_pr_url(db: &AsyncDatabase, pr_url: &str, status: &str) -> String {
+        let task = crate::db::NewTask {
+            agent_id: db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "test-task".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("test-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: Some("self_dev".to_string()),
+            metadata: Some(serde_json::json!({"claude_pilot": {"pr_url": pr_url}}).to_string()),
+            r#type: None,
+            dispatch_class: None,
+        };
+        let task_id = db.create_task(task).await.unwrap();
+        if status != "pending" {
+            db.update_task_status(&task_id, status).await.unwrap();
+        }
+        task_id
+    }
+
+    /// Create a callback child task for the given parent.
+    async fn create_callback_child(
+        db: &AsyncDatabase,
+        parent_id: &str,
+        label: &str,
+        status: &str,
+    ) -> String {
+        let task = crate::db::NewTask {
+            agent_id: db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: Some(parent_id.to_string()),
+            depth: 0,
+            label: label.to_string(),
+            trigger_type: crate::task_engine::types::trigger_type::CALLBACK.to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: crate::task_engine::types::action_type::RESUME_AGENT.to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: Some("test-session".to_string()),
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let child_id = db.create_task(task).await.unwrap();
+        if status != "pending" {
+            db.update_task_status(&child_id, status).await.unwrap();
+        }
+        child_id
+    }
+
+    #[tokio::test]
+    async fn block_ac_fallback_to_llm_when_tool_not_found() {
+        // Empty SkillRegistry — run_claude_pilot is not resolvable.
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = crate::skills::SkillRegistry::from_dir(tmp.path());
+        let db = cb_test_db().await;
+
+        let pr_url = "https://github.com/senara-solutions/mika/pull/1630";
+        let task_id = create_task_with_pr_url(&db, pr_url, "in_progress").await;
+
+        let event = PrReviewEvent {
+            state: "commented".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 1630,
+            title: "fix: something".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/1630#pullrequestreview-1"
+                .to_string(),
+            body: "VERDICT: block[ac]\n- [❌] unsatisfied: AC1 missing".to_string(),
+        };
+
+        let result = try_engine_dispatch(
+            &db,
+            &skills,
+            &task_id,
+            None,
+            &event,
+            "dev-pilot",
+            "run_claude_pilot",
+            "AC1 missing",
+            "test-session",
+            "trace-1",
+        )
+        .await;
+
+        assert!(
+            matches!(result, EngineDispatchResult::Fallback { .. }),
+            "Expected Fallback when tool not in registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn block_ac_idempotent_collapse_with_deferred() {
+        // Set up a task with a pending deferred child — subsequent block[ac]
+        // should return "fix is queued" without creating new tasks.
+        let db = cb_test_db().await;
+        let pr_url = "https://github.com/senara-solutions/mika/pull/1631";
+        let task_id = create_task_with_pr_url(&db, pr_url, "in_progress").await;
+
+        // Create a pending deferred child
+        create_callback_child(
+            &db,
+            &task_id,
+            crate::agent::DEFERRED_DISPATCH_LABEL,
+            "pending",
+        )
+        .await;
+
+        let event = PrReviewEvent {
+            state: "commented".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 1631,
+            title: "fix: something".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/1631#pullrequestreview-1"
+                .to_string(),
+            body: "VERDICT: block[ac]\n- [❌] unsatisfied: AC1 missing".to_string(),
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = crate::skills::SkillRegistry::from_dir(tmp.path());
+
+        let action =
+            handle_block_ac(&event, &db, None, None, "test-session", "trace-1", &skills).await;
+
+        // Should return Handled with "queued" message, not a new dispatch
+        match action {
+            VerdictAction::Handled { pre_digest } => {
+                assert!(
+                    pre_digest.contains("queued"),
+                    "Expected 'queued' in idempotent collapse pre-digest, got: {pre_digest}"
+                );
+                assert!(
+                    pre_digest.contains("deferred"),
+                    "Expected 'deferred' in idempotent collapse pre-digest, got: {pre_digest}"
+                );
+            }
+            other => panic!("Expected VerdictAction::Handled, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn block_ac_idempotent_collapse_in_flight() {
+        // Set up a task with an in-flight (non-deferred) callback child.
+        let db = cb_test_db().await;
+        let pr_url = "https://github.com/senara-solutions/mika/pull/1632";
+        let task_id = create_task_with_pr_url(&db, pr_url, "in_progress").await;
+
+        // Create an in-progress (active, non-deferred) callback child
+        create_callback_child(
+            &db,
+            &task_id,
+            "long_running:run_claude_pilot",
+            "in_progress",
+        )
+        .await;
+
+        let event = PrReviewEvent {
+            state: "commented".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 1632,
+            title: "fix: something".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/1632#pullrequestreview-1"
+                .to_string(),
+            body: "VERDICT: block[ac]\n- [❌] unsatisfied: AC1 missing".to_string(),
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = crate::skills::SkillRegistry::from_dir(tmp.path());
+
+        let action =
+            handle_block_ac(&event, &db, None, None, "test-session", "trace-1", &skills).await;
+
+        // Should return Handled with "in-flight" message
+        match action {
+            VerdictAction::Handled { pre_digest } => {
+                assert!(
+                    pre_digest.contains("in-flight"),
+                    "Expected 'in-flight' in pre-digest, got: {pre_digest}"
+                );
+                assert!(
+                    !pre_digest.contains("queued"),
+                    "Should NOT contain 'queued' for in-flight dispatch: {pre_digest}"
+                );
+            }
+            other => panic!("Expected VerdictAction::Handled, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn has_pending_deferred_child_detects_deferred() {
+        let db = cb_test_db().await;
+        let task = crate::db::NewTask {
+            agent_id: db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "test-parent".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let parent_id = db.create_task(task).await.unwrap();
+
+        // No deferred child yet
+        assert!(!has_pending_deferred_child(&db, &parent_id).await);
+
+        // Add a deferred child
+        create_callback_child(
+            &db,
+            &parent_id,
+            crate::agent::DEFERRED_DISPATCH_LABEL,
+            "pending",
+        )
+        .await;
+        assert!(has_pending_deferred_child(&db, &parent_id).await);
+    }
+
+    #[tokio::test]
+    async fn has_pending_deferred_child_ignores_non_deferred() {
+        let db = cb_test_db().await;
+        let task = crate::db::NewTask {
+            agent_id: db.agent_id().to_string(),
+            team_run_id: None,
+            parent_task_id: None,
+            depth: 0,
+            label: "test-parent".to_string(),
+            trigger_type: "manual".to_string(),
+            cron_expr: None,
+            event_source: None,
+            event_offset_secs: None,
+            condition_expr: None,
+            next_fire_at: None,
+            timeout_at: None,
+            action_type: "none".to_string(),
+            action_config: "{}".to_string(),
+            input_context: None,
+            created_by_session: None,
+            created_trace_id: None,
+            reference_url: None,
+            source: None,
+            metadata: None,
+            r#type: None,
+            dispatch_class: None,
+        };
+        let parent_id = db.create_task(task).await.unwrap();
+
+        // Add a regular (non-deferred) callback child
+        create_callback_child(&db, &parent_id, "long_running:run_claude_pilot", "pending").await;
+
+        // Should NOT detect as deferred
+        assert!(!has_pending_deferred_child(&db, &parent_id).await);
+    }
+
+    #[tokio::test]
+    async fn block_ci_fallback_to_llm_when_tool_not_found() {
+        // Mirror of block_ac_fallback test for block[ci].
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = crate::skills::SkillRegistry::from_dir(tmp.path());
+        let db = cb_test_db().await;
+
+        let pr_url = "https://github.com/senara-solutions/mika/pull/1633";
+        let task_id = create_task_with_pr_url(&db, pr_url, "in_progress").await;
+
+        let event = PrReviewEvent {
+            state: "commented".to_string(),
+            repo: "senara-solutions/mika".to_string(),
+            pr_number: 1633,
+            title: "fix: something".to_string(),
+            reviewer: "mika-qa".to_string(),
+            review_url: "https://github.com/senara-solutions/mika/pull/1633#pullrequestreview-1"
+                .to_string(),
+            body: "VERDICT: block[ci]\nREASON: CI failing".to_string(),
+        };
+
+        let result = try_engine_dispatch(
+            &db,
+            &skills,
+            &task_id,
+            None,
+            &event,
+            "dev-pilot",
+            "run_claude_pilot",
+            "CI failing",
+            "test-session",
+            "trace-1",
+        )
+        .await;
+
+        assert!(
+            matches!(result, EngineDispatchResult::Fallback { .. }),
+            "Expected Fallback when tool not in registry"
         );
     }
 }

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -1713,7 +1713,7 @@ const MAX_PENDING_DEFERRED_CALLBACKS: i64 = 10;
 /// Adding a new call site that does NOT pass guard 0 first would let
 /// unauthorized dispatches forge authorization. If you add one, document the
 /// guard-0 equivalence at the call site and update this comment.
-async fn register_deferred_callback(
+pub(crate) async fn register_deferred_callback(
     db: &AsyncDatabase,
     task_id: &str,
     input: &serde_json::Value,

--- a/crates/mika-agent/tests/eval/test_verdict_handler.rs
+++ b/crates/mika-agent/tests/eval/test_verdict_handler.rs
@@ -15,11 +15,18 @@ use serde_json::json;
 use mika_agent::async_db::AsyncDatabase;
 use mika_agent::db::{Database, NewTask};
 use mika_agent::server::verdict_handler::{VerdictAction, try_handle_pr_review_verdict};
+use mika_agent::skills::SkillRegistry;
 use mika_agent::task_engine::types::{action_type, trigger_type};
 
 /// Default agent ID used by `AsyncDatabase::new()`.
 const AGENT_ID: &str = "mika";
 const SESSION_ID: &str = "verdict-test-session";
+
+/// Empty SkillRegistry for tests that don't need real skill resolution.
+fn test_skills() -> SkillRegistry {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    SkillRegistry::from_dir(tmp.path())
+}
 
 /// Helper to create an in-memory async database for tests.
 async fn test_db() -> AsyncDatabase {
@@ -100,14 +107,21 @@ async fn verdict_block_ci_no_task_passes_through_with_enrichment() -> Result<()>
         "VERDICT: block[ci]\n\nCI checks are failing.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     // With no matching task, block[ci] passes through with enrichment
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             let e = enrichment.expect("block[ci] with no task should enrich");
@@ -142,13 +156,20 @@ async fn verdict_block_ci_with_task_is_handled() -> Result<()> {
         "VERDICT: block[ci]\n\nCI checks are failing.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -194,13 +215,20 @@ async fn verdict_block_ac_with_task_is_handled() -> Result<()> {
          REASON: Two plan ACs unsatisfied.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -254,13 +282,20 @@ async fn verdict_block_ac_retry_limit_escalates() -> Result<()> {
         "VERDICT: block[ac]\nREASON: ACs still unsatisfied after 3 attempts.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -313,13 +348,20 @@ async fn verdict_block_security_escalates() -> Result<()> {
         "VERDICT: block[security]\nREASON: Hardcoded API key found.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -372,13 +414,20 @@ async fn verdict_block_pipeline_escalates() -> Result<()> {
         "VERDICT: block[pipeline]\nREASON: Missing pipeline artifacts.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(pre_digest.contains("block[pipeline]"));
@@ -422,13 +471,20 @@ async fn verdict_block_ci_retry_limit_escalates() -> Result<()> {
         "VERDICT: block[ci]\nREASON: CI still failing after 3 fix attempts.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -481,13 +537,20 @@ async fn verdict_hold_review_with_task_is_handled() -> Result<()> {
         "VERDICT: hold[review]\n\nNeeds design input.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -537,14 +600,21 @@ async fn verdict_hold_review_no_task_passes_through() -> Result<()> {
         "VERDICT: hold[review]\n\nNeeds another look.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     // With no task, hold[review] passes through with enrichment
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             let e = enrichment.expect("hold[review] with no task should enrich");
@@ -572,13 +642,20 @@ async fn verdict_missing_is_handled_structurally() -> Result<()> {
         "Looks good, approved!",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(
@@ -615,9 +692,16 @@ async fn verdict_missing_logs_audit_event() -> Result<()> {
         "Just some comments without a verdict line.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     // Should be handled
     assert!(
@@ -659,13 +743,20 @@ async fn verdict_changes_requested_block_ac_single_dispatch() -> Result<()> {
         "VERDICT: block[ac]\nREASON: ACs unsatisfied.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Handled { pre_digest } => {
             assert!(pre_digest.contains("block[ac]"));
@@ -704,14 +795,19 @@ async fn verdict_pass_approved_with_task_no_token_passthrough() -> Result<()> {
     );
 
     let action = try_handle_pr_review_verdict(
-        &text, &db, None, // no token
-        None, SESSION_ID, "trace-1",
+        &text,
+        &db,
+        None, // no token
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
     )
     .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             let e = enrichment.expect("no-token pass should enrich");
@@ -750,6 +846,7 @@ async fn verdict_block_ac_sequential_retries() -> Result<()> {
         None,
         SESSION_ID,
         "trace-1",
+        &test_skills(),
     )
     .await;
     match &action1 {
@@ -771,6 +868,7 @@ async fn verdict_block_ac_sequential_retries() -> Result<()> {
         None,
         SESSION_ID,
         "trace-2",
+        &test_skills(),
     )
     .await;
     match &action2 {
@@ -792,6 +890,7 @@ async fn verdict_block_ac_sequential_retries() -> Result<()> {
         None,
         SESSION_ID,
         "trace-3",
+        &test_skills(),
     )
     .await;
     match &action3 {
@@ -813,6 +912,7 @@ async fn verdict_block_ac_sequential_retries() -> Result<()> {
         None,
         SESSION_ID,
         "trace-4",
+        &test_skills(),
     )
     .await;
     match &action4 {
@@ -855,13 +955,20 @@ async fn non_pr_review_event_passes_through() -> Result<()> {
                 https://github.com/senara-solutions/mika/issues/100\n\n\
                 Assigned to: @mika-dev";
 
-    let action =
-        try_handle_pr_review_verdict(text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             assert!(
@@ -891,13 +998,20 @@ async fn verdict_pass_no_task_passes_through() -> Result<()> {
         "VERDICT: pass\n\nAll good.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             assert!(
@@ -935,13 +1049,20 @@ async fn verdict_pass_completed_task_passes_through() -> Result<()> {
         "VERDICT: pass\n\nAll good.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             assert!(
@@ -1010,13 +1131,20 @@ async fn verdict_pass_pending_task_passes_through() -> Result<()> {
         "VERDICT: pass\n\nAll good.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             assert!(
@@ -1050,14 +1178,19 @@ async fn verdict_pass_no_github_token_passes_through() -> Result<()> {
     );
 
     let action = try_handle_pr_review_verdict(
-        &text, &db, None, // no github token
-        None, SESSION_ID, "trace-1",
+        &text,
+        &db,
+        None, // no github token
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
     )
     .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             let e = enrichment.expect("no-token should enrich");
@@ -1085,13 +1218,20 @@ async fn non_approved_review_passes_through() -> Result<()> {
         "VERDICT: pass\n\nLooks good.",
     );
 
-    let action =
-        try_handle_pr_review_verdict(&text, &db, Some("fake-token"), None, SESSION_ID, "trace-1")
-            .await;
+    let action = try_handle_pr_review_verdict(
+        &text,
+        &db,
+        Some("fake-token"),
+        None,
+        SESSION_ID,
+        "trace-1",
+        &test_skills(),
+    )
+    .await;
 
     match action {
         VerdictAction::Dispatched { .. } => {
-            unreachable!("verdict handler never returns Dispatched (mika#1572)")
+            unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
         VerdictAction::Passthrough { enrichment } => {
             assert!(

--- a/docs/plans/2026-06-29-1630-fix-verdict-handler-block-ac-block-ci-plan.md
+++ b/docs/plans/2026-06-29-1630-fix-verdict-handler-block-ac-block-ci-plan.md
@@ -1,0 +1,306 @@
+# Plan: fix(verdict-handler): block[ac]/block[ci] verdicts don't re-dispatch when slot frees
+
+**Issue:** senara-solutions/mika#1630
+**Type:** fix (loop-breaker class)
+**Branch:** `fix/1630/verdict-handler-block-ac-block-ci`
+
+## Problem
+
+`verdict_handler::handle_block_ac` and `handle_block_ci` return `VerdictAction::Handled { pre_digest }` instructing the LLM to call `run_claude_pilot`. This is **LLM-mediated dispatch** — the engine hands off the dispatch decision to the LLM.
+
+When the implement slot is occupied by another task (e.g., a stuck orphan), two failure modes cascade:
+
+1. **LLM non-compliance:** The LLM reads the pre-digest but doesn't call `run_claude_pilot` (misinterpretation, token budget, or unrelated EndTurn guards firing first).
+2. **LLM calls it, slot stays busy:** The LLM calls `run_claude_pilot`, `register_deferred_callback` fires, but the blocking dispatch never completes (stuck orphan). The deferred wrapper waits indefinitely — functionally correct but practically equivalent to a loop-break when the orphan outlives the operator's patience.
+
+The founding incident (PR #1626, mika#1612): 3 consecutive `block[ac]` verdicts over ~35 minutes produced zero auto-dispatches. The implement slot was held by an orphan task for CI fix mika#1623. Manual intervention (cancel orphan + tactical spawn) was required.
+
+## Root Cause
+
+The verdict handler for block[ac]/block[ci] relies on **LLM-mediated dispatch**: it returns a prescriptive pre-digest and hopes the LLM calls the tool. Compare with the ready-label handler (mika#1572), which spawns the dispatch subprocess **engine-side** before the LLM turn — eliminating LLM dependency entirely.
+
+The deferred dispatch infrastructure (mika#1011, mika#1175) handles slot-busy scenarios correctly when `register_deferred_callback` is called. But for block[ac]/block[ci], that function is only reached if the LLM actually calls `run_claude_pilot` — the engine never registers the deferred callback itself.
+
+## Solution
+
+Migrate block[ac]/block[ci] to **engine-side dispatch**, following the ready-label handler pattern (mika#1572). The verdict handler will:
+
+1. **Try engine-side dispatch first** (slot free → spawn subprocess directly)
+2. **Register deferred callback when slot is busy** (engine-side, no LLM dependency)
+3. **Fall back to prescriptive pre-digest** only when other readiness checks fail (non-slot rejections)
+
+This eliminates the LLM-dependency gap for the auto-fix dispatch path.
+
+## Requirements
+
+From issue ACs:
+
+- **AC1:** Reproduce: simulate block[ac] while implement slot held → zero auto-dispatch (current behavior, for regression test baseline)
+- **AC2:** Post-fix: same scenario → deferred wrapper registered engine-side; once slot frees, fix dispatched without operator intervention
+- **AC3:** N consecutive blocks on same PR collapse to one in-flight fix (idempotent)
+- **AC4:** Audit event `verdict_redispatch_deferred` emitted when verdict cannot fire immediately
+
+## Detailed Design
+
+### Step 1: Widen `register_deferred_callback` visibility
+
+**File:** `crates/mika-agent/src/skills/executor.rs`
+
+Change `register_deferred_callback` from `async fn` (private) to `pub(crate) async fn`. The verdict handler (same crate, different module) needs to call it when the slot is busy.
+
+### Step 2: Thread `SkillRegistry` into verdict handler
+
+**File:** `crates/mika-agent/src/server/verdict_handler.rs`
+
+Add `skills: &SkillRegistry` parameter to:
+- `try_handle_pr_review_verdict()` (public entry point)
+- `handle_block_ac()` (internal)
+- `handle_block_ci()` (internal)
+
+**File:** `crates/mika-agent/src/server/handlers.rs`
+
+Pass `&skills` to `try_handle_pr_review_verdict()` at the call site (line ~774). The `skills` binding is already in scope (used by the ready-label handler call below).
+
+### Step 3: Extract shared engine-side dispatch helper
+
+**File:** `crates/mika-agent/src/server/verdict_handler.rs`
+
+Create a shared helper for the engine-side dispatch attempt, reusable by both block[ac] and block[ci]:
+
+```rust
+/// Result of an engine-side dispatch attempt from the verdict handler.
+enum EngineDispatchResult {
+    /// Subprocess spawned; return Dispatched to the LLM.
+    Spawned { callback_task_id: String },
+    /// Slot busy; deferred callback registered engine-side.
+    Deferred { deferred_task_id: String },
+    /// Dispatch readiness failed for a non-slot reason; fall back to LLM-mediated.
+    Fallback { reason: String },
+}
+```
+
+```rust
+async fn try_engine_dispatch(
+    db: &AsyncDatabase,
+    skills: &SkillRegistry,
+    task_id: &str,
+    github_token: Option<&str>,
+    event: &PrReviewEvent,
+    target_skill: &str, // "dev-pilot"
+    target_tool: &str,  // "run_claude_pilot"
+    iteration_context: &str, // AC list or CI failure context
+    session_id: &str,
+    trace_id: &str,
+) -> EngineDispatchResult
+```
+
+The helper follows the ready-label handler pattern (steps 9a–9i of `ready_label_handler.rs`):
+
+1. **Resolve dispatch tool** from `SkillRegistry` via `skills.resolve_tool_by_name(target_tool)`. On failure → `Fallback`.
+
+2. **Extract handler command** and `estimated_duration_secs` from `ToolHandler::Exec`. On non-long-running → `Fallback`.
+
+3. **Build dispatch input:**
+   ```json
+   {
+     "skill": "dev-pilot",
+     "prompt": "<repo>#<pr_number>",
+     "task_id": "<task_id>",
+     "iteration_context": "<ac_summary or ci_context>"
+   }
+   ```
+   `prompt` uses `<repo>#<pr_number>` (bare form, not owner-qualified — dispatch-lib only accepts this form, per mika#1593).
+
+4. **Call `validate_dispatch_readiness()`** with `originating_message = None` (engine-side dispatches are pre-authorized by the verdict handler's own event-type gate — the webhook already passed the PR review parse).
+
+5. **Branch on result:**
+   - **Passes:** Create callback task via `build_callback_task`, spawn subprocess via `spawn_long_running_exec`, auto-transition parent to `in_progress` → `Spawned`.
+   - **Fails with `global_dispatch_active` error:** Call `register_deferred_callback(db, task_id, &dispatch_input)` → `Deferred`. (The deferred infrastructure handles promotion when the slot frees.)
+   - **Fails with other error:** → `Fallback` (let the LLM-mediated path try; may hit different guard states).
+
+6. **Slot-busy detection:** Parse the rejection JSON for `"error": "global_dispatch_active"`. The rejection is a JSON string; extract the `"error"` field to discriminate slot-busy from other rejections.
+
+### Step 4: Wire engine-side dispatch into `handle_block_ac`
+
+**File:** `crates/mika-agent/src/server/verdict_handler.rs`
+
+After the existing retry counter increment and AC extraction (lines 693–728), insert the engine-side dispatch attempt:
+
+```rust
+// Engine-side dispatch (mika#1630) — eliminate LLM-dependency gap.
+match try_engine_dispatch(
+    db, skills, &task_id, github_token, event,
+    "dev-pilot", "run_claude_pilot", &ac_summary,
+    session_id, trace_id,
+).await {
+    EngineDispatchResult::Spawned { callback_task_id } => {
+        // Subprocess spawned engine-side. Return Dispatched so the LLM
+        // acknowledges without dispatching again.
+        return VerdictAction::Dispatched {
+            pre_digest: format_block_ac_dispatched_pre_digest(
+                event, &ac_summary, &task_id, new_count, &callback_task_id,
+            ),
+            task_id: task_id.clone(),
+        };
+    }
+    EngineDispatchResult::Deferred { deferred_task_id } => {
+        // Slot busy; deferred callback registered engine-side (AC2).
+        // Emit audit event (AC4).
+        let _ = db.log_audit_event(
+            session_id,
+            "verdict_redispatch_deferred",
+            &format!("task:{task_id}"),
+            None,
+            Some("deferred"),
+            Some(&format!(
+                "verdict=block[ac] deferred_id={deferred_task_id} pr_url={}",
+                event.pr_url()
+            )),
+            Some(trace_id),
+        ).await;
+        // Return Handled with deferred notice — the LLM runs but does NOT
+        // need to dispatch (the deferred wrapper handles it).
+        return VerdictAction::Handled {
+            pre_digest: format_block_ac_deferred_pre_digest(
+                event, &ac_summary, &task_id, new_count,
+            ),
+        };
+    }
+    EngineDispatchResult::Fallback { reason } => {
+        // Non-slot readiness failure. Fall through to the existing
+        // LLM-mediated prescriptive pre-digest (backward compatible).
+        warn!(
+            task_id = %task_id,
+            reason = %reason,
+            "verdict engine-dispatch fallback — LLM-mediated path"
+        );
+    }
+}
+
+// Existing code: return prescriptive pre-digest for LLM-mediated dispatch
+VerdictAction::Handled {
+    pre_digest: format_block_ac_pre_digest(event, &ac_summary, &task_id, new_count),
+}
+```
+
+### Step 5: Wire engine-side dispatch into `handle_block_ci`
+
+Same pattern as Step 4, with `"dev-pilot"` / `"run_claude_pilot"` and CI context instead of AC summary.
+
+### Step 6: Add pre-digest formatters
+
+**File:** `crates/mika-agent/src/server/verdict_handler.rs`
+
+Two new formatters per verdict class (4 total):
+
+- `format_block_ac_dispatched_pre_digest` — engine-side dispatch succeeded; tells LLM the dispatch already fired (mirrors `format_engine_dispatch_pre_digest` in ready-label handler).
+- `format_block_ac_deferred_pre_digest` — slot busy, deferred callback registered; tells LLM the fix is queued and will auto-fire when the slot frees. The LLM should NOT call `run_claude_pilot`.
+- `format_block_ci_dispatched_pre_digest` — same, CI variant.
+- `format_block_ci_deferred_pre_digest` — same, CI variant.
+
+All pre-digests start with `<verdict_handler>` to avoid triggering INTENT_GUARDS.
+
+### Step 7: Idempotent collapse (AC3)
+
+The existing `has_active_callback_child(db, &task_id)` check at line 573 already catches both real dispatches AND deferred wrappers (both have `trigger_type='callback'` and `status='pending'` or `status='in_progress'`). When a deferred wrapper is pending, a subsequent block[ac] verdict for the same task will hit this check and return "fix already in-flight."
+
+**Enhancement:** Distinguish the pre-digest message between "fix is actively running" (real dispatch) and "fix is queued, will fire when slot frees" (deferred wrapper). Check the child's label for `:deferred` suffix:
+
+```rust
+if has_active_callback_child(db, &task_id).await {
+    let is_deferred = has_pending_deferred_child(db, &task_id).await;
+    let status_msg = if is_deferred {
+        "a fix is queued (deferred — waiting for dispatch slot)"
+    } else {
+        "a fix is already in-flight"
+    };
+    return VerdictAction::Handled {
+        pre_digest: format!("... {} for task {task_id} ...", status_msg),
+    };
+}
+```
+
+Add a helper `has_pending_deferred_child` that checks child tasks for the `:deferred` label suffix.
+
+### Step 8: Handle `VerdictAction::Dispatched` in handlers.rs for verdict handler
+
+**File:** `crates/mika-agent/src/server/handlers.rs`
+
+The verdict handler's match arm at line 783 currently has:
+```rust
+VerdictAction::Dispatched { .. } => {}
+```
+
+This is a no-op because previously only the ready-label handler returned `Dispatched`. Now block[ac]/block[ci] can also return it. The behavior is correct — `Dispatched` pre-digests replace `req.text` the same way `Handled` does. Update the match arm:
+
+```rust
+VerdictAction::Dispatched { pre_digest, .. } => {
+    req.text = pre_digest;
+}
+```
+
+### Step 9: Tests
+
+#### Unit tests (verdict_handler.rs)
+
+1. **`block_ac_engine_dispatch_spawns_when_slot_free`** — Mock SkillRegistry with a resolvable `run_claude_pilot` tool. Set up a task with no active callbacks. Call `handle_block_ac`. Assert `VerdictAction::Dispatched` returned and callback task created in DB.
+
+2. **`block_ac_registers_deferred_when_slot_busy`** — Set up a task + another task with an active callback (occupying the implement slot). Call `handle_block_ac`. Assert `VerdictAction::Handled` with deferred notice in pre-digest. Assert deferred callback task exists in DB with label `long_running:run_claude_pilot:deferred`. Assert `verdict_redispatch_deferred` audit event.
+
+3. **`block_ac_idempotent_collapse`** — Set up a task with a pending deferred child. Call `handle_block_ac`. Assert `VerdictAction::Handled` with "fix is queued" message. No new tasks created.
+
+4. **`block_ci_engine_dispatch_spawns_when_slot_free`** — Mirror of test 1 for block[ci].
+
+5. **`block_ci_registers_deferred_when_slot_busy`** — Mirror of test 2 for block[ci].
+
+6. **`block_ac_fallback_to_llm_when_tool_not_found`** — SkillRegistry without `run_claude_pilot`. Assert `VerdictAction::Handled` with existing prescriptive pre-digest (LLM-mediated fallback).
+
+#### Eval grounding regression (optional)
+
+If time permits, add a scenario to `tests/eval/grounding_regressions/` for the verdict-handler dispatch-gap failure class.
+
+## Verification Contract
+
+| Signal | What to check | Expected post-fix |
+|--------|--------------|-------------------|
+| S1 — Engine dispatch fires | `grep verdict_engine_dispatch server.log` | Event emitted on block[ac]/block[ci] when slot is free |
+| S2 — Deferred registration | `grep verdict_redispatch_deferred server.log` | Event emitted when slot is busy (AC4) |
+| S3 — Deferred promotion | `grep deferred_dispatch_promoted server.log` | Deferred wrapper promotes when blocking dispatch completes |
+| S4 — Idempotent collapse | Consecutive block[ac] verdicts on same PR → single callback child | No duplicate deferred wrappers |
+| S5 — Fallback path | `grep "verdict engine-dispatch fallback" server.log` | LLM-mediated path fires when SkillRegistry can't resolve tool |
+
+## Risks
+
+1. **Pre-digest collision with INTENT_GUARDS.** The `webhook_no_unauthorized_dispatch` guard (entry b in INTENT_GUARDS) rejects turns where `run_claude_pilot` was successfully called AND the message starts with `[GitHub]`. For `Dispatched` returns, the subprocess is spawned engine-side (not via the LLM tool call), so the guard's tool-call check doesn't fire. The `<verdict_handler>` prefix in pre-digests also prevents false-positive matching. **Mitigation:** Existing — the guard only checks LLM-initiated tool calls.
+
+2. **`originating_message` for validate_dispatch_readiness.** The verdict handler's engine-side dispatch passes `originating_message = None` because the dispatch is engine-authorized. Guard (0) (`unauthorized_webhook_dispatch`) only fires when `originating_message.is_some()`. Passing `None` skips guard (0) — which is correct because the verdict handler already validated the event type. The ready-label handler passes the original text; we pass `None` for simplicity. Both are safe.
+
+3. **Retry counter was already incremented.** The verdict handler increments the retry counter BEFORE the engine-side dispatch attempt. If the dispatch is deferred, the counter reflects the attempt (correct). If the same verdict retriggers (qa syncs on same HEAD), `has_active_callback_child` catches the deferred wrapper and skips (AC3).
+
+## Definition of Done
+
+- [ ] `register_deferred_callback` is `pub(crate)` in `executor.rs`
+- [ ] `SkillRegistry` threaded into verdict handler
+- [ ] `try_engine_dispatch` helper implemented
+- [ ] `handle_block_ac` uses engine-side dispatch with deferred fallback
+- [ ] `handle_block_ci` uses engine-side dispatch with deferred fallback
+- [ ] `VerdictAction::Dispatched` handled in handlers.rs verdict match arm
+- [ ] Deferred pre-digest formatters added
+- [ ] Idempotent collapse distinguishes "in-flight" from "queued"
+- [ ] `verdict_redispatch_deferred` audit event emitted (AC4)
+- [ ] Unit tests pass for engine dispatch, deferred registration, idempotent collapse
+- [ ] `cargo clippy` clean
+- [ ] `cargo test` passes
+
+## Acceptance criteria
+
+- **AC1 (reproduce):** Unit test `block_ac_registers_deferred_when_slot_busy` demonstrates current-equivalent scenario: block[ac] verdict while slot held → deferred wrapper created (vs zero dispatch in current code).
+- **AC2 (auto-dispatch):** When slot frees (blocking dispatch completes), the periodic backstop in `engine::tick_loop` promotes the deferred wrapper → fix dispatch fires without operator intervention. Verified by S3 signal.
+- **AC3 (idempotent collapse):** Unit test `block_ac_idempotent_collapse` → N consecutive blocks on same PR produce exactly one queued fix attempt.
+- **AC4 (audit event):** Unit test `block_ac_registers_deferred_when_slot_busy` asserts `verdict_redispatch_deferred` audit event written.
+
+## Out of Scope
+
+- **Orphan reaper improvements:** The orphan task that blocked the slot in the founding incident is a separate concern (mika#871, mika#1162). This fix ensures the verdict-driven dispatch survives a busy slot; orphan reaping is independent.
+- **CI failure handler engine-side dispatch:** `ci_failure_handler` has a similar LLM-mediated dispatch pattern. Deferring to a separate ticket if the pattern proves successful here.
+- **Periodic verdict-replay tick:** The issue proposed an alternative (lighter) approach of replaying recent verdict events. Engine-side dispatch + deferred callback is the chosen approach — it composes with existing infrastructure and has proven reliability from the ready-label handler.


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: dirty-worktree)

This PR was created by dispatch-lib's git-workflow recovery.

The dev-pilot session wrote file changes but never completed the git workflow (no `git commit` or `gh pr create`). Per the mika#1271 content/workflow split contract, dispatch-lib took ownership of the git layer: staged, committed with `wip()` prefix, pushed, and opened this draft PR to preserve the content.

**This is a draft PR requiring human review.** The content has NOT passed `/ce:review` and may contain partially-coherent multi-file changes.

### Recovery metadata
- Recovery class: `dirty-worktree`
- Pilot session: `51f387a4-3585-4765-92bf-1ec625b67e8a`
- Turns: 129
- Cost: $11.722129749999993

Closes #1630