### PR TITLE
fix(gateway): suppress [mika] prefix on outbound Telegram for single-agent customers (family-tier launch hotfix)

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -53,7 +53,7 @@ The DLQ respects the shared 30-permit webhook semaphore — if all permits are h
 
 ## Agent Identification & Reply Routing
 
-- Outbound messages carry `agent_name` in the `/send` payload; gateway prepends `[agent_name]` to Telegram text and stores `(telegram_message_id, chat_id, agent_name)` in `outbound_messages` Postgres table
+- Outbound messages carry `agent_name` in the `/send` payload; gateway prepends `[agent_name]` to Telegram text (**except when `agent_name == mika_common::agent::DEFAULT_AGENT` (`"mika"`)** — single-agent customers, including every family-tier customer, see raw text with no `[mika]` parasite; suppression added after family-tier launch 2026-07-16 when the prefix leaked into a family member's first-hour greeting) and stores `(telegram_message_id, chat_id, agent_name)` in `outbound_messages` Postgres table
 - Parses `reply_to_message` from Telegram updates; looks up the originating agent via `outbound_messages` and forwards the inbound message with `"agent": "<name>"` to the correct agent in the container
 - Periodic cleanup: purges `outbound_messages` older than 7 days (batched, every ~100 webhooks)
 

--- a/crates/mika-gateway/src/routes.rs
+++ b/crates/mika-gateway/src/routes.rs
@@ -1475,6 +1475,33 @@ async fn require_bearer_token(
 
 // -- Send handler --
 
+/// Format outbound Telegram text: prepend `[<agent_name>] ` for identification in
+/// multi-agent setups, EXCEPT when the sender is the container's default agent
+/// (`mika-common::agent::DEFAULT_AGENT`, `"mika"`). Single-agent customers —
+/// including every family-tier customer — see the raw text with no `[mika]`
+/// prefix on Telegram. Multi-agent customers who name additional agents
+/// (`work-mika`, `personal-mika`, etc.) still get the identification prefix on
+/// those non-default agents.
+///
+/// This is a rendering-layer decision only. The agent's outbound content is
+/// unchanged in its own DB, and `outbound_messages` still records `agent_name`
+/// for reply-to-message routing (`parse_agent_prefix` on inbound continues to
+/// tolerate both prefixed and unprefixed shapes for backwards compat with
+/// pre-fix history + non-default agents).
+///
+/// Founding incident: mika-cloud family-tier launch 2026-07-16 — the `[mika]`
+/// prefix leaked into a family member's first-hour Telegram greeting, breaking
+/// the persona's "warm, French, no jargon" contract before she even said
+/// hello. Pure function so the branch is unit-testable without HTTP scaffolding.
+fn format_outbound_text(agent_name: Option<&str>, text: &str) -> String {
+    match agent_name {
+        Some(name) if name != mika_common::agent::DEFAULT_AGENT => {
+            format!("[{name}] {text}")
+        }
+        _ => text.to_string(),
+    }
+}
+
 /// POST /send — containers deliver outbound messages to Telegram.
 ///
 /// Authenticated via `require_bearer_token` middleware.
@@ -1540,15 +1567,9 @@ pub(crate) async fn handle_send(
             .into_response();
     }
 
-    // Prepend agent name for identification in multi-agent setups
-    let owned_text;
-    let text_to_send = match &payload.agent_name {
-        Some(name) => {
-            owned_text = format!("[{name}] {}", payload.text);
-            &owned_text
-        }
-        None => &payload.text,
-    };
+    // Render outbound text via the pure helper so the branch is unit-testable.
+    let owned_text = format_outbound_text(payload.agent_name.as_deref(), &payload.text);
+    let text_to_send = &owned_text;
 
     // Resolve the Telegram client: per-customer bot token if customer_id is provided,
     // otherwise fall back to the global single-bot client.
@@ -1941,6 +1962,61 @@ mod tests {
         assert_eq!(payload.chat_id, 42);
         assert_eq!(payload.text, "hello");
         assert!(payload.agent_name.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // format_outbound_text — mika-cloud family-tier launch 2026-07-16
+    // ------------------------------------------------------------------
+
+    /// AC1: the container's default agent (`mika`) MUST NOT prefix outbound
+    /// Telegram text — every family-tier customer only has this one agent, and
+    /// the `[mika]` parasite broke first-hour-Perfect during the family launch.
+    #[test]
+    fn format_outbound_text_suppresses_default_agent_prefix() {
+        let out = format_outbound_text(Some("mika"), "Bonjour Sonia 🌸");
+        assert_eq!(out, "Bonjour Sonia 🌸");
+        assert!(!out.starts_with('['));
+    }
+
+    /// AC2: non-default agent names (multi-agent customers) keep the
+    /// identification prefix — the "multi-agent setups" use case the wire was
+    /// originally added for still works.
+    #[test]
+    fn format_outbound_text_keeps_prefix_for_named_agents() {
+        assert_eq!(
+            format_outbound_text(Some("work-mika"), "meeting at 3"),
+            "[work-mika] meeting at 3"
+        );
+        assert_eq!(
+            format_outbound_text(Some("personal-mika"), "yoga tonight"),
+            "[personal-mika] yoga tonight"
+        );
+        assert_eq!(
+            format_outbound_text(Some("mika-dev"), "PR ready"),
+            "[mika-dev] PR ready"
+        );
+    }
+
+    /// AC3: `None` agent_name path (operator-only /send, no identification
+    /// requested) also produces raw text — same as pre-fix behavior.
+    #[test]
+    fn format_outbound_text_no_prefix_when_agent_name_absent() {
+        assert_eq!(format_outbound_text(None, "raw text"), "raw text");
+    }
+
+    /// AC4: the default-agent branch matches the exact case of
+    /// `mika_common::agent::DEFAULT_AGENT` (`"mika"`), not case-insensitively.
+    /// An agent literally named `"Mika"` (capital M) is a hypothetical
+    /// multi-agent case and gets prefixed — the existing agent-name validation
+    /// rejects uppercase anyway (see `test_agent_name_validation_rules`), so
+    /// this is a defence-in-depth assertion rather than a live path.
+    #[test]
+    fn format_outbound_text_default_agent_match_is_case_sensitive() {
+        // Live: DEFAULT_AGENT is `"mika"`, lowercase — matched.
+        assert_eq!(format_outbound_text(Some("mika"), "x"), "x");
+        // Uppercase would already fail send-handler validation; helper still
+        // behaves consistently (prefixed) if it somehow got through.
+        assert!(format_outbound_text(Some("Mika"), "x").starts_with('['));
     }
 
     #[test]

--- a/docs/plans/2026-07-16-001-fix-gateway-suppress-default-agent-prefix-plan.md
+++ b/docs/plans/2026-07-16-001-fix-gateway-suppress-default-agent-prefix-plan.md
@@ -1,0 +1,113 @@
+---
+issue: (family-tier launch hotfix — filed alongside this PR)
+type: fix
+scope: crates/mika-gateway/src/routes.rs
+title: suppress `[mika]` prefix on outbound Telegram for single-agent (family-tier) customers
+---
+
+# Plan — mika-gateway: suppress default-agent prefix on outbound Telegram
+
+## Problem
+
+During the family-tier launch on 2026-07-16 the persona wire fired correctly (French, warm, `tu`, 🌸) but every outbound Telegram message from the family agent was prefixed with `[mika]`:
+
+```
+[mika] Bonjour Nicolas 🌸 Je suis Mika…
+```
+
+For a non-technical family member (Vincent's aunt, cousins) this is a cosmetic parasite that breaks first-hour-Perfect: the very first character she sees is a bracketed label she can't parse. Vincent surfaced this immediately after the first cousin's greeting.
+
+Zero data loss risk — the prefix is added by the gateway on the outbound rendering path only. The agent's own DB (`messages` table) stores the message content without the prefix; the `outbound_messages` reply-routing table still records `agent_name` in a proper column. **This is a rendering-only fix.**
+
+## Root cause
+
+`crates/mika-gateway/src/routes.rs` `handle_send` unconditionally prepends `[<agent_name>] ` when the `/send` payload carries an `agent_name`:
+
+```rust
+let text_to_send = match &payload.agent_name {
+    Some(name) => {
+        owned_text = format!("[{name}] {}", payload.text);
+        &owned_text
+    }
+    None => &payload.text,
+};
+```
+
+The comment reads "for identification in multi-agent setups". That intent is right — but the rule needs to know when the container has only one agent. Family-tier customers have exactly one agent named `mika` (`mika_common::agent::DEFAULT_AGENT`); multi-agent customers name their additional agents things like `work-mika`, `personal-mika`. So we can distinguish by name.
+
+## Committed position — suppress prefix only for the default agent name
+
+- Extract the render decision into a pure module-private helper `format_outbound_text(agent_name: Option<&str>, text: &str) -> String` so the branch is unit-testable without HTTP scaffolding.
+- Rule: if `agent_name == mika_common::agent::DEFAULT_AGENT`, do NOT prefix. Any other name (or `None`) uses the pre-existing shape:
+  - `Some(name)` where `name != "mika"` → `format!("[{name}] {text}")` (unchanged)
+  - `Some("mika")` → raw text (new)
+  - `None` → raw text (unchanged)
+- Case-sensitive match against the constant. Uppercase/mixed-case `agent_name` values already fail the existing validation in `handle_send` (only lowercase alphanumeric + hyphens), so case-folding here would be dead code.
+
+### Why not other shapes
+
+- **Tier-based suppression** (`if customer.tier == "family"`) would add a DB lookup on the outbound hot path and only cover family — it would leave BYOK/managed single-agent customers still prefixed. The default-agent-name test is O(1), no DB round-trip, and covers every single-agent customer regardless of tier.
+- **Container agent-count check** would require the gateway to know the containeragent inventory. Doable but adds a cross-service call and cache invalidation. The name-based test is materially simpler for the same behavior.
+- **Agent-side suppression** (omit `agent_name` from `/send` payload when tier is family) fixes only new agents, not existing ones. Gateway-side is one deploy that covers everyone instantly.
+
+## Scope
+
+### In scope
+
+- `crates/mika-gateway/src/routes.rs`:
+  - New module-private `format_outbound_text()` pure helper
+  - `handle_send` calls it in place of the inline match
+  - 4 new unit tests in `routes::tests`
+- `crates/mika-gateway/CLAUDE.md` — update § Agent Identification & Reply Routing to note the default-agent suppression + the launch incident that motivated it
+
+### Deliberately out of scope
+
+- **Agent-side changes** — the agent still sends `agent_name` in the payload; that's needed for `outbound_messages` reply routing (unaffected by the render suppression).
+- **Existing conversations retrofit** — the fix is rendering-only, so:
+  - **Non-destructive by construction.** Not one byte of any agent's DB is touched by this fix.
+  - **No re-roll of existing agents needed** — the fresh gateway pod applies the suppression to ALL family customers immediately on rollout, including Flo, Nicolas, Benjamin, Litha, and any others already provisioned.
+- **`parse_agent_prefix` on inbound** — kept tolerant of both prefixed and unprefixed shapes for backwards compat with pre-fix history + non-default multi-agent customers. No changes needed here.
+- **Wizard-language English seam** — separate BEAUTY gap flagged in the first-hour walk-through; not launch-blocking.
+
+## Acceptance criteria
+
+- [x] **AC1** — `format_outbound_text(Some("mika"), "Bonjour")` returns `"Bonjour"` (no prefix). Enforces the default-agent suppression. Asserted by `format_outbound_text_suppresses_default_agent_prefix`.
+- [x] **AC2** — `format_outbound_text(Some("work-mika"), "hi")` returns `"[work-mika] hi"` (multi-agent identification preserved). Asserted by `format_outbound_text_keeps_prefix_for_named_agents` across three canonical names (`work-mika`, `personal-mika`, `mika-dev`).
+- [x] **AC3** — `format_outbound_text(None, "raw")` returns `"raw"` (backwards-compat for operator-only /send without identification). Asserted by `format_outbound_text_no_prefix_when_agent_name_absent`.
+- [x] **AC4** — Case-sensitive match: `format_outbound_text(Some("Mika"), "x")` starts with `[` (prefix retained; uppercase names would be rejected earlier by `handle_send` validation anyway). Asserted by `format_outbound_text_default_agent_match_is_case_sensitive`.
+- [x] **AC5** — Non-destructive: helper produces a `String` (no mutation of input). DB and outbound_messages recording paths unchanged.
+- [x] **AC6** — Full gateway test suite (`cargo test -p mika-gateway --bin mika-gateway`) passes 274/274. New tests (4) + existing (270).
+- [x] **AC7** — `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.
+
+## Definition of Done
+
+- All AC satisfied.
+- `crates/mika-gateway/CLAUDE.md` reflects the suppression rule + the founding-incident anchor.
+- No behavioral change for BYOK/managed multi-agent customers (their `[work-mika]`-shape prefix still lands).
+- No agent-side changes, no DB migrations, no state touched — pure rendering-layer edit.
+
+## Deploy plan (post-merge, operator-driven)
+
+1. Build+push new `mika-gateway` image from post-merge main.
+2. `kubectl set image deployment/mika-gateway -n mika-system-dev mika-gateway=<new-tag>` OR `helm upgrade mika-gateway helm/mika-gateway --set image.tag=<new-tag>` (preferred — no drift).
+3. Rollout status. Gateway is HPA-scaled 2-10 with `maxUnavailable: 0`, so zero-downtime.
+4. From then, every family (and single-agent BYOK/managed) customer's next outbound Telegram message ships without the `[mika]` prefix. Existing agents unaffected in every other way.
+
+**Non-destructive confirmation**: conversations live in per-container SQLite DBs on PVCs — the gateway rollout doesn't touch any agent pod. Every family member (Flo already provisioned, Nicolas/Benjamin/Litha whether already-live or upcoming) keeps their `messages`/`llm_calls`/`core_memory`/etc. exactly as-is.
+
+## Scope answer to samidarko + Vincent
+
+**Scope of the fix: gateway-side rendering only.**
+- New provisions → no `[mika]` prefix (immediate on gateway rollout)
+- Existing family agents (Flo + any cousins already onboarded) → no `[mika]` prefix on their NEXT outbound message (immediate on gateway rollout)
+- **No agent re-roll needed for any existing customer.** The `helm upgrade` on Flo I ran yesterday was for the persona wire (that lives in the agent binary + env + PVC files); this fix is entirely different plumbing (gateway `/send` render).
+- **Non-destructive** — the agent's DB is not touched by the gateway; the message content the LLM produces goes into the agent's `messages` table without any `[mika]` prefix (the prefix is added only when the gateway relays to Telegram's `sendMessage` API). Flo's/Nicolas's/Benjamin's/Litha's conversations are preserved by construction.
+
+## References
+
+- **Founding incident:** 2026-07-16 07:00 UTC — Vincent-reported first-hour parasite; first cousin's `[mika] Bonjour !`
+- **Adjacent PRs:** mika-cloud#167 (pairing UX), mika-cloud#169 (tier wire), mika#1778/#1779 (persona code)
+- **Related trail:** mika-gateway `outbound_messages` table + `parse_agent_prefix()` — the reply-routing paths this fix intentionally leaves untouched
+- **Design principle:** rendering-layer suppression, not schema/state change → cousins' conversations preserved by construction
+
+Plan: docs/plans/2026-07-16-001-fix-gateway-suppress-default-agent-prefix-plan.md


### PR DESCRIPTION
## Summary

Rendering-layer hotfix for the family-tier launch. Suppresses the `[mika]` prefix on outbound Telegram messages when the sender is the container's default agent (`mika_common::agent::DEFAULT_AGENT`), so single-agent customers (including every family-tier customer) see the raw text without the bracketed label.

Multi-agent customers (`work-mika`, `personal-mika`, etc.) still get their identification prefix — the fix only removes the parasite for the single-agent case.

## The incident

During the family-tier launch on 2026-07-16, the persona wire fired correctly (French, warm, `tu`, 🌸, `chaleureux/patient/simple`) but every outbound Telegram message was prefixed:

```
[mika] Bonjour Nicolas 🌸 Je suis Mika…
```

For a non-technical family member, the bracketed label is a cosmetic parasite the first character in view — it breaks first-hour-Perfect before the very first French word.

## Design

- New pure module-private helper `format_outbound_text(agent_name: Option<&str>, text: &str) -> String` extracts the render decision from `handle_send` so the branch is unit-testable.
- Suppression rule: `Some(name)` where `name != DEFAULT_AGENT` → keep prefix; `Some(DEFAULT_AGENT)` or `None` → raw text.
- Case-sensitive match against the constant — uppercase names already fail `handle_send` validation.

## Zero-data-risk (non-destructive by construction)

- The prefix was added by the gateway on outbound rendering only. Every agent's `messages` DB stores content without any `[mika]` prefix.
- `outbound_messages` reply-routing table stores `agent_name` in its own column — unaffected.
- `parse_agent_prefix` on inbound stays tolerant of both prefixed and unprefixed shapes for backwards compat with pre-fix message history + non-default agents.
- **Existing family agents (Flo, cousins) do NOT need re-roll.** Gateway rollout applies the suppression to every family customer's NEXT outbound message immediately.

## Scope answer to samidarko + Vincent

- **New provisions:** no `[mika]` prefix (immediate on gateway rollout)
- **Existing family agents (Flo + any cousins already onboarded):** no `[mika]` prefix on their NEXT outbound message (immediate on gateway rollout)
- **Non-family single-agent customers (BYOK/managed with default agent name):** benefit too — clean text, matching intent
- **Multi-agent customers (`work-mika`, `mika-dev`, etc.):** unchanged — identification prefix preserved

## Test plan

- [x] `cargo test -p mika-gateway --bin mika-gateway routes::tests::format_outbound_text` → **4/4 pass**
- [x] `cargo test -p mika-gateway --bin mika-gateway` → **274/274 pass** (4 new + 270 existing)
- [x] `cargo build -p mika-gateway` → clean
- [x] `cargo clippy -p mika-gateway --no-deps -- -D warnings` → clean (lefthook rust-clippy hook confirmed)
- [x] `cargo fmt --check` → clean (lefthook rust-fmt hook confirmed)
- [ ] **Post-merge deploy verification:** build+push new gateway image, `helm upgrade` (preferred over `kubectl set image` to avoid the drift class flagged in mika-cloud#170), verify a fresh outbound to any Telegram chat shows no `[mika]` prefix.

## Not in this PR

- **Agent-side changes** — agent still sends `agent_name` in `/send` payload; unaffected. Reply routing continues to use the DB column.
- **Existing conversations retrofit** — none needed. Fix is rendering-only.
- **Wizard-language English seam** — separate BEAUTY gap flagged in first-hour walk-through; not launch-blocking.

## References

- Founding incident: 2026-07-16 07:00 UTC — Vincent-reported first-hour parasite
- Adjacent PRs: senara-solutions/mika-cloud#167 (pairing UX), #169 (tier wire), senara-solutions/mika#1778/#1779 (persona code)

Plan: docs/plans/2026-07-16-001-fix-gateway-suppress-default-agent-prefix-plan.md