### PR TITLE
chore(deps): bump rmcp + anyhow to clear RUSTSEC-2026-0189 + 0190 (mika#1654)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Mika is a conversation-first AI executive assistant with per-customer container 
 - **HTTP server:** Axum 0.8 (mika-spirit binary). See `crates/mika-agent/CLAUDE.md` for endpoint details.
 - **HTTP client:** reqwest 0.12 with rustls-tls
 - **Async runtime:** tokio
-- **MCP client:** rmcp 0.17 (official Rust MCP SDK) — stdio and Streamable HTTP transports
+- **MCP client:** rmcp 2.0 (official Rust MCP SDK) — stdio and Streamable HTTP transports
 - **Config:** config-rs with `MIKA_` env prefix + dotenvy for `~/.mika/.env` secrets
 - **Logging:** tracing + tracing-subscriber (JSON for prod, pretty for dev) + optional OpenTelemetry export via `telemetry` feature flag
 - **Telemetry:** opentelemetry 0.31 + tracing-opentelemetry 0.32, feature-gated OTLP HTTP export (Langfuse-compatible)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ opentelemetry-otlp = { version = "0.31", features = ["http-proto"] }
 tracing-opentelemetry = "0.32"
 
 # Error handling
-anyhow = "1"
+anyhow = "1.0.103"
 thiserror = "2"
 
 # UUID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ png = "0.17"
 unicode-width = "0.2"
 
 # MCP (Model Context Protocol)
-rmcp = { version = "0.17", default-features = false, features = [
+rmcp = { version = "2.0", default-features = false, features = [
     "client",
     "transport-child-process",
     "transport-streamable-http-client",

--- a/crates/mika-agent/src/mcp/mod.rs
+++ b/crates/mika-agent/src/mcp/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use mika_common::claude::ToolDefinition;
-use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::model::{CallToolRequestParams, ContentBlock};
 use rmcp::service::{RoleClient, RunningService, ServiceExt};
 use rmcp::transport::TokioChildProcess;
 use tracing::{info, warn};
@@ -177,14 +177,12 @@ impl McpManager {
             }
         };
 
-        let arguments = input.as_object().cloned();
-
-        let params = CallToolRequestParams {
-            meta: None,
-            name: tool_name.clone().into(),
-            arguments,
-            task: None,
-        };
+        // rmcp 2.0: CallToolRequestParams is #[non_exhaustive] — construct via
+        // the name constructor + builder instead of a struct literal.
+        let mut params = CallToolRequestParams::new(tool_name.clone());
+        if let Some(arguments) = input.as_object().cloned() {
+            params = params.with_arguments(arguments);
+        }
 
         let result = match conn.service.call_tool(params).await {
             Ok(r) => r,
@@ -359,14 +357,14 @@ fn convert_mcp_result(result: &rmcp::model::CallToolResult, tool_name: &str) -> 
     let mut images = Vec::new();
 
     for content in &result.content {
-        match &**content {
-            RawContent::Text(t) => {
+        match content {
+            ContentBlock::Text(t) => {
                 if !text.is_empty() {
                     text.push('\n');
                 }
                 text.push_str(&t.text);
             }
-            RawContent::Image(img) => {
+            ContentBlock::Image(img) => {
                 if images.len() >= MAX_MCP_IMAGES {
                     warn!(
                         tool = tool_name,
@@ -423,7 +421,7 @@ fn convert_mcp_result(result: &rmcp::model::CallToolResult, tool_name: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::{CallToolResult, Content};
+    use rmcp::model::{CallToolResult, ContentBlock};
 
     /// Create an empty manager for testing.
     fn empty_manager() -> McpManager {
@@ -490,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_convert_mcp_result_text_only() {
-        let result = CallToolResult::success(vec![Content::text("Hello from MCP")]);
+        let result = CallToolResult::success(vec![ContentBlock::text("Hello from MCP")]);
         let output = convert_mcp_result(&result, "greet");
         assert!(!output.is_error);
         assert_eq!(output.content, "Hello from MCP");
@@ -499,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_convert_mcp_result_error() {
-        let result = CallToolResult::error(vec![Content::text("Something went wrong")]);
+        let result = CallToolResult::error(vec![ContentBlock::text("Something went wrong")]);
         let output = convert_mcp_result(&result, "fail");
         assert!(output.is_error);
         assert_eq!(output.content, "Something went wrong");
@@ -516,7 +514,7 @@ mod tests {
     #[test]
     fn test_convert_mcp_result_truncation() {
         let long_text = "x".repeat(MAX_OUTPUT_LEN + 500);
-        let result = CallToolResult::success(vec![Content::text(long_text)]);
+        let result = CallToolResult::success(vec![ContentBlock::text(long_text)]);
         let output = convert_mcp_result(&result, "verbose");
         assert!(output.content.contains("truncated"));
         assert!(output.content.len() < MAX_OUTPUT_LEN + 100);
@@ -525,9 +523,9 @@ mod tests {
     #[test]
     fn test_convert_mcp_result_multiple_text_blocks() {
         let result = CallToolResult::success(vec![
-            Content::text("Line 1"),
-            Content::text("Line 2"),
-            Content::text("Line 3"),
+            ContentBlock::text("Line 1"),
+            ContentBlock::text("Line 2"),
+            ContentBlock::text("Line 3"),
         ]);
         let output = convert_mcp_result(&result, "multi");
         assert!(!output.is_error);


### PR DESCRIPTION
## What

Two dependency bumps to clear the two RustSec advisories failing the `Security` gate on `main`:

- **`rmcp` 0.17.0 → 2.0.0** — clears **RUSTSEC-2026-0189** (DNS-rebinding, sev 8.8). Advisory fix is ">=1.4.0"; 2.0.0 is latest stable, avoiding a near-future re-bump.
- **`anyhow` 1.0.102 → 1.0.103** — clears **RUSTSEC-2026-0190** ("Unsoundness in `Error::downcast_mut()`"). The workspace `deny.toml` treats unsound advisories as **fatal** in `cargo deny check` (cargo audit only flags it as an allowed warning — this is why it surfaced on CI, not in the initial local audit).

## Why

`Security` is a required status check on `main`, and it fails on every fresh CI run while either advisory is present. This is the **binding constraint** blocking three qa-APPROVED PRs from merging:

- #1647 (verdict-handler block[ac]/block[ci] re-dispatch — mika#1630)
- #1656 (skill-review allowlist for mika-dev)
- #1658 (native Z.AI provider — mika#1657)

## Migration scope

**anyhow**: API-stable patch — version constraint only, no source changes.

**rmcp**: sole consumer is `crates/mika-agent/src/mcp/mod.rs` (`mcp/config.rs` is pure serde). Three mechanical API changes in rmcp 2.0:

| 0.17 | 2.0 |
|------|-----|
| `model::RawContent` (matched via `&**content`) | `model::ContentBlock` — `CallToolResult.content` is now `Vec<ContentBlock>`, matched directly |
| `CallToolRequestParams { meta, name, arguments, task }` struct literal | `CallToolRequestParams::new(name).with_arguments(args)` (type is now `#[non_exhaustive]`) |
| test helper `Content::text(..)` | `ContentBlock::text(..)` |

HTTP/stdio transport construction (`StreamableHttpClientTransportConfig::with_uri`/`auth_header`/`custom_headers`/`from_config`, `TokioChildProcess::new`, `ServiceExt::serve`, `list_tools`, `cancel`) is **unchanged** in 2.0 — no edits to `connect_stdio`/`connect_http`.

## Validation

- `cargo build --workspace` ✓
- `cargo test -p mika-agent mcp` → **37 passed, 0 failed**
- `cargo clippy -p mika-agent --all-targets` ✓ (no new warnings)
- `cargo deny check advisories` → **advisories ok** — RUSTSEC-2026-0189 + 0190 both cleared
- `cargo audit` → 0 vulnerabilities

Closes #1654
