### PR TITLE
chore(well-known-agents): add skill-review to mika-dev allowlist for self-tuning

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -144,6 +144,7 @@ allowlist = [\n\
   \"build-mika\",\n\
   \"deploy-mika\",\n\
   \"agents-teams\",\n\
+  \"skill-review\",\n\
   \"address-pr-comments\",\n\
   \"resolve-pr-conflicts\",\n\
   \"self-check\",\n\
@@ -1913,7 +1914,10 @@ mod tests {
             );
         }
 
-        let qa_only = ["qa-review", "qa-review-build-callback", "skill-review"];
+        // skill-review is SHARED, not role-only (like tmux/shell-exec above): mika-qa
+        // reviews skills, and mika-dev self-tunes model-specific variants of its own
+        // prompts via review_skill. Reclassified from qa-only when added to mika-dev.
+        let qa_only = ["qa-review", "qa-review-build-callback"];
         for skill in &qa_only {
             assert!(
                 qa_allowlist.contains(&skill.to_string()),
@@ -2098,8 +2102,8 @@ mod tests {
             .expect("mika-dev must have allowlist");
         assert_eq!(
             allowlist.len(),
-            25,
-            "mika-dev allowlist should have 25 skills (permission-policy retired mika#1193)"
+            26,
+            "mika-dev allowlist should have 26 skills (permission-policy retired mika#1193)"
         );
     }
 
@@ -2423,8 +2427,8 @@ mod tests {
             .expect("reconciler must add [skills].allowlist");
         assert_eq!(
             allowlist.len(),
-            25,
-            "mika-dev reconciled allowlist must contain all 25 spec skills"
+            26,
+            "mika-dev reconciled allowlist must contain all 26 spec skills"
         );
         assert!(allowlist.contains(&"self-dev".to_string()));
         assert!(allowlist.contains(&"dev-pilot".to_string()));
@@ -2516,7 +2520,7 @@ mod tests {
             !allowlist.contains(&"only-self-dev".to_string()),
             "operator-weakened allowlist must be overwritten"
         );
-        assert_eq!(allowlist.len(), 25);
+        assert_eq!(allowlist.len(), 26);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `skill-review` to mika-dev's `[skills].allowlist` in `MIKA_DEV_IDENTITY` (`crates/mika-agent/src/well_known_agents.rs`), so mika-dev can invoke `review_skill` to generate model-tuned `system_prompt.md` variants of her own skill prompts under `generated/<provider>/<model>/`. Needed because her prompts were authored for Sonnet-4-6 but her runtime is now `openrouter/z-ai/glm-5.2` (mika#1633). mika-qa already has this skill allowlisted; this brings mika-dev to parity.

`skill-review` is trust-critical (declared in its own `system_prompt.md`) — it refuses to generate a variant of itself, so exposing it to mika-dev does not let her rewrite the skill-review prompt. Trust boundary is preserved by the skill's own logic.

## Reviewer note — intentional test change (please don't bounce on this)

The const add is one line, but it is coupled to three small test updates in the same file, all artifacts of the *same* single conceptual change:

- Bump mika-dev allowlist count asserts 25 → 26 (`test_dev_identity_allowlist_count`, `test_reconcile_adds_missing_allowlist_for_mika_dev`, `test_reconcile_overwrites_drifted_allowlist`).
- **Reclassify `skill-review` from qa-only to shared** in `test_dev_qa_allowlists_have_no_overlap`. Previously the dev/qa no-overlap invariant listed `skill-review` as QA-only. It is now a shared capability (like `tmux`/`shell-exec`): mika-qa reviews skills; mika-dev self-tunes its own model-specific variants. A one-line code comment in the test records this rationale so the reclassification reads as deliberate, not a snuck-in green-the-suite edit.

## References

- mika#1633 (glm-5.2 base-model swap for mika-dev)

Pipeline-Exempt: no-plan
Pipeline-Exempt: code-only