### PR TITLE
fix(qa-review): remove per-turn AtomicBool dedup guard blocking multi-PR reviews (ROLEX-P0)

### DIFF
--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -2130,21 +2130,28 @@ async fn run_gh(input: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolOutput 
         );
     }
 
-    // Per-turn PR review idempotency guard (#695): if the command is `pr review ...`
-    // and we already posted a review in this turn, reject with a structured error.
-    // Retained as fallback when pr_reviews_posted is None (CLI/test contexts).
-    if pr_dedup_key.is_some()
-        && ctx
-            .pr_review_posted
-            .load(std::sync::atomic::Ordering::Acquire)
-    {
-        return ToolOutput::error(
-            "{\"error\": \"duplicate_pr_review\", \"message\": \"A PR review was already \
-             posted in this turn. Duplicate reviews create duplicate webhooks. End your \
-             turn — the review is already submitted.\"}"
-                .to_string(),
-        );
-    }
+    // Per-turn PR review idempotency guard REMOVED (Rolex-P0 2026-07-26).
+    //
+    // The old guard read `ctx.pr_review_posted: &AtomicBool` — a single
+    // boolean for "any pr review posted this turn". It rejected ALL
+    // subsequent pr review calls in the same turn, even when the LLM was
+    // legitimately reviewing DIFFERENT PRs (e.g. mika-qa batch-reviewing
+    // wip-rescue drafts). Observed live: 3/4 parallel `pr review` calls
+    // for 4 distinct PR numbers were silently rejected with a fake
+    // "duplicate_pr_review" error, blocking mika-qa from ever posting
+    // reviews on the real dispatch PRs (#1834/#1836) — first-merge Rolex
+    // blocker.
+    //
+    // The correct per-PR dedup is done by the session-scope check above
+    // (lines ~2118-2131), keyed by `pr_dedup_key`. It correctly prevents
+    // same-PR-twice within a session (across turns) — the real intent of
+    // #695. The AtomicBool per-turn guard was redundant in server mode
+    // and too coarse everywhere.
+    //
+    // `ctx.pr_review_posted` field is left in place (still set to true
+    // on successful post below) to avoid a large-scale ToolContext type
+    // change. Cleanup in follow-up: remove the field + threading across
+    // ~15 call sites.
 
     // Tool-argument suffix validation (mika#899): check --body argument against
     // skill-declared required_tool_arg_suffixes BEFORE subprocess spawn.


### PR DESCRIPTION
## ROLEX-P0 — the bug blocking every merge tonight

