### PR TITLE
fix(mika#1663): skill-review variant path uses provider naming

### DIFF
--- a/crates/mika-agent/src/skills/index.rs
+++ b/crates/mika-agent/src/skills/index.rs
@@ -370,7 +370,19 @@ pub(crate) fn resolve_canonical_provider_model<'a>(
         && !real_provider.is_empty()
         && !real_model.is_empty()
     {
-        return (real_provider, real_model);
+        // Normalize the aggregator-namespace provider segment to its canonical
+        // ProviderKind config-key form so the variant directory matches what
+        // `scan_generated_variants` accepts. OpenRouter routes GLM as
+        // `z-ai/glm-5.2`, but the loader only recognizes `zai` (the config
+        // key). Without this, variants were written under `generated/z-ai/`
+        // and silently orphaned (mika#1663). On parse failure (provider not a
+        // known ProviderKind), fall back to the raw split — fail-open,
+        // preserving legacy behavior for unmapped aggregator namespaces.
+        let canonical_provider: &'a str = match real_provider.parse::<ProviderKind>() {
+            Ok(real_kind) => real_kind.config_prefix(),
+            Err(_) => real_provider,
+        };
+        return (canonical_provider, real_model);
     }
 
     (provider_name, model_name)
@@ -5023,6 +5035,97 @@ mod tests {
             resolved.variant_descriptor(),
             "generated_canonical:minimax/minimax-m2.7"
         );
+    }
+
+    #[test]
+    fn test_resolve_canonical_normalizes_openrouter_zai_alias() {
+        // AC3 (mika#1663): OpenRouter routes GLM as `z-ai/glm-5.2`, but the
+        // variant loader only accepts the config-key form `zai`. The resolver
+        // must collapse the `z-ai` aggregator namespace to `zai` so the writer
+        // and the loader agree on the on-disk directory name.
+        assert_eq!(
+            resolve_canonical_provider_model("openrouter", "z-ai/glm-5.2"),
+            ("zai", "glm-5.2")
+        );
+    }
+
+    #[test]
+    fn test_resolve_canonical_leaves_matching_namespace_unchanged() {
+        // Providers whose OpenRouter namespace already equals their config key
+        // (minimax, anthropic, deepseek, …) are unaffected by normalization.
+        assert_eq!(
+            resolve_canonical_provider_model("openrouter", "minimax/minimax-m2.7"),
+            ("minimax", "minimax-m2.7")
+        );
+        assert_eq!(
+            resolve_canonical_provider_model("openrouter", "anthropic/claude-sonnet-4"),
+            ("anthropic", "claude-sonnet-4")
+        );
+    }
+
+    #[test]
+    fn test_resolve_canonical_native_zai_unchanged() {
+        // Native zai (`llm_provider = "zai"`) has no slash in its model name —
+        // the split path is never taken, inputs pass through unchanged. This is
+        // the read side that must converge on the same `zai` key the OpenRouter
+        // write side now produces.
+        assert_eq!(
+            resolve_canonical_provider_model("zai", "glm-5.2"),
+            ("zai", "glm-5.2")
+        );
+    }
+
+    #[test]
+    fn test_resolve_canonical_unknown_namespace_fails_open() {
+        // An aggregator namespace that is not a known ProviderKind is left
+        // verbatim — fail-open preserves legacy behavior for unmapped routes.
+        assert_eq!(
+            resolve_canonical_provider_model("openrouter", "someprovider/some-model"),
+            ("someprovider", "some-model")
+        );
+    }
+
+    #[test]
+    fn test_resolve_prompt_openrouter_zai_finds_canonical_zai_variant() {
+        // End-to-end loop invariant for mika#1663: a variant stored under the
+        // canonical `zai/glm-5.2` key (where the fixed writer now lands) is
+        // found when resolved via the OpenRouter `z-ai/glm-5.2` ctx.
+        let mut entry = SkillEntry {
+            manifest: SkillManifest {
+                skill: super::super::manifest::SkillInfo {
+                    name: "test".to_string(),
+                    description: "test".to_string(),
+                    version: String::new(),
+                    always_on: false,
+                    timeout_secs: 30,
+                    dependencies: vec![],
+                    max_prompt_size: None,
+                },
+                triggers: super::super::manifest::Triggers { keywords: vec![] },
+                llm: Default::default(),
+                constraints: Default::default(),
+                output: Default::default(),
+                context: std::collections::HashMap::new(),
+                variants: Default::default(),
+            },
+            dir: PathBuf::from("/skills/test"),
+            keywords_lower: vec![],
+            prompt_snippet: "Base prompt.".to_string(),
+            skill_tools: vec![],
+            enabled: true,
+            has_override: false,
+            provider_overrides: HashMap::new(),
+            prompt_sources: SkillEntry::empty_prompt_sources(),
+            model_overrides: HashMap::new(),
+        };
+        entry
+            .generated_model_prompts_mut()
+            .insert("zai/glm-5.2".to_string(), "GLM variant.".to_string());
+
+        let resolved = entry.resolve_prompt("openrouter", "z-ai/glm-5.2");
+        assert_eq!(resolved.text, "GLM variant.");
+        assert_eq!(resolved.source, PromptVariantSource::GeneratedCanonical);
+        assert_eq!(resolved.key.as_deref(), Some("zai/glm-5.2"));
     }
 
     #[test]

--- a/crates/mika-agent/src/startup.rs
+++ b/crates/mika-agent/src/startup.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use mika_common::home;
-use tracing::info;
+use mika_common::llm::ProviderKind;
+use tracing::{info, warn};
 
 use crate::db::Database;
 
@@ -54,6 +55,12 @@ pub fn seed_core_memory_if_empty(db: &Database, home_dir: &Path, agent_name: &st
 /// (`_shared/`) are seeded unconditionally because they are infrastructure
 /// (dispatch plumbing), not skill prompts. See mika#923.
 pub fn seed_bundled_skills_if_needed(agent_home: &Path, disabled: bool) {
+    // One-shot repair of orphaned generated skill variants (mika#1663). Runs
+    // in all modes — including MIKA_DISABLE_BUNDLED_SKILLS — because orphaned
+    // variants exist independently of bundled-skill seeding and should be
+    // repaired regardless of that debugging flag.
+    migrate_generated_variant_provider_dirs(agent_home);
+
     let (global_home, is_multi_agent) = resolve_global_home(agent_home);
     let library_dir = home::library_skills_dir(&global_home);
     let agent_skills_dir = agent_home.join("skills");
@@ -129,6 +136,131 @@ fn resolve_global_home(agent_home: &Path) -> (std::path::PathBuf, bool) {
     (agent_home.to_path_buf(), false)
 }
 
+/// One-shot migration: rename generated-variant provider directories whose
+/// name is a non-canonical `ProviderKind` alias (e.g. OpenRouter's `z-ai`) to
+/// the canonical config-key form (`zai`) that `scan_generated_variants`
+/// accepts (mika#1663).
+///
+/// Variants written under an aggregator-namespace provider segment were
+/// silently orphaned: the writer used the raw OpenRouter namespace string
+/// (`z-ai`), but the loader only recognizes `ProviderKind::from_str`-parseable
+/// config-key names (`zai`). The writer is fixed forward
+/// (`resolve_canonical_provider_model` now normalizes the aggregator split);
+/// this migration repairs variants already on disk.
+///
+/// Walks `<agent_home>/skills/*/generated/<provider>/`. A provider dir
+/// qualifies when its name parses to a `ProviderKind` but differs from that
+/// kind's `config_prefix()` — exactly the alias case (e.g. `z-ai` → `zai`).
+/// Skill directories are commonly symlinks into the shared library, so the
+/// physical rename lands in the library; idempotent across agents that share
+/// it.
+///
+/// Idempotent: a directory already in canonical form is skipped. When both the
+/// alias dir and the canonical dir exist, model subdirectories are merged
+/// (canonical wins on collision) and the alias dir is removed. All filesystem
+/// errors are warn-and-continue — a migration failure must never block startup.
+pub fn migrate_generated_variant_provider_dirs(agent_home: &Path) {
+    let skills_dir = agent_home.join("skills");
+    let skill_entries = match std::fs::read_dir(&skills_dir) {
+        Ok(rd) => rd,
+        Err(_) => return, // no skills dir yet (fresh install) — nothing to migrate
+    };
+
+    for skill_entry in skill_entries.flatten() {
+        let skill_name = skill_entry.file_name().to_string_lossy().into_owned();
+        // Skip support dirs (`_shared/`) and dotfiles — they hold no variants.
+        if skill_name.starts_with('_') || skill_name.starts_with('.') {
+            continue;
+        }
+        let generated_root = skill_entry.path().join("generated");
+        let provider_dirs = match std::fs::read_dir(&generated_root) {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+
+        for provider_entry in provider_dirs.flatten() {
+            let provider_path = provider_entry.path();
+            if !provider_path.is_dir() {
+                continue;
+            }
+            let name = match provider_path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // Only alias dirs qualify: parseable to a ProviderKind but not
+            // already the canonical config-key form.
+            let Ok(kind) = name.parse::<ProviderKind>() else {
+                continue;
+            };
+            let canonical = kind.config_prefix();
+            if name == canonical {
+                continue;
+            }
+
+            let canonical_path = generated_root.join(canonical);
+            if !canonical_path.exists() {
+                match std::fs::rename(&provider_path, &canonical_path) {
+                    Ok(()) => info!(
+                        skill = %skill_name,
+                        from = %name,
+                        to = %canonical,
+                        "migrated orphaned generated variant provider dir (mika#1663)"
+                    ),
+                    Err(e) => warn!(
+                        skill = %skill_name,
+                        from = %name,
+                        to = %canonical,
+                        error = %e,
+                        "failed to migrate generated variant provider dir"
+                    ),
+                }
+                continue;
+            }
+
+            // Canonical dir already exists — merge per-model subdirs.
+            let model_dirs = match std::fs::read_dir(&provider_path) {
+                Ok(rd) => rd,
+                Err(_) => continue,
+            };
+            for model_entry in model_dirs.flatten() {
+                let src_model = model_entry.path();
+                let model_name = match src_model.file_name() {
+                    Some(n) => n.to_owned(),
+                    None => continue,
+                };
+                let dst_model = canonical_path.join(&model_name);
+                if dst_model.exists() {
+                    // Canonical wins — drop the stale alias copy.
+                    let _ = std::fs::remove_dir_all(&src_model);
+                } else if let Err(e) = std::fs::rename(&src_model, &dst_model) {
+                    warn!(
+                        skill = %skill_name,
+                        model = %model_name.to_string_lossy(),
+                        error = %e,
+                        "failed to merge generated variant model dir during migration"
+                    );
+                }
+            }
+            // Remove the (now hopefully empty) alias provider dir.
+            if let Err(e) = std::fs::remove_dir(&provider_path) {
+                warn!(
+                    skill = %skill_name,
+                    dir = %name,
+                    error = %e,
+                    "failed to remove migrated alias provider dir (may be non-empty)"
+                );
+            } else {
+                info!(
+                    skill = %skill_name,
+                    from = %name,
+                    to = %canonical,
+                    "merged orphaned generated variants into canonical provider dir (mika#1663)"
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +306,113 @@ mod tests {
             skill_dirs.is_empty(),
             "skill directories should not be created when disabled"
         );
+    }
+
+    fn write_variant(agent_home: &Path, skill: &str, provider: &str, model: &str, body: &str) {
+        let dir = agent_home
+            .join("skills")
+            .join(skill)
+            .join("generated")
+            .join(provider)
+            .join(model);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("system_prompt.md"), body).unwrap();
+    }
+
+    #[test]
+    fn test_migrate_renames_zai_alias_dir() {
+        // mika#1663: an orphaned `z-ai/` variant dir is renamed to canonical `zai/`.
+        let tmp = tempfile::tempdir().unwrap();
+        write_variant(tmp.path(), "dev-pilot", "z-ai", "glm-5.2", "GLM variant");
+
+        migrate_generated_variant_provider_dirs(tmp.path());
+
+        let gen_dir = tmp.path().join("skills/dev-pilot/generated");
+        assert!(
+            !gen_dir.join("z-ai").exists(),
+            "alias dir should be removed after migration"
+        );
+        let migrated = gen_dir.join("zai/glm-5.2/system_prompt.md");
+        assert!(migrated.is_file(), "variant should now live under zai/");
+        assert_eq!(std::fs::read_to_string(migrated).unwrap(), "GLM variant");
+    }
+
+    #[test]
+    fn test_migrate_is_idempotent_and_skips_canonical() {
+        // A canonical `zai/` dir is untouched; a second run is a no-op.
+        let tmp = tempfile::tempdir().unwrap();
+        write_variant(
+            tmp.path(),
+            "dev-pilot",
+            "zai",
+            "glm-5.2",
+            "already canonical",
+        );
+
+        migrate_generated_variant_provider_dirs(tmp.path());
+        migrate_generated_variant_provider_dirs(tmp.path());
+
+        let path = tmp
+            .path()
+            .join("skills/dev-pilot/generated/zai/glm-5.2/system_prompt.md");
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "already canonical");
+    }
+
+    #[test]
+    fn test_migrate_merges_into_existing_canonical_dir() {
+        // When both alias and canonical dirs exist, non-colliding models move
+        // over and the canonical copy wins on collision; alias dir is removed.
+        let tmp = tempfile::tempdir().unwrap();
+        // Collision: same model in both — canonical must win.
+        write_variant(tmp.path(), "dev-pilot", "zai", "glm-5.2", "canonical wins");
+        write_variant(tmp.path(), "dev-pilot", "z-ai", "glm-5.2", "stale alias");
+        // Non-colliding model only in the alias dir — must migrate.
+        write_variant(tmp.path(), "dev-pilot", "z-ai", "glm-4.6", "alias only");
+
+        migrate_generated_variant_provider_dirs(tmp.path());
+
+        let gen_dir = tmp.path().join("skills/dev-pilot/generated");
+        assert!(!gen_dir.join("z-ai").exists(), "alias dir should be gone");
+        assert_eq!(
+            std::fs::read_to_string(gen_dir.join("zai/glm-5.2/system_prompt.md")).unwrap(),
+            "canonical wins",
+            "canonical content must win on collision"
+        );
+        assert_eq!(
+            std::fs::read_to_string(gen_dir.join("zai/glm-4.6/system_prompt.md")).unwrap(),
+            "alias only",
+            "non-colliding model must migrate into canonical dir"
+        );
+    }
+
+    #[test]
+    fn test_migrate_ignores_unknown_and_support_dirs() {
+        // Unknown provider names (not a ProviderKind) and `_shared/` are left alone.
+        let tmp = tempfile::tempdir().unwrap();
+        write_variant(tmp.path(), "dev-pilot", "mystery-vendor", "m1", "keep me");
+        write_variant(tmp.path(), "_shared", "z-ai", "glm-5.2", "support dir");
+
+        migrate_generated_variant_provider_dirs(tmp.path());
+
+        assert!(
+            tmp.path()
+                .join("skills/dev-pilot/generated/mystery-vendor/m1/system_prompt.md")
+                .is_file(),
+            "unknown provider dir must be left untouched"
+        );
+        assert!(
+            tmp.path()
+                .join("skills/_shared/generated/z-ai/glm-5.2/system_prompt.md")
+                .is_file(),
+            "support dirs must be skipped by the migration"
+        );
+    }
+
+    #[test]
+    fn test_migrate_no_skills_dir_is_noop() {
+        // Fresh install with no skills dir must not panic.
+        let tmp = tempfile::tempdir().unwrap();
+        migrate_generated_variant_provider_dirs(tmp.path());
     }
 
     #[test]

--- a/crates/mika-common/src/llm/mod.rs
+++ b/crates/mika-common/src/llm/mod.rs
@@ -392,7 +392,12 @@ impl FromStr for ProviderKind {
             "kimi" => Ok(ProviderKind::Kimi),
             "qwen" => Ok(ProviderKind::Qwen),
             "mikamodel" => Ok(ProviderKind::MikaModel),
-            "zai" => Ok(ProviderKind::ZAi),
+            // `zai` is the canonical config-key form (matches `config_prefix`
+            // and `Display`). `z-ai` is the OpenRouter-namespace alias
+            // (`z-ai/glm-5.2`) — accepted so `resolve_canonical_provider_model`
+            // can normalize aggregator-split provider names to the canonical
+            // key the skill-variant loader requires (mika#1663).
+            "zai" | "z-ai" => Ok(ProviderKind::ZAi),
             _ => Err(format!(
                 "unknown provider '{s}'. Known providers: anthropic, openai, openrouter, groq, ollama, mistral, google, deepseek, minimax, kimi, qwen, mikamodel, zai"
             )),
@@ -583,6 +588,12 @@ mod tests {
         // Z.AI direct uses bare model ids (e.g. `glm-5.2`), no provider slash.
         assert!(!ProviderKind::ZAi.model_names_contain_slash());
         assert_eq!("zai".parse::<ProviderKind>(), Ok(ProviderKind::ZAi));
+        // OpenRouter-namespace alias (`z-ai/glm-5.2`) parses to the same kind
+        // so `resolve_canonical_provider_model` can normalize it (mika#1663).
+        assert_eq!("z-ai".parse::<ProviderKind>(), Ok(ProviderKind::ZAi));
+        assert_eq!("Z-AI".parse::<ProviderKind>(), Ok(ProviderKind::ZAi));
+        // Canonical form survives a Display→FromStr round-trip as `zai`.
+        assert_eq!(ProviderKind::ZAi.to_string(), "zai");
     }
 
     #[test]

--- a/docs/plans/2026-06-30-013-fix-1663-skill-review-variant-path-naming-plan.md
+++ b/docs/plans/2026-06-30-013-fix-1663-skill-review-variant-path-naming-plan.md
@@ -1,0 +1,95 @@
+---
+issue: 1663
+type: fix
+date: 2026-06-30
+---
+
+# Plan — fix(skill-review): variant path provider-name normalization (mika#1663)
+
+## Problem
+
+`review_skill` writes variants to `generated/<provider>/<sanitized_model>/system_prompt.md`. The `<provider>` segment comes from `resolve_canonical_provider_model(ctx.provider_name, ctx.model_name)` in `crates/mika-agent/src/skills/index.rs`. When the agent is configured via OpenRouter (`llm_provider = "openrouter"`, `model = "z-ai/glm-5.2"`), the resolver splits the slash to produce `("z-ai", "glm-5.2")` — taking the OpenRouter-namespace string as the canonical provider name.
+
+The runtime variant loader (`crates/mika-agent/src/skills/index.rs::scan_generated_variants`) validates directory names by parsing them as `ProviderKind` via `from_str`, which **only accepts the config-key-prefix form**: `"zai"`, not `"z-ai"`. Directory `generated/z-ai/glm-5.2/` fails the parse gate → variant silently skipped → root prompt loaded instead.
+
+**Hard evidence (body-cited, codebase-verified):**
+- `crates/mika-common/src/llm/mod.rs::FromStr for ProviderKind` accepts `"zai"` only; `"z-ai"` returns `Err`.
+- `crates/mika-common/src/llm/mod.rs::ProviderKind::config_prefix()` returns `"zai"` for `ProviderKind::ZAi` (used by `Display` impl).
+- `crates/mika-agent/src/skills/index.rs::resolve_canonical_provider_model` splits OpenRouter `"z-ai/glm-5.2"` into `("z-ai", "glm-5.2")` with no normalization step.
+- Live state: 6 variants under `~/.mika/skills/<skill>/generated/zai/glm-5.2/` work correctly (mika-dev is now on `llm_provider = "zai"` native after mika#1657 deploy + operator-CC manual `mv z-ai zai`). Pre-fix state was `generated/z-ai/`.
+
+This bug surfaces whenever the operator switches from `openrouter/z-ai/glm-5.2` (which writes to `z-ai/`) to native `zai/glm-5.2` (which reads from `zai/`) — variants generated under OpenRouter routing become inert.
+
+## Architectural lineage
+
+- mika#1633 — glm-5.2 swap (introduced OpenRouter routing of z-ai/glm-5.2).
+- mika#1657 — Z.AI native provider (introduced `ProviderKind::ZAi` + `"zai"` config key, surfacing the naming-mismatch).
+- mika#1190 — calibration discipline (variants are core to per-model-tuned cost-reduction; this bug silently nullifies it).
+
+## Fix shape (Option A — writer normalization, architect-confirmable)
+
+The body proposes "Fix the writer" — compute the variant directory using `ProviderKind::from_str().config_prefix()` (or equivalent canonical form). Concrete steps:
+
+1. **Extend `ProviderKind::from_str` to accept the `"z-ai"` alias.** Currently the match-arm only accepts `"zai"`. Add `"z-ai"` as an alternate matching to `ProviderKind::ZAi`. This is the OpenRouter-namespace-tolerance layer.
+2. **Normalize `resolve_canonical_provider_model`'s OpenRouter-split output.** After splitting, attempt `ProviderKind::from_str(real_provider)`; on success, replace `real_provider` with the parsed kind's `config_prefix()`. On failure, return the raw split (legacy behavior, fail-open).
+3. **The variant-loader (`scan_generated_variants`) stays as-is** — it accepts only `ProviderKind::from_str`-parseable directory names, which after Step 1 includes both `"zai"` and (transitively, via the writer normalization) NEVER `"z-ai"` because Step 2 collapses it before the path is written.
+
+The body's stated bug is about path-write inconsistency. The root cause is actually the **OpenRouter→canonical name normalization missing in the resolver**, which the FromStr alias + resolver normalization together fix.
+
+## Implementation outline
+
+1. **Edit `crates/mika-common/src/llm/mod.rs::FromStr for ProviderKind`**: add `"z-ai" => Ok(ProviderKind::ZAi)` arm. Document as "OpenRouter-namespace alias." If other providers have similar dash-or-no-dash variation in OpenRouter's namespace (`deepseek` vs `deepseek-r1` patterns, `qwen` vs `qwen-2-72b`), audit and add aliases in this same PR. (Likely zero or one — focused commit.)
+
+2. **Edit `crates/mika-agent/src/skills/index.rs::resolve_canonical_provider_model`**: after the OpenRouter split path, normalize the `real_provider` half via `ProviderKind::from_str(real_provider).map(|k| k.config_prefix())` — on success use that, on failure leave unchanged. This means even if a future OpenRouter alias is added (`x-y`) and `FromStr` knows it, the variant path keeps using the canonical key.
+
+3. **One-shot data migration:** add a startup hook (or operator CLI command) that renames existing `generated/z-ai/` directories to `generated/zai/`. Architect-bearing — could be:
+   - **3a** Inline in `seed_bundled_skills_if_needed()` or skill registry init (fires once per restart, idempotent).
+   - **3b** A `mika skills migrate` CLI command operators run manually.
+   - **3c** Just document the manual `mv` command in the PR body; let operators run it.
+   The body explicitly mentions AC2 wants "auto-migrate or one-shot rename migration documented." Lean (3a) for cleanest UX; (3c) is the minimal-risk option. Plan defers shape to architect.
+
+4. **Unit test (AC3):** assert that for `ctx.provider_name = "openrouter"`, `ctx.model_name = "z-ai/glm-5.2"`, the resolved canonical provider is `"zai"` (not `"z-ai"`). Test added to `crates/mika-agent/src/skills/index.rs`'s `#[cfg(test)] mod tests` (mirrors existing `test_resolve_canonical_provider_model_openrouter` style at line 4469).
+
+5. **Smoke test (AC4):** after PR merge + deploy, run `mika ask --agent mika-dev "use review_skill to inspect dev-groom"` from an OpenRouter-routed agent (if any still exist) OR document the expected behavior: variant writes to `generated/zai/glm-5.2/`. Next `mika ask` confirms variant loads via `per_skill_bytes` log line.
+
+## Acceptance criteria
+
+- **AC1** — `review_skill` writes variants to `generated/zai/glm-5.2/` (not `z-ai`) when called from an agent routed via OpenRouter (`openrouter/z-ai/glm-5.2`) AND when called from an agent on native `zai`. Both paths converge on `zai/`.
+
+- **AC2** — Existing variants under `z-ai/` auto-migrate via Step 3a (inline auto-migrate in `seed_bundled_skills_if_needed()`, idempotent walk-and-mv). Architect-confirmed shape.
+
+- **AC2b (architect sharpening)** — OpenRouter↔canonical-name audit documented in PR body. Implementer checks explicitly: `deepseek/` (vs config `deepseek-r1`/`deepseek-chat`), `qwen/` (vs `qwen-3-*`), `google/` (vs `google-2-*`), `anthropic/` (vs `claude-*`). Each entry: either "no mismatch (OpenRouter and config use the same name)" or "mismatch — alias added: `<openrouter>` → `<config>`." If more than one additional alias needs adding beyond z-ai/zai, surface to architect — likely a scope-expansion signal.
+
+- **AC3** — Unit test in `crates/mika-agent/src/skills/index.rs` asserts `resolve_canonical_provider_model("openrouter", "z-ai/glm-5.2")` returns `("zai", "glm-5.2")`. Mirror the existing `test_resolve_canonical_provider_model_openrouter` test style.
+
+- **AC4** — Post-fix smoke: `mika ask --agent <openrouter-routed-agent> "use review_skill to inspect dev-groom"` writes to `generated/zai/glm-5.2/`. On next `mika ask` from any agent (zai-native OR openrouter-routed), `per_skill_bytes` log line shows variant size, not root size. Verified via log inspection in PR body.
+
+## Out of scope
+
+- **`refusal_regression` calibration `max_tokens` issue** — different ticket (mika#1665), different root cause.
+- **`reasoning_content` surface in OpenAI-compatible adapter for Z.AI** — different ticket.
+- **Audit of other OpenRouter aliases for dash-vs-no-dash mismatch.** Plan §1 says "audit in this PR" — that audit may turn up zero or one additional alias. If more than two surface, file a separate sweep ticket; don't expand scope here.
+
+## Files involved
+
+- `crates/mika-common/src/llm/mod.rs::FromStr for ProviderKind` — Step 1 (add `"z-ai"` alias)
+- `crates/mika-agent/src/skills/index.rs::resolve_canonical_provider_model` — Step 2 (normalize OpenRouter-split provider via config_prefix)
+- `crates/mika-agent/src/skills/index.rs` `#[cfg(test)] mod tests` — Step 4 (unit test, AC3)
+- `crates/mika-agent/src/server/mod.rs` OR new CLI command — Step 3 (data migration, architect-bearing)
+- No skill prompt changes; no schema migration
+
+## Verification
+
+- **Static:** `cargo build --release` clean. `cargo test -p mika-common` covers FromStr round-trip. `cargo test -p mika-agent skills::index` covers resolver normalization.
+- **Live (AC4):** run `mika ask --agent mika-dev "list known skills"` (any read-only call) and check `~/.mika/agents/mika-dev/logs/mika.log.<date>` for `system_prompt_assembled` event. `per_skill_bytes` for any variant-having skill should match the variant file size, not the root size.
+- **Data migration verification (AC2):** after restart with migration applied, `ls ~/.mika/skills/*/generated/` returns directories named `zai/` (or other ProviderKind-canonical keys), zero `z-ai/` directories.
+
+## References
+
+- mika#1633 — glm-5.2 swap (introduced OpenRouter routing of z-ai/glm-5.2)
+- mika#1657 — Z.AI native provider (introduced ProviderKind::ZAi + "zai" config key)
+- mika#1190 — calibration discipline (variants are load-bearing for per-model tuning)
+- `crates/mika-common/src/llm/mod.rs:372-376` — Display impl uses config_prefix → "zai"
+- `crates/mika-common/src/llm/mod.rs:378-398` — FromStr impl accepts only "zai" today
+- `crates/mika-agent/src/skills/index.rs::resolve_canonical_provider_model` — the splitter that produces "z-ai" without normalization
+- mika-dev's `system_prompt_assembled` log evidence (per_skill_bytes 1623 vs 3292 — body-cited)


### PR DESCRIPTION
Auto-created by dispatch-lib (mika#1383 structural completion gate).

The pilot session completed work and committed but did not reach `gh pr create` before its turn ended. dispatch-lib takes ownership of the commit→PR tail per mika#1271 (content/workflow split). The pilot owned content; dispatch-lib owns git/PR.

Pilot session: `eb6913be-b5db-4154-9ec9-d6a2f5bfe0db`
Branch: `fix/1663/skill-review-variant-path-uses-provider`

Closes #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)