### PR TITLE
fix(loop-substrate): widen grooming-marker gate for parameterized GROOMED verdicts (mika#1725 mech 2)

### DIFF
--- a/crates/mika-agent/src/auto_pull.rs
+++ b/crates/mika-agent/src/auto_pull.rs
@@ -46,7 +46,11 @@ pub struct Issue {
 pub fn is_groomed(body: &str) -> bool {
     static GROOMING_HISTORY_RE: OnceLock<Regex> = OnceLock::new();
     let re = GROOMING_HISTORY_RE.get_or_init(|| {
-        Regex::new(r"(?m)^> - \*\*Grooming history:\*\*.+second-pass \(GROOMED\)")
+        // Mirrors GROOMED_VERDICT_RE in skills/executor.rs (#1725): accept the
+        // canonical strict form AND parameterized/annotated variants like
+        // `second-pass (GROOMED, session abc)` or `— session-id: uuid`.
+        // The character class after `GROOMED` is the structural discriminator.
+        Regex::new(r"(?m)^> - \*\*Grooming history:\*\*.+second-pass \(GROOMED[\s\)\.,;:—-]")
             .expect("grooming history regex must compile")
     });
     re.is_match(body)
@@ -482,6 +486,80 @@ This ticket has been GROOMED and is ready.
     #[test]
     fn test_is_groomed_empty_body() {
         assert!(!is_groomed(""));
+    }
+
+    // ── #1725 parameterized GROOMED verdict widening ──
+
+    #[test]
+    fn test_is_groomed_comma_parameter() {
+        // `second-pass (GROOMED, session-id fd4c1a14)` — a form orchestrator-CC
+        // produced at mika#1723 dispatch that the strict regex rejected.
+        let body = r#"## Description
+
+> - **Branch:** `feat/123/some-feature`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md` (committed on branch @ abc1234)
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED, session fd4c1a14)
+"#;
+        assert!(is_groomed(body), "comma-parameterized GROOMED must match");
+    }
+
+    #[test]
+    fn test_is_groomed_em_dash_annotation() {
+        // `second-pass (GROOMED — session-id: uuid)` — the shape orchestrator-CC
+        // routinely emits with em-dash-separated session-id annotation.
+        let body = r#"## Description
+
+> - **Branch:** `feat/123/some-feature`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md` (committed on branch @ abc1234)
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED — session-id: 550e8400)
+"#;
+        assert!(
+            is_groomed(body),
+            "em-dash-annotated GROOMED must match; body=\n{body}"
+        );
+    }
+
+    #[test]
+    fn test_is_groomed_period_terminator() {
+        let body = r#"## Description
+
+> - **Branch:** `feat/123/some-feature`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md` (committed on branch @ abc1234)
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED. Full ratification.)
+"#;
+        assert!(is_groomed(body), "period-terminated GROOMED must match");
+    }
+
+    #[test]
+    fn test_is_groomed_reject_prose_groomedly() {
+        // Ensure `GROOMED` followed by a word-continuation char (letter) is
+        // rejected — the character class after GROOMED is the discriminator.
+        let body = r#"## Description
+
+> - **Branch:** `feat/123/some-feature`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md` (committed on branch @ abc1234)
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMEDLY) — not a real form
+"#;
+        assert!(
+            !is_groomed(body),
+            "letter-continuation after GROOMED must not match"
+        );
+    }
+
+    #[test]
+    fn test_is_groomed_first_pass_groomed_rejected() {
+        // Ensure the `second-pass (` prefix requirement blocks `first-pass (GROOMED)`
+        // which is not a valid ratification signal (first-pass is READY/ITERATE/ESCALATE).
+        let body = r#"## Description
+
+> - **Branch:** `feat/123/some-feature`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md` (committed on branch @ abc1234)
+> - **Grooming history:** first-pass (GROOMED) — no second-pass line
+"#;
+        assert!(
+            !is_groomed(body),
+            "first-pass (GROOMED) without second-pass must not match"
+        );
     }
 
     // ── priority_rank tests ──

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -4,11 +4,13 @@
 // files, creating shared-mutable-state bugs. All skill output goes to stdout/stderr.
 
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use anyhow::{Result, bail};
 use base64::Engine;
+use regex::Regex;
 use serde::Deserialize;
 use tokio::io::AsyncWriteExt;
 use tracing::{debug, info, warn};
@@ -796,10 +798,35 @@ fn extract_skill_from_input(input: &serde_json::Value) -> Option<&str> {
 /// contiguous substring. `docs/plans/` is the essential anchoring directory
 /// prefix.
 ///
-/// The groomed-verdict check accepts both the canonical `second-pass (GROOMED)`
-/// and the spec-tolerated paraphrase `second-pass (READY, paraphrased GROOMED`
-/// shapes (#1108). The grooming spec's Phase 5 may emit either form; the gate
-/// must accept everything the spec authorizes.
+/// The groomed-verdict check accepts the canonical `second-pass (GROOMED)`,
+/// the spec-tolerated paraphrase `second-pass (READY, paraphrased GROOMED`,
+/// and parameterized/annotated variants like `second-pass (GROOMED, session ...)`
+/// or `second-pass (GROOMED — session-id: ...)` (#1725). The grooming spec's
+/// Phase 5 and orchestrator-manual verdict-landing both routinely emit
+/// parameterized forms; the gate must accept everything the spec authorizes.
+///
+/// # Regex shape
+///
+/// `second-pass \(GROOMED[\s\)\.,;:—-]` — the character class after `GROOMED` is
+/// the structural discriminator. It matches:
+/// - `)` (canonical strict form: `second-pass (GROOMED)`)
+/// - `,` (parameter: `second-pass (GROOMED, session abc)`)
+/// - `.` (terminator: `second-pass (GROOMED. Full ratification.)`)
+/// - `;` `:` (annotators)
+/// - `—` `-` (dash-separated annotation: `second-pass (GROOMED — session-id: uuid)`)
+/// - whitespace (any word-boundary follow-on)
+///
+/// Anchoring to the `second-pass (` prefix + a delimiter after `GROOMED`
+/// structurally distinguishes the verdict-line callout from prose like
+/// "the ticket was GROOMED yesterday" or "GROOMED status pending".
+static GROOMED_VERDICT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"second-pass \(GROOMED[\s\)\.,;:—-]").expect("groomed verdict regex must compile")
+});
+static PARAPHRASED_GROOMED_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"second-pass \(READY, paraphrased GROOMED")
+        .expect("paraphrased groomed regex must compile")
+});
+
 pub fn check_grooming_markers(issue_body: &str) -> Vec<&'static str> {
     let mut missing = Vec::new();
     if !issue_body.contains("> - **Branch:**") {
@@ -808,8 +835,8 @@ pub fn check_grooming_markers(issue_body: &str) -> Vec<&'static str> {
     if !issue_body.contains("docs/plans/") {
         missing.push("plan_callout");
     }
-    let has_groomed_marker = issue_body.contains("second-pass (GROOMED)")
-        || issue_body.contains("second-pass (READY, paraphrased GROOMED");
+    let has_groomed_marker =
+        GROOMED_VERDICT_RE.is_match(issue_body) || PARAPHRASED_GROOMED_RE.is_match(issue_body);
     if !has_groomed_marker {
         missing.push("groomed_verdict");
     }
@@ -5648,6 +5675,108 @@ Verdict: GROOMED
         assert_eq!(
             missing,
             vec!["branch_callout", "plan_callout", "groomed_verdict"]
+        );
+    }
+
+    // --- check_grooming_markers #1725 parameterized verdict widening ---
+
+    /// mika#1723 dispatch failure shape: orchestrator-CC produced
+    /// `second-pass (GROOMED, session fd4c1a14)` — the comma broke the strict
+    /// substring match, gate rejected with `dispatch_no_grooming_marker`.
+    #[test]
+    fn test_grooming_markers_accepts_comma_parameter() {
+        let body = r#"
+> - **Branch:** `fix/1725/loop-substrate`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md`
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED, session fd4c1a14)
+"#;
+        let missing = check_grooming_markers(body);
+        assert!(
+            missing.is_empty(),
+            "comma-parameterized GROOMED must pass, got: {missing:?}"
+        );
+    }
+
+    /// Em-dash-annotated form (canonical orchestrator-CC session-id shape).
+    #[test]
+    fn test_grooming_markers_accepts_em_dash_annotation() {
+        let body = r#"
+> - **Branch:** `fix/1725/loop-substrate`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md`
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED — session-id: fd4c1a14)
+"#;
+        let missing = check_grooming_markers(body);
+        assert!(
+            missing.is_empty(),
+            "em-dash-annotated GROOMED must pass, got: {missing:?}"
+        );
+    }
+
+    /// Period-terminated form: `second-pass (GROOMED. Full ratification.)`.
+    #[test]
+    fn test_grooming_markers_accepts_period_terminator() {
+        let body = r#"
+> - **Branch:** `fix/1725/loop-substrate`
+> - **Plan:** `docs/plans/2026-07-04-001-fix-plan.md`
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMED. Full ratification.)
+"#;
+        let missing = check_grooming_markers(body);
+        assert!(
+            missing.is_empty(),
+            "period-terminated GROOMED must pass, got: {missing:?}"
+        );
+    }
+
+    /// False-positive guard: prose `"the ticket was GROOMED yesterday"` must
+    /// NOT satisfy the check. The `second-pass (` prefix anchor blocks it.
+    #[test]
+    fn test_grooming_markers_rejects_prose_groomed_without_prefix() {
+        let body = r#"
+> - **Branch:** `feat/something`
+> - **Plan:** `docs/plans/some-plan.md`
+
+Discussion: the ticket was GROOMED yesterday but never actually reviewed.
+GROOMED status pending in another ticket.
+"#;
+        let missing = check_grooming_markers(body);
+        assert_eq!(
+            missing,
+            vec!["groomed_verdict"],
+            "prose GROOMED without `second-pass (` prefix must not match"
+        );
+    }
+
+    /// False-positive guard: `second-pass (GROOMEDLY)` — letter-continuation
+    /// after GROOMED must be rejected by the character class discriminator.
+    #[test]
+    fn test_grooming_markers_rejects_letter_continuation() {
+        let body = r#"
+> - **Branch:** `feat/something`
+> - **Plan:** `docs/plans/some-plan.md`
+> - **Grooming history:** first-pass (READY) → second-pass (GROOMEDLY reviewed) — bogus
+"#;
+        let missing = check_grooming_markers(body);
+        assert_eq!(
+            missing,
+            vec!["groomed_verdict"],
+            "letter-continuation after GROOMED must not match"
+        );
+    }
+
+    /// False-positive guard: `first-pass (GROOMED)` — the `second-pass (`
+    /// prefix requirement blocks this; first-pass verdict is READY/ITERATE/ESCALATE.
+    #[test]
+    fn test_grooming_markers_rejects_first_pass_groomed() {
+        let body = r#"
+> - **Branch:** `feat/something`
+> - **Plan:** `docs/plans/some-plan.md`
+> - **Grooming history:** first-pass (GROOMED) — no second-pass, invalid
+"#;
+        let missing = check_grooming_markers(body);
+        assert_eq!(
+            missing,
+            vec!["groomed_verdict"],
+            "first-pass (GROOMED) without second-pass must not match"
         );
     }
 

--- a/docs/plans/2026-07-04-001-fix-loop-substrate-auto-groom-convergence-plan.md
+++ b/docs/plans/2026-07-04-001-fix-loop-substrate-auto-groom-convergence-plan.md
@@ -96,8 +96,19 @@ Regex::new(r"(?m)^> - \*\*Grooming history:\*\*.+second-pass \(GROOMED[\s\)\.,;:
 - **AC6 (existing test coverage preserved):** The existing tests at `crates/mika-agent/src/skills/executor.rs:5557+` (`test_grooming_markers_*`) continue to pass without modification. Only new tests are added.
 - **AC7 (in-flight tickets unaffected):** Tickets whose body carries the strict canonical `second-pass (GROOMED)` form (no comma parameter) continue to dispatch identically. No regression on cm#56/57/58/59/60 whose grooming-history callouts use the strict form.
 
+## Scope split (2026-07-11 amendment)
+
+Mechanism 2 (grooming-marker gate widening) is the sole scope of this PR. **Mechanism 1 (dev-groom `_iterate_groom_loop` convergence failure — AC1 investigation + AC2 fix) is deferred to a follow-up ticket, `senara-solutions/mika#1772`.** Rationale:
+
+- AC1 is investigation-first (server.log grep for tasks `e781006e-ade5-445d-83a3-dc1d005e8288` / `f490c32f-6aa0-4942-b10f-c3e13204f75e`, plus a shell handler read of `skills/bundled/dev-groom/handler.sh`). The A/B/C fix direction only becomes concrete after AC1 names the specific failure candidate.
+- AC2's regression test needs a reproducer fixture that depends on which of the A/B/C candidates AC1 identifies.
+- Mechanism 2 is a well-scoped structural regex widening that unblocks the mika#1723 dispatch-rejection route-around today, independent of the mechanism 1 diagnosis.
+
+Only AC3–AC7 (Mechanism 2's regex-widening ACs) apply to this PR. AC1 + AC2 are tracked in mika#1772 and will land in a separate scoped PR after root cause is named.
+
 ## Out of scope
 
+- **Mechanism 1 investigation and fix (AC1 + AC2)** — deferred to mika#1772 as documented above.
 - Renaming `_iterate_groom_loop` or restructuring dev-groom's handler flow (bigger refactor).
 - Changing the writer-side canonical form (this is a structural gate fix — writers can produce any of the accepted forms, and orchestrator-CC's current `— session-id:` shape is one accepted form).
 - Adding a `parse_paraphrased_disposition()` mika-arch helper library (future ticket if the paraphrase set grows).

--- a/docs/plans/2026-07-04-001-fix-loop-substrate-auto-groom-convergence-plan.md
+++ b/docs/plans/2026-07-04-001-fix-loop-substrate-auto-groom-convergence-plan.md
@@ -1,0 +1,136 @@
+---
+issue: 1725
+type: fix
+scope: loop-substrate
+title: auto-groom convergence failure + grooming-marker gate rigidity
+---
+
+# Plan — mika#1725: auto-groom convergence failure + grooming-marker gate rigidity
+
+## Why
+
+Two mechanisms both bite the autonomous loop's dispatch path today. Ticket route-around cost accumulates on every fresh grooming.
+
+**Note on the ticket body's diagnosis:** the body claims the grooming-marker gate uses `Plan: docs/plans/` literal-substring check. Reading the actual code at `crates/mika-agent/src/skills/executor.rs:803-817` (`check_grooming_markers()`) — the check for the plan marker is just `docs/plans/` (no `Plan:` prefix required). The failure mode I actually hit on mika#1723 dispatch was the SECOND check — `second-pass (GROOMED)` requires literal `(GROOMED)` immediately followed by `)`. My initial body carried `second-pass (GROOMED, session fd4c1a14)` — the `,` after `GROOMED` broke the substring match. So mechanism 2 is real, but on the GROOMED verdict marker, not the Plan marker. This plan corrects that scope.
+
+## Mechanism 1: auto-groom architect convergence failure (dev-groom)
+
+**Symptom.** `mika#1723` dispatch at 17:58Z produced parent task `e781006e-ade5-445d-83a3-dc1d005e8288` and callback child `f490c32f-6aa0-4942-b10f-c3e13204f75e`. Callback delivered with `PIPELINE FAILURE: architect convergence did not complete (_iterate_groom_loop returned non-zero). Plan exists on branch but architect verdict is missing.` Parent transitioned to `blocked` at 18:03Z.
+
+**Investigation.** Root cause candidates (mutually non-exclusive):
+1. mika-arch first-pass returned ITERATE, second-pass ran before revisions applied
+2. mika-arch first-pass returned a paraphrased Disposition the loop didn't parse (per `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`)
+3. mika-arch second-pass hit a timeout mid-turn
+4. Intermediate step (plan-write, plan-read, session-continuation) failed silently
+
+**Investigation step 1:** grep `/var/log/mika/server.log` for `task_id=e781006e-ade5-445d-83a3-dc1d005e8288` or `f490c32f-6aa0-4942-b10f-c3e13204f75e` OR the `_iterate_groom_loop` return value site. Establish which of the four candidates fired.
+
+**Investigation step 2:** read `skills/bundled/dev-groom/handler.sh` (the `_iterate_groom_loop` implementation) to understand the convergence contract. It expects mika-arch first-pass → apply revisions → mika-arch second-pass → GROOMED. The non-zero return could be from ITERATE without applied revisions, ESCALATE from first-pass, or a session-continuity break.
+
+**Fix shape.** Depends on investigation outcome. Three plausible directions:
+
+- **A. Session-continuity fix.** If the second-pass session doesn't correctly reference the first-pass session, mika-arch has no context for "what changed." Fix: pass `session_id` explicitly on the second-pass invocation.
+- **B. Paraphrase tolerance in `_iterate_groom_loop`.** Match arch's own known paraphrase set (`docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md`): "Proceed" ≈ READY, "Ratify" ≈ READY, etc.
+- **C. Escalate on convergence failure with actionable diagnostic.** Instead of setting parent `blocked` with an opaque `PIPELINE FAILURE`, capture WHICH step failed + WHAT the last arch response was. Enables faster orchestrator-manual fallback.
+
+**Recommendation:** all three at different layers. A + B are code-level fixes; C is defensive observability that speeds recovery on future convergence classes we haven't seen yet.
+
+## Mechanism 2: grooming-marker gate rigidity on parameterized GROOMED verdict
+
+**Actual failure shape (verified against `check_grooming_markers()` at `crates/mika-agent/src/skills/executor.rs:811-812`):**
+
+```rust
+let has_groomed_marker = issue_body.contains("second-pass (GROOMED)")
+    || issue_body.contains("second-pass (READY, paraphrased GROOMED");
+```
+
+The check requires literal `second-pass (GROOMED)` OR literal `second-pass (READY, paraphrased GROOMED` — the first form requires `)` immediately after `GROOMED`. When orchestrator-CC produces `second-pass (GROOMED, session fd4c1a14)`, the `,` breaks the substring match — dispatch rejects with `dispatch_no_grooming_marker` + `missing_signals: ["groomed_verdict"]`.
+
+**Fix shape (structural widening):**
+
+Replace the substring match with a regex tolerating parameterized forms:
+
+```rust
+static GROOMED_VERDICT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Match `second-pass (GROOMED)` OR `second-pass (GROOMED, ...)` OR
+    // `second-pass (GROOMED — ...)` — the parameter/annotation is optional and
+    // any character after GROOMED except a word-continuation is acceptable.
+    Regex::new(r"second-pass \(GROOMED[\s\)\.,;:—-]").unwrap()
+});
+static PARAPHRASED_GROOMED_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"second-pass \(READY, paraphrased GROOMED").unwrap()
+});
+
+pub fn check_grooming_markers(issue_body: &str) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if !issue_body.contains("> - **Branch:**") {
+        missing.push("branch_callout");
+    }
+    if !issue_body.contains("docs/plans/") {
+        missing.push("plan_callout");
+    }
+    let has_groomed_marker = GROOMED_VERDICT_RE.is_match(issue_body)
+        || PARAPHRASED_GROOMED_RE.is_match(issue_body);
+    if !has_groomed_marker {
+        missing.push("groomed_verdict");
+    }
+    missing
+}
+```
+
+**Same widening applied to `auto_pull.rs:49` regex:**
+
+```rust
+Regex::new(r"(?m)^> - \*\*Grooming history:\*\*.+second-pass \(GROOMED[\s\)\.,;:—-]")
+```
+
+**Why regex not more permissive substring:** naked `GROOMED` in the body without the `second-pass (` context would false-positive on prose like "the ticket was groomed" or "GROOMED status pending." The regex anchors to the `second-pass (` prefix + a delimiter after `GROOMED`, which structurally distinguishes verdict-line from prose.
+
+## Acceptance criteria
+
+- **AC1 (Mechanism 1 investigation):** The plan is amended (during implementation) with named root cause from `server.log` for e781006e / f490c32f. The candidate list narrows to ONE of A/B/C/other.
+- **AC2 (Mechanism 1 fix):** Whichever of A/B/C applies, `dev-groom`'s `_iterate_groom_loop` no longer returns non-zero on the class of failure that happened at 17:58Z. Regression test uses a fixture that reproduces the specific step failure identified in AC1.
+- **AC3 (Mechanism 2 fix — executor.rs):** `check_grooming_markers` accepts `second-pass (GROOMED)`, `second-pass (GROOMED, session fd4c1a14)`, `second-pass (GROOMED — session-id: fd4c1a14)`, `second-pass (GROOMED. Full ratification.)` — verified by unit test with each form.
+- **AC4 (Mechanism 2 fix — auto_pull.rs):** Same widening applied at the sibling regex site. Same test set.
+- **AC5 (regression — no false positive):** Prose like `"the ticket was GROOMED yesterday"` or `"GROOMED status pending"` does NOT satisfy the check. Unit test asserts absence-of-`second-pass (` context is rejected.
+- **AC6 (existing test coverage preserved):** The existing tests at `crates/mika-agent/src/skills/executor.rs:5557+` (`test_grooming_markers_*`) continue to pass without modification. Only new tests are added.
+- **AC7 (in-flight tickets unaffected):** Tickets whose body carries the strict canonical `second-pass (GROOMED)` form (no comma parameter) continue to dispatch identically. No regression on cm#56/57/58/59/60 whose grooming-history callouts use the strict form.
+
+## Out of scope
+
+- Renaming `_iterate_groom_loop` or restructuring dev-groom's handler flow (bigger refactor).
+- Changing the writer-side canonical form (this is a structural gate fix — writers can produce any of the accepted forms, and orchestrator-CC's current `— session-id:` shape is one accepted form).
+- Adding a `parse_paraphrased_disposition()` mika-arch helper library (future ticket if the paraphrase set grows).
+
+## Dependencies
+
+**Blocked by:** none. mika#1719 fix (PR#1726) is UNRELATED — this is a separate substrate class.
+
+**Blocks:** nothing directly. Loop-quality improvement.
+
+**Order relative to Prime #446:** Prime task #446 blocks new autonomous dispatches until mika#1719 fix ships. This ticket is GROOMED now and dispatchable once #446 lifts.
+
+## Verification
+
+```bash
+# Unit tests
+cargo test -p mika-agent --lib skills::executor::tests::grooming_markers
+
+# Integration: reproduce the mika#1723 dispatch shape with the current form
+cargo test -p mika-agent --lib server::ready_label_handler::tests
+
+# Manual: verify the fix accepts orchestrator-CC's actual body format
+echo '> - **Grooming history:** first-pass (READY) → second-pass (GROOMED) — session-id: fd4c1a14' | \
+  cargo run --bin grooming-marker-check
+```
+
+## References
+
+- `crates/mika-agent/src/skills/executor.rs:803-817` (`check_grooming_markers`)
+- `crates/mika-agent/src/auto_pull.rs:43-56` (sibling regex check)
+- `crates/mika-agent/src/skills/executor.rs:793` (comment noting canonical shape)
+- `docs/solutions/best-practices/mika-arch-first-dogfood-2026-04-25.md` (arch paraphrase drift context — mechanism 1 candidate B)
+- `docs/solutions/workflow-issues/grooming-branch-callout-required-2026-04-25.md` (canonical grooming callout discipline)
+- mika#919, mika#1108 (the gate origin + observability additions)
+- mika#1725 body (original filing with diagnosis correction noted above)
+- `feedback_prompt_enforcement_fragile` — the doctrine motivating a structural gate widening over writer-side discipline


### PR DESCRIPTION
## Summary

- Widen `check_grooming_markers()` (executor.rs) and `is_groomed()` (auto_pull.rs) from strict substring match to shared regex accepting parameterized/annotated GROOMED verdicts.
- Fixes the mika#1723 dispatch-rejection route-around: orchestrator-CC's canonical `second-pass (GROOMED — session-id: uuid)` and `second-pass (GROOMED, session abc)` shapes now pass the gate.
- Preserves all existing test coverage; adds 11 new tests (accept-set + reject-set).

## Scope: mechanism 2 only

Per the plan at `docs/plans/2026-07-04-001-fix-loop-substrate-auto-groom-convergence-plan.md`, ticket #1725 has two mechanisms:

1. **Mechanism 1** — dev-groom `_iterate_groom_loop` convergence failure on mika#1723 (2026-07-04 17:58Z). Requires server.log investigation + shell handler read + A/B/C fix direction. **Deferred to a follow-up PR** — the plan's AC1 is investigation-first, not code-first. I've started reading the server.log for tasks `e781006e-ade5-445d-83a3-dc1d005e8288` / `f490c32f-6aa0-4942-b10f-c3e13204f75e` but the root cause diagnosis + fix belong in their own scoped PR.

2. **Mechanism 2** (this PR) — grooming-marker gate rigidity on parameterized GROOMED. Well-scoped structural regex widening.

Companion PR for mechanism 1 will be filed after the log investigation names the specific failure candidate (A: session-continuity / B: paraphrase tolerance / C: escalate-with-diagnostic).

## Regex shape

Both sites now use the same character-class discriminator:

```
r"second-pass \(GROOMED[\s\)\.,;:—-]"
```

The character class after `GROOMED` matches:
- `)` — canonical strict form: `second-pass (GROOMED)`
- `,` — parameter: `second-pass (GROOMED, session abc)`
- `.` — terminator: `second-pass (GROOMED. Full ratification.)`
- `;` `:` — annotators
- `—` `-` — dash-separated annotation: `second-pass (GROOMED — session-id: uuid)`
- whitespace — any word-boundary follow-on

Anchor to `second-pass (` prefix + delimiter after `GROOMED` structurally distinguishes verdict-line callouts from:
- Prose: "the ticket was GROOMED yesterday" / "GROOMED status pending"
- Typo: `first-pass (GROOMED)` — first-pass verdict is READY/ITERATE/ESCALATE, not GROOMED
- Letter-continuation: `second-pass (GROOMEDLY)` — rejected by class discriminator

## Acceptance criteria (plan-scoped)

- **AC3** (executor.rs) — ✅ `test_grooming_markers_accepts_comma_parameter` + `_em_dash_annotation` + `_period_terminator`
- **AC4** (auto_pull.rs) — ✅ `test_is_groomed_comma_parameter` + `_em_dash_annotation` + `_period_terminator`
- **AC5** (no false positives) — ✅ `test_grooming_markers_rejects_prose_groomed_without_prefix` + `_rejects_letter_continuation` + `_rejects_first_pass_groomed`; mirrored in auto_pull.rs
- **AC6** (existing tests preserved) — ✅ All 6 pre-existing `test_grooming_markers_*` tests pass without modification; all 7 pre-existing `test_is_groomed_*` tests pass unchanged
- **AC7** (in-flight tickets unaffected) — ✅ Strict `second-pass (GROOMED)` form still matches; cm#56/57/58/59/60 grooming-history callouts using the strict form dispatch identically

## Deferred (documented in follow-up)

- **AC1 (investigation)** — server.log grep for `task_id=e781006e-ade5-445d-83a3-dc1d005e8288` returned 14 hits; root-cause classification underway
- **AC2 (mechanism 1 fix)** — separate PR after AC1 completes

Tracked in: senara-solutions/mika#1772

## Test plan

- [x] `cargo test -p mika-agent --lib skills::executor::tests::test_grooming_markers` — 12/12 pass
- [x] `cargo test -p mika-agent --lib auto_pull::tests` — 28/28 pass (including new + existing)
- [x] `cargo clippy -p mika-agent --lib --no-deps -- -D warnings` — clean
- [x] Pre-commit hook rust-fmt + rust-clippy — pass

Ref: mika#1725 (plan §Mechanism 2), mika#1723 (originating dispatch failure), mika#919 + mika#1108 (gate origin + observability additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784



Tracked in: senara-solutions/mika#1772 (mechanism 1 — investigation-first, deferred per plan AC1)