mika-qa was silently rejecting 3/4 of its parallel \`pr review\` calls with a fake \`duplicate_pr_review\` internal error — even for reviews on **DIFFERENT** PR numbers. Result: 0 merges since restart, Vincent visibly blocked (\"je fais 3 pas et plus rien ne bouge\").

## Live evidence

Session \`0406a089-264f-4a26-8fdb-90a2b7b5d4bf\` (2026-07-26 16:55Z), triggered by webhook \`PR ready_for_review #1834\`:

| PR | success | output |
|----|---------|--------|
| 1838 | 1 (posted) | (OK) |
| 1839 | **0 (rejected)** | \`{\"error\":\"duplicate_pr_review\",\"message\":\"A PR review was already posted in this turn...\"}\` |
| 1840 | **0 (rejected)** | same |
| 1841 | **0 (rejected)** | same |

All 4 pr review calls fired in parallel from ONE LLM turn, for 4 DISTINCT wip-rescue PRs. The old per-turn guard checked \`ctx.pr_review_posted: &AtomicBool\` — a single boolean for \"any pr review this turn\", NOT keyed by PR. After the first successful post set it \`true\`, all subsequent posts (even for other PRs) were rejected.

mika-qa then burned remaining turn budget on downstream research and NEVER got to emit \`pr review 1834 --approve\` / \`pr review 1836 --approve\` for the real dispatch PRs. Chain broken; verdict_handler never invoked.

## Root cause — \`crates/mika-agent/src/skills/builtin_handlers.rs:2133-2148\`

```rust
if pr_dedup_key.is_some()
    && ctx.pr_review_posted.load(Ordering::Acquire)  // AtomicBool: any-pr, not per-pr
{
    return ToolOutput::error(\"duplicate_pr_review...\");
}
```

The **session-scope check just above** (lines 2118-2131, \`ctx.pr_reviews_posted: DashMap<sessionId, HashSet<prDedupKey>>\`, added in mika#821) correctly dedupes **per-PR** across turns. That's the real intent of #695 (no same-PR review twice → no duplicate webhooks). The AtomicBool per-turn guard was redundant in server mode and too coarse everywhere.

## Fix — 13-line deletion + 22-line comment

Delete the per-turn AtomicBool CHECK. Keep the session-scope map (correct). Keep the AtomicBool field set-on-success (avoids ToolContext type churn across ~15 call sites — cleanup in follow-up F2 below).

Diff summary: +22 / -15 (net +7 lines, all in one file). See the commit for the full explanatory comment.

## Verify

- \`cargo test -p mika-agent --lib\` → **3451 pass, 0 fail** (full lib regression clean)
- \`cargo clippy -p mika-agent --tests\` → no warnings
- \`cargo fmt\` → clean
- Pre-commit lefthook — all green (rust-fmt, rust-clippy workspace-wide)
- No test named \`duplicate_pr_review\` exists → removed guard had no regression coverage. \`make_pr_dedup_key\` tests (×4) stay green.

## Impact expected post-deploy

- mika-qa multi-PR turns work: all N parallel \`pr review\` calls posted correctly (one webhook per PR, no false rejection).
- Turn budget preserved for real work — mika-qa now emits \`pr review 1834 --approve --body \"VERDICT: pass...\"\` and same for #1836.
- \`verdict_handler\` sees APPROVED review with \`VERDICT: pass\` → forge-gate perimeter check → **#1834 touches \`pr_merge_with_gate.rs\` = DECISION-CORE → hold[review] semantics → Vincent hand-merges → PREMIER ROLEX MERGE**.

## Deploy checklist

1. \`git fetch origin fix/qa-review-per-turn-dedup-multi-pr-bug\`
2. \`cd mika && git checkout fix/qa-review-per-turn-dedup-multi-pr-bug\` (samidarko autorité restart/deploy)
3. \`make deploy\` (or scripts/mika-deploy — full binary rebuild + install + restart mika-spirit)
4. Retrigger #1834: \`gh pr edit 1834 --repo senara-solutions/mika --add-label workin\` OR \`gh pr ready 1834 --undo && sleep 3 && gh pr ready 1834\` (draft cycle to re-fire \`ready_for_review\` webhook)
5. Watch:
   ```bash
   sqlite3 -readonly ~/.mika/data/mika.db \"
     SELECT created_at, tool_name, success, substr(input,1,100)
     FROM tool_calls WHERE agent_id='mika-qa' AND created_at > datetime('now', '-15 minutes')
       AND tool_name='run_gh' AND input LIKE '%pr review 1834%approve%';\"
   ```
6. If non-empty → review submitted. Then: \`gh pr view 1834 --repo senara-solutions/mika --json reviews\` — expect \`state=APPROVED\` from \`mika-platform-qa\`.
7. Vincent hand-merges #1834 (DECISION-CORE per forge-gate #1831) → **first Rolex merge**.

## Merge policy — Vincent-gated

Do NOT merge autonomously. This PR touches \`crates/mika-agent/src/skills/builtin_handlers.rs\` = DECISION-CORE per forge-gate #1831 (dispatch-authority adjacent — tool gating on run_gh). Even after this fix ships, the forge-gate perimeter classifier will hold[review] this PR itself. **Vincent hand-merges after review.**

## Follow-ups

- **F1** (separate PR, post-Rolex): qa-review prompt drift — LLM currently batch-fetches all 6 open PRs in response to a single webhook trigger. Tune prompt in \`skills/bundled/qa-review/system_prompt.md\` to focus on the ONE PR mentioned in the trigger. Reduces turn budget waste further.
- **F2** (refactor): remove \`pr_review_posted: &AtomicBool\` field entirely from \`ToolContext\` + threading across ~15 call sites. Mechanical, low-risk cleanup.
- **F3** (already committed): permission-classifier claude-pilot-py tier1/tier2 allow-list gaps (blocking 15% of pilots on legit dev commands). Deferred pending Rolex unblock.

## Reference

- mika#821 (session-scope map introduction — the correct per-PR dedup)
- mika#695 (original per-turn AtomicBool guard — coarse-grained bug)
- mika#1831 (forge-gate perimeter — will hold this PR for Vincent-hand-merge)
- Samidarko-CC spool report \`2026-07-26-205422-...ROLEX-P0-per-turn-dedup-BUG-fix-inline-PR-incoming.md\` (full diagnostic chain)