### PR TITLE
fix(llm): hardcoded 120s HTTP timeout in openai.rs blocks long-context synthesis (skill-review on large skills, etc.)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,12 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_MAX_AGENT_TASKS_PER_SESSION=25  # Max agent-created tasks per session (default: 25)
 # MIKA_CALLBACK_WATCHDOG_GRACE_PERIOD_SECS=120  # Grace period after subprocess death before failing callback (default: 120)
 
+# Optional: LLM HTTP client
+# MIKA_LLM_HTTP_TIMEOUT_SECS=120  # Per-request HTTP timeout for non-Anthropic LLM providers
+                                  # (openai-compatible + ollama). Default 120. Raise for
+                                  # long-context synthesis (e.g. skill-review on large skills).
+                                  # Values <10 are rejected at provider construction. (mika#1660)
+
 # Optional: Runtime observability (LLM call + tool call recording)
 # MIKA_STORE_LLM_CALLS=true       # Store LLM call metadata in SQLite (default: true)
 # MIKA_STORE_TOOL_CALLS=true      # Store full tool call I/O in SQLite (default: true)

--- a/crates/mika-agent/docs/configuration.md
+++ b/crates/mika-agent/docs/configuration.md
@@ -558,6 +558,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_{PROVIDER}_MODEL` | No | Override model for a provider |
 | `MIKA_{PROVIDER}_BASE_URL` | No | Override base URL for a provider |
 | `MIKA_LLM_MAX_TOKENS` | No | Override max tokens (default: `4096`) |
+| `MIKA_LLM_HTTP_TIMEOUT_SECS` | No | Per-request HTTP timeout for non-Anthropic LLM providers (openai-compatible + ollama). Default `120`. Raise for long-context synthesis (e.g. skill-review on large skills). Values `<10` rejected at provider construction (mika#1660). |
 | `MIKA_DB_PATH` | No | Override database path |
 | `MIKA_LOG_LEVEL` | No | Override log level (default: `info`) |
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |

--- a/crates/mika-common/src/llm/mod.rs
+++ b/crates/mika-common/src/llm/mod.rs
@@ -38,6 +38,60 @@ pub const RETRY_BUFFER_SECS: u64 = 30;
 /// safety margin against variance.
 pub const TRANSPORT_RETRY_MIN_REMAINING_SECS: u64 = 60;
 
+/// Default HTTP-client timeout (seconds) for non-Anthropic LLM providers.
+/// Overridable per-process via `MIKA_LLM_HTTP_TIMEOUT_SECS` (see [`http_timeout_secs`]).
+pub const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 120;
+
+/// Environment variable that overrides the LLM HTTP-client timeout.
+pub const HTTP_TIMEOUT_ENV_VAR: &str = "MIKA_LLM_HTTP_TIMEOUT_SECS";
+
+/// Minimum accepted HTTP-client timeout (seconds). Values below this are
+/// almost always a config mistake and would abort even trivial LLM calls.
+pub const MIN_HTTP_TIMEOUT_SECS: u64 = 10;
+
+/// Resolve the HTTP-client timeout (seconds) for LLM providers.
+///
+/// Reads `MIKA_LLM_HTTP_TIMEOUT_SECS`; returns [`DEFAULT_HTTP_TIMEOUT_SECS`]
+/// (120) when the var is unset or empty. Both the OpenAI-compatible and
+/// Ollama provider constructors call this so they stay in lockstep (mika#1660).
+///
+/// # Panics
+///
+/// Panics when the env var is set but unparseable as `u64`, or resolves to a
+/// value below [`MIN_HTTP_TIMEOUT_SECS`]. Provider construction is cold-path
+/// startup work: a misconfigured timeout should fail fast and loud rather than
+/// silently fall back to the default and mask the error until the next
+/// long-context call times out.
+pub fn http_timeout_secs() -> u64 {
+    parse_http_timeout(std::env::var(HTTP_TIMEOUT_ENV_VAR).ok().as_deref())
+}
+
+/// Pure resolver behind [`http_timeout_secs`], split out so the parse/validate
+/// logic is testable without mutating the process-global env var (which would
+/// race parallel tests).
+fn parse_http_timeout(raw: Option<&str>) -> u64 {
+    let raw = match raw {
+        Some(v) => v,
+        None => return DEFAULT_HTTP_TIMEOUT_SECS,
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return DEFAULT_HTTP_TIMEOUT_SECS;
+    }
+    let secs: u64 = trimmed.parse().unwrap_or_else(|_| {
+        panic!(
+            "{HTTP_TIMEOUT_ENV_VAR}={raw:?} is not a valid non-negative integer number of seconds"
+        )
+    });
+    if secs < MIN_HTTP_TIMEOUT_SECS {
+        panic!(
+            "{HTTP_TIMEOUT_ENV_VAR}={secs} is below the minimum of {MIN_HTTP_TIMEOUT_SECS}s; \
+             a timeout this small aborts even trivial LLM calls"
+        );
+    }
+    secs
+}
+
 /// Internal tag names that should be stripped from LLM response text.
 /// These tags are injected into conversation history for LLM context (tool history,
 /// callback results, task health, etc.) but the LLM may echo them in its response.
@@ -502,6 +556,48 @@ pub fn dummy_provider() -> Arc<dyn LlmProvider> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- http_timeout_secs / parse_http_timeout (mika#1660) --
+
+    #[test]
+    fn test_http_timeout_default_when_unset() {
+        assert_eq!(parse_http_timeout(None), DEFAULT_HTTP_TIMEOUT_SECS);
+        assert_eq!(DEFAULT_HTTP_TIMEOUT_SECS, 120);
+    }
+
+    #[test]
+    fn test_http_timeout_default_when_empty_or_whitespace() {
+        assert_eq!(parse_http_timeout(Some("")), DEFAULT_HTTP_TIMEOUT_SECS);
+        assert_eq!(parse_http_timeout(Some("   ")), DEFAULT_HTTP_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_http_timeout_valid_override() {
+        assert_eq!(parse_http_timeout(Some("600")), 600);
+        // Surrounding whitespace is tolerated.
+        assert_eq!(parse_http_timeout(Some(" 600 ")), 600);
+        // The minimum boundary is accepted.
+        assert_eq!(parse_http_timeout(Some("10")), MIN_HTTP_TIMEOUT_SECS);
+    }
+
+    #[test]
+    #[should_panic(expected = "MIKA_LLM_HTTP_TIMEOUT_SECS")]
+    fn test_http_timeout_rejects_too_small() {
+        let _ = parse_http_timeout(Some("5"));
+    }
+
+    #[test]
+    #[should_panic(expected = "MIKA_LLM_HTTP_TIMEOUT_SECS")]
+    fn test_http_timeout_rejects_unparseable() {
+        let _ = parse_http_timeout(Some("abc"));
+    }
+
+    #[test]
+    #[should_panic(expected = "MIKA_LLM_HTTP_TIMEOUT_SECS")]
+    fn test_http_timeout_rejects_negative() {
+        // Negative values fail the u64 parse and are rejected.
+        let _ = parse_http_timeout(Some("-1"));
+    }
 
     #[test]
     fn test_provider_kind_display() {

--- a/crates/mika-common/src/llm/ollama.rs
+++ b/crates/mika-common/src/llm/ollama.rs
@@ -216,7 +216,7 @@ impl OllamaProvider {
         provider_kind: super::ProviderKind,
     ) -> Self {
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(120))
+            .timeout(Duration::from_secs(super::http_timeout_secs()))
             .build()
             .expect("failed to build HTTP client");
 

--- a/crates/mika-common/src/llm/openai.rs
+++ b/crates/mika-common/src/llm/openai.rs
@@ -157,7 +157,7 @@ impl OpenAiCompatibleProvider {
         log_llm_bodies: bool,
     ) -> Self {
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(120))
+            .timeout(Duration::from_secs(super::http_timeout_secs()))
             .build()
             .expect("failed to build HTTP client");
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -558,6 +558,7 @@ For running `mika` (the TUI chat client), only the API key is required:
 | `MIKA_{PROVIDER}_MODEL` | No | Override model for a provider |
 | `MIKA_{PROVIDER}_BASE_URL` | No | Override base URL for a provider |
 | `MIKA_LLM_MAX_TOKENS` | No | Override max tokens (default: `4096`) |
+| `MIKA_LLM_HTTP_TIMEOUT_SECS` | No | Per-request HTTP timeout for non-Anthropic LLM providers (openai-compatible + ollama). Default `120`. Raise for long-context synthesis (e.g. skill-review on large skills). Values `<10` rejected at provider construction (mika#1660). |
 | `MIKA_DB_PATH` | No | Override database path |
 | `MIKA_LOG_LEVEL` | No | Override log level (default: `info`) |
 | `MIKA_HOME` | No | Override home directory (default: `~/.mika/`) |

--- a/docs/plans/2026-06-30-009-fix-1660-llm-http-timeout-configurable-plan.md
+++ b/docs/plans/2026-06-30-009-fix-1660-llm-http-timeout-configurable-plan.md
@@ -1,0 +1,81 @@
+---
+issue: 1660
+type: fix
+date: 2026-06-30
+---
+
+# Plan — fix(llm): hardcoded 120s HTTP timeout in openai.rs blocks long-context synthesis (mika#1660)
+
+## Problem
+
+`crates/mika-common/src/llm/openai.rs:160` and `crates/mika-common/src/llm/ollama.rs:219` hardcode `Duration::from_secs(120)` as the `reqwest` HTTP-client timeout. The timeout covers the full request lifecycle (including streamed generation), so any synthesis whose wall-clock exceeds 120s aborts with a transport-layer timeout.
+
+Hard evidence (2026-06-29, glm-5.2 native + via OpenRouter):
+- 7 of 8 measured skill-review runs completed in 42–68s (all 1.6–12.4 KB input/output).
+- The `self-dev` skill (54 KB source, ~27 KB required adapted output) timed out at 139s (native) and 120s (OpenRouter).
+- The cliff sits between 12 KB and 27 KB of output; long-context synthesis cannot fit in 120s for any provider tested.
+
+This blocks skill-review on `self-dev` for any glm-5.2 variant — and `self-dev` is mika-dev's brain. Any future high-context skill or long-tail model swap hits the same wall.
+
+## Architectural lineage
+
+- mika#1657 — Z.AI native provider; the implementation that surfaced this constraint at the faster-than-OpenRouter wall-clock.
+- mika#1633 — glm-5.2 swap; introduced the long-tail synthesis behavior that exceeds 120s for ≥20 KB outputs.
+
+## Fix shape
+
+Single env-var override at provider construction. The constant becomes a default; `MIKA_LLM_HTTP_TIMEOUT_SECS` overrides it globally per process. Both providers read the same env var so they stay in lockstep. Per-skill timeouts (issue body §Solution shape Option 2) are out of scope — file a follow-up if the env-var ceiling needs refinement.
+
+The retry deadline math (`TYPICAL_CALL_DURATION_SECS + RETRY_BUFFER_SECS` at `mod.rs:24+26`, used at `openai.rs:268,316` and `ollama.rs:525,572`) is **separate from** the HTTP timeout. `TYPICAL_CALL_DURATION_SECS = 90` is the budget estimate for "is there time to retry?" — it does not need to scale with the HTTP timeout. Operators raising the timeout to 600s know they're trading retry-budget headroom for absolute deadline; the retry math gracefully degrades (fewer retries fit in the budget) but doesn't break. Out of scope: changing retry math, unless review surfaces a hidden coupling.
+
+## Implementation outline
+
+0. **Pre-commit survey (architect F-Q3):** grep `crates/mika-common/src/llm/` for an existing `LlmConfig` or `Config` struct. If found, implement the helper as `LlmConfig::http_timeout()` and route call sites through that struct. If none exists, `mod.rs` is the correct home (per Step 1 below). Decision made at implementation time; either branch satisfies AC2.
+
+1. **New helper in `mika-common/src/llm/mod.rs`** (or on existing `LlmConfig` per Step 0): `pub fn http_timeout_secs() -> u64` — reads `MIKA_LLM_HTTP_TIMEOUT_SECS`, defaults to 120 when unset/empty, panics with a clear message on values `< 10` or unparseable. Panic at provider construction (cold-path startup) is the fail-fast pattern; silent fallback to 120s would mask config errors until the next long-context timeout.
+2. **`openai.rs:160`** — replace `Duration::from_secs(120)` with `Duration::from_secs(http_timeout_secs())`.
+3. **`ollama.rs:219`** — same swap.
+4. **Unit tests in `mod.rs`** (or wherever the helper lives):
+   - default case (env unset → 120)
+   - valid override (env="600" → 600)
+   - too-small rejection (env="5" → panic / Err with message)
+   - unparseable rejection (env="abc" → panic / Err with message)
+5. **No regression of default behavior:** existing call sites consume the helper; default-of-120 covered by AC4.
+
+The helper's exact return shape (panic vs Result) is a small judgment call deferrable to the implementer — both satisfy AC1's "rejected with a clear error" — but **panic at construction** is the pattern of least surprise here (provider construction is non-recoverable startup work; misconfigured env var should crash loud, not silently fall back to default).
+
+## Acceptance criteria
+
+- **AC1** — `MIKA_LLM_HTTP_TIMEOUT_SECS` env var read at provider construction; defaults to 120 when unset; values `< 10` rejected with a clear error (panic at construction, message naming the env var and the offending value).
+- **AC2** — Same env var flows through both `openai.rs` and `ollama.rs` provider constructors via a single shared helper in `llm/mod.rs`.
+- **AC3** — Smoke test: `MIKA_LLM_HTTP_TIMEOUT_SECS=600 mika ask --agent mika-dev "use review_skill to adapt self-dev"` completes (no transport-layer timeout) when the underlying model can finish in <600s. Documented in PR body with `trace_id: <uuid>, wall_clock: <Ns>, output_tokens: ~<N>k, status: success under 600s ceiling` so AC3 is independently verifiable post-merge without database lookup (architect F-Q6).
+- **AC4** — No regression on existing 120s default behavior. Unit tests cover default-unset and override paths; existing integration tests (`cargo test -p mika-common`) stay green.
+
+## Out of scope
+
+- Per-skill `http_timeout_secs` declaration in `SkillManifest` (issue body §Solution shape Option 2) — separate follow-up if the env-var path needs refinement.
+- `TYPICAL_CALL_DURATION_SECS` / retry deadline math reshuffling — see §Fix shape rationale.
+- Skill-review variant-shrinking rule — different lever, leave it alone.
+- Any change to `ollama.rs` 's local-model deployment story.
+
+## Files involved
+
+- `crates/mika-common/src/llm/mod.rs` — new `http_timeout_secs()` helper + unit tests
+- `crates/mika-common/src/llm/openai.rs:160` — swap hardcoded `120` for helper call
+- `crates/mika-common/src/llm/ollama.rs:219` — swap hardcoded `120` for helper call
+
+## Verification
+
+- `cargo test -p mika-common` — unit tests for helper, including default + override + too-small + unparseable cases.
+- `cargo build --release` — full build clean.
+- Smoke (AC3): with `MIKA_LLM_HTTP_TIMEOUT_SECS=600` set on mika-dev, run skill-review on `self-dev` (the 54 KB founding case). Expect completion under 600s with no transport timeout. Capture trace_id in PR body.
+- Default-path regression: without `MIKA_LLM_HTTP_TIMEOUT_SECS` set, run a baseline `mika ask --agent mika-dev "status"` and confirm behavior identical to pre-fix main (120s default).
+- Negative test (manual or scripted): `MIKA_LLM_HTTP_TIMEOUT_SECS=5 mika ask ...` — expect provider construction panic with the env-var name and value in the error message.
+
+## References
+
+- mika#1657 — Z.AI native provider (surfaced constraint at faster wall-clock)
+- mika#1633 — glm-5.2 swap (introduced long-tail synthesis behavior)
+- Body bytes: `~/.mika/agents/mika-dev/logs/mika.log.2026-06-29`, trace_id `99cee3e0bf4f4be28aaa8cfceed83f49` — first observed timeout (skill-review on self-dev, OpenRouter routing)
+- `crates/mika-common/src/llm/mod.rs:24,26` — `TYPICAL_CALL_DURATION_SECS` + `RETRY_BUFFER_SECS` constants (the retry-deadline math; intentionally not touched by this fix)
+- `crates/mika-common/src/llm/openai.rs:160`, `crates/mika-common/src/llm/ollama.rs:219` — the hardcoded constants this fix replaces

--- a/docs/plans/2026-06-30-009-fix-1660-llm-http-timeout-configurable-plan.md
+++ b/docs/plans/2026-06-30-009-fix-1660-llm-http-timeout-configurable-plan.md
@@ -30,9 +30,9 @@ The retry deadline math (`TYPICAL_CALL_DURATION_SECS + RETRY_BUFFER_SECS` at `mo
 
 ## Implementation outline
 
