### PR TITLE
feat(well-known-agents): swap mika-qa base model to zai/glm-5.2 (mika#1670)

### DIFF
--- a/crates/mika-agent/src/well_known_agents.rs
+++ b/crates/mika-agent/src/well_known_agents.rs
@@ -172,6 +172,19 @@ llm_max_tokens = 8192
 log_level = "info"
 "#;
 
+/// mika-qa config.toml — switches base model to the native Z.AI provider
+/// (zai/glm-5.2) per mika#1670. Calibration gate satisfied: 100% pass (5/5,
+/// mika#1632 suite). Uses native `zai` (mika#1657), not openrouter — that is
+/// the provider the calibration run exercised and the current-correct routing.
+const MIKA_QA_CONFIG: &str = r#"# Mika QA — fabrication-catching review agent.
+# Base model switched to zai/glm-5.2 per mika#1670 calibration evidence (5/5 PASS).
+
+llm_provider = "zai"
+zai_model = "glm-5.2"
+llm_max_tokens = 16384
+log_level = "info"
+"#;
+
 /// mika-qa agent specification.
 ///
 /// Uses identity-driven `[skills].allowlist` (D2 cross-cutting, #815).
@@ -184,7 +197,7 @@ pub static MIKA_QA: WellKnownAgent = WellKnownAgent {
     soul: MIKA_QA_SOUL,
     // Empty: mika-qa uses identity allowlist, not denylist (#815).
     disabled_skills: &[],
-    config_toml: None,
+    config_toml: Some(MIKA_QA_CONFIG),
     // KG disabled (#800): mika-qa has zero `query_knowledge_graph` usage —
     // retrieval goes through `search_memory` (FTS5+vec over memory_facts).
     // Eliminates shared-corpus extractor race on the mika-docs corpus.
@@ -1865,6 +1878,14 @@ mod tests {
     }
 
     #[test]
+    fn test_mika_qa_config_toml_is_valid_toml() {
+        let config: toml::Value =
+            toml::from_str(MIKA_QA_CONFIG).expect("MIKA_QA_CONFIG should be valid TOML");
+        assert_eq!(config["llm_provider"].as_str(), Some("zai"));
+        assert_eq!(config["zai_model"].as_str(), Some("glm-5.2"));
+    }
+
+    #[test]
     fn test_seed_skill_overrides_non_well_known() {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
@@ -2860,16 +2881,18 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
 
-        // Pre-seed mika-qa (which has config_toml: None) with a custom config.
-        mika_common::home::bootstrap_agent(home, "mika-qa").unwrap();
-        let agent_dir = mika_common::agent::agent_dir(home, "mika-qa");
-        fs::write(agent_dir.join("identity.toml"), MIKA_QA_IDENTITY).unwrap();
+        // Pre-seed mika-test (which has config_toml: None) with a custom config.
+        // mika-qa moved to Some(MIKA_QA_CONFIG) in mika#1670, so mika-test is now
+        // the well-known agent exemplifying the None-config skip path.
+        mika_common::home::bootstrap_agent(home, "mika-test").unwrap();
+        let agent_dir = mika_common::agent::agent_dir(home, "mika-test");
+        fs::write(agent_dir.join("identity.toml"), MIKA_TEST_IDENTITY).unwrap();
         let custom = "log_level = \"debug\"\n";
         fs::write(agent_dir.join("config.toml"), custom).unwrap();
 
         // Reconcile must not overwrite — spec has no config_toml.
-        reconcile_well_known_config(home, &MIKA_QA);
-        let after = read_config(home, "mika-qa");
+        reconcile_well_known_config(home, &MIKA_TEST);
+        let after = read_config(home, "mika-test");
         assert_eq!(
             after, custom,
             "agents without spec config must be untouched"

--- a/docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.json
+++ b/docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "timestamp": "2026-06-30T11:15:18.400777880+00:00",
+  "providers": {
+    "mika-qa": {
+      "model": "zai/glm-5.2",
+      "scenarios": {
+        "absence_claim_grounding": {
+          "outcome": "pass",
+          "error_class": null,
+          "input_tokens": 500,
+          "output_tokens": 1276,
+          "latency_ms": 23487
+        },
+        "no_fabricated_fix": {
+          "outcome": "pass",
+          "error_class": null,
+          "input_tokens": 1212,
+          "output_tokens": 1152,
+          "latency_ms": 20313
+        },
+        "per_ac_enumeration": {
+          "outcome": "pass",
+          "error_class": null,
+          "input_tokens": 657,
+          "output_tokens": 781,
+          "latency_ms": 14221
+        },
+        "verdict_format_precision": {
+          "outcome": "pass",
+          "error_class": null,
+          "input_tokens": 594,
+          "output_tokens": 427,
+          "latency_ms": 9492
+        },
+        "wip_rescue_skip": {
+          "outcome": "pass",
+          "error_class": null,
+          "input_tokens": 525,
+          "output_tokens": 903,
+          "latency_ms": 16597
+        }
+      }
+    }
+  }
+}

--- a/docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.md
+++ b/docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.md
@@ -1,0 +1,24 @@
+# Calibration Report: mika-qa
+
+**Model:** zai/glm-5.2
+**Date:** 2026-06-30 11:15 UTC
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Pass rate | 100.0% (5/5) |
+| Input tokens | 3488 |
+| Output tokens | 4539 |
+| Total latency | 84110ms |
+| Confidence | single-shot |
+
+## Per-Scenario Results
+
+| Scenario | Result | Latency | Tokens (in/out) | Failure Class |
+|----------|--------|---------|-----------------|---------------|
+| verdict_format_precision | PASS | 9492ms | 594/427 | - |
+| per_ac_enumeration | PASS | 14221ms | 657/781 | - |
+| absence_claim_grounding | PASS | 23487ms | 500/1276 | - |
+| wip_rescue_skip | PASS | 16597ms | 525/903 | - |
+| no_fabricated_fix | PASS | 20313ms | 1212/1152 | - |

--- a/docs/plans/2026-06-30-003-feat-1670-swap-mika-qa-glm-5.2-plan.md
+++ b/docs/plans/2026-06-30-003-feat-1670-swap-mika-qa-glm-5.2-plan.md
@@ -1,0 +1,174 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+issue: senara-solutions/mika#1670
+plan_type: feat
+created: 2026-06-30
+---
+
+# feat: Swap mika-qa base model to zai/glm-5.2 (mika#1670)
+
+> **Target repo:** mika · **Issue:** senara-solutions/mika#1670 · **Branch:** `feat/1670/well-known-agents-swap-mika-qa-base`
+
+---
+
+## Summary
+
+Switch the well-known `mika-qa` agent's base LLM from its current default (inherited Anthropic) to **`zai/glm-5.2`** via the native Z.AI provider (mika#1657), mirroring the `MIKA_DEV_CONFIG` precedent (mika#1633). The swap is gated by a passing mika-qa calibration run (5/5 PASS, 2026-06-30 11:15 UTC) per the mika#1190 calibration-required-before-swap rule. Ships the source-of-truth `config_toml` change, a TOML-validity test mirroring mika-dev's, the committed calibration evidence, and a runtime config apply so the live agent picks up the swap without a fresh provision.
+
+---
+
+## Problem Frame
+
+**WHY.** mika-qa is the **fabrication-catching layer** of the autonomous loop — mika-dev on glm-5.2 is workable *because* mika-qa catches its fabrications. Putting mika-qa itself on a glm-5.2 base is a cost reduction (native Z.AI bypasses OpenRouter margin) and a 1M-context unlock for the qa layer, but it must not weaken the catcher. The mika-qa calibration suite (mika#1632, 5 scenarios: verdict format precision, per-AC enumeration, absence-claim grounding, wip-rescue skip, no-fabricated-fix) was designed for exactly this risk class. All 5 PASS → glm-5.2 can hold the qa contract.
+
+**Evidence.**
+- Calibration run: `target/eval-calibration/mika-qa-20260630-111518.{json,md}` — 5/5 PASS, single-shot, 3488 in / 4539 out tokens, 84.1s wall (verified present in worktree).
+- Source precedent: `crates/mika-agent/src/well_known_agents.rs:166` (`MIKA_DEV_CONFIG`), `:103` (`config_toml: Some(MIKA_DEV_CONFIG)`), `:1860` (`test_mika_dev_config_toml_is_valid_toml`).
+- Current state: `MIKA_QA` at `well_known_agents.rs:180` has `config_toml: None` (`:187`).
+- Native provider env: `MIKA_ZAI_API_KEY` / `MIKA_ZAI_MODEL` (default `glm-5.2`) — root `CLAUDE.md` Environment Variables.
+- Directory convention: `docs/eval/calibration/mika-dev-1633/mika-dev-glm-5.2-post-1633.{json,md}` (verified present).
+
+**Divergence from mika-dev's config (intentional).** `MIKA_DEV_CONFIG` uses `llm_provider = "openrouter"` + `openrouter_model = "z-ai/glm-5.2"` (source still reflects the pre-native-provider era; runtime is on native zai — a known drift, out of scope per the ticket). This swap uses the **native** provider directly: `llm_provider = "zai"` + `zai_model = "glm-5.2"`. That is the current-correct shape and what the calibration run exercised (`"model": "zai/glm-5.2"` in the artifact).
+
+---
+
+## Requirements
+
+- **R1.** Add a `MIKA_QA_CONFIG` const string with `llm_provider = "zai"` and `zai_model = "glm-5.2"`, parallel to `MIKA_DEV_CONFIG`. (AC1)
+- **R2.** Set `MIKA_QA.config_toml = Some(MIKA_QA_CONFIG)` (currently `None`). (AC2)
+- **R3.** Add a TOML-validity test mirroring `test_mika_dev_config_toml_is_valid_toml`, asserting provider/model fields. (AC3)
+- **R4.** Commit the calibration artifacts under `docs/eval/calibration/mika-qa-1632/`. (AC4)
+- **R5.** Apply the swap to the running agent's runtime config (`~/.mika/agents/mika-qa/config.toml`) so the live mika-qa picks up zai/glm-5.2 — verified by `mika --agent mika-qa ask "what model are you running?"`. (AC5)
+- **R6.** No regression in existing happy-path qa-review behavior shape; calibration remains green on subsequent runs. (AC6)
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Native `zai` provider, not openrouter.** Use `llm_provider = "zai"` + `zai_model = "glm-5.2"`. Matches the provider the calibration run actually exercised and the current-correct routing (mika#1657). Do **not** copy mika-dev's openrouter shape — that would route through a different provider than what was calibrated.
+- **KTD2 — `llm_max_tokens = 16384`.** The ticket specifies 16384 for mika-qa (vs mika-dev's 8192). qa-review emits per-AC enumeration + finding lists; the calibration's `absence_claim_grounding` scenario alone produced 1276 output tokens. 16384 leaves headroom; glm-5.2's context budget supports it. Carry the ticket's value.
+- **KTD3 — Artifact filename mirrors the `-post-<ticket>` convention.** Name the committed files `mika-qa-glm-5.2-post-1632.{json,md}` (mirroring `mika-dev-glm-5.2-post-1633.{json,md}`), under `docs/eval/calibration/mika-qa-1632/`. The `1632` directory/suffix ties to the calibration-suite ticket (mika#1632), exactly as mika-dev-1633 ties to mika#1633. This is a deliberate, consistency-driven read of the ticket's looser `mika-qa-glm-5.2-post-calibration` suggestion — AC4 only pins the directory, not the filename.
+- **KTD4 — Const placement + doc comment.** Place `MIKA_QA_CONFIG` adjacent to `MIKA_QA` (after the `MIKA_QA_IDENTITY` block or beside `MIKA_DEV_CONFIG`), with a doc comment citing mika#1670 + the 5/5 calibration result, mirroring the `MIKA_DEV_CONFIG` comment at `:164-165`.
+- **KTD5 — Runtime apply is a manual operator step, documented but not code.** AC5 (`~/.mika/agents/mika-qa/config.toml`) is a deploy-time runtime mutation outside the Rust source. The reconcile path (`reconcile_well_known_config`, `well_known_agents.rs:658`) writes spec `config_toml` to the runtime file on provision when the spec defines a config — so after this change + a provision/deploy cycle the runtime file converges automatically. The plan documents the explicit apply + verification (AC5) as the Verification Contract, not as an Implementation Unit.
+
+---
+
+## Implementation Units
+
+### U1. Add `MIKA_QA_CONFIG` and wire it onto the `MIKA_QA` spec
+
+- **Goal:** Source-of-truth model swap for mika-qa. (R1, R2)
+- **Dependencies:** none
+- **Files:** `crates/mika-agent/src/well_known_agents.rs`
+- **Approach:**
+  - Add `const MIKA_QA_CONFIG: &str` with a doc comment mirroring `MIKA_DEV_CONFIG` (`:164-173`):
+    ```toml
+    # Mika QA — fabrication-catching review agent.
+    # Base model switched to zai/glm-5.2 per mika#1670 calibration evidence (5/5 PASS).
+
+    llm_provider = "zai"
+    zai_model = "glm-5.2"
+    llm_max_tokens = 16384
+    log_level = "info"
+    ```
+  - Change `MIKA_QA.config_toml` from `None` (`:187`) to `Some(MIKA_QA_CONFIG)`.
+- **Patterns to follow:** `MIKA_DEV_CONFIG` const + `MIKA_DEV.config_toml: Some(...)` at `:103`.
+- **Test scenarios:** covered by U2. (Config wiring is exercised by the reconcile tests that already key off `spec.config_toml` — see `test_reconcile_well_known_config_*` at `:2816`+; no behavioral branch added here beyond `None → Some`.)
+- **Verification:** `cargo build -p mika-agent` compiles; the const parses (U2 test).
+
+### U2. TOML-validity test for `MIKA_QA_CONFIG`
+
+- **Goal:** Regression-gate the swapped provider/model fields. (R3)
+- **Dependencies:** U1
+- **Files:** `crates/mika-agent/src/well_known_agents.rs` (`#[cfg(test)] mod tests`)
+- **Approach:** Add `test_mika_qa_config_toml_is_valid_toml` mirroring `test_mika_dev_config_toml_is_valid_toml` (`:1859-1865`):
+  - parse `MIKA_QA_CONFIG` via `toml::from_str`,
+  - assert `llm_provider == "zai"`,
+  - assert `zai_model == "glm-5.2"`.
+- **Patterns to follow:** `test_mika_dev_config_toml_is_valid_toml` verbatim shape.
+- **Test scenarios:**
+  - Happy path: `MIKA_QA_CONFIG` parses as valid TOML and both field assertions hold.
+  - (Implicit regression) a malformed const or wrong provider/model value fails the assertion — this is the guard's purpose.
+- **Verification:** `cargo test -p mika-agent test_mika_qa_config_toml_is_valid_toml` passes.
+
+### U3. Commit calibration evidence under `docs/eval/calibration/mika-qa-1632/`
+
+- **Goal:** Durable, in-repo calibration record for the swap. (R4)
+- **Dependencies:** none
+- **Files:**
+  - `docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.json` (copy of `target/eval-calibration/mika-qa-20260630-111518.json`)
+  - `docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.md` (copy of `target/eval-calibration/mika-qa-20260630-111518.md`)
+- **Approach:** `git`-tracked copy of the ephemeral `target/` artifacts into the committed calibration tree, byte-identical, mirroring `mika-dev-1633/`.
+- **Test scenarios:** `Test expectation: none — committed evidence files, no behavioral change.`
+- **Verification:** both files present in `git status`; content matches the `target/` originals (`diff` clean).
+
+### U4. Doc-sync touchpoint check (no doc edits expected)
+
+- **Goal:** Confirm no `docs/`-as-single-source-of-truth file needs a sync run for this change. (R6 hygiene)
+- **Dependencies:** U1–U3
+- **Files:** none expected
+- **Approach:** This change touches Rust source + a new `docs/eval/calibration/` tree only. `docs/eval/calibration/` is **not** in the `crates/mika-agent/docs/` build-time include set (that path covers `architecture/`, `configuration/`, etc., not calibration evidence), so `scripts/sync-agent-docs.sh` + the CI `docs-sync` job are not triggered. Confirm by checking the build.rs include surface; if calibration docs were unexpectedly in scope, run the sync script.
+- **Test scenarios:** `Test expectation: none — verification-only unit.`
+- **Verification:** CI `docs-sync` job green on the PR (no unsynced-doc failure).
+
+---
+
+## Verification Contract
+
+Run in the worktree before PR:
+
+1. `cargo build -p mika-agent` — compiles with `config_toml: Some(MIKA_QA_CONFIG)`.
+2. `cargo test -p mika-agent test_mika_qa_config_toml_is_valid_toml` — new test passes. (AC3)
+3. `cargo test -p mika-agent well_known` — no regression in well-known-agent tests (allowlist parity, reconcile, etc.). (AC6)
+4. `cargo clippy -p mika-agent` / `cargo fmt --check` — clean.
+5. Artifact presence: `docs/eval/calibration/mika-qa-1632/mika-qa-glm-5.2-post-1632.{json,md}` tracked; byte-identical to `target/eval-calibration/mika-qa-20260630-111518.{json,md}`. (AC4)
+
+**Runtime-apply verification (AC5 — deploy-time, operator/post-merge step, not gating the PR build):**
+
+6. After `make deploy` (or `MIKA_DISABLE_AGENT_PROVISIONING` unset so reconcile writes the spec config), `~/.mika/agents/mika-qa/config.toml` shows `llm_provider = "zai"` + `zai_model = "glm-5.2"`.
+7. `mika --agent mika-qa ask "what model are you running?"` confirms zai/glm-5.2.
+8. A confirmatory `make calibrate-mika-qa MODEL=zai/glm-5.2` re-run stays 5/5 (AC6 — drift check).
+
+---
+
+## Definition of Done
+
+- [ ] `MIKA_QA_CONFIG` const added with `llm_provider = "zai"` + `zai_model = "glm-5.2"` + `llm_max_tokens = 16384`.
+- [ ] `MIKA_QA.config_toml = Some(MIKA_QA_CONFIG)`.
+- [ ] `test_mika_qa_config_toml_is_valid_toml` added and passing.
+- [ ] Calibration artifacts committed under `docs/eval/calibration/mika-qa-1632/`.
+- [ ] `cargo build`, `cargo test` (well-known scope), `clippy`, `fmt` all clean.
+- [ ] PR body documents the AC5 runtime-apply + verification steps as the post-merge/deploy action.
+
+## Acceptance criteria
+
+- [ ] AC1. `MIKA_QA_CONFIG` constant added with `llm_provider = "zai"` + `zai_model = "glm-5.2"`.
+- [ ] AC2. `MIKA_QA.config_toml = Some(MIKA_QA_CONFIG)`.
+- [ ] AC3. Validation test passes (mirrors mika-dev's test).
+- [ ] AC4. Calibration artifacts committed under `docs/eval/calibration/mika-qa-1632/`.
+- [ ] AC5. After `make deploy`, running `mika --agent mika-qa ask "what model are you running?"` confirms zai/glm-5.2.
+- [ ] AC6. Existing happy-path qa-review behaviors unchanged in shape; no regression in calibration on subsequent runs.
+
+---
+
+## Scope Boundaries
+
+**In scope:** source `config_toml` swap, validity test, committed calibration evidence, runtime-apply documentation/verification.
+
+### Deferred to Follow-Up Work
+- **mika-qa variant generation** (skill-review-tuned prompts for the 6 prompt-heavy skills: qa-review, qa-review-build-callback, build-mika, deploy-mika, self-check, dev-handsoff) — POST-swap, separate workstream. Per `feedback_skill_variant_gen_tied_to_runtime_model`: variant generation persists to the agent's runtime model and must be done **post-swap**, never as pre-swap prep.
+- **Refactor `MIKA_DEV_CONFIG` openrouter → native zai** to fix the source/runtime drift — separate ticket if worth fixing.
+
+---
+
+## Sources & Research
+
+- `crates/mika-agent/src/well_known_agents.rs` — `MIKA_DEV_CONFIG` (`:166`), `MIKA_DEV.config_toml` (`:103`), `MIKA_QA` (`:180`, `config_toml: None` at `:187`), `test_mika_dev_config_toml_is_valid_toml` (`:1859`), reconcile tests (`:2816`+).
+- `target/eval-calibration/mika-qa-20260630-111518.{json,md}` — calibration evidence (5/5 PASS).
+- `docs/eval/calibration/mika-dev-1633/` — directory + filename convention precedent.
+- Root `CLAUDE.md` § Environment Variables (`MIKA_ZAI_API_KEY`/`MIKA_ZAI_MODEL`), § Model calibration (#1190).
+- `crates/mika-agent/CLAUDE.md` § Evaluation — Model Calibration (#1190): mika-qa 5-scenario suite.
+- Lineage: mika#1632 (calibration suite, PR #1644), mika#1190 (framework), mika#1633 (mika-dev swap, PR #1635), mika#1657 (native Z.AI provider).

--- a/docs/solutions/architecture-patterns/well-known-agent-config-toml-override.md
+++ b/docs/solutions/architecture-patterns/well-known-agent-config-toml-override.md
@@ -1,6 +1,7 @@
 ---
 title: Per-agent config.toml override via WellKnownAgent spec
 date: 2026-04-22
+last_updated: 2026-06-30
 category: architecture-patterns
 module: startup, config
 problem_type: best_practice
@@ -8,6 +9,7 @@ component: agent_provisioning
 severity: low
 applies_when:
   - Adding a well-known agent that needs a different LLM model
+  - Swapping an existing well-known agent's base model (post-calibration)
   - Controlling per-agent cost by assigning cheaper models to simple tasks
 tags:
   - agent-provisioning
@@ -15,6 +17,7 @@ tags:
   - llm-model
   - well-known-agents
   - cost-optimization
+  - model-swap
 ---
 
 # Per-agent config.toml override via WellKnownAgent spec
@@ -35,9 +38,17 @@ Use it when the agent's **entire** config profile differs from the default — d
 
 Use `skill_overrides.llm_provider/llm_model` when only specific skills should use a different model while the agent's default model serves other skills normally.
 
-### Key constraint
+### Key behavior: reconcile updates existing agents (updated 2026-06-30)
 
-`config_toml` is only written on first creation (when `!agent_exists()`). Existing agents are never overwritten. To update a deployed agent's config, either delete and re-provision, or edit `~/.mika/agents/<name>/config.toml` directly.
+`config_toml` is written on first creation, **and** `reconcile_well_known_config()` (added with the mika-dev swap, #1633) re-writes a deployed agent's `config.toml` to match the spec on every provision pass when the spec defines a config. This is what makes a base-model swap take effect on an already-provisioned agent after `make deploy` — no delete-and-re-provision needed. (The earlier "existing agents are never overwritten" guidance predated reconcile and is no longer true.) Operators can still set `MIKA_DISABLE_AGENT_PROVISIONING=1` to freeze a hand-edited runtime config across deploys.
+
+### Swapping the base model of an existing agent (#1633 mika-dev, #1670 mika-qa)
+
+A model swap on a *well-known* agent is gated by the calibration framework (#1190): never change `config_toml`'s provider/model without a passing `make calibrate-<role>` run, and commit the artifacts under `docs/eval/calibration/<role>-<ticket>/<role>-<model>-post-<ticket>.{json,md}` (mirror the directory + filename convention, not a looser ad-hoc name). Two non-obvious traps:
+
+1. **Match the provider the calibration run exercised — not the precedent's provider.** `MIKA_DEV_CONFIG` still uses `llm_provider = "openrouter"` + `openrouter_model = "z-ai/glm-5.2"` (it predates the native Z.AI provider, #1657, and its source has drifted from its runtime). When mika-qa swapped to the same model, copying mika-dev's openrouter shape would route through a *different provider* than the one the mika-qa calibration validated. Use the native form the artifact records: `llm_provider = "zai"` + `zai_model = "glm-5.2"`.
+
+2. **Re-anchor the "None-config exemplar" reconcile test.** `test_reconcile_config_skips_agents_without_spec_config` proves reconcile leaves a `config_toml: None` agent's hand-written config untouched. It picks one concrete well-known agent as the exemplar. Each time that exemplar agent *gains* a spec config, the test's premise breaks (reconcile now overwrites it) and the test must be re-pointed at another agent still carrying `config_toml: None`. Order so far: the test used mika-qa until #1670 moved it to `mika-test`. The remaining `None`-config well-known agents are the only valid exemplars — verify the candidate is still `None` before re-anchoring.
 
 ## Examples
 
@@ -69,4 +80,9 @@ fn test_relay_config_toml_is_valid_toml() {
 ## Related
 
 - Issue #721 — mika-relay agent (first user of config_toml)
+- Issue #1633 — mika-dev base-model swap to glm-5.2; added `reconcile_well_known_config()`
+- Issue #1670 — mika-qa base-model swap to native zai/glm-5.2; re-anchored the reconcile-skip test on mika-test
+- Issue #1190 — model calibration framework (swap gate)
+- Issue #1657 — native Z.AI provider (`zai`/`zai_model`)
 - `docs/solutions/architecture-patterns/well-known-agent-provisioning-dev-mode.md` — parent pattern
+- `docs/solutions/best-practices/model-calibration-framework-structural-assertions-2026-05-18.md` — calibration suite design


### PR DESCRIPTION
## Why

mika-qa is the **fabrication-catching layer** of the autonomous loop — mika-dev on glm-5.2 is workable *because* mika-qa catches its fabrications. This swaps mika-qa's own base to native `zai/glm-5.2` (mika#1657) for cost reduction + 1M-context unlock, gated by the mika#1632 calibration suite.

## Calibration gate (5/5 PASS)

`make calibrate-mika-qa MODEL=zai/glm-5.2` — 2026-06-30 11:15 UTC, single-shot, 100% (5/5): verdict_format_precision, per_ac_enumeration, absence_claim_grounding, wip_rescue_skip, no_fabricated_fix. Artifacts committed under `docs/eval/calibration/mika-qa-1632/`.

## What ships

- `MIKA_QA_CONFIG` const (`llm_provider = "zai"`, `zai_model = "glm-5.2"`, `llm_max_tokens = 16384`) + `MIKA_QA.config_toml = Some(MIKA_QA_CONFIG)`, mirroring the `MIKA_DEV_CONFIG` precedent (mika#1633).
- `test_mika_qa_config_toml_is_valid_toml` mirroring mika-dev's validity test.
- Re-anchored `test_reconcile_config_skips_agents_without_spec_config` onto `mika-test` (still `config_toml: None`), since mika-qa now carries a spec config.
- Calibration evidence under `docs/eval/calibration/mika-qa-1632/`.
- Compound doc update capturing the model-swap traps (calibrated-provider vs precedent-provider; None-config-exemplar test re-anchor) and fixing the stale "existing agents never overwritten" note.

### Native zai, not openrouter
Uses `llm_provider = "zai"` (mika#1657) — the provider the calibration run exercised — not mika-dev's drifted openrouter shape. Refactoring mika-dev's source to native zai is out of scope (separate ticket).

## Verification

- `cargo build -p mika-agent`, `cargo test -p mika-agent well_known` (63 pass incl. new test), `clippy`, `fmt` — all clean.
- Calibration artifacts byte-identical to the `target/` originals.

## Post-merge / deploy (AC5)

After `make deploy`, `reconcile_well_known_config()` rewrites `~/.mika/agents/mika-qa/config.toml` to the new spec. Confirm with `mika --agent mika-qa ask "what model are you running?"` → zai/glm-5.2, and a confirmatory `make calibrate-mika-qa MODEL=zai/glm-5.2` stays 5/5.

## Out of scope (deferred)

- mika-qa skill-variant generation (POST-swap, per `feedback_skill_variant_gen_tied_to_runtime_model`).
- Refactoring `MIKA_DEV_CONFIG` openrouter → native zai (separate ticket).

Closes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)