### PR TITLE
fix(gateway): route pull_request.ready_for_review to mika-qa (mika#1822)

### DIFF
--- a/crates/mika-gateway/CLAUDE.md
+++ b/crates/mika-gateway/CLAUDE.md
@@ -26,7 +26,7 @@ Telegram and GitHub webhook router with Postgres customer registry. Handles text
 
 HMAC-SHA256 signature validation via `X-Hub-Signature-256`. Event routing:
 - `issues.assigned` and `issues.labeled` and `issue_comment.created` and `pull_request_review.submitted` and `pull_request.closed` and `check_suite.completed(failure/timed_out/success)` -> mika-dev
-- `pull_request.opened/synchronize/review_requested` -> mika-qa
+- `pull_request.opened/synchronize/review_requested/ready_for_review` -> mika-qa (`ready_for_review` added mika#1822 — draft→ready transitions were previously dropped as "not routable", stranding every wip-rescue-shaped PR without an autonomous review; same pitfall documented for `.github/workflows/*.yml` triggers in `docs/solutions/best-practices/gha-pr-workflow-event-pitfalls-2026-04-29.md` lines 38-53)
 - **Review-requested reviewer filter (mika#1655):** `pull_request.review_requested` routes to mika-qa via `route_event`, but a post-route guard (`is_suppressed_review_request` in `github.rs`) drops the event unless `requested_reviewer.login == QA_REVIEWER_LOGIN` (`mika-platform-qa`). This makes operator-driven re-requests (`gh api .../requested_reviewers` for the QA bot) trigger an autonomous qa-review while preventing human-reviewer requests (or team requests carrying `requested_team` instead of `requested_reviewer`) from spinning up a full qa-review session. Fail-closed: a missing/unresolvable reviewer is suppressed. The guard sits between routing and the `info!` dispatch log, alongside the skill denylist (#845) and synchronize no-diff (#886) guards.
 - Delivery UUID dedup via 10k-entry LRU cache
 - 256KB body limit

--- a/crates/mika-gateway/src/github.rs
+++ b/crates/mika-gateway/src/github.rs
@@ -318,7 +318,10 @@ pub fn route_event(
         ("issues", Some("assigned")) => Some("mika-dev"),
         ("issues", Some("labeled")) => Some("mika-dev"),
         ("issue_comment", Some("created")) => Some("mika-dev"),
-        ("pull_request", Some("opened" | "synchronize" | "review_requested")) => Some("mika-qa"),
+        (
+            "pull_request",
+            Some("opened" | "synchronize" | "review_requested" | "ready_for_review"),
+        ) => Some("mika-qa"),
         ("pull_request", Some("closed")) => Some("mika-dev"),
         ("pull_request_review", Some("submitted")) => Some("mika-dev"),
         ("check_suite", Some("completed")) => match check_conclusion {
@@ -1690,6 +1693,19 @@ mod tests {
     }
 
     #[test]
+    fn test_route_event_pr_ready_for_review() {
+        // mika#1822: draft→ready transitions were silently dropped as
+        // "not routable" because the routing table only covered opened /
+        // synchronize / review_requested. Every PR opened as draft (dispatch-lib's
+        // wip-rescue path, systematic) then promoted to ready never triggered
+        // mika-qa. This test pins the routing table entry that closes the gap.
+        assert_eq!(
+            route_event("pull_request", Some("ready_for_review"), None),
+            Some("mika-qa")
+        );
+    }
+
+    #[test]
     fn test_route_event_pr_closed() {
         assert_eq!(
             route_event("pull_request", Some("closed"), None),
@@ -1812,7 +1828,13 @@ mod tests {
 
     #[test]
     fn test_secondary_targets_pull_request_events_no_fanout() {
-        for action in ["opened", "synchronize", "review_requested", "closed"] {
+        for action in [
+            "opened",
+            "synchronize",
+            "review_requested",
+            "ready_for_review",
+            "closed",
+        ] {
             assert!(
                 secondary_targets("pull_request", Some(action), None).is_empty(),
                 "pull_request.{action} must not fan out"


### PR DESCRIPTION
## Summary

- Add `ready_for_review` to `route_event()`'s `pull_request` alternation → routes to `mika-qa`.
- Add `test_route_event_pr_ready_for_review` unit test; extend `test_secondary_targets_pull_request_events_no_fanout` loop with the new action.
- Update `crates/mika-gateway/CLAUDE.md` to reflect the routing table and cross-reference the pre-existing pitfall doc.

## Problem

`pull_request.ready_for_review` was silently dropped as `not routable, dropping` (`crates/mika-gateway/src/github.rs:774`) and returned 200 OK to GitHub. Every PR opened as draft (dispatch-lib's `wip-rescue` path is systematic) then un-drafted never triggered an autonomous mika-qa review — the merge cycle stalled for the entire autonomous loop.

**Founding incident**: PR #1821 was un-drafted at `2026-07-23T14:14:40Z` by `samidarko`. State at diag time: `MERGEABLE`, all 12 status checks SUCCESS, `reviewDecision: REVIEW_REQUIRED`, `reviews: []`. Zero attempts by `mika-platform-qa` — the routing table never told the gateway to send the event.

Ironically, `docs/solutions/best-practices/gha-pr-workflow-event-pitfalls-2026-04-29.md` (lines 38-53) already documented this exact class for `.github/workflows/*.yml` triggers — the guidance was applied to workflow files but never ported back to the gateway routing table.

## Diff

```rust
// crates/mika-gateway/src/github.rs
-        ("pull_request", Some("opened" | "synchronize" | "review_requested")) => Some("mika-qa"),
+        (
+            "pull_request",
+            Some("opened" | "synchronize" | "review_requested" | "ready_for_review"),
+        ) => Some("mika-qa"),
```

Plus symmetric extensions to the two unit tests that cover this table.

## Test plan

- [x] `cargo fmt -p mika-gateway` — clean.
- [x] `cargo clippy -p mika-gateway --tests` — no warnings, no errors.
- [x] `cargo test -p mika-gateway route_event` — 18/18 pass including the new `test_route_event_pr_ready_for_review`.
- [x] Pre-commit lefthook — no-secrets ✓, no-large-files ✓, rust-fmt ✓, rust-clippy ✓ (workspace-wide).
- [ ] **Post-merge verification** (operator-driven, out of PR scope):
  1. Wait for deploy of new gateway binary.
  2. Grep gateway logs for the exact delivery of the ready-toggle event (`event_type=pull_request action=ready_for_review`) — should now show routing to `mika-qa` instead of the `not routable, dropping` WARN.
  3. Trigger a re-dispatch on PR #1821 (`gh api ... requested_reviewers` for `mika-platform-qa`) to unblock its review cycle immediately; subsequent draft→ready PRs will work automatically.

## Context — why this bypasses the autonomous loop

Vincent authored this fix hors-loop (co-implemented via orchestrator-CC directly) because it fixes the review-cycle substrate itself — the loop is what's broken. Autonomous dispatch of this ticket via `ready` label would have required a working review cycle, i.e. this fix, to complete. Explicit warrant per `feedback_warrant_extension_additive_surface_and_substrate_live_burn` (substrate live-burn).

Companion sibling tickets — will flow through the normal loop once this PR merges:
- **mika#1823** — `dispatch-lib`: retry `_arch_ask` once on UNPARSED disposition (fragility 2, PIPELINE_INCOMPLETE recurrence).
- **mika#1824** — `auto_pull`: stuck-ready reconciler phase 2 (fragility 1, heal ready-orphans).

## Merge policy — Vincent-gated

**Do not merge autonomously**. This PR touches the review-cycle / merge-gate mechanism itself. Per the self-substrate human-gate invariant (`feedback_wedge_class_closed_is_not_substrate_stabilized` + the flagged batch categories in samidarko's 2026-07-23 sync), any change to loop-decision-making machinery is Vincent-gated by hand. mika-dev's auto-merge on `pass` verdict should not fire on this class.

Closes #1822