### PR TITLE
fix(dockerfile): pin agent builder to rust:1.93-bookworm (glibc mismatch)

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -13,7 +13,14 @@ RUN npm ci --ignore-scripts \
  && npm run build --prefix dashboard
 
 # === Builder stage ===
-FROM rust:1.93-slim AS builder
+# Use rust:1.93-bookworm (NOT -slim) to match debian:bookworm-slim runtime
+# (glibc 2.36). The -slim tag was rebased on Debian 13 (trixie, glibc 2.41),
+# so binaries built there link against GLIBC_2.39+ symbols and fail at runtime
+# with `libc.so.6: version 'GLIBC_2.39' not found`. Dockerfile.gateway already
+# migrated for this exact class; this file was missed until family-customer-1's
+# 2026-07-09 provisioning surfaced it (agent pod CrashLoopBackOff after image
+# rebuild against current mika main).
+FROM rust:1.93-bookworm AS builder
 
 # Install C compiler for rusqlite bundled SQLite (no OpenSSL needed — uses rustls)
 RUN apt-get update && apt-get install -y --no-install-recommends gcc libc-dev pkg-config && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

**Vincent-critical / substrate-blocking.** Family-customer-1's onboarding surfaced this live 2026-07-09 14:15Z when the mika-agent image was rebuilt at main HEAD as part of the final onboarding-ladder deploy hop:

```
mika-spirit: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by mika-spirit)
```

Pod crash-looped. Vincent's live release was **rolled back to `adc23281`** (safe state, 1/1 Running); console secret `MIKA_AGENT_IMAGE_TAG` reverted so new provisions don't land on the broken image. Cluster is steady while this ships.

## Root cause

- `rust:1.93-slim` was rebased on Debian 13 (trixie), glibc 2.41. Rust toolchain there link-links against GLIBC_2.39+ symbols.
- Runtime is `debian:bookworm-slim` (Debian 12, glibc 2.36).
- Binary won't run.

**`Dockerfile.gateway` already fixed this exact class** with an explanatory comment. `Dockerfile.agent` was missed until today.

## Fix

One-line pin — mirror the gateway's pattern:

```diff
- FROM rust:1.93-slim AS builder
+ FROM rust:1.93-bookworm AS builder
```

Plus a matching comment naming the surfacing event.

## Audit alongside

Grepped the whole workspace — this was the ONLY affected Dockerfile:

| File | Builder | Status |
|---|---|---|
| `mika/Dockerfile.gateway` | `rust:1.93-bookworm` | ✓ already correct |
| `mika/Dockerfile.agent` | `rust:1.93-slim` | ✗ this PR |
| `mika-cloud/Dockerfile` | `rust:1.93-bookworm` | ✓ already correct |
| `mika-skills/`, `claude-pilot-py/`, `wizzard/` | no rust Dockerfiles | n/a |

## Test plan

- [x] `docker pull rust:1.93-slim` → `ldd (Debian GLIBC 2.41-12+deb13u1) 2.41` — trixie confirmed
- [x] `docker pull rust:1.93-bookworm` → `ldd (Debian GLIBC 2.36-9+deb12u13) 2.36` — bookworm confirmed, matches runtime
- [x] `docker pull debian:bookworm-slim` → glibc 2.36 (runtime baseline)
- [ ] Post-merge: rebuild mika-agent at merge SHA, push to ECR, update `MIKA_AGENT_IMAGE_TAG` in `mika-console-secrets`, rollout console, `helm upgrade` Vincent's release — expect 1/1 Running on new tag with MIKA_CUSTOMER_ID env preserved. Same 4-step hop I ran this morning (fixed on rev 5 rollback via helm history).

Local docker rebuild not re-attempted before commit — the diagnosis is trusted based on the paired ldd output above and the identical failure mode `Dockerfile.gateway` already comments on. If CI's `docker-build` job surfaces anything unexpected, we iterate.

## Impact scope

- ONLY affects fresh builds of `mika-agent` (per-customer pods). Existing pods on `adc23281` (built pre-rebase) keep running.
- Blocks Vincent's final-hop deploy on the mika-cloud onboarding ladder (parent-issue thread n≈23 in the family-arm cascade).

Refs the mika-cloud family-customer-1 chain from 2026-07-08 → 09 (mika-cloud#158/#159/#160/#161/#162/#163/#164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784