### PR TITLE
feat(spirit): add /healthz K8s-convention liveness endpoint (mika#1735)

### DIFF
--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -678,7 +678,8 @@ This separation lets you give dashboard users a read-only token that cannot muta
 
 | Endpoint | Method | Auth | Purpose |
 |----------|--------|------|---------|
-| `/health` | GET | None | Liveness/readiness probe |
+| `/health` | GET | None | Combined liveness+readiness probe — returns 503 during startup, 200 with `uptime_secs` when ready. |
+| `/healthz` | GET | None | Kubernetes-convention pure liveness probe — returns 200 unconditionally while the router is up, including during startup (mika#1735). |
 | `/message` | POST | Internal token | Receives messages (202 async processing, 10MB body limit) |
 | `/tasks/{id}/complete` | POST | Internal token | Completes a callback task (200 sync; 409 if already completed; 100KB result cap; echoes `task_id` in error bodies) |
 | `/api/v1/rewind/resolve` | POST | Internal token | Resolve recent exchanges for a session (returns anchor point and trace IDs) |

--- a/crates/mika-agent/docs/openapi/mika-spirit.yaml
+++ b/crates/mika-agent/docs/openapi/mika-spirit.yaml
@@ -67,7 +67,7 @@ paths:
     get:
       tags:
       - handlers
-      summary: GET /health — Liveness/readiness probe (no auth required).
+      summary: GET /health — Combined liveness+readiness probe (no auth required).
       operationId: handle_health
       responses:
         '200':
@@ -78,6 +78,25 @@ paths:
                 $ref: '#/components/schemas/HealthResponse'
         '503':
           description: Server is starting up
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /healthz:
+    get:
+      tags:
+      - handlers
+      summary: GET /healthz — Kubernetes-convention liveness probe (no auth required).
+      description: |-
+        Distinct from `/health`: this is a pure liveness endpoint — "is the process
+        alive and able to serve HTTP?" — so it returns 200 unconditionally when the
+        router is running, including during startup. This matches the semantics ops
+        tooling and K8s probes expect from `/healthz` (readiness is a separate
+        concern, tracked as a follow-up if `/readyz` is ever needed). See mika#1735.
+      operationId: handle_healthz
+      responses:
+        '200':
+          description: Server is alive
           content:
             application/json:
               schema:

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -67,7 +67,7 @@ fn should_emit_rate_limit_audit(
     }
 }
 
-/// GET /health — Liveness/readiness probe (no auth required).
+/// GET /health — Combined liveness+readiness probe (no auth required).
 #[utoipa::path(
     get,
     path = "/health",
@@ -91,6 +91,30 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
         Json(HealthResponse {
             status: "ok".to_string(),
             uptime_secs: Some(state.startup_time.elapsed().as_secs()),
+        }),
+    )
+}
+
+/// GET /healthz — Kubernetes-convention liveness probe (no auth required).
+///
+/// Distinct from `/health`: this is a pure liveness endpoint — "is the process
+/// alive and able to serve HTTP?" — so it returns 200 unconditionally when the
+/// router is running, including during startup. This matches the semantics ops
+/// tooling and K8s probes expect from `/healthz` (readiness is a separate
+/// concern, tracked as a follow-up if `/readyz` is ever needed). See mika#1735.
+#[utoipa::path(
+    get,
+    path = "/healthz",
+    responses(
+        (status = 200, description = "Server is alive", body = HealthResponse),
+    )
+)]
+pub async fn handle_healthz() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(HealthResponse {
+            status: "ok".to_string(),
+            uptime_secs: None,
         }),
     )
 }

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -313,8 +313,12 @@ fn build_router(state: AppState) -> Router {
         .nest("/dashboard", embedded_dashboard::dashboard_routes())
         // Root: redirect to dashboard (if enabled) or return JSON info
         .route("/", get(embedded_dashboard::handle_root))
-        // Health endpoint is OUTSIDE auth layer (for health probes)
+        // Health endpoints are OUTSIDE auth layer (for health probes).
+        // `/health` is the combined liveness+readiness (503 during startup).
+        // `/healthz` is the K8s-convention pure liveness (always 200 when
+        // router is up) — see mika#1735.
         .route("/health", get(handlers::handle_health))
+        .route("/healthz", get(handlers::handle_healthz))
         // inject_request_meta must be inner to TraceLayer so that on the response
         // path it inserts RequestMeta into extensions BEFORE on_response reads them.
         .layer(middleware::from_fn(inject_request_meta))
@@ -323,7 +327,7 @@ fn build_router(state: AppState) -> Router {
                 .make_span_with(|request: &http::Request<_>| {
                     let path = request.uri().path();
                     let method = request.method();
-                    if path == "/health" {
+                    if path == "/health" || path == "/healthz" {
                         tracing::debug_span!("http_request", %method, path)
                     } else {
                         tracing::info_span!("http_request", %method, path)
@@ -1629,6 +1633,57 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "ok");
         assert!(json["uptime_secs"].is_number());
+    }
+
+    // mika#1735: /healthz is a pure liveness probe — 200 unconditionally when
+    // the router is up, distinct from /health's combined liveness+readiness.
+    #[tokio::test]
+    async fn test_healthz_returns_200_before_ready() {
+        let state = test_state();
+        // Do NOT flip state.ready — /healthz must still return 200.
+        let app = test_app(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        // Pure liveness omits uptime_secs — the field is skipped when None.
+        assert!(json.get("uptime_secs").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_healthz_returns_200_after_ready() {
+        let state = test_state();
+        state.ready.store(true, Ordering::Release);
+        let app = test_app(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert!(json.get("uptime_secs").is_none());
     }
 
     #[tokio::test]

--- a/crates/mika-agent/src/server/openapi.rs
+++ b/crates/mika-agent/src/server/openapi.rs
@@ -16,6 +16,7 @@ use super::types;
     ),
     paths(
         handlers::handle_health,
+        handlers::handle_healthz,
         handlers::handle_message,
         handlers::handle_task_complete,
         embedded_dashboard::handle_enable,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -678,7 +678,8 @@ This separation lets you give dashboard users a read-only token that cannot muta
 
 | Endpoint | Method | Auth | Purpose |
 |----------|--------|------|---------|
-| `/health` | GET | None | Liveness/readiness probe |
+| `/health` | GET | None | Combined liveness+readiness probe — returns 503 during startup, 200 with `uptime_secs` when ready. |
+| `/healthz` | GET | None | Kubernetes-convention pure liveness probe — returns 200 unconditionally while the router is up, including during startup (mika#1735). |
 | `/message` | POST | Internal token | Receives messages (202 async processing, 10MB body limit) |
 | `/tasks/{id}/complete` | POST | Internal token | Completes a callback task (200 sync; 409 if already completed; 100KB result cap; echoes `task_id` in error bodies) |
 | `/api/v1/rewind/resolve` | POST | Internal token | Resolve recent exchanges for a session (returns anchor point and trace IDs) |

--- a/docs/openapi/mika-spirit.yaml
+++ b/docs/openapi/mika-spirit.yaml
@@ -67,7 +67,7 @@ paths:
     get:
       tags:
       - handlers
-      summary: GET /health — Liveness/readiness probe (no auth required).
+      summary: GET /health — Combined liveness+readiness probe (no auth required).
       operationId: handle_health
       responses:
         '200':
@@ -78,6 +78,25 @@ paths:
                 $ref: '#/components/schemas/HealthResponse'
         '503':
           description: Server is starting up
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /healthz:
+    get:
+      tags:
+      - handlers
+      summary: GET /healthz — Kubernetes-convention liveness probe (no auth required).
+      description: |-
+        Distinct from `/health`: this is a pure liveness endpoint — "is the process
+        alive and able to serve HTTP?" — so it returns 200 unconditionally when the
+        router is running, including during startup. This matches the semantics ops
+        tooling and K8s probes expect from `/healthz` (readiness is a separate
+        concern, tracked as a follow-up if `/readyz` is ever needed). See mika#1735.
+      operationId: handle_healthz
+      responses:
+        '200':
+          description: Server is alive
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- Adds `/healthz` — a pure liveness endpoint (200 unconditionally when the router is up, including during startup), distinct from the existing `/health` (503 during startup, 200 when ready).
- MPC-manual-rescue implementation of `mika#1735` (sub-E of the `mika#1727` thin-client fan-out) while the autonomous loop is wedged (Prime's ratified Component A, samidarko relay).

## Motivation

Root's un-wedge diagnosis flagged that mika-spirit lacked a `/healthz` endpoint — SC's health-probe script hit 404 and would incorrectly interpret a live-but-endpoint-missing server as "not up." K8s and most ops tooling convention on `/healthz` for liveness; adding it fixes the false-negative without changing any layer's contract.

## What lands

- `crates/mika-agent/src/server/handlers.rs` — new `handle_healthz` handler returning 200 with `{"status": "ok"}` unconditionally. Uses existing `HealthResponse` struct with `uptime_secs: None` (skipped from output via `#[serde(skip_serializing_if = "Option::is_none")]`).
- `crates/mika-agent/src/server/mod.rs` — route `.route("/healthz", get(handlers::handle_healthz))` next to `/health`, outside the auth layer. TraceLayer conditional extended to log both paths at DEBUG.
- `crates/mika-agent/src/server/openapi.rs` — new handler registered in `AgentApiDoc::paths()`.
- `docs/openapi/mika-spirit.yaml` + `crates/mika-agent/docs/openapi/mika-spirit.yaml` — regenerated via `cargo test -p mika-agent server::openapi::tests::write_agent_openapi_yaml -- --ignored`, synced via `scripts/sync-agent-docs.sh`.
- `docs/architecture.md` + `crates/mika-agent/docs/architecture.md` — endpoint table updated with both `/health` and `/healthz` rows describing the semantic difference.

## Test plan

- [x] `cargo build -p mika-agent` — compiles clean
- [x] `cargo clippy -p mika-agent --lib -- -D warnings` — clean
- [x] `cargo fmt -p mika-agent` — clean
- [x] `cargo test -p mika-agent healthz` — 2 new tests pass:
  - `test_healthz_returns_200_before_ready` — asserts 200 when `state.ready` is false; body `{"status":"ok"}` with `uptime_secs` absent
  - `test_healthz_returns_200_after_ready` — asserts 200 when `state.ready` is true; body `{"status":"ok"}` with `uptime_secs` absent
- [x] `cargo test -p mika-agent test_health` — 13 pass (existing `/health` regression tests unchanged and still passing)
- [x] OpenAPI spec regenerated + `docs-sync` performed (CI `docs-sync` job will re-verify)

## Not in scope

- Readiness endpoint (`/readyz`). If we want pure readiness, that's a separate small ticket.
- DB / disk / downstream health surfaces. This is LIVENESS only per the sub-E ticket body ("Am I alive?" not "Am I healthy?").
- Any change to gateway or `mika doctor` — those consume `/healthz` naturally without further changes.
- The mika#1727 Phase 2 refactor of `commands/chat.rs` — held per Prime's discipline until sub-tickets A/B/C/D/E/F clear their surfaces.

## Related

- Closes #1735
- Refs `mika#1727` (parent thin-client refactor)
- Sibling sub-tickets: A (`mika#1731`), B (`mika#1732`), C (`mika#1733` — 6 sharpenings), D (`mika#1734`), F (`mika#1736`), G (`mika#1737` — arch-ratified)
- Prime ratification (2026-07-06 afternoon) + samidarko relay authorizing MPC-manual-rescue attack on sub-E

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784