### PR TITLE
docs(architecture): fix §14 A2A drift — MessageStream + SSE method mapping

### DIFF
--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -684,7 +684,7 @@ This separation lets you give dashboard users a read-only token that cannot muta
 | `/api/v1/rewind/resolve` | POST | Internal token | Resolve recent exchanges for a session (returns anchor point and trace IDs) |
 | `/api/v1/rewind/preview` | POST | Internal token | Preview a rewind operation (messages to delete, reversals, task cancellations, warnings) |
 | `/api/v1/rewind/execute` | POST | Internal token | Execute a rewind (delete messages, reverse mutations, cancel tasks, inject context marker) |
-| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit) — dispatches `message/send`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe` |
+| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit) — dispatches `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe` |
 | `/a2a/{agent_name}/agent.json` | GET | Internal token | Returns A2A Agent Card (capabilities, skills, auth schemes) |
 
 ### Dashboard API (read-only)

--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -781,7 +781,7 @@ external A2A agents via the `a2a_call` tool.
 | Module | Responsibility |
 |--------|---------------|
 | `types.rs` | A2A protocol types: `AgentCard`, `Task`, `Message`, `Part`, `Artifact`, `TaskStatus`, `TaskState` |
-| `jsonrpc.rs` | JSON-RPC 2.0 request/response types, A2A method enum (`MessageSend`, `TaskGet`, `TaskCancel`, `TaskResubscribe`, `TaskPushNotificationSet`, `TaskPushNotificationGet`) |
+| `jsonrpc.rs` | JSON-RPC 2.0 request/response types, A2A method enum (`MessageSend`, `MessageStream`, `TaskGet`, `TaskCancel`, `TaskResubscribe`, `TaskPushNotificationSet`, `TaskPushNotificationGet`) |
 | `params.rs` | Typed parameter structs: `MessageSendParams`, `TaskIdParams`, `TaskQueryParams` |
 | `state_machine.rs` | `TaskStateMachine` — validates state transitions (submitted → working → completed/failed/canceled) |
 | `streaming.rs` | SSE streaming types: `StreamEvent`, `TaskStatusUpdateEvent`, `TaskArtifactUpdateEvent` |
@@ -793,7 +793,7 @@ A2A routes are merged into the main router with internal token auth (no CORS):
 
 | Endpoint | Method | Auth | Purpose |
 |----------|--------|------|---------|
-| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit). Dispatches `message/send`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`. Returns SSE stream for `message/send`. |
+| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit). Dispatches `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`. Returns SSE stream for `message/stream` and `tasks/resubscribe`; single JSON response for `message/send`. |
 | `/a2a/{agent_name}/agent.json` | GET | Internal token | Returns the agent's A2A Agent Card (capabilities, skills, auth schemes) |
 
 ### Gateway Proxy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -684,7 +684,7 @@ This separation lets you give dashboard users a read-only token that cannot muta
 | `/api/v1/rewind/resolve` | POST | Internal token | Resolve recent exchanges for a session (returns anchor point and trace IDs) |
 | `/api/v1/rewind/preview` | POST | Internal token | Preview a rewind operation (messages to delete, reversals, task cancellations, warnings) |
 | `/api/v1/rewind/execute` | POST | Internal token | Execute a rewind (delete messages, reverse mutations, cancel tasks, inject context marker) |
-| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit) — dispatches `message/send`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe` |
+| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit) — dispatches `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe` |
 | `/a2a/{agent_name}/agent.json` | GET | Internal token | Returns A2A Agent Card (capabilities, skills, auth schemes) |
 
 ### Dashboard API (read-only)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -781,7 +781,7 @@ external A2A agents via the `a2a_call` tool.
 | Module | Responsibility |
 |--------|---------------|
 | `types.rs` | A2A protocol types: `AgentCard`, `Task`, `Message`, `Part`, `Artifact`, `TaskStatus`, `TaskState` |
-| `jsonrpc.rs` | JSON-RPC 2.0 request/response types, A2A method enum (`MessageSend`, `TaskGet`, `TaskCancel`, `TaskResubscribe`, `TaskPushNotificationSet`, `TaskPushNotificationGet`) |
+| `jsonrpc.rs` | JSON-RPC 2.0 request/response types, A2A method enum (`MessageSend`, `MessageStream`, `TaskGet`, `TaskCancel`, `TaskResubscribe`, `TaskPushNotificationSet`, `TaskPushNotificationGet`) |
 | `params.rs` | Typed parameter structs: `MessageSendParams`, `TaskIdParams`, `TaskQueryParams` |
 | `state_machine.rs` | `TaskStateMachine` — validates state transitions (submitted → working → completed/failed/canceled) |
 | `streaming.rs` | SSE streaming types: `StreamEvent`, `TaskStatusUpdateEvent`, `TaskArtifactUpdateEvent` |
@@ -793,7 +793,7 @@ A2A routes are merged into the main router with internal token auth (no CORS):
 
 | Endpoint | Method | Auth | Purpose |
 |----------|--------|------|---------|
-| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit). Dispatches `message/send`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`. Returns SSE stream for `message/send`. |
+| `/a2a/{agent_name}` | POST | Internal token | A2A JSON-RPC handler (2MB body limit). Dispatches `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`. Returns SSE stream for `message/stream` and `tasks/resubscribe`; single JSON response for `message/send`. |
 | `/a2a/{agent_name}/agent.json` | GET | Internal token | Returns the agent's A2A Agent Card (capabilities, skills, auth schemes) |
 
 ### Gateway Proxy


### PR DESCRIPTION
## Summary

Two-line drift fix in `docs/architecture.md §14` (A2A Protocol section), verified against source. Samidarko-flagged; one-line-class fix landed directly per her routing.

## Drift 1: `jsonrpc.rs` enum missing `MessageStream`

Doc line 784 listed only `MessageSend`, `TaskGet`, `TaskCancel`, `TaskResubscribe`, `TaskPushNotificationSet`, `TaskPushNotificationGet`. Source at `crates/mika-a2a/src/jsonrpc.rs:118-119` has both `MessageSend` AND `MessageStream`.

## Drift 2: SSE returns from wrong method

Doc line 796 said "Returns SSE stream for `message/send`." Source verified:

- `crates/mika-agent/src/server/a2a.rs:91` — `A2aMethod::MessageStream => handle_message_stream(...)`
- `crates/mika-agent/src/server/a2a.rs:310` — `/// Handle \`message/stream\` — SSE streaming response via the real agent loop.`
- `crates/mika-agent/src/server/a2a.rs:461-477` — SSE stream construction under `handle_message_stream`
- `crates/mika-agent/src/server/a2a.rs:183-...` — `handle_message_send` returns non-SSE response

SSE is `message/stream`. `message/send` returns a single JSON response. Also added `message/stream` to the dispatch list.

## Test plan

- [x] Doc claims verified against source at named file:line
- [x] `scripts/sync-agent-docs.sh` run to sync `crates/mika-agent/docs/architecture.md` (CI docs-sync gate)
- [x] Both files committed together (diff-stat: 4 insertions, 4 deletions across 2 files)