### PR TITLE
feat(server): task-event SSE stream wire + verification catalog (#1732)

### DIFF
--- a/crates/mika-agent/docs/architecture.md
+++ b/crates/mika-agent/docs/architecture.md
@@ -827,6 +827,37 @@ Each A2A task gets its own session for message history.
 registry. Skills are mapped to A2A skills with their keywords as `tags`. The card
 advertises `streaming` and `stateTransitionHistory` capabilities. Auth scheme: `bearer`.
 
+### 14.2 SSE Frame Catalog
+
+mika-spirit ships three sibling SSE surfaces, each with a deliberate choice of
+discriminator key + correlation scope. They coexist by design — do NOT unify.
+
+| Surface | Discriminator | Scope | Route pattern | Crate | Introduced |
+|---|---|---|---|---|---|
+| `mika_a2a::streaming::StreamEvent` | `#[serde(tag = "kind")]` | Per-task (`a2a_broadcasters: DashMap<TaskId, Sender>`) | JSON-RPC-inline SSE (`POST /a2a/{agent}` with `message/stream` method) | `mika-a2a` | mika#1731 adds `ToolCallStart` / `ToolCallResult` variants + `Unknown` catch-all |
+| `PermissionStreamFrame` | `#[serde(tag = "event")]` | Per-process (single `AppState.permissions_channel`) | `GET /api/v1/dashboard/permissions/stream` (+ POST-back `/decide`) | `mika-agent` server | mika#1741 (sub-C AC1) |
+| `TaskEventFrame` (mika#1732) | `#[serde(tag = "event")]` | Per-process (single `AppState.task_events_channel`) | `GET /api/v1/dashboard/tasks/stream` | `mika-agent` server | this ticket |
+
+**Four axes of deliberate divergence:**
+
+1. **Discriminator key** — A2A uses `kind`, Dashboard uses `event`.
+2. **Correlation scope** — A2A is per-task (each `message/stream` gets its own bounded broadcast); Dashboard streams are per-process global broadcasts frames tag their originating agent/session.
+3. **Route pattern** — A2A rides on JSON-RPC POST body; Dashboard uses dedicated GET endpoints.
+4. **Crate location** — A2A frames live in `mika-a2a` (protocol-owned); Dashboard frames live in `mika-agent` server module (deploy-owned).
+
+**Shared discipline (all three surfaces):**
+
+- Additive variants only. No renames; no field removals.
+- Forward-compat `#[serde(other)]` catch-all (`Unknown`) — consumers tolerate future `kind`/`event` values without a re-release gate.
+- Slow-consumer discipline: `tokio::sync::broadcast` drop-oldest + an explicit `OverflowMarker` frame that surfaces the drop count on the wire.
+- UTF-8-safe truncation on preview fields (500-char cap by convention).
+
+**Full field-by-field references:**
+
+- `crates/mika-agent/docs/a2a-stream-frame-catalog-2026-07-10.md` — `StreamEvent` variants.
+- `crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md` — `PermissionStreamFrame` variants.
+- `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` — `TaskEventFrame` variants.
+
 
 ## 15. Failed Sends (Durable Outbox Pattern)
 

--- a/crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md
+++ b/crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md
@@ -1,0 +1,136 @@
+# Task-event live stream frame catalog
+
+**Ticket:** mika#1732 (sub-B of mika#1727 TUI thin-client)
+**Date:** 2026-07-10
+**Wire ships in:** PR-to-be from branch `feat/1732/new-sse-endpoint-task-event-live-stream`
+
+## Purpose
+
+Enumerate every SSE frame type the `GET /api/v1/dashboard/tasks/stream` handler broadcasts (once emission is wired). Consumers (TUI status pane from mika#1727, dashboard task-flow subscribers, future sub-tickets) should treat this as the single authoritative reference for the wire shape.
+
+## Transport
+
+- Handler: `handle_tasks_events_stream` at `crates/mika-agent/src/server/tasks_stream.rs`.
+- Route: `GET /api/v1/dashboard/tasks/stream` — registered in `dashboard_routes` at `crates/mika-agent/src/server/mod.rs` alongside `/dashboard/permissions/stream`.
+- Auth: `require_dashboard_or_internal_token` middleware — accepts either `MIKA_DASHBOARD_TOKEN` or `MIKA_INTERNAL_TOKEN` (superuser).
+- Frame encoding: plain `axum::response::sse::Event::default().data(json_string)`. No `event:` or `id:` header on the SSE envelope — the discriminator lives inside the JSON body via `#[serde(tag = "event")]`. `KeepAlive::default()` heartbeat.
+- Channel: per-process single `Arc<TaskEventsChannel>` on `AppState.task_events_channel`. Wraps a `tokio::sync::broadcast::Sender<TaskEventFrame>` with capacity `CHANNEL_CAP = 256`. Rationale: task-transition traffic can burst higher than permissions traffic (dispatch cascade, callback delivery flurry); 2× the permissions cap of 128.
+- Slow-consumer discipline: `BroadcastStreamRecvError::Lagged(n)` is translated to a `TaskEventFrame::OverflowMarker { dropped_count: n }` frame on the wire. Drop-oldest is Tokio's default. Emission is fire-and-forget — `broadcast_frame().is_ok()` returning `false` (zero subscribers) is informational, not an error.
+
+## `TaskEventFrame` variants
+
+Six event variants + one overflow marker + one forward-compat catch-all.
+
+### 1. `TaskCreated` — `"event": "task_created"`
+
+Fired on `db.create_task()` after a successful INSERT.
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | The new task ID |
+| `agentId` | `String` | Owning agent (consumers may filter client-side) |
+| `kind` | `String` | Task trigger_type: `manual` \| `callback` \| `recurring` \| `a2a` |
+| `actionType` | `String` | E.g. `resume_agent`, `send_message`, `none` |
+| `label` | `Option<String>` | Task label if set |
+| `parentTaskId` | `Option<String>` | Parent task if a child task |
+| `createdAt` | `String` | ISO 8601 UTC |
+
+### 2. `TaskClaimed` — `"event": "task_claimed"`
+
+Fired when a task transitions to `in_progress` (dispatch fired).
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | |
+| `agentId` | `String` | |
+| `claimedAt` | `String` | ISO 8601 UTC |
+
+### 3. `TaskCompleted` — `"event": "task_completed"`
+
+Fired on `db.update_task_completed()`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | |
+| `agentId` | `String` | |
+| `completedAt` | `String` | ISO 8601 UTC |
+| `resultPreview` | `Option<String>` | 500-char UTF-8-safe truncated result. Full body via `GET /api/v1/tasks/{taskId}` |
+
+### 4. `TaskFailed` — `"event": "task_failed"`
+
+Fired on `db.update_task_failed()`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | |
+| `agentId` | `String` | |
+| `failedAt` | `String` | ISO 8601 UTC |
+| `errorPreview` | `Option<String>` | 500-char UTF-8-safe truncated error summary |
+
+### 5. `TaskDelivered` — `"event": "task_delivered"`
+
+Fired on `db.mark_task_delivered()` when a completed / failed callback is consumed by the resume dispatcher.
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | |
+| `agentId` | `String` | |
+| `deliveredAt` | `String` | ISO 8601 UTC |
+
+### 6. `TaskCancelled` — `"event": "task_cancelled"`
+
+Fired on `db.update_task_status(id, "cancelled")` from HTTP handlers or engine-driven cancels.
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | `String` | |
+| `agentId` | `String` | |
+| `cancelledAt` | `String` | ISO 8601 UTC |
+| `reason` | `Option<String>` | Cancellation reason if set |
+
+### 7. `OverflowMarker` — `"event": "overflow_marker"`
+
+Emitted by the SSE handler (not a task-engine site) when `BroadcastStreamRecvError::Lagged(n)` fires. Signals to the consumer that at least one frame was dropped due to slow-consumer backpressure.
+
+| Field | Type | Notes |
+|---|---|---|
+| `droppedCount` | `u64` | Count of dropped frames since the last successful recv |
+
+### 8. `Unknown` — `#[serde(other)]` catch-all
+
+Forward-compat variant. Deserializes any `event` value not matched by the above variants. Consumers should match `Unknown` and fall through with a log-and-ignore branch.
+
+## Sibling divergence — do not conflate
+
+Three sibling SSE surfaces now coexist:
+
+| Surface | Discriminator | Scope | Route pattern | Crate |
+|---|---|---|---|---|
+| `mika_a2a::streaming::StreamEvent` (mika#1731) | `tag = "kind"` | Per-task | JSON-RPC-inline SSE | `mika-a2a` |
+| `PermissionStreamFrame` (mika#1741) | `tag = "event"` | Per-process | `GET /dashboard/permissions/stream` | `mika-agent` server |
+| `TaskEventFrame` (mika#1732, this file) | `tag = "event"` | Per-process | `GET /dashboard/tasks/stream` | `mika-agent` server |
+
+The A2A vs Dashboard divergence is intentional and load-bearing: A2A is JSON-RPC transport with task-scoped sessions; Dashboard is HTTP SSE with global tenant-scoped streams. `TaskEventFrame` follows `PermissionStreamFrame` because it lives in the same Dashboard family, not because the discriminator was arbitrary. Do NOT retrofit `StreamEvent` to `tag = "event"` — that would break existing A2A consumers.
+
+## Emission sites (for the follow-up ticket)
+
+The wire ships in this PR. Emission from task_engine transition sites is a follow-up (see plan §Out of scope). Top-level catalog for the emitter:
+
+- **`db.create_task()` → `TaskCreated`** — every call site. Consider emitting from the `AsyncDatabase::create_task_async` wrapper for centralization.
+- **`db.claim_and_fire_task()` → `TaskClaimed`** — `dispatcher.rs` at each dispatch site.
+- **`db.update_task_completed()` → `TaskCompleted`** — `dispatcher.rs:1702, 1752, 636, 647`; `engine.rs:837, 871`.
+- **`db.update_task_failed()` → `TaskFailed`** — `dispatcher.rs:1368, 1403`; `engine.rs:661, 744, 482`.
+- **`db.mark_task_delivered()` → `TaskDelivered`** — `dispatcher.rs:481`; `engine.rs:417`.
+- **`db.update_task_status(id, "cancelled")` → `TaskCancelled`** — `handle_task_cancel` in `server/handlers.rs`, `cancel_task_and_kill`, `process_kill.rs`.
+
+Emit AFTER the successful DB write. Frame captures the AFTER state — the caller reads the same fields it wrote (timestamps, agent_id, etc.) to populate.
+
+## Truncation helper
+
+`truncate_preview(s: &str) -> String` at `crates/mika-agent/src/server/tasks_stream.rs`. UTF-8-safe: iterates codepoints, takes the first 500, appends `…` if any were dropped. Guards against mika#764 byte-slice-lint class.
+
+## Related docs
+
+- `docs/architecture.md` §14.2 SSE Frame Catalog — cross-references all three sibling enums.
+- `crates/mika-agent/docs/a2a-stream-frame-catalog-2026-07-10.md` — mika#1731 sibling verification note.
+- `docs/plans/2026-07-10-004-feat-1732-task-event-sse-plan.md` — this ticket's plan.

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -15,6 +15,7 @@ pub mod permissions_stream;
 pub mod ready_label_handler;
 pub mod rewind;
 pub mod state;
+pub mod tasks_stream;
 pub mod types;
 pub mod variants;
 pub(crate) mod verdict;
@@ -272,6 +273,13 @@ fn build_router(state: AppState) -> Router {
         .route(
             "/dashboard/permissions/{request_id}/decide",
             post(permissions_stream::handle_permission_decide),
+        )
+        // Task-event live stream (mika#1732 sub-B): SSE surface for task
+        // lifecycle transitions. Wire-only in v1 — emission from task_engine
+        // transition sites lands in a follow-up ticket.
+        .route(
+            "/dashboard/tasks/stream",
+            get(tasks_stream::handle_tasks_events_stream),
         )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
@@ -1312,6 +1320,7 @@ pub async fn run_server(settings: &Settings) -> Result<()> {
         pr_reviews_posted,
         rate_limit_audit_last: Arc::new(dashmap::DashMap::new()),
         permissions_channel: Arc::new(permissions_stream::PermissionsChannel::new()),
+        task_events_channel: Arc::new(tasks_stream::TaskEventsChannel::new()),
     };
 
     let app = build_router(state.clone());
@@ -1600,6 +1609,7 @@ mod tests {
             pr_reviews_posted: Arc::new(dashmap::DashMap::new()),
             rate_limit_audit_last: Arc::new(dashmap::DashMap::new()),
             permissions_channel: Arc::new(permissions_stream::PermissionsChannel::new()),
+            task_events_channel: Arc::new(tasks_stream::TaskEventsChannel::new()),
         }
     }
 

--- a/crates/mika-agent/src/server/state.rs
+++ b/crates/mika-agent/src/server/state.rs
@@ -105,6 +105,12 @@ pub struct AppState {
     /// broadcast channel + pending-decision map. See
     /// `crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md § AC1`.
     pub permissions_channel: Arc<super::permissions_stream::PermissionsChannel>,
+    /// Task-event live stream broadcast surface (mika#1732). Per-process
+    /// broadcast channel carrying `TaskEventFrame` lifecycle events. Wire
+    /// only in v1 — the emission-from-transition-sites plumbing lands in a
+    /// follow-up ticket. See
+    /// `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md`.
+    pub task_events_channel: Arc<super::tasks_stream::TaskEventsChannel>,
 }
 
 impl AppState {

--- a/crates/mika-agent/src/server/tasks_stream.rs
+++ b/crates/mika-agent/src/server/tasks_stream.rs
@@ -1,0 +1,475 @@
+//! Task-event live stream for the TUI status pane (mika#1732 sub-B).
+//!
+//! Wire protocol between mika-spirit's task engine and the TUI / dashboard:
+//! every task lifecycle transition (created / claimed / completed / failed /
+//! delivered / cancelled) is broadcast on an SSE channel. Consumers see live
+//! task state changes without polling `GET /api/v1/tasks`.
+//!
+//! **Wire-first split (mika#1732 v1).** This module ships the SSE surface —
+//! the enum, the channel primitive, the handler, and the route contract.
+//! Emission from `task_engine` transition sites is deferred to a follow-up
+//! ticket; the wire is dormant until that lands. Same pattern as mika#1741
+//! (`permissions_stream.rs`) and mika#1731 (`mika_a2a::streaming`).
+//!
+//! **Sibling divergence — do not conflate.** Three sibling SSE surfaces
+//! now coexist, each with a deliberate choice of discriminator key + scope:
+//!
+//! | Surface                                | Discriminator | Scope          | Route pattern                    |
+//! |----------------------------------------|---------------|----------------|----------------------------------|
+//! | `mika_a2a::streaming::StreamEvent`     | `tag = "kind"`  | Per-task       | JSON-RPC-inline SSE              |
+//! | `PermissionStreamFrame` (mika#1741)    | `tag = "event"` | Per-process    | `GET /dashboard/permissions/stream` |
+//! | `TaskEventFrame` (this file, mika#1732)| `tag = "event"` | Per-process    | `GET /dashboard/tasks/stream`    |
+//!
+//! The A2A vs Dashboard family divergence is intentional: A2A is JSON-RPC
+//! transport with task-scoped sessions; Dashboard is HTTP SSE with global
+//! tenant-scoped streams. `TaskEventFrame` follows `PermissionStreamFrame`
+//! because it lives in the same Dashboard family, not because the
+//! discriminator key was arbitrary.
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+use tracing::warn;
+
+use super::state::AppState;
+
+/// Bounded broadcast capacity — slow consumers drop-oldest per the ticket's
+/// AC3. Emission NEVER blocks on subscriber-slow behavior. 256 is double the
+/// permissions channel cap because task-transition traffic can burst higher
+/// on dispatch cascades and callback-delivery flurries.
+const CHANNEL_CAP: usize = 256;
+
+/// UTF-8-safe truncation cap for `result_preview` / `error_preview` fields.
+/// Frames are glanceable receipts; the full call remains queryable via
+/// `GET /api/v1/tasks/{task_id}` for the details view.
+const PREVIEW_CAP_CHARS: usize = 500;
+
+/// UTF-8-safe truncation for preview fields. Cuts at a codepoint boundary
+/// and appends U+2026 when truncation actually removed characters. Guards
+/// against the mika#764 byte-slice lint class.
+fn truncate_preview(s: &str) -> String {
+    if s.chars().count() <= PREVIEW_CAP_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(PREVIEW_CAP_CHARS).collect();
+    out.push('…');
+    out
+}
+
+// ── Wire types ────────────────────────────────────────────────────────────
+
+/// Frame emitted on the SSE stream. Discriminated by the outer `event:`
+/// field (via serde's `tag = "event"`). Each transition variant carries the
+/// task and agent identifiers so consumers can correlate against
+/// `GET /api/v1/tasks/{task_id}` for the full record.
+///
+/// Consumers MUST tolerate unknown `event` values via the `Unknown`
+/// catch-all — new variants may ship additively (mika#1734 permission
+/// bridge, mika#1736 session-messages stream both anticipated).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TaskEventFrame {
+    /// A new task row was written to `tasks`. Fired on `db.create_task()`.
+    TaskCreated {
+        task_id: String,
+        agent_id: String,
+        /// `trigger_type` — one of `manual` / `callback` / `recurring` / `a2a`.
+        kind: String,
+        /// Action type (e.g. `resume_agent`, `send_message`, `none`).
+        action_type: String,
+        label: Option<String>,
+        parent_task_id: Option<String>,
+        /// ISO 8601 UTC.
+        created_at: String,
+    },
+    /// A task transitioned to `in_progress` (dispatch fired).
+    TaskClaimed {
+        task_id: String,
+        agent_id: String,
+        claimed_at: String,
+    },
+    /// A task transitioned to `completed`.
+    TaskCompleted {
+        task_id: String,
+        agent_id: String,
+        completed_at: String,
+        /// Truncated preview of the task result (500-char cap, UTF-8 safe).
+        /// Full body remains queryable via `GET /api/v1/tasks/{task_id}`.
+        result_preview: Option<String>,
+    },
+    /// A task transitioned to `failed`.
+    TaskFailed {
+        task_id: String,
+        agent_id: String,
+        failed_at: String,
+        /// Truncated preview of the error summary (500-char cap, UTF-8 safe).
+        error_preview: Option<String>,
+    },
+    /// A completed / failed callback was consumed by the resume dispatcher.
+    TaskDelivered {
+        task_id: String,
+        agent_id: String,
+        delivered_at: String,
+    },
+    /// A task transitioned to `cancelled` (operator or engine-driven).
+    TaskCancelled {
+        task_id: String,
+        agent_id: String,
+        cancelled_at: String,
+        reason: Option<String>,
+    },
+    /// Emitted by the SSE handler when `BroadcastStream` reports
+    /// `Lagged(n)` — the client fell behind and `n` frames were dropped.
+    /// Same discipline as `PermissionStreamFrame::OverflowMarker`.
+    OverflowMarker { dropped_count: u64 },
+    /// Forward-compat catch-all. Consumers should match `Unknown` and
+    /// fall through with a log-and-ignore branch. New variants will land
+    /// in follow-up tickets (mika#1727 TUI subscriber refactor, etc.).
+    #[serde(other)]
+    Unknown,
+}
+
+impl TaskEventFrame {
+    /// Helper: build a `TaskCompleted` frame with the result field
+    /// UTF-8-safe truncated. Emission-follow-up sites call this rather
+    /// than the struct literal so the truncation invariant is enforced.
+    pub fn completed(
+        task_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        completed_at: impl Into<String>,
+        result: Option<&str>,
+    ) -> Self {
+        Self::TaskCompleted {
+            task_id: task_id.into(),
+            agent_id: agent_id.into(),
+            completed_at: completed_at.into(),
+            result_preview: result.map(truncate_preview),
+        }
+    }
+
+    /// Helper: build a `TaskFailed` frame with the error field
+    /// UTF-8-safe truncated.
+    pub fn failed(
+        task_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        failed_at: impl Into<String>,
+        error: Option<&str>,
+    ) -> Self {
+        Self::TaskFailed {
+            task_id: task_id.into(),
+            agent_id: agent_id.into(),
+            failed_at: failed_at.into(),
+            error_preview: error.map(truncate_preview),
+        }
+    }
+}
+
+// ── Channel primitive ─────────────────────────────────────────────────────
+
+/// Per-server task-event broadcast surface. One instance lives on
+/// `AppState.task_events_channel`; task-engine transition sites push frames
+/// via [`Self::broadcast_frame`]; the SSE handler subscribes via
+/// [`Self::subscribe`].
+///
+/// The channel is per-process, not per-agent. Frames carry `agent_id` so
+/// consumers can filter client-side. Single-tenant deploy shape makes this
+/// the right default; a per-agent `DashMap<AgentId, Sender>` upgrade path
+/// is documented in the emission-follow-up ticket if multi-tenant becomes
+/// real (see mika#1732 plan §Risks).
+pub struct TaskEventsChannel {
+    outgoing: broadcast::Sender<TaskEventFrame>,
+}
+
+impl TaskEventsChannel {
+    pub fn new() -> Self {
+        let (outgoing, _) = broadcast::channel(CHANNEL_CAP);
+        Self { outgoing }
+    }
+
+    /// Broadcast a task-event frame to all connected SSE subscribers.
+    /// Returns `false` when zero subscribers are connected (informational
+    /// only — the wire is dormant until a client connects; no cursor
+    /// replay is implemented for v1).
+    ///
+    /// Emission is fire-and-forget: an error here NEVER fails the caller's
+    /// DB write. Log at `debug!` if you want visibility during rollout.
+    pub fn broadcast_frame(&self, frame: TaskEventFrame) -> bool {
+        self.outgoing.send(frame).is_ok()
+    }
+
+    /// Subscribe to the stream. Used by the SSE handler; each subscription
+    /// gets its own bounded receiver with drop-oldest slow-consumer
+    /// behavior (translated to `OverflowMarker` on the wire).
+    pub fn subscribe(&self) -> broadcast::Receiver<TaskEventFrame> {
+        self.outgoing.subscribe()
+    }
+
+    /// Test-only accessor. Non-test callers SHOULD NOT depend on subscriber
+    /// presence for correctness — emission is fire-and-forget by contract.
+    #[cfg(test)]
+    pub fn receiver_count(&self) -> usize {
+        self.outgoing.receiver_count()
+    }
+}
+
+impl Default for TaskEventsChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── HTTP handler ─────────────────────────────────────────────────────────
+
+/// GET /api/v1/dashboard/tasks/stream — SSE channel for task lifecycle
+/// events (mika#1732 sub-B).
+///
+/// Auth: bearer via `MIKA_INTERNAL_TOKEN` OR `MIKA_DASHBOARD_TOKEN` — wired
+/// at route-registration time in `server::mod.rs` alongside sibling
+/// dashboard SSE endpoints (`permissions_stream`).
+///
+/// Slow-consumer discipline (ticket AC3): `BroadcastStreamRecvError::Lagged`
+/// is translated to a `TaskEventFrame::OverflowMarker { dropped_count }`
+/// frame on the wire. The stream never crashes on lag — it emits the
+/// marker and resumes.
+pub async fn handle_tasks_events_stream(State(state): State<AppState>) -> impl IntoResponse {
+    let rx = state.task_events_channel.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(frame) => match serde_json::to_string(&frame) {
+            Ok(json) => Some(Ok::<_, std::convert::Infallible>(
+                Event::default().data(json),
+            )),
+            Err(e) => {
+                warn!(error = %e, "failed to serialize task event frame");
+                None
+            }
+        },
+        Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(dropped)) => {
+            // Slow-consumer overflow — emit a marker frame and resume.
+            let overflow = TaskEventFrame::OverflowMarker {
+                dropped_count: dropped,
+            };
+            serde_json::to_string(&overflow)
+                .ok()
+                .map(|json| Ok(Event::default().data(json)))
+        }
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serde round-trip tests — one per emitted variant. Guards against
+    // silent wire-tag drift.
+
+    #[test]
+    fn task_created_round_trip_preserves_fields() {
+        let frame = TaskEventFrame::TaskCreated {
+            task_id: "task-1".to_string(),
+            agent_id: "mika".to_string(),
+            kind: "manual".to_string(),
+            action_type: "none".to_string(),
+            label: Some("Investigate mika#1732".to_string()),
+            parent_task_id: None,
+            created_at: "2026-07-10T13:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: TaskEventFrame = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEventFrame::TaskCreated {
+                task_id, agent_id, ..
+            } => {
+                assert_eq!(task_id, "task-1");
+                assert_eq!(agent_id, "mika");
+            }
+            other => panic!("expected TaskCreated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_completed_round_trip_with_truncated_result() {
+        let big_result = "a".repeat(PREVIEW_CAP_CHARS + 50);
+        let frame =
+            TaskEventFrame::completed("task-2", "mika", "2026-07-10T13:01:00Z", Some(&big_result));
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: TaskEventFrame = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEventFrame::TaskCompleted { result_preview, .. } => {
+                let preview = result_preview.expect("result should be Some");
+                // Truncated to PREVIEW_CAP_CHARS + 1 ellipsis codepoint.
+                assert_eq!(preview.chars().count(), PREVIEW_CAP_CHARS + 1);
+                assert!(preview.ends_with('…'));
+            }
+            other => panic!("expected TaskCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_failed_round_trip_with_truncated_error() {
+        let big_error = "err ".repeat(PREVIEW_CAP_CHARS);
+        let frame =
+            TaskEventFrame::failed("task-3", "mika", "2026-07-10T13:02:00Z", Some(&big_error));
+        let json = serde_json::to_string(&frame).unwrap();
+        let parsed: TaskEventFrame = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEventFrame::TaskFailed { error_preview, .. } => {
+                let preview = error_preview.expect("error should be Some");
+                assert!(preview.chars().count() <= PREVIEW_CAP_CHARS + 1);
+                assert!(preview.ends_with('…'));
+            }
+            other => panic!("expected TaskFailed, got {other:?}"),
+        }
+    }
+
+    // Wire-tag stability tests — every variant's serde tag string is
+    // asserted. Silent renames break subscribers, so pin the strings.
+
+    #[test]
+    fn wire_tag_strings_are_stable() {
+        let cases: Vec<(TaskEventFrame, &str)> = vec![
+            (
+                TaskEventFrame::TaskCreated {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    kind: "manual".into(),
+                    action_type: "none".into(),
+                    label: None,
+                    parent_task_id: None,
+                    created_at: "ts".into(),
+                },
+                "task_created",
+            ),
+            (
+                TaskEventFrame::TaskClaimed {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    claimed_at: "ts".into(),
+                },
+                "task_claimed",
+            ),
+            (
+                TaskEventFrame::TaskCompleted {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    completed_at: "ts".into(),
+                    result_preview: None,
+                },
+                "task_completed",
+            ),
+            (
+                TaskEventFrame::TaskFailed {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    failed_at: "ts".into(),
+                    error_preview: None,
+                },
+                "task_failed",
+            ),
+            (
+                TaskEventFrame::TaskDelivered {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    delivered_at: "ts".into(),
+                },
+                "task_delivered",
+            ),
+            (
+                TaskEventFrame::TaskCancelled {
+                    task_id: "t".into(),
+                    agent_id: "a".into(),
+                    cancelled_at: "ts".into(),
+                    reason: None,
+                },
+                "task_cancelled",
+            ),
+            (
+                TaskEventFrame::OverflowMarker { dropped_count: 1 },
+                "overflow_marker",
+            ),
+        ];
+        for (frame, expected) in cases {
+            let value = serde_json::to_value(&frame).unwrap();
+            assert_eq!(
+                value["event"].as_str().unwrap(),
+                expected,
+                "wire tag for {frame:?}"
+            );
+        }
+    }
+
+    // Forward-compat catch-all.
+
+    #[test]
+    fn unknown_event_falls_to_catch_all_variant() {
+        let future = serde_json::json!({
+            "event": "future_variant_not_yet_added",
+            "task_id": "t",
+            "extra": 42,
+        });
+        let parsed: TaskEventFrame = serde_json::from_value(future).unwrap();
+        assert!(
+            matches!(parsed, TaskEventFrame::Unknown),
+            "unknown event should land in Unknown catch-all"
+        );
+    }
+
+    // Channel mechanics.
+
+    #[tokio::test]
+    async fn broadcast_frame_reaches_subscriber() {
+        let channel = TaskEventsChannel::new();
+        let mut rx = channel.subscribe();
+        let frame = TaskEventFrame::TaskDelivered {
+            task_id: "t".into(),
+            agent_id: "a".into(),
+            delivered_at: "ts".into(),
+        };
+        assert!(channel.broadcast_frame(frame));
+        let received = rx.recv().await.expect("should receive frame");
+        match received {
+            TaskEventFrame::TaskDelivered { task_id, .. } => assert_eq!(task_id, "t"),
+            other => panic!("expected TaskDelivered, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn broadcast_frame_zero_subscribers_returns_false() {
+        let channel = TaskEventsChannel::new();
+        assert_eq!(channel.receiver_count(), 0);
+        let frame = TaskEventFrame::OverflowMarker { dropped_count: 0 };
+        // No subscribers — send returns Err internally; broadcast_frame
+        // reports false but does NOT panic or fail the caller.
+        assert!(!channel.broadcast_frame(frame));
+    }
+
+    #[test]
+    fn truncate_preview_below_cap_untouched() {
+        let s = "short preview";
+        assert_eq!(truncate_preview(s), "short preview");
+    }
+
+    #[test]
+    fn truncate_preview_over_cap_appends_ellipsis() {
+        let s = "a".repeat(PREVIEW_CAP_CHARS + 10);
+        let out = truncate_preview(&s);
+        assert_eq!(out.chars().count(), PREVIEW_CAP_CHARS + 1);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_preview_utf8_safe() {
+        // Multi-byte codepoints must not split at a byte boundary
+        // (mika#764 lint class).
+        let s = "é".repeat(PREVIEW_CAP_CHARS + 10);
+        let out = truncate_preview(&s);
+        assert_eq!(out.chars().count(), PREVIEW_CAP_CHARS + 1);
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -827,6 +827,37 @@ Each A2A task gets its own session for message history.
 registry. Skills are mapped to A2A skills with their keywords as `tags`. The card
 advertises `streaming` and `stateTransitionHistory` capabilities. Auth scheme: `bearer`.
 
+### 14.2 SSE Frame Catalog
+
+mika-spirit ships three sibling SSE surfaces, each with a deliberate choice of
+discriminator key + correlation scope. They coexist by design — do NOT unify.
+
+| Surface | Discriminator | Scope | Route pattern | Crate | Introduced |
+|---|---|---|---|---|---|
+| `mika_a2a::streaming::StreamEvent` | `#[serde(tag = "kind")]` | Per-task (`a2a_broadcasters: DashMap<TaskId, Sender>`) | JSON-RPC-inline SSE (`POST /a2a/{agent}` with `message/stream` method) | `mika-a2a` | mika#1731 adds `ToolCallStart` / `ToolCallResult` variants + `Unknown` catch-all |
+| `PermissionStreamFrame` | `#[serde(tag = "event")]` | Per-process (single `AppState.permissions_channel`) | `GET /api/v1/dashboard/permissions/stream` (+ POST-back `/decide`) | `mika-agent` server | mika#1741 (sub-C AC1) |
+| `TaskEventFrame` (mika#1732) | `#[serde(tag = "event")]` | Per-process (single `AppState.task_events_channel`) | `GET /api/v1/dashboard/tasks/stream` | `mika-agent` server | this ticket |
+
+**Four axes of deliberate divergence:**
+
+1. **Discriminator key** — A2A uses `kind`, Dashboard uses `event`.
+2. **Correlation scope** — A2A is per-task (each `message/stream` gets its own bounded broadcast); Dashboard streams are per-process global broadcasts frames tag their originating agent/session.
+3. **Route pattern** — A2A rides on JSON-RPC POST body; Dashboard uses dedicated GET endpoints.
+4. **Crate location** — A2A frames live in `mika-a2a` (protocol-owned); Dashboard frames live in `mika-agent` server module (deploy-owned).
+
+**Shared discipline (all three surfaces):**
+
+- Additive variants only. No renames; no field removals.
+- Forward-compat `#[serde(other)]` catch-all (`Unknown`) — consumers tolerate future `kind`/`event` values without a re-release gate.
+- Slow-consumer discipline: `tokio::sync::broadcast` drop-oldest + an explicit `OverflowMarker` frame that surfaces the drop count on the wire.
+- UTF-8-safe truncation on preview fields (500-char cap by convention).
+
+**Full field-by-field references:**
+
+- `crates/mika-agent/docs/a2a-stream-frame-catalog-2026-07-10.md` — `StreamEvent` variants.
+- `crates/mika-agent/docs/permission-decision-protocol-2026-07-06.md` — `PermissionStreamFrame` variants.
+- `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` — `TaskEventFrame` variants.
+
 
 ## 15. Failed Sends (Durable Outbox Pattern)
 

--- a/docs/plans/2026-07-10-004-feat-1732-task-event-sse-plan.md
+++ b/docs/plans/2026-07-10-004-feat-1732-task-event-sse-plan.md
@@ -1,0 +1,249 @@
+---
+ticket: mika#1732
+branch: feat/1732/new-sse-endpoint-task-event-live-stream
+type: feat
+scope: crates/mika-agent
+grooming: /mika-groom-ticket
+parent: mika#1727 (Phase 1 audit sub-ticket B)
+---
+
+# Plan — mika#1732 task-event SSE stream for TUI status pane
+
+## Problem
+
+Sub-issue of mika#1727 (TUI as thin HTTP client of mika-spirit). The TUI's status pane wants live task-transition events (created / claimed / completed / failed / delivered) as they happen. Today the closest surface is `GET /api/v1/tasks` (snapshot list at `crates/mika-agent/src/server/dashboard.rs:639`); a thin-client TUI would have to poll it, which wastes cycles and produces stale rendering between polls. This ticket adds an SSE endpoint that pushes task events as they happen.
+
+## Verification result
+
+**Verified — new SSE surface is required.** The current mika-spirit HTTP surface has:
+
+- `GET /api/v1/tasks` (`crates/mika-agent/src/server/mod.rs:132`, handler at `dashboard.rs:639-678`) — paginated snapshot returning `PaginatedResponse<TaskResponse>`. Query filters (status, trigger_type, action_type, agent_id, team_run_id, source, from, to). Single-shot; no subscription.
+- `GET /api/v1/tasks/{task_id}` — detail.
+- No streaming route for task transitions exists. Zero broadcast channel for task events.
+- **Reusable sibling primitive:** `PermissionsChannel` at `crates/mika-agent/src/server/permissions_stream.rs` (shipped in mika#1741). Per-process `broadcast::Sender<PermissionStreamFrame>` on `AppState.permissions_channel` (`state.rs:107`), capacity 128, `#[serde(tag = "event", rename_all = "snake_case")]`, explicit `OverflowMarker { dropped_count }` frame that translates `BroadcastStreamRecvError::Lagged` into the wire (`permissions_stream.rs:199-225`). Route registered at `server/mod.rs:268-275` with `require_dashboard_or_internal_token` middleware (`server/auth.rs:48`) via the `dashboard_routes` block. This is exactly the shape #1732 needs.
+
+Task lifecycle transition sites are extensive — every `db.update_task_completed`, `db.update_task_failed`, `db.mark_task_delivered`, `db.claim_and_fire_task`, `db.update_task_status`, `db.create_task` is a potential emit point. Full list documented in the pre-groom investigation (agent scratchpad; §Emission sites below has the top-level summary).
+
+## Coordination with mika#1731
+
+mika#1731 (PR#1756, awaiting review) is **strictly additive on mika-a2a** — new variants on `mika_a2a::streaming::StreamEvent` in a different crate. This ticket is **strictly additive on mika-agent server** — new module `server/tasks_stream.rs`, new field on `AppState`, new route. **No coordination required.** Both PRs land independently.
+
+## Scope
+
+### In scope for v1 (this PR — the WIRE)
+
+Same wire-first split samidarko-claude endorsed on mika#1731 (PR#1756) and mika#1741 (PR#1741). Ship the SSE surface + channel primitive + frame catalog + unit tests. Defer the emission-from-transition-sites plumbing to a follow-up ticket that lands when a consumer (mika#1727 TUI) is ready.
+
+**AC1 — New module `crates/mika-agent/src/server/tasks_stream.rs`.** Mirrors `permissions_stream.rs` in shape:
+
+- `TaskEventFrame` enum with `#[serde(tag = "event", rename_all = "snake_case")]` — same convention as `PermissionStreamFrame` (server-crate dashboard SSE family; NOT the mika-a2a `StreamEvent` `tag = "kind"` convention which is per-task JSON-RPC-inline SSE). This is a deliberate choice — the ticket is a sibling of `permissions_stream`, not of `message/stream`.
+- Six variants + one overflow + one catch-all (details in §Implementation guardrails).
+- `TaskEventsChannel` struct wrapping `broadcast::Sender<TaskEventFrame>`, capacity `TASK_EVENTS_CHANNEL_CAP = 256`. Rationale: task-transition traffic can burst (dispatch cascade, callback delivery flurry) higher than permissions traffic; double the permissions cap of 128.
+- `broadcast_frame(&self, frame: TaskEventFrame) -> bool` — non-blocking, `send().is_ok()`. Zero subscribers is informational.
+- `handle_tasks_events_stream(State<AppState>)` — SSE handler mirroring `handle_permissions_stream` at `permissions_stream.rs:180-233`. Uses `BroadcastStream::new(rx).filter_map(...)` to translate `Lagged(n)` into a `TaskEventFrame::OverflowMarker { dropped_count: n }` on the wire.
+- `receiver_count()` accessor gated `#[cfg(test)]`.
+
+**AC2 — Route registration.** `GET /api/v1/dashboard/tasks/stream` (or `/api/v1/tasks/stream` — the exact path is a small grooming call; recommend `/api/v1/dashboard/tasks/stream` to mirror `/dashboard/permissions/stream` for discoverability). Wired into `dashboard_routes` at `crates/mika-agent/src/server/mod.rs` alongside the existing `/dashboard/permissions/stream` and `/dashboard/permissions/{request_id}/decide` routes at `server/mod.rs:268-275`. Auth via the shared `dashboard_routes.route_layer(...)` at `server/mod.rs:276-279` — `require_dashboard_or_internal_token`. **No new auth class; no per-tenant scope changes.**
+
+**AC3 — `AppState.task_events_channel: Arc<TaskEventsChannel>` field.** Constructed identically to `permissions_channel` in `test_state()` at `server/mod.rs:1602` and in production init at `server/mod.rs:1314`. Single per-process instance. Frames carry `agent_id` for consumer-side filtering — no per-agent DashMap. Justification: single-tenant deploy shape (mika#1727 audit: "single-user boxes run it as a local process on 127.0.0.1:8081") + parity with `PermissionsChannel` which is also per-process.
+
+**AC4 — Slow-consumer discipline.** Handled by `broadcast::channel`'s built-in `Lagged` + an explicit `TaskEventFrame::OverflowMarker { dropped_count: u64 }` frame that surfaces on the wire when the client falls behind. `permissions_stream.rs:199-225` is the reference. Drop-oldest is Tokio's default for `broadcast::channel`; no additional buffering layer. Emission is fire-and-forget: `broadcast_frame().is_ok()` returning `false` (zero subscribers) does not fail the caller.
+
+**AC5 — Frame enum shape.**
+
+```rust
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TaskEventFrame {
+    /// A new task row was written to `tasks`. Fired on `db.create_task()`.
+    TaskCreated {
+        task_id: String,
+        agent_id: String,
+        kind: String,          // "manual" | "callback" | "recurring" | "a2a"
+        action_type: String,   // e.g. "resume_agent", "none", "send_message"
+        label: Option<String>,
+        parent_task_id: Option<String>,
+        created_at: String,
+    },
+    /// A task transitioned to `in_progress` (dispatch fired).
+    TaskClaimed {
+        task_id: String,
+        agent_id: String,
+        claimed_at: String,
+    },
+    /// A task transitioned to `completed`.
+    TaskCompleted {
+        task_id: String,
+        agent_id: String,
+        completed_at: String,
+        result_preview: Option<String>,   // truncated at 500 chars
+    },
+    /// A task transitioned to `failed`.
+    TaskFailed {
+        task_id: String,
+        agent_id: String,
+        failed_at: String,
+        error_preview: Option<String>,    // truncated at 500 chars
+    },
+    /// A completed/failed callback was consumed by the resume dispatcher.
+    TaskDelivered {
+        task_id: String,
+        agent_id: String,
+        delivered_at: String,
+    },
+    /// A task transitioned to `cancelled` (operator or engine-driven).
+    TaskCancelled {
+        task_id: String,
+        agent_id: String,
+        cancelled_at: String,
+        reason: Option<String>,
+    },
+    /// Emitted by the SSE handler when `BroadcastStream` reports `Lagged(n)` —
+    /// the client fell behind and n frames were dropped.
+    OverflowMarker { dropped_count: u64 },
+    /// Forward-compat catch-all — future variants ship additively.
+    #[serde(other)]
+    Unknown,
+}
+```
+
+Same forward-compat catch-all pattern as mika#1731 (`StreamEvent::Unknown`). Kebab-case `event` values via `rename_all = "snake_case"` — matches `PermissionStreamFrame` convention.
+
+**AC6 — Truncation policy.** `result_preview` and `error_preview` are UTF-8-safe truncated at 500 chars via a reused or inlined `truncate_utf8_safe` helper. If mika#1731 lands first, reuse `mika_a2a::streaming::truncate_tool_summary`. If this PR lands first, inline a `truncate_summary` helper in `tasks_stream.rs` — same shape (codepoint iterator + `…` suffix on overflow, guards against mika#764 byte-slice lint).
+
+**AC7 — Unit tests.** Match `permissions_stream.rs:274-374` exactly:
+- Frame serde round-trip for every emit variant (six of them + OverflowMarker).
+- `event` tag value stability test — asserts the wire strings (`"task_created"`, `"task_claimed"`, `"task_completed"`, `"task_failed"`, `"task_delivered"`, `"task_cancelled"`, `"overflow_marker"`) to catch silent breakage.
+- `Unknown` catch-all deserialization test — an unknown `event` value lands in `Unknown` without panic.
+- `broadcast_frame_reaches_subscriber` — subscribe → emit → recv, mirrors `permissions_stream.rs:354`.
+- `broadcast_frame_zero_subscribers_no_error` — `broadcast_frame` returns cleanly with no receivers.
+- Optional: `overflow_marker_fires_on_lag` — send `TASK_EVENTS_CHANNEL_CAP + 10` frames without draining, verify `OverflowMarker` surfaces. This is testable at the `BroadcastStream` layer without a full router.
+
+**AC8 — Docs.**
+- `docs/architecture.md` §14.2 SSE Frame Catalog (already established by mika#1731; if #1731 hasn't merged yet, this PR either extends it if #1731 lands first or introduces the §14.2 subsection heading itself and references the mika-a2a StreamEvent enum without duplication). Add `TaskEventFrame` row + cross-reference to `PermissionStreamFrame` and `StreamEvent` — three sibling SSE surfaces with divergent scopes/tags but shared "additive + catch-all" discipline.
+- New verification note at `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` — mirrors the mika#1731 catalog note. Emit-site table pointing to §Emission sites (below) for post-emission-PR wiring.
+
+**AC9 — Build + lint clean.**
+- `cargo build -p mika-agent`
+- `cargo test -p mika-agent --lib tasks_stream`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+### Out of scope for v1 (deferred to follow-up mika#new)
+
+**AC5 of the ticket (emission wiring) is scope-reduced from this PR.** The emission sites are extensive — every DB-side transition needs a corresponding `broadcast_frame` call. That plumbing requires:
+
+- Threading `Arc<TaskEventsChannel>` into `TaskDispatcher` (`task_engine/dispatcher.rs`) and `TaskEngine` (`task_engine/engine.rs`) at construction time (mika#1732 v1 does NOT touch these files — the `AsyncDatabase` API is agnostic to the channel).
+- Or emitting from callers immediately after successful DB writes. Callers include `dispatcher.rs:481, 636, 647, 1159, 1194, 1603, 1702, 1752`, `engine.rs:661, 744, 837, 871, 384, 417, 453, 482`, plus HTTP handlers `server/handlers.rs::handle_task_complete`, `handle_task_cancel`, plus `task_engine/process_kill.rs:404, 464`, plus every `db.create_task(NewTask{...})` site (widespread).
+- Deciding on read-then-write vs read-post-write ordering (frame captures the AFTER state; the caller must read the new state to populate the frame fields — or the frame is written before the SQL commit and rolled back on failure — a real design question, not a mechanical rewrite).
+- Integration test for the full lifecycle (10 concurrent subscribers + 100 events/sec, ticket AC5's load target).
+
+That's a substantial diff on top of the wire. Split to follow-up ticket **mika#new** (to be filed alongside this PR — mirrors mika#1757 for #1731). Reactivate when mika#1727 (TUI) is ready to consume the frames.
+
+**Also out of scope for v1:**
+- **TUI rendering** — mika#1727 closing PR.
+- **Cursor replay** — the ticket's discipline lineage (D5 / cm#99) mentions replay-on-reconnect. Not part of v1; if the TUI needs it, a separate ticket adds a per-frame monotonic ID column + replay handler. Same pattern as mika#1741 which shipped without replay.
+- **Cross-tenant subscription policies** — single-tenant Phase 1 shape (ticket §Not in scope).
+- **Historical query** — ticket §Not in scope; `GET /api/v1/tasks` snapshot remains.
+- **Heartbeat frame** — ticket lists as "optional; for phantom-task detection". Deferred to the emission follow-up when we know if the task_engine actually needs it separately from `TaskClaimed` / periodic `TaskEvent::updated_at`.
+
+## Implementation guardrails
+
+### File and function targets
+
+| Change | File | Location |
+|---|---|---|
+| New module — enum, channel primitive, handler, tests | `crates/mika-agent/src/server/tasks_stream.rs` | New file |
+| Module registration | `crates/mika-agent/src/server/mod.rs` | Near `pub mod permissions_stream;` |
+| Route registration | `crates/mika-agent/src/server/mod.rs` | In `dashboard_routes` block near `/dashboard/permissions/stream` at line 268 |
+| `AppState.task_events_channel` field | `crates/mika-agent/src/server/state.rs` | Near `permissions_channel` at line 107 |
+| `AppState` construction | `crates/mika-agent/src/server/mod.rs` | Prod init (~line 1314), test-state factory (~line 1602) |
+| Architecture doc §14.2 | `docs/architecture.md` + doc-synced copy | Add `TaskEventFrame` row |
+| Verification note | `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` | New file |
+
+### Emission sites (for the follow-up ticket)
+
+Top-level catalog for the emission-plumbing PR. Every site emits AFTER the successful DB write.
+
+- **`db.create_task()` → `TaskCreated`** — every call site. High-cardinality (many creation paths); consider emitting from `AsyncDatabase::create_task_async` wrapper rather than callers if that's the shape task_engine settles on.
+- **`db.claim_and_fire_task()` → `TaskClaimed`** — `dispatcher.rs` at each dispatch site.
+- **`db.update_task_completed()` → `TaskCompleted`** — `dispatcher.rs:1702, 1752, 636, 647`, `engine.rs:837, 871`.
+- **`db.update_task_failed()` → `TaskFailed`** — `dispatcher.rs:1368, 1403`, `engine.rs:661, 744, 482`.
+- **`db.mark_task_delivered()` → `TaskDelivered`** — `dispatcher.rs:481`, `engine.rs:417`.
+- **`db.update_task_status(id, "cancelled")` → `TaskCancelled`** — `handle_task_cancel` in `server/handlers.rs`, `cancel_task_and_kill`, `process_kill.rs`.
+
+### Backwards compatibility
+
+- No existing frame renamed or removed (no existing frames on this route).
+- No existing route touched.
+- No auth-class change.
+- No schema migration.
+- New `AppState` field; every construction site of `AppState` must include `task_events_channel: Arc::new(TaskEventsChannel::new())`. Two sites (prod + test-state).
+
+### Threading + Send bounds
+
+`TaskEventsChannel` must be `Send + Sync + Clone` (via `Arc<...>`). `broadcast::Sender<T>` is `Clone + Send + Sync` when `T: Send`. `TaskEventFrame` derives `Debug, Clone, Serialize, Deserialize` — the derived `Clone` is trivial (all fields are `String`/`Option<String>`/`u64`), no manual impl needed.
+
+### Documentation update — §14.2 SSE Frame Catalog
+
+If #1731 lands first, this PR extends the existing §14.2 table with a `TaskEventFrame` row + cross-reference to `PermissionStreamFrame` and `StreamEvent` — one sentence noting the four divergence axes (discriminator key, correlation scope, route, crate location).
+
+If this PR lands first, introduce §14.2 heading standalone. #1731's PR (or a follow-up) will merge its content in when it lands.
+
+## Acceptance criteria
+
+**AC1.** New module `crates/mika-agent/src/server/tasks_stream.rs` defines `TaskEventFrame` enum with the six event variants, `OverflowMarker`, and `Unknown` catch-all. `#[serde(tag = "event", rename_all = "snake_case")]`.
+
+**AC2.** `TaskEventsChannel` struct wraps `broadcast::Sender<TaskEventFrame>` with capacity 256, exposes `broadcast_frame(&self, frame: TaskEventFrame) -> bool` and `subscribe(&self) -> broadcast::Receiver<TaskEventFrame>`. Test-only `receiver_count()` accessor.
+
+**AC3.** `handle_tasks_events_stream(State<AppState>) -> Sse<...>` handler translates `BroadcastStreamRecvError::Lagged(n)` into `TaskEventFrame::OverflowMarker { dropped_count: n }` on the wire. `KeepAlive::default()` heartbeat.
+
+**AC4.** Route `GET /api/v1/dashboard/tasks/stream` is registered inside `dashboard_routes` at `server/mod.rs`, guarded by `require_dashboard_or_internal_token` middleware.
+
+**AC5.** `AppState.task_events_channel: Arc<TaskEventsChannel>` field is populated in both production init and `test_state()`.
+
+**AC6.** Truncation of `result_preview` / `error_preview` at 500 chars is UTF-8-safe (codepoint-boundary + U+2026 ellipsis on overflow). No naive byte slicing (guards against mika#764 lint script).
+
+**AC7.** Unit tests inside `tasks_stream.rs` cover: (a) serde round-trip for every variant, (b) `event` tag string stability for each variant, (c) `Unknown` catch-all deserializes without panic on unknown `event` value, (d) `broadcast_frame_reaches_subscriber` positive path, (e) zero-subscribers fires without error.
+
+**AC8.** `docs/architecture.md` §14.2 SSE Frame Catalog gets a `TaskEventFrame` row + cross-reference to `PermissionStreamFrame` (mika#1741) and `StreamEvent` (mika#1731). New verification note at `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md`. Doc-synced via `scripts/sync-agent-docs.sh`.
+
+**AC9.** `cargo build -p mika-agent`, `cargo test -p mika-agent --lib tasks_stream`, and `cargo clippy --workspace --all-targets -- -D warnings` all pass.
+
+## Verification steps (post-implementation)
+
+1. `cargo test -p mika-agent --lib tasks_stream` — new unit tests green.
+2. `cargo clippy --workspace --all-targets -- -D warnings` — clean.
+3. Manual (post-emission-follow-up only): local mika-spirit + `curl -N -H "Authorization: Bearer $MIKA_INTERNAL_TOKEN" http://localhost:8081/api/v1/dashboard/tasks/stream`, observe SSE stream. Any operator action creating/completing a task should produce a frame. This is documented for the emission follow-up PR, not this one.
+
+## Rollout
+
+- Merge to `main` → next `make deploy` picks it up. No cluster ops.
+- No consumer yet; the wire is dormant. When the emission follow-up lands, dashboard subscribers begin receiving frames. When mika#1727 (TUI) migrates, that's the actual UX unlock.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Broadcast channel capacity 256 chosen by gut. | Channel-level tests validate `OverflowMarker` behavior; if production traffic overflows sustainedly, capacity is a one-const-edit change. Track in the emission-follow-up if observed. |
+| Extra `AppState` field must be added everywhere `AppState` is constructed. | Only 2 sites: prod init at `server/mod.rs:1314`, `test_state()` at `server/mod.rs:1602`. Compiler-enforced. |
+| Emission from every task-transition site is a large diff. | Deferred to follow-up ticket per samidarko-endorsed wire-first pattern. This PR ships only the surface. |
+| Frame captures BEFORE vs AFTER state at emission. | Emit AFTER successful DB write. Frame constructor reads the same fields the caller wrote (timestamps, agent_id, etc.). Documented in the follow-up ticket. |
+| Downstream client-side filtering by agent_id is a scan. | Acceptable for single-tenant deploy. If multi-tenant becomes real, add a `?agent_id=X` query filter at the handler; frames still pass the whole enum through the channel — filter at consumption. Follow-up. |
+| Doc section §14.2 SSE Frame Catalog collision with mika#1731. | mika#1731 introduces §14.2 in PR#1756. If PR#1756 has not merged by review-time, this PR extends the same table; if it has, ditto. Additive. If both PRs miss each other, one merges its section and the other rebase-adds its row — no risk of loss. |
+
+## Files changed (expected)
+
+- `crates/mika-agent/src/server/tasks_stream.rs` — new module. ~350 lines (enum + channel + handler + tests).
+- `crates/mika-agent/src/server/mod.rs` — module registration + route + 2 AppState construction sites. ~10 lines added.
+- `crates/mika-agent/src/server/state.rs` — 1 new field. ~3 lines.
+- `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` — new verification note. ~100 lines.
+- `docs/architecture.md` + `crates/mika-agent/docs/architecture.md` (via doc-sync) — §14.2 addition. ~15 lines.
+
+Estimated diff: ~480 net lines added.
+
+## Grooming history
+
+- 2026-07-10 — `/ce:plan` draft (with pre-groom verification pass).
+- 2026-07-10 — `mika-arch` first-pass review (session `4ac4247a-0d38-4ac2-a8fe-6196fe31bf9f`): **Disposition: READY**. All three uncertainties confirmed. Two refinements to fold into the follow-up ticket:
+  1. Follow-up must document the DashMap upgrade path explicitly. Note that `db.rs`-layer emitters are agent-agnostic, so per-agent scoping requires either threading `agent_id` through the DB layer (wrong layer concern) or keeping a parallel per-process channel for DB-layer events.
+  2. Follow-up must carry a **time-bound commitment** — the emission plumbing follow-up should merge within 14 days of this PR or be escalated to P1. Prevents the "permissions_stream has been dead code for months" recurrence. Load-bearing for mika#1727.
+- Architect also endorsed documenting the current three-axis divergence between A2A and Dashboard SSE families as a first-class architectural invariant in §14.2, with an additional row noting the family membership (A2A vs Dashboard) as an implicit fourth axis (crate location).


### PR DESCRIPTION
Closes #1732

## Summary

Ships the wire for the task-event SSE live stream per mika#1732 (sub-B of mika#1727 TUI thin-client). Same wire-first split samidarko-claude endorsed on mika#1731 (PR#1756).

**Verification result:** confirmed new SSE surface is required. Existing `GET /api/v1/tasks` (`dashboard.rs:639`) is a paginated snapshot; no broadcast channel for task events exists. Reusable sibling primitive is `PermissionsChannel` from mika#1741 which shipped exactly this shape.

**New module `crates/mika-agent/src/server/tasks_stream.rs`:**

- `TaskEventFrame` enum with six lifecycle variants (`TaskCreated`, `TaskClaimed`, `TaskCompleted`, `TaskFailed`, `TaskDelivered`, `TaskCancelled`) + `OverflowMarker { dropped_count }` + `#[serde(other)] Unknown` catch-all.
- Serde tags via `#[serde(tag = "event", rename_all = "snake_case")]` — matches `PermissionStreamFrame` convention (dashboard SSE family; A2A `StreamEvent` uses `tag = "kind"` — deliberate divergence).
- `TaskEventsChannel` wrapping `broadcast::Sender<TaskEventFrame>` with capacity 256 (2× permissions cap because task-transition traffic bursts higher on dispatch cascades / callback flurries).
- `handle_tasks_events_stream` handler translates `BroadcastStreamRecvError::Lagged(n)` into `TaskEventFrame::OverflowMarker { dropped_count: n }` on the wire. `KeepAlive::default()` heartbeat.
- UTF-8-safe 500-char `truncate_preview()` for `result_preview` / `error_preview` fields (mika#764 byte-slice lint class).
- `TaskEventFrame::completed()` / `TaskEventFrame::failed()` constructors enforce truncation at build sites.

**Route + state:**

- `GET /api/v1/dashboard/tasks/stream` registered on `dashboard_routes` alongside `/dashboard/permissions/stream` with `require_dashboard_or_internal_token` middleware. No new auth class.
- `AppState.task_events_channel: Arc<TaskEventsChannel>` field populated identically in prod init (`server/mod.rs:1314`) and `test_state()` (`server/mod.rs:1602`).

**Docs:**

- Verification catalog: `crates/mika-agent/docs/tasks-event-stream-frame-catalog-2026-07-10.md` enumerating every variant with field types and emit-site targets for the follow-up.
- Architecture `§14.2 SSE Frame Catalog` documenting the four deliberate divergence axes (discriminator key, correlation scope, route pattern, crate location) across the three sibling SSE surfaces (`StreamEvent`, `PermissionStreamFrame`, `TaskEventFrame`).
- Doc-synced via `scripts/sync-agent-docs.sh`.

## Scope reduction from architect-READY plan

The ticket's AC2 (emission from every task_engine transition site + integration test), AC4 (stub consumer), and AC5 (load test) are deferred to a follow-up ticket. Emission touches ~15 transition sites in `dispatcher.rs` + `engine.rs` + `handlers.rs` + `process_kill.rs`, plus threading `Arc<TaskEventsChannel>` into `TaskDispatcher` at construction, plus BEFORE-vs-AFTER-write ordering discipline. Substantial diff on top of the wire.

Architect endorsed the split with two sharpenings folded into the follow-up ticket:
1. **14-day-or-P1 time-bound commitment** — prevents dead-code accumulation. Load-bearing for mika#1727 (TUI).
2. **DashMap upgrade path documented** — for multi-tenant future.

Tracked in: senara-solutions/mika#1758

## Grooming

Plan: `mika/docs/plans/2026-07-10-004-feat-1732-task-event-sse-plan.md` — mika-arch first-pass verdict `Disposition: READY` on session `4ac4247a-0d38-4ac2-a8fe-6196fe31bf9f`. All three uncertainties confirmed correct: per-process channel over per-agent DashMap (YAGNI); `tag = "event"` over `tag = "kind"` (reinforces dashboard-SSE-family invariant, not arbitrary divergence); wire-first pattern with time-bound follow-up.

## Test plan

- [x] `cargo test -p mika-agent --lib tasks_stream` — 10 tests pass (serde round-trip for TaskCreated/Completed/Failed, wire-tag string stability across all 7 event tags, Unknown catch-all deserialization, broadcast_frame_reaches_subscriber, zero-subscribers-no-error, three truncate_preview tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build -p mika-agent` — clean
- [ ] Post-emission (follow-up mika#1758): integration test exercising synthetic task lifecycle create → claim → complete → deliver produces the corresponding frame sequence
- [ ] Post-emission (follow-up): load test 10 concurrent subscribers + 100 events/sec sustained for 30s
- [ ] Manual verify (post-emission): local mika-spirit + `curl -N -H "Authorization: Bearer $MIKA_INTERNAL_TOKEN" http://localhost:8081/api/v1/dashboard/tasks/stream` observes SSE stream frames on any task operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784