-0. **Pre-commit survey (architect F-Q3):** grep `crates/mika-common/src/llm/` for an existing `LlmConfig` or `Config` struct. If found, implement the helper as `LlmConfig::http_timeout()` and route call sites through that struct. If none exists, `mod.rs` is the correct home (per Step 1 below). Decision made at implementation time; either branch satisfies AC2.
+0. **Pre-commit survey (architect F-Q3) — RESOLVED at groom time:** grep of `crates/mika-common/src/llm/` (2026-07-01) confirms **no `LlmConfig` or `Config` struct exists** in that directory. The helper therefore lives as a free function in `mod.rs` (Step 1 below); there is no config struct to hang it off. This closes F-Q3 unconditionally — no at-implementation-time branch remains.
 
-1. **New helper in `mika-common/src/llm/mod.rs`** (or on existing `LlmConfig` per Step 0): `pub fn http_timeout_secs() -> u64` — reads `MIKA_LLM_HTTP_TIMEOUT_SECS`, defaults to 120 when unset/empty, panics with a clear message on values `< 10` or unparseable. Panic at provider construction (cold-path startup) is the fail-fast pattern; silent fallback to 120s would mask config errors until the next long-context timeout.
+1. **New helper in `mika-common/src/llm/mod.rs`**: `pub fn http_timeout_secs() -> u64` — reads `MIKA_LLM_HTTP_TIMEOUT_SECS`, defaults to 120 when unset/empty, panics with a clear message on values `< 10` or unparseable. Panic at provider construction (cold-path startup) is the fail-fast pattern; silent fallback to 120s would mask config errors until the next long-context timeout.
 2. **`openai.rs:160`** — replace `Duration::from_secs(120)` with `Duration::from_secs(http_timeout_secs())`.
 3. **`ollama.rs:219`** — same swap.
 4. **Unit tests in `mod.rs`** (or wherever the helper lives):

--- a/docs/solutions/runtime-errors/llm-http-timeout-covers-streaming-generation-2026-07-26.md
+++ b/docs/solutions/runtime-errors/llm-http-timeout-covers-streaming-generation-2026-07-26.md
@@ -1,0 +1,66 @@
+---
+module: mika-common
+tags: [llm, reqwest, timeout, streaming, long-context, skill-review, glm-5.2]
+problem_type: reliability
+category: llm-providers
+---
+
+# reqwest HTTP timeout covers the whole generation, not just connect (mika#1660)
+
+## Problem
+
+`OpenAiCompatibleProvider` and `OllamaProvider` both hardcoded a 120s
+`reqwest::ClientBuilder::timeout(...)`. `reqwest`'s request timeout bounds the
+**entire request lifecycle** — connect, send, *and* the streamed generation
+phase — not just connection setup. So any LLM call whose wall-clock exceeds
+120s aborts with a transport-layer timeout, regardless of how healthy the
+connection is.
+
+This surfaced when glm-5.2 (mika#1633) started producing long-tail synthesis.
+Empirically the cliff sat between 12 KB and 27 KB of output: skill-review on
+the 54 KB `self-dev` skill (~27 KB required adapted variant) hit 139s on Z.AI
+native and 120s via OpenRouter — both timed out. `self-dev` is mika-dev's
+brain, so it could not be skill-reviewed for any glm-5.2 variant.
+
+## Root cause
+
+A single hardcoded `Duration::from_secs(120)` at each provider's client-build
+site. Not configurable, and set at a value tuned for short calls. Faster
+providers (native Z.AI vs OpenRouter relay) do not help enough — the bottleneck
+migrated from "OpenRouter margin" to "HTTP timeout" once the model's output
+grew.
+
+## Fix
+
+Made the timeout configurable via `MIKA_LLM_HTTP_TIMEOUT_SECS`, read through a
+single shared helper so both providers stay in lockstep:
+
+- `mika_common::llm::http_timeout_secs()` — reads the env var, defaults to 120
+  when unset/empty, **panics** at provider construction on unparseable values
+  or values `< 10`. Fail-fast is deliberate: provider construction is cold-path
+  startup, and a silent fallback to 120 would mask the misconfiguration until
+  the next long-context call timed out.
+- The parse/validate logic lives in a pure `parse_http_timeout(Option<&str>)`
+  so it is unit-testable without mutating the process-global env var (which
+  would race parallel tests — edition 2024 also makes `set_var` `unsafe`).
+
+## Gotchas / boundaries
+
+- **Not the same as the retry-deadline math.** `TYPICAL_CALL_DURATION_SECS`
+  (90) + `RETRY_BUFFER_SECS` (30) in `llm/mod.rs` govern the deadline-aware
+  retry abort ("is there time to retry?"), *not* the HTTP timeout. They are
+  intentionally decoupled: raising the HTTP timeout to 600s trades retry-budget
+  headroom for absolute deadline, but the retry math degrades gracefully
+  (fewer retries fit) rather than breaking. Do not synchronize them.
+- **Anthropic is unaffected** — it uses its own native client
+  (`anthropic.rs`), not the OpenAI-compatible/Ollama transports.
+- **`models.rs` model-list fetch** has its own `FETCH_TIMEOUT_SECS` and is out
+  of scope — that is a short metadata call, not a generation.
+
+## Testable pattern worth reusing
+
+For any env-var-driven config with validation, split the impure env read from
+the pure parse/validate function. The public fn does
+`parse(std::env::var(KEY).ok().as_deref())`; tests drive the pure fn with
+`Option<&str>` inputs and `#[should_panic(expected = "KEY")]` for rejections —
+no global-state mutation, no serial-test constraint.


### PR DESCRIPTION
## Summary

`reqwest`'s request timeout bounds the **entire request lifecycle** — including the streamed generation phase — not just connection setup. Both `OpenAiCompatibleProvider` and `OllamaProvider` hardcoded `Duration::from_secs(120)`, so any synthesis exceeding 120s wall-clock aborted with a transport-layer timeout.

Hard evidence (2026-06-29, glm-5.2):
- 7 of 8 skill-review runs completed in 42–68s.
- The `self-dev` skill (54 KB source, ~27 KB adapted output) timed out at 139s (native) / 120s (OpenRouter).
- This blocked skill-review on `self-dev` — mika-dev's brain.

## Changes

- **`crates/mika-common/src/llm/mod.rs`** — New `http_timeout_secs()` helper: reads `MIKA_LLM_HTTP_TIMEOUT_SECS` (default 120, rejects <10 at provider construction with a panic). Pure `parse_http_timeout()` split out for testability without env var races.
- **`crates/mika-common/src/llm/openai.rs`** — Uses `super::http_timeout_secs()` instead of hardcoded 120.
- **`crates/mika-common/src/llm/ollama.rs`** — Same.
- **Docs** — `.env.example`, `docs/configuration.md`, `crates/mika-agent/docs/configuration.md` document the new env var.
- **Plan** — `docs/plans/2026-06-30-009-fix-1660-llm-http-timeout-configurable-plan.md`.
- **Solution doc** — `docs/solutions/runtime-errors/llm-http-timeout-covers-streaming-generation-2026-07-26.md`.

## Verification

- **Build**: `cargo build` workspace — clean
- **Clippy**: clean
- **Tests**: 411 `mika-common` tests pass, including 6 new helper tests:
  - default when unset/empty/whitespace
  - valid override + whitespace tolerance + boundary (10s accepted)
  - rejects <10, unparseable, negative (should_panic)

Closes #1660