### PR TITLE
fix(verify-pipeline): case-insensitive AC-heading match (mika#1639 secondary)

### DIFF
--- a/docs/plans/2026-06-30-001-fix-1639-verify-pipeline-ac-heading-case-plan.md
+++ b/docs/plans/2026-06-30-001-fix-1639-verify-pipeline-ac-heading-case-plan.md
@@ -1,0 +1,101 @@
+# Plan: fix verify-pipeline.sh AC-heading case-sensitivity (mika#1639 secondary)
+
+## Problem frame (WHY)
+
+`scripts/verify-pipeline.sh` enforces the mika#1600 plan-quality gate with a
+**case-sensitive** match on the Acceptance-criteria heading:
+
+- Line ~112: `grep -q '^## Acceptance criteria'` (presence check)
+- Line ~117: `sed -n '/^## Acceptance criteria/,/^## /{ ... }'` (non-empty-content check)
+
+A plan that writes the heading in title case (`## Acceptance Criteria`, capital C)
+fails the gate even though it has a valid, non-empty AC section. The autonomous-loop
+groom command instructs lowercase, but the LLM frequently title-cases the noun
+phrase out of natural English habit — so ~50% of autonomous-loop plans fail
+Pipeline Artifacts CI on this exact heading-case mismatch.
+
+**Hard evidence (4 PRs hand-fixed today):** #1623 (commit 2bd622ea), #1626
+(c9643057), #1628 (8a02bb2a), #1638 (fe3a5b5c) — each required a manual one-character
+lowercase edit to the plan heading to pass the gate. That's repeated operator labor
+for a one-character regression class with zero value added by the case-sensitivity
+(no realistic plan misses the AC concept by writing it in title case).
+
+This is the **secondary** half of mika#1639. The primary half (tier1 policy-deny on
+`make verify-bundled-skills`) lives in claude-pilot-py and shipped via
+senara-solutions/claude-pilot-py#48.
+
+## Scope boundaries
+
+**In scope:** make the two AC-heading matchers in `scripts/verify-pipeline.sh`
+case-insensitive, plus a regression test.
+
+**Out of scope:** anything tier1/permission-policy (that's the cpp primary, done);
+the groom command's lowercase instruction (it stays — this fix makes the gate
+*tolerant*, it does not change what grooming emits). No other behavior of
+verify-pipeline.sh changes.
+
+## Definition of Done
+
+- [ ] `scripts/verify-pipeline.sh` accepts `## Acceptance Criteria` (and any case) at both the presence check and the content-emptiness extraction.
+- [ ] A regression test in `scripts/verify-pipeline-test.sh` covers the title-case heading → PASS case.
+- [ ] `bash scripts/verify-pipeline-test.sh` is all-green; `bash scripts/verify-pipeline.sh` passes on this branch's own plan.
+
+## Implementation units
+
+### U1. Case-insensitive AC-heading matching in verify-pipeline.sh
+
+**Goal:** title-case `## Acceptance Criteria` passes the mika#1600 gate.
+
+**Files:** `scripts/verify-pipeline.sh` (modify)
+
+**Approach:** two surgical changes in the mika#1600 block (~lines 106-124):
+- Presence check: `grep -q '^## Acceptance criteria'` → `grep -qi '^## Acceptance criteria'`.
+- Content extraction: add the GNU `I` (case-insensitive) flag to the **start** address only — `sed -n '/^## Acceptance criteria/I,/^## /{ ... }'`. The end address `/^## /` and the inner `/^## /d` are already case-agnostic (they match any `## ` heading prefix, including a title-case AC heading), so only the start address needs `I`.
+
+GNU `grep -i` and GNU `sed` address-`I` are both available on the CI runner (GitHub
+Actions Ubuntu) and dev hosts (Gentoo) — verified at plan time. Keep the literal
+heading text `Acceptance criteria` unchanged; only the match becomes case-folding.
+
+**Patterns to follow:** the existing block; no structural change.
+
+**Test scenarios:** covered by U2.
+
+**Verification:** `bash scripts/verify-pipeline.sh` passes on this branch (its own
+plan uses lowercase, still accepted); a title-case plan also passes (U2).
+
+### U2. Regression test for the title-case heading
+
+**Goal:** lock the case-insensitive behavior.
+
+**Files:** `scripts/verify-pipeline-test.sh` (modify)
+
+**Approach:** add one case after the existing mika#1600 AC cases (~line 450),
+mirroring `=== AC check: plan with AC section present → PASS ===` but with a
+title-case heading `## Acceptance Criteria` and a non-empty body. Assert PASS
+(`Pipeline verification passed`). This exercises both the presence check and the
+content-emptiness extraction through the title-case path.
+
+**Test scenarios:**
+- A plan with `## Acceptance Criteria` (capital C) + non-empty checkbox body → `verify-pipeline.sh` exits 0 (PASS). *(Covers AC3, AC4)*
+
+**Verification:** `bash scripts/verify-pipeline-test.sh` reports the new case PASS
+and zero failures overall.
+
+## Acceptance criteria
+
+- [ ] AC3 — `scripts/verify-pipeline.sh` accepts BOTH `## Acceptance Criteria` and `## Acceptance criteria` as the heading (case-insensitive), for both the presence check and the content-emptiness extraction.
+- [ ] AC4 — A plan with title-case `## Acceptance Criteria` and a non-empty body passes the gate (would have unblocked #1623/#1626/#1628/#1638 without the manual lowercase edit), proven by a green regression test.
+
+## Verification contract
+
+1. `bash scripts/verify-pipeline-test.sh` — all cases PASS, including the new title-case case.
+2. `bash scripts/verify-pipeline.sh` — passes on this branch (sanity: the gate still accepts a valid plan).
+
+## Sources & research
+
+- mika#1639 — coupled parent ticket (secondary half).
+- mika#1600 — the AC-heading gate this fix relaxes.
+- mika#1627 — propagated AC-injection to the autonomous groom command (did not eliminate the title-case failures — see evidence).
+- senara-solutions/claude-pilot-py#48 — the primary half (tier1 make allowlist).
+- `scripts/verify-pipeline.sh:112,117` — the two case-sensitive matchers.
+- `scripts/verify-pipeline-test.sh:377-450` — existing mika#1600 AC test cases (pattern to mirror).

--- a/docs/solutions/workflow-issues/verify-pipeline-ac-heading-case-insensitive-2026-06-30.md
+++ b/docs/solutions/workflow-issues/verify-pipeline-ac-heading-case-insensitive-2026-06-30.md
@@ -1,0 +1,86 @@
+---
+title: Structural gates over LLM-authored plan markdown must case-fold the heading match
+tags:
+  - mika-platform
+  - workflow
+  - ci
+  - verify-pipeline
+  - plan-quality
+  - dev-groom
+module: scripts/verify-pipeline.sh
+problem_type: workflow_issue
+category: workflow-issues
+severity: medium
+created: 2026-06-30
+---
+
+# Structural gates over LLM-authored plan markdown must case-fold the heading match
+
+## Symptom
+
+The mika#1600 Pipeline Artifacts CI gate fails a PR with:
+
+```
+FAIL: Plan 'docs/plans/....md' missing '## Acceptance criteria' section. See mika#1600.
+```
+
+— **even though the plan has a complete, non-empty Acceptance-criteria section** — when
+the plan writes the heading in title case (`## Acceptance Criteria`, capital C) instead
+of the sentence case the gate matched literally (`## Acceptance criteria`).
+
+## Root cause
+
+`scripts/verify-pipeline.sh` matched the heading **case-sensitively** at two sites:
+
+- presence: `grep -q '^## Acceptance criteria'`
+- non-empty-content: `sed -n '/^## Acceptance criteria/,/^## /{ ... }'`
+
+The autonomous-loop groom command instructs lowercase, but heading text is
+**LLM-authored natural language**, and the model frequently title-cases the noun
+phrase out of habit. The lowercase instruction is a prompt, and prompt enforcement is
+fragile (`feedback_prompt_enforcement_fragile`): ~50% of autonomous-loop plans came out
+title-cased and hit this gate. Four PRs were hand-fixed in a single day
+(#1623 commit 2bd622ea, #1626 c9643057, #1628 8a02bb2a, #1638 fe3a5b5c) — each a
+one-character lowercase edit to the heading. The case-sensitivity added zero value: no
+realistic plan misses the AC concept by writing it in title case.
+
+## Fix (mika#1639 secondary half)
+
+Fold case at both matchers — control over the structural gate, not another prompt rule:
+
+- `grep -q` -> `grep -qi`
+- sed start-address gets the GNU `I` flag: `/^## Acceptance criteria/I,/^## /{ ... }`.
+  Only the **start** address needs it; the end address `/^## /` and the inner `/^## /d`
+  already match any `## ` heading prefix case-agnostically.
+
+Both GNU flags are available on the CI runner (GitHub Actions Ubuntu) and dev hosts
+(Gentoo). Test it **behaviorally** through the script, not by re-encoding the regex:
+`scripts/verify-pipeline-test.sh` adds a title-case-heading -> PASS case alongside the
+existing present/missing/empty cases (run `bash scripts/verify-pipeline-test.sh`).
+
+## The recurring class (n=2): structural matchers over LLM-authored plan markdown
+
+This is the **same class** as
+[`find-issue-plan-header-shape-widening-2026-06-27.md`](find-issue-plan-header-shape-widening-2026-06-27.md):
+a structural matcher over plan markdown the pilot/groom *writes* was too literal, so a
+legitimate plan went invisible/rejected. There the variation axis was header **shape**
+(`**Ticket:**` vs `**Issue:**`); here it is **case**. Both recur because the matched
+text is natural language the model generates, not a pinned token.
+
+- **n=1 — header shape** (mika#1381/#771/#1600 -> fix #1602): widen the `_find_issue_plan`
+  content-fallback alternation in `dispatch-lib.sh`.
+- **n=2 — heading case** (mika#1639): case-fold the `verify-pipeline.sh` AC-heading match.
+
+**Rule of thumb:** when a gate or discovery function matches a heading/label/marker that
+an LLM authors, make the match tolerant of the natural-language variation the model will
+produce (case, surrounding punctuation, the obvious synonym), and pin the behavior with a
+fixture. Fix the matcher (control), not the prompt (documentation) — the prompt is the
+wrong layer for a structural invariant.
+
+## When NOT to over-widen
+
+Tolerance is for *cosmetic* natural-language variation, not for accepting a malformed
+artifact. The case-fold here still requires the literal heading text and a non-empty body
+— a plan with no AC section, or an empty one, still FAILs (covered by the existing test
+cases). Don't relax a gate past the point where it still proves the thing it exists to
+prove.

--- a/scripts/verify-pipeline-test.sh
+++ b/scripts/verify-pipeline-test.sh
@@ -449,6 +449,32 @@ output=$(run_verify "") || exit_code=$?
 assert_fail "AC check: plan with empty AC section → FAIL" "$exit_code" "$output" "empty '## Acceptance criteria' section"
 cleanup_test_repo
 
+echo ""
+echo "=== AC check: plan with title-case heading → PASS (mika#1639) ==="
+setup_test_repo
+git checkout -b feat/test -q
+mkdir -p docs/plans src
+cat > docs/plans/test-plan.md <<'PLANEOF'
+# Plan: test
+
+## Definition of Done
+
+- [ ] Something done
+
+## Acceptance Criteria
+
+- [ ] AC1. First criterion
+- [ ] AC2. Second criterion
+PLANEOF
+echo "code" > src/main.rs
+git add docs/plans/test-plan.md src/main.rs
+git commit -q -m "feat: plan with title-case AC heading"
+write_mock_gh ""
+output="" ; exit_code=0
+output=$(run_verify "") || exit_code=$?
+assert_pass "AC check: title-case '## Acceptance Criteria' → PASS" "$exit_code" "$output" "Pipeline verification passed"
+cleanup_test_repo
+
 # =========================================================================
 # Summary
 # =========================================================================

--- a/scripts/verify-pipeline.sh
+++ b/scripts/verify-pipeline.sh
@@ -108,13 +108,18 @@ if [[ -n "$PLAN" ]]; then
   # Take the first plan file if multiple exist
   PLAN_FILE=$(echo "$PLAN" | head -1)
   if [[ -f "$PLAN_FILE" ]]; then
-    # Check for ## Acceptance criteria heading
-    if ! grep -q '^## Acceptance criteria' "$PLAN_FILE"; then
+    # Check for ## Acceptance criteria heading (case-insensitive: the autonomous
+    # groom command instructs lowercase, but the LLM frequently title-cases the
+    # noun phrase — mika#1639. `grep -qi` / sed start-address `I` flag (both GNU)
+    # fold case so `## Acceptance Criteria` is accepted.)
+    if ! grep -qi '^## Acceptance criteria' "$PLAN_FILE"; then
       echo "FAIL: Plan '$PLAN_FILE' missing '## Acceptance criteria' section. See mika#1600." >&2
       ERRORS=$((ERRORS + 1))
     else
-      # Check for at least one non-blank line after the heading
-      AC_CONTENT=$(sed -n '/^## Acceptance criteria/,/^## /{ /^## /d; /^[[:space:]]*$/d; p; }' "$PLAN_FILE")
+      # Check for at least one non-blank line after the heading. Only the start
+      # address needs the `I` flag; the end address `/^## /` and inner `/^## /d`
+      # already match any `## ` heading prefix case-agnostically.
+      AC_CONTENT=$(sed -n '/^## Acceptance criteria/I,/^## /{ /^## /d; /^[[:space:]]*$/d; p; }' "$PLAN_FILE")
       if [[ -z "$AC_CONTENT" ]]; then
         echo "FAIL: Plan '$PLAN_FILE' has empty '## Acceptance criteria' section. See mika#1600." >&2
         ERRORS=$((ERRORS + 1))


### PR DESCRIPTION
Makes the mika#1600 Acceptance-criteria gate in `scripts/verify-pipeline.sh` case-insensitive, so a plan that title-cases the heading (`## Acceptance Criteria`) passes instead of failing Pipeline Artifacts CI.

This is the **secondary** half of mika#1639. The **primary** half (claude-pilot tier1 policy-deny on `make verify-bundled-skills`) shipped via senara-solutions/claude-pilot-py#48.

## Why

The gate matched the heading case-sensitively (`grep -q '^## Acceptance criteria'` + a `sed` extraction). The autonomous-loop groom command instructs lowercase, but the heading is **LLM-authored natural language** and the model frequently title-cases the noun phrase — so ~50% of autonomous plans failed CI on this exact mismatch. Prompt enforcement is the wrong layer for a structural invariant (`feedback_prompt_enforcement_fragile`).

**Hard evidence — 4 PRs hand-fixed today**, each a one-character lowercase edit to the plan heading: #1623 (commit 2bd622ea), #1626 (c9643057), #1628 (8a02bb2a), #1638 (fe3a5b5c).

## What

Two surgical case-folds in the mika#1600 block of `scripts/verify-pipeline.sh`:
- presence check: `grep -q` → `grep -qi`
- content-emptiness extraction: GNU `I` flag on the sed **start** address (`/^## Acceptance criteria/I,/^## /{ ... }`). The end address and inner `/^## /d` are already case-agnostic.

Both GNU flags verified available on the CI runner (Ubuntu) and dev hosts (Gentoo). The literal heading text is unchanged; only the match folds case.

## Tests

`scripts/verify-pipeline-test.sh` gains a title-case-heading → PASS case alongside the existing present/missing/empty cases. **`bash scripts/verify-pipeline-test.sh`: 18 passed, 0 failed.** The missing-AC and empty-AC cases still FAIL correctly — the relaxation does not open a false-accept path (a plan still needs the heading text + a non-empty body).

## Acceptance criteria (from mika#1639)

- **AC3** — the gate accepts both `## Acceptance Criteria` and `## Acceptance criteria`, at both the presence check and the content-emptiness extraction. ✓
- **AC4** — a title-case plan with a non-empty body passes (would have unblocked #1623/#1626/#1628/#1638 without the manual edit), proven by a green regression test. ✓

## Compound

Captured the recurring class in `docs/solutions/workflow-issues/verify-pipeline-ac-heading-case-insensitive-2026-06-30.md` — same class as `find-issue-plan-header-shape-widening-2026-06-27.md` (structural matchers over LLM-authored plan markdown must tolerate natural-language variation; n=2: header shape, then heading case).

Closes #1639