### PR TITLE
fix(dispatch-lib): bypass pre-commit hook on post-flight rescue commits (mika#1685)

### DIFF
--- a/docs/plans/2026-06-30-018-fix-1685-dispatch-lib-rescue-noverify-plan.md
+++ b/docs/plans/2026-06-30-018-fix-1685-dispatch-lib-rescue-noverify-plan.md
@@ -1,0 +1,106 @@
+---
+issue: 1685
+type: fix
+date: 2026-06-30
+---
+
+# Plan — fix(dispatch-lib): post-flight rescue commits bypass pre-commit hook (mika#1685)
+
+## Problem
+
+`skills/bundled/_shared/dispatch-lib.sh` post-flight rescue paths call `git commit` WITHOUT `--no-verify`. The pre-commit hook (lefthook with `rust-clippy`) runs on every rescue commit. When the pilot leaves any clippy nit in the worktree, the hook rejects the commit → `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook after cargo-fmt retry` → parent task → blocked. The 95% complete work is stranded; no PR opens.
+
+Hard evidence (2026-06-30 14:30-16:18Z): three blocked tasks (mika#1680, mika#1682, mika#1676) all carry the identical callback prefix `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook after cargo-fmt retry`. Modal cause across the 5-task wedge per Mika Prime bearing 2026-06-30 ~16:32Z (session `00000000`).
+
+## Architectural lineage
+
+- mika#1282 — original dirty-worktree rescue (line 890 `git commit`)
+- mika#1396 — commit-pushed-no-pr rescue retry (line 924 `git commit` — cargo-fmt fallback)
+- mika#1383 — auto-PR-create trailing content (line 1020 `git commit`)
+- mika#1058 — callback can't retry pilot (the trap, downstream of this cause — separate fix)
+- mika#1639 (CLOSED) — sibling permission-policy fix shipped earlier today
+
+## Fix shape (one-line edits × 3 sites + rationale comment)
+
+Add `--no-verify` to all three rescue `git commit` invocations in `skills/bundled/_shared/dispatch-lib.sh`:
+
+- **Line 890** (mika#1282 dirty-worktree initial commit): `git -C "$WORKTREE_DIR" commit -m "..." --no-verify`
+- **Line 924** (mika#1282 cargo-fmt retry commit): `git -C "$WORKTREE_DIR" commit -m "..." --no-verify`
+- **Line 1020** (mika#1383 trailing-content commit): `git -C "$WORKTREE_DIR" commit -m "..." --no-verify`
+
+**Rationale comment** added next to one of the calls (or in a top-of-block doc-comment):
+
+```bash
+# Rescue commits bypass the pre-commit hook (--no-verify) by design (mika#1685):
+# the rescue path's purpose is to SALVAGE work for operator review, not to gate
+# it on lint. A single clippy nit (one-line typo) should not strand 29-turn,
+# $4-cost pilot work as a dead block. CI runs clippy as a check on the rescue
+# draft PR, surfacing the same signal at the right layer — visible to the
+# operator + the autonomous-loop's clippy-fix-retry path, not as a hard block.
+```
+
+## Implementation outline
+
+1. **Read the three call sites** at `dispatch-lib.sh:890`, `:924`, `:1020`. Confirm each is the rescue-path commit (not a developer-tool commit elsewhere).
+
+2. **Add `--no-verify` to each**. Position: after `-m "..."` argument, before any redirect (`2>&9`). Pattern: `git -C "$WORKTREE_DIR" commit -m "..." --no-verify`.
+
+3. **Add rationale comment** above the line 890 block (the first/canonical site). Reference mika#1685 + the operator-review-not-lint-gate principle.
+
+4. **Re-evaluate `cargo-fmt retry` mechanism (lines 920-930 area).** Architect-bearing question: does this retry still make sense once `--no-verify` ships? Two options:
+   - **Keep it** — `cargo fmt` is still useful as best-effort formatting before the rescue commit. The retry-after-format is now a no-op because the first commit (also `--no-verify`) already succeeded.
+   - **Remove it** — the retry's value (re-formatting after a fmt-hook failure) is moot since the hook no longer fires. Code path becomes dead.
+   
+   My read: keep it cheap (`cargo fmt` is fast, harmless on clean worktree); remove the second `git commit` retry since the first one always succeeds now. Architect can confirm.
+
+5. **Regression test** — add a dispatch-lib integration test (or extend `skills/bundled/_shared/tests/test-dispatch-lib.sh`) that:
+   - Seeds a worktree with a deliberate clippy warning (e.g., a `repeat().collect()`).
+   - Runs the rescue path.
+   - Asserts: rescue commit succeeds (returns 0), PR opens with `wip-rescue` label, no `PIPELINE FAILURE` emitted.
+
+## Acceptance criteria
+
+- **AC1** — `dispatch-lib.sh:890,924,1020` rescue `git commit` invocations include `--no-verify`. Verified by reading the PR diff.
+
+- **AC2** — Rationale comment added above the line 890 block (or equivalent canonical site), referencing mika#1685 + the operator-review-not-lint-gate principle. Comment includes the substring "CI runs clippy as a check on the rescue draft PR" or equivalent semantic.
+
+- **AC3** — Regression test exists: a worktree with a deliberate clippy nit successfully rescues via the dispatch-lib path. PR opens, no `PIPELINE FAILURE`. Test placement in `skills/bundled/_shared/tests/test-dispatch-lib.sh` if it exists; else implementer documents manual verification in PR body.
+
+- **AC4** — `cargo-fmt retry` mechanism architect-bearing decision applied: either kept-and-noted (retry is now defensive) or removed (dead code post-fix). Either acceptable; PR body documents the choice.
+
+- **AC5** — Regression check: a worktree with NO clippy issues still rescues cleanly. The `--no-verify` doesn't break the happy path (it just skips the hook that would've also passed). Verified by existing rescue smoke tests OR new test.
+
+## Out of scope
+
+- **mika#1058 callback-can't-retry-pilot trap.** Separate substrate ticket (Concern 1 per Prime bearing — the trap, downstream of this cause). After this lands, Concern 1's urgency drops sharply because failures land as draft PRs instead of blocks.
+- **Permission-policy errs-strict class (Concern 3).** Separate substrate ticket (mika#1686). Affects pilots BEFORE clippy — different cause class.
+- **Silent pilot death (Concern 4).** Observation-class ticket (mika#1687). Different mechanism.
+- **The 6 wedged tickets' clippy fixes.** Per Prime: recovery via rescue-to-draft (not hand-fix) AFTER this lands. Operator action.
+
+## Operational composition
+
+Per Prime ruling 2026-06-30 ~16:32Z: **DO NOT re-toggle ready on the 6 wedged tickets until this fix lands in the running substrate.** Re-toggling pre-fix burns $4×6 against the same hook reject. Recovery for the 6 wedged tickets is rescue-to-draft (preserve their existing branch work — the 29-turn / $4-cost pilots' implementation is real and shouldn't be re-burned), gated on this fix landing first.
+
+## Files involved
+
+- `skills/bundled/_shared/dispatch-lib.sh:890,924,1020` — three rescue `git commit` calls
+- `skills/bundled/_shared/tests/test-dispatch-lib.sh` (if exists) — regression test
+- No Rust/source-code changes; no schema migration
+
+## Verification
+
+- **Static:** PR diff shows `--no-verify` added at exactly the three rescue commit sites, no other commits. Rationale comment present.
+- **Synthetic (AC3):** dispatch-lib test harness rescue with deliberate clippy seed — passes.
+- **Regression (AC5):** dispatch-lib test harness rescue with no issues — still passes.
+- **Live (post-merge):** the next pilot session that exits with a clippy nit successfully rescues to a draft PR + `wip-rescue` label. Verified in the autonomous-loop's next dispatch.
+
+## References
+
+- mika#1282 — original dirty-worktree rescue
+- mika#1396 — commit-pushed-no-pr rescue retry
+- mika#1383 — auto-PR-create
+- mika#1058 — callback deferred dispatch (the trap, separate)
+- mika#1058 callback turn constraint — why the retry is trapped
+- Mika Prime bearing 2026-06-30 ~16:32Z (session `00000000`) — modal cause ratification + ordering ruling
+- Hard evidence tasks: `dd81ff3b`, `48d03390`, `12f621bc` (all `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook`)
+- `skills/bundled/_shared/dispatch-lib.sh:890,924,1020` — edit targets

--- a/docs/solutions/workflow-issues/dispatch-lib-rescue-commit-pre-commit-hook-wedge-2026-06-30.md
+++ b/docs/solutions/workflow-issues/dispatch-lib-rescue-commit-pre-commit-hook-wedge-2026-06-30.md
@@ -1,0 +1,75 @@
+---
+title: Post-flight rescue commits must bypass the pre-commit hook — one clippy nit wedged the salvage path
+tags:
+  - dispatch-lib
+  - autonomous-loop
+  - lefthook
+  - pre-commit
+  - clippy
+  - rescue
+  - dev-pilot
+module: skills/bundled/_shared/dispatch-lib.sh
+problem_type: workflow_issue
+category: workflow-issues
+severity: high
+created: 2026-06-30
+---
+
+# Post-flight rescue commits must bypass the pre-commit hook — one clippy nit wedged the salvage path
+
+## Problem
+
+dispatch-lib's post-flight rescue paths (mika#1282 dirty-worktree, mika#1383 trailing-content) auto-commit a claude-pilot's uncommitted work into a draft PR so a 29-turn, ~$4 pilot session isn't lost when it ends with a dirty worktree. Those `git commit` calls ran the repo's pre-commit hook (lefthook → `rust-clippy -D warnings`). A single clippy nit left in the worktree by the pilot rejected the rescue commit, so the salvage never landed and the parent task went `blocked` — the 95%-complete work stranded with no PR. Modal cause of a 6-task loop wedge on 2026-06-30 (n=3+ confirmed: tasks `dd81ff3b`/mika#1680, `48d03390`/mika#1682, `12f621bc`/mika#1676).
+
+## Symptoms
+
+- Parent dispatch task transitions `in_progress → blocked`.
+- Identical callback result prefix across affected tasks:
+  `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook after cargo-fmt retry.`
+- Worktree left dirty for operator inspection; no draft PR opens.
+- The leftover clippy error is typically trivial (e.g. `std::iter::repeat(' ').take(300).collect()` should be `" ".repeat(300)`).
+
+## What Didn't Work (the trap that hid the root cause)
+
+dispatch-lib already had a reactive rescue retry: on a rejected commit it checked `grep "rust-fmt\|cargo fmt\|rustfmt"` against the captured hook output and, on a match, ran `cargo fmt --all` and re-committed. That retry could **never** fix a clippy rejection — `cargo fmt` reformats, it does not satisfy `clippy -D warnings`. The retry fired anyway and hit the same wall, producing the "after cargo-fmt retry" failure message.
+
+## Why the clippy failure hit the fmt-retry branch (the non-obvious mechanism)
+
+`lefthook.yml` runs `rust-fmt` **and** `rust-clippy` as sibling pre-commit commands. lefthook prints **all** step names in its decoration block (the `2>&1`-captured output dispatch-lib greps), including `rust-fmt`, even when **clippy** is the step that actually failed. So a pure clippy rejection still matched `grep "rust-fmt"`, routed down the fmt-retry path, and surfaced the misleading "cargo-fmt retry" message. The grep was keying on a step *name present in the output*, not the step that *failed* — a classic "the log mentions X, therefore X is the cause" misread baked into control flow.
+
+## Solution
+
+Add `--no-verify` to all three rescue `git commit` invocations in `skills/bundled/_shared/dispatch-lib.sh` (mika#1685). The rescue path's purpose is to **salvage work for operator review**, not to gate it on lint — a one-line typo must not strand a $4 pilot. Lint still surfaces at the right layer: CI re-runs `cargo fmt --check` + `clippy` on the resulting draft PR (`ci.yml`), and `wip-staleness-check.yml` re-clippies `wip-rescue` drafts when main moves.
+
+```sh
+# before
+git -C "$WORKTREE_DIR" commit -m "wip(...): impl staged by post-flight recovery (mika#1282) ..." > "$RESCUE_COMMIT_ERR" 2>&1
+# after
+git -C "$WORKTREE_DIR" commit -m "wip(...): impl staged by post-flight recovery (mika#1282) ..." --no-verify > "$RESCUE_COMMIT_ERR" 2>&1
+```
+
+`--no-verify` placed after the multi-line `-m` value is parsed correctly: `-m` consumes exactly the one quoted message argument, then `--no-verify` is an option to `git commit`. The pre-existing `rust-fmt` reactive-retry branch becomes effectively unreachable on hook grounds once the initial commit bypasses the hook; it was kept-and-noted (mika#1685 AC4) defensively rather than removed.
+
+## Trade-off (accepted, tracked)
+
+`git commit --no-verify` is **all-or-nothing** — it skips the *entire* lefthook pre-commit block, not just lint. That block also runs `no-secrets` (API-key / private-key regex scan) and `no-large-files` (1 MB cap), and **CI does not replicate those**. So the rescue path no longer secret-scans before pushing the branch to origin. Accepted because: the rescue output is a **draft** PR (operator-gated, never auto-merged), the secret-prone scaffold paths (`.claude/*.local.*`, `claude-pilot.json`, `.claude/commands/`) are already excluded from rescue staging (mika#1288/#1419), and secrets are scrubbed at the engine DB/tool-call layer. A CI secret-scan net is tracked as a follow-up: **mika#1689**.
+
+A surgical alternative (skip only the lint commands via `LEFTHOOK_EXCLUDE=rust-fmt,rust-clippy,...`) was rejected: it keys on lefthook-specific env semantics and hard-codes the lint command names, so it would **re-wedge** the moment a new lint command is added to `lefthook.yml`. `--no-verify` is future-proof against pre-commit config drift, which matters more for a loop-substrate unblock than preserving the secret scan on this one fallback path.
+
+## Prevention
+
+- **A rescue/salvage path's job is to preserve work for review, not to enforce quality gates.** Quality belongs on the PR (CI), where it's a check rather than a hard block that can strand work. When you find a lint gate on a salvage path, that's usually the bug.
+- **Don't grep a multi-step hook's combined output for a step *name* to infer the *failing* step.** lefthook (and most parallel hook runners) print every step's name; a name in the output proves the step ran, not that it failed. If you must branch on which step failed, key on per-step exit status, not on string presence in the decoration block.
+- **`--no-verify` is all-or-nothing** — before reaching for it, enumerate every command the pre-commit hook runs (`lefthook.yml` here) and confirm nothing load-bearing (secret scan, large-file guard) is silently dropped. If something is, either accept-and-track it or move that check to a layer the bypass can't skip.
+- Regression guard lives at `skills/bundled/_shared/tests/test_rescue_commit_no_verify.sh`: proves a rejecting pre-commit hook blocks a bare commit but not `--no-verify`, and statically asserts all three rescue sites still carry the flag.
+
+## References
+
+- mika#1685 — this fix
+- mika#1689 — follow-up: add a CI secret-scan net for `wip-rescue` draft PRs
+- mika#1282 — original dirty-worktree rescue
+- mika#1383 — commit-pushed-no-pr / trailing-content rescue
+- mika#1296 — the cargo-fmt reactive-retry mechanism (now defensive)
+- mika#1058 — callback-can't-retry-pilot trap (downstream of this cause; separate)
+- `skills/bundled/_shared/lefthook.yml` — the pre-commit command set
+- `.github/workflows/ci.yml`, `.github/workflows/wip-staleness-check.yml` — where clippy re-surfaces on the draft PR

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -887,11 +887,37 @@ ${RESULT}"
                     # blank on every false-positive rejection. Combined
                     # `>file 2>&1` captures the full lefthook decoration
                     # block including ⛔ failure lines.
+                    #
+                    # mika#1685: rescue commits bypass the pre-commit hook
+                    # (--no-verify) BY DESIGN. The rescue path's purpose is to
+                    # SALVAGE pilot work for operator review, not to gate it on
+                    # lint. lefthook runs rust-clippy on pre-commit; a single
+                    # clippy nit (one-line typo like `repeat().collect()`) would
+                    # otherwise reject the rescue commit and strand a 29-turn,
+                    # $4-cost pilot's work as a dead block (modal loop-wedge
+                    # cause, n=3+ on 2026-06-30). CI re-runs cargo fmt --check +
+                    # clippy on the resulting draft PR (ci.yml; wip-staleness-check
+                    # re-clippies wip-rescue drafts when main moves), so the LINT
+                    # signal still surfaces at the right layer — for the operator
+                    # and the autonomous-loop's clippy-fix-retry path, not as a
+                    # hard pre-commit block.
+                    #
+                    # TRADE-OFF, by design: --no-verify is all-or-nothing, so it
+                    # ALSO skips lefthook's no-secrets + no-large-files gates,
+                    # which CI does NOT replicate today (mika#1689 tracks adding a
+                    # CI secret-scan net). Accepted because the rescue output is a
+                    # DRAFT PR (operator-gated, never auto-merged), the secret-prone
+                    # scaffold paths are already excluded from staging above, and
+                    # secrets are scrubbed at the DB/tool-call layer. Do NOT remove
+                    # --no-verify here without first moving the LINT gate somewhere
+                    # the rescue path can still open its draft PR.
+                    # Mika Prime bearing 2026-06-30 ~16:32Z ratified this as the
+                    # wedge-cause fix (Concern 2, ahead of mika#1058).
                     if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): impl staged by post-flight recovery (mika#1282)
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection.
-Scaffold paths excluded (mika#1288, mika#1419)." > "$RESCUE_COMMIT_ERR" 2>&1; then
+Scaffold paths excluded (mika#1288, mika#1419)." --no-verify > "$RESCUE_COMMIT_ERR" 2>&1; then
                         # Commit succeeded on first try — proceed normally
                         rm -f "$RESCUE_COMMIT_ERR"
 
@@ -908,6 +934,12 @@ ${RESULT}"
                         # Mark for draft PR creation in Unit 2
                         RESCUED_DIRTY_WORKTREE=1
                     elif grep -q "rust-fmt\|cargo fmt\|rustfmt" "$RESCUE_COMMIT_ERR" 2>/dev/null; then
+                        # mika#1685 (AC4, kept-and-noted): with --no-verify on the
+                        # initial commit above, the pre-commit hook no longer runs,
+                        # so this fmt-rejection branch is now effectively unreachable
+                        # on hook grounds. Retained defensively rather than removed —
+                        # the retry commit below also carries --no-verify so the path
+                        # stays consistent if a future change reintroduces a hook.
                         # Pre-commit rust-fmt hook rejected — auto-fix and retry (mika#1296).
                         # Capture cargo fmt stderr so it surfaces in the PIPELINE FAILURE message
                         # if the retry also fails (review-guide.md § Single Responsibility — failure
@@ -925,7 +957,7 @@ ${RESULT}"
 
 Content written by pilot session ${SESSION_ID:-unknown} but git commit was never invoked.
 Auto-rescued by dispatch-lib dirty-worktree detection (cargo fmt applied).
-Scaffold paths excluded (mika#1288, mika#1419)." > "$RESCUE_COMMIT_ERR" 2>&1; then
+Scaffold paths excluded (mika#1288, mika#1419)." --no-verify > "$RESCUE_COMMIT_ERR" 2>&1; then
                             # Retry succeeded after cargo fmt
                             rm -f "$RESCUE_COMMIT_ERR"
 
@@ -1017,7 +1049,9 @@ ${RESULT}"
                 git -C "$WORKTREE_DIR" add -A -- \
                     ':!.claude/commands/' ':!.claude/claude-pilot.json' ':!.claude/settings.local.json' ':!.claude/*.local.*' 2>&9 || true
                 if ! git -C "$WORKTREE_DIR" diff --cached --quiet 2>&9; then
-                    if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): trailing content after pilot end_turn (mika#1383)" 2>&9; then
+                    # mika#1685: bypass pre-commit hook — see rationale on the
+                    # mika#1282 rescue commit above. Same salvage-not-gate principle.
+                    if git -C "$WORKTREE_DIR" commit -m "wip(${REPO}#${ISSUE_NUM}): trailing content after pilot end_turn (mika#1383)" --no-verify 2>&9; then
                         git -C "$WORKTREE_DIR" push origin "$BRANCH" 2>&9 || true
                         POST_RUN_HEAD=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || true)
                         RESULT="${RESULT}

--- a/skills/bundled/_shared/tests/test_rescue_commit_no_verify.sh
+++ b/skills/bundled/_shared/tests/test_rescue_commit_no_verify.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Test suite for post-flight rescue-commit hook bypass (mika#1685).
+#
+# WHY: dispatch-lib's post-flight rescue paths (mika#1282 dirty-worktree,
+# mika#1383 trailing-content) call `git commit` to SALVAGE a pilot's work into
+# a draft PR when the pilot left the worktree dirty. lefthook runs rust-clippy
+# on pre-commit; a single clippy nit the pilot left behind would reject the
+# rescue commit and strand 29-turn, $4-cost work as a dead block — the modal
+# loop-wedge cause (n=3+ on 2026-06-30). The fix adds `--no-verify` to the
+# rescue commits so the salvage always lands; CI surfaces clippy on the draft
+# PR at the right layer.
+#
+# This suite proves the MECHANISM the fix relies on (the rescue blocks are
+# inline in run_claude_pilot, not callable in isolation, so we exercise the
+# git behavior directly against a real temp repo) plus a static guard that the
+# three rescue commit sites still carry --no-verify.
+#
+# Run: bash skills/bundled/_shared/tests/test_rescue_commit_no_verify.sh
+# Expected: all assertions pass, exit 0. No network / cargo / clippy required.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH_LIB="$SCRIPT_DIR/../dispatch-lib.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✓ $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  ✗ $label"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+    fi
+}
+
+# Build a throwaway git repo with a pre-commit hook that always rejects
+# (stands in for lefthook's rust-clippy step failing on a leftover nit).
+# Echoes the repo dir on stdout.
+make_repo_with_failing_hook() {
+    local repo
+    repo="$(mktemp -d "${TMPDIR:-/tmp}/mika-1685-test.XXXXXX")"
+    git -C "$repo" init -q
+    git -C "$repo" config user.email test@example.com
+    git -C "$repo" config user.name "Test"
+    mkdir -p "$repo/.git/hooks"
+    cat > "$repo/.git/hooks/pre-commit" <<'HOOK'
+#!/bin/bash
+# Simulated clippy rejection — the exact wedge condition.
+echo "⛔ rust-clippy: leftover lint" >&2
+exit 1
+HOOK
+    chmod +x "$repo/.git/hooks/pre-commit"
+    printf 'content\n' > "$repo/file.txt"
+    git -C "$repo" add -A
+    printf '%s' "$repo"
+}
+
+# ============================================================================
+# Test 1: bare `git commit` is REJECTED by the failing hook (the wedge)
+# ============================================================================
+echo ""
+echo "Test: bare git commit rejected by pre-commit hook (reproduces wedge)"
+echo "--------------------------------------------------------------------"
+
+REPO="$(make_repo_with_failing_hook)"
+rc=0
+git -C "$REPO" commit -m "wip: rescue" >/dev/null 2>&1 || rc=$?
+assert_eq "bare commit: rejected (non-zero exit)" "1" "$( [ "$rc" -ne 0 ] && echo 1 || echo 0 )"
+HEAD_COUNT=$(git -C "$REPO" rev-list --count HEAD 2>/dev/null || echo 0)
+assert_eq "bare commit: HEAD did not advance (no commit)" "0" "$HEAD_COUNT"
+rm -rf "$REPO"
+
+# ============================================================================
+# Test 2 (AC3): `git commit --no-verify` SUCCEEDS despite the failing hook
+# ============================================================================
+echo ""
+echo "Test (AC3): git commit --no-verify rescues despite clippy-equivalent nit"
+echo "-----------------------------------------------------------------------"
+
+REPO="$(make_repo_with_failing_hook)"
+rc=0
+git -C "$REPO" commit -m "wip: rescue" --no-verify >/dev/null 2>&1 || rc=$?
+assert_eq "no-verify commit: succeeds (exit 0)" "0" "$rc"
+HEAD_COUNT=$(git -C "$REPO" rev-list --count HEAD 2>/dev/null || echo 0)
+assert_eq "no-verify commit: HEAD advanced (commit landed)" "1" "$HEAD_COUNT"
+rm -rf "$REPO"
+
+# ============================================================================
+# Test 3 (AC5): no hook present — --no-verify still rescues cleanly (happy path)
+# ============================================================================
+echo ""
+echo "Test (AC5): clean worktree, no hook — --no-verify still commits"
+echo "---------------------------------------------------------------"
+
+REPO="$(mktemp -d "${TMPDIR:-/tmp}/mika-1685-clean.XXXXXX")"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name "Test"
+printf 'content\n' > "$REPO/file.txt"
+git -C "$REPO" add -A
+rc=0
+git -C "$REPO" commit -m "wip: rescue" --no-verify >/dev/null 2>&1 || rc=$?
+assert_eq "happy path: --no-verify commits cleanly (exit 0)" "0" "$rc"
+HEAD_COUNT=$(git -C "$REPO" rev-list --count HEAD 2>/dev/null || echo 0)
+assert_eq "happy path: HEAD advanced" "1" "$HEAD_COUNT"
+rm -rf "$REPO"
+
+# ============================================================================
+# Test 4 (AC1): static guard — every rescue-path commit carries --no-verify
+# ============================================================================
+echo ""
+echo "Test (AC1): all rescue git-commit sites in dispatch-lib carry --no-verify"
+echo "------------------------------------------------------------------------"
+
+# Each rescue commit is `git -C "$WORKTREE_DIR" commit -m "wip(...`. The flag
+# may sit on the same line (mika#1383 inline) or on the message's closing line
+# (mika#1282 multi-line -m). Pull each commit invocation plus its following
+# lines up to the line that opens the redirect/`; then`, and assert --no-verify
+# appears in that window. awk: from a rescue commit opener, accumulate lines
+# until one contains '2>&' (the redirect that closes the invocation), then
+# check the accumulated block for --no-verify.
+MISSING=$(awk '
+    /git -C "\$WORKTREE_DIR" commit -m "wip\(/ { inblock=1; block=""; }
+    inblock { block = block $0 "\n"; }
+    inblock && /2>&/ {
+        inblock=0;
+        if (block !~ /--no-verify/) bad++;
+    }
+    END { print bad+0 }
+' "$DISPATCH_LIB")
+assert_eq "static guard: rescue commits missing --no-verify" "0" "$MISSING"
+
+# Belt-and-suspenders: there are exactly 3 rescue commit invocations today.
+RESCUE_COUNT=$(grep -c 'git -C "\$WORKTREE_DIR" commit -m "wip(' "$DISPATCH_LIB")
+assert_eq "static guard: rescue commit invocation count" "3" "$RESCUE_COUNT"
+
+# ============================================================================
+# Test 5: dispatch-lib still parses (the edits did not break shell syntax)
+# ============================================================================
+echo ""
+echo "Test: dispatch-lib.sh passes bash -n"
+echo "------------------------------------"
+
+rc=0
+bash -n "$DISPATCH_LIB" 2>/dev/null || rc=$?
+assert_eq "dispatch-lib: bash -n clean" "0" "$rc"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Why

dispatch-lib's post-flight rescue paths (mika#1282 dirty-worktree, mika#1383 trailing-content) auto-commit a claude-pilot's uncommitted work into a draft PR so a 29-turn, ~$4 session isn't lost when the pilot ends with a dirty worktree. Those `git commit` calls ran lefthook's pre-commit hook (`rust-clippy -D warnings`). **A single clippy nit the pilot left behind rejected the rescue commit** → parent task `blocked`, 95%-complete work stranded, no PR. Modal cause of the 2026-06-30 6-task loop wedge (n=3+: `dd81ff3b`/#1680, `48d03390`/#1682, `12f621bc`/#1676 — all carrying `PIPELINE FAILURE: auto-rescue commit rejected by pre-commit hook after cargo-fmt retry`). Mika Prime bearing 2026-06-30 ~16:32Z ratified this as the wedge-cause fix (Concern 2, ahead of mika#1058).

### Mechanism (the non-obvious bit)

`lefthook.yml` runs `rust-fmt` **and** `rust-clippy`, and lefthook prints **all** step names in its output. dispatch-lib's reactive retry grepped that output for `"rust-fmt"`, so a **clippy** rejection matched, routed down the `cargo fmt` retry path (which can't fix clippy), and re-failed with the misleading "after cargo-fmt retry" message.

## What

- Add `--no-verify` to all three rescue `git commit` sites in `skills/bundled/_shared/dispatch-lib.sh`. Salvage is for operator review, not a lint gate — CI re-runs `fmt`/`clippy` on the draft PR (`ci.yml`; `wip-staleness-check.yml` re-clippies wip-rescue drafts when main moves).
- Rationale comment at the canonical site explaining *why* `--no-verify` is here (so a future reader doesn't "fix" it).
- **AC4 (kept-and-noted):** the `cargo-fmt` reactive-retry branch is now effectively unreachable on hook grounds; retained defensively with a note rather than removed (minimal diff, matches the plan's verification contract).
- **New regression test** `skills/bundled/_shared/tests/test_rescue_commit_no_verify.sh` (9 assertions, no network/cargo): a rejecting pre-commit hook blocks a bare commit but not `--no-verify` (**AC3**); the no-hook happy path still commits (**AC5**); static guard asserts all three sites carry `--no-verify` (**AC1**).
- Compound doc: `docs/solutions/workflow-issues/dispatch-lib-rescue-commit-pre-commit-hook-wedge-2026-06-30.md`.

## Acceptance criteria

- [x] **AC1** — all three rescue `git commit` calls include `--no-verify` (verified by diff + static test guard)
- [x] **AC2** — rationale comment at the canonical site referencing mika#1685 + the operator-review-not-lint-gate principle
- [x] **AC3** — regression test: worktree with a clippy-equivalent reject rescues via `--no-verify` (no PIPELINE FAILURE)
- [x] **AC4** — `cargo-fmt retry` decision applied: kept-and-noted as now-defensive, documented here and in-code
- [x] **AC5** — regression: a worktree with no hook issue still rescues cleanly (`--no-verify` doesn't break the happy path)

## Trade-off (tracked)

`git commit --no-verify` is all-or-nothing — it also skips lefthook's `no-secrets` + `no-large-files` gates, and **CI does not replicate those**. Accepted because the rescue output is a **draft** PR (operator-gated, never auto-merged), secret-prone scaffold paths are already excluded from rescue staging (mika#1288/#1419), and secrets are scrubbed at the engine DB/tool-call layer. A surgical `LEFTHOOK_EXCLUDE` alternative was rejected — it would re-wedge the moment a new lint command is added. **Follow-up to add a CI secret-scan net: mika#1689.**

## Verification

- `bash -n` + `shellcheck -S error` clean on dispatch-lib.sh
- New test: 9/9 pass · existing `test_force_push_guard.sh`: 14/14 pass
- `make verify-bundled-skills`: all 5 structural checks pass
- `scripts/verify-pipeline.sh`: pass

Independent adversarial review (cross-checked flag placement, arg parsing, redirects, scope, test efficacy) confirmed the fix correct; its one actionable finding (the `no-secrets` bypass) is addressed by the trade-off note above + mika#1689.

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)