### PR TITLE
fix(server): remove leftover ready label when a draft PR opens for its closing issue (mika#1849)

### DIFF
--- a/crates/mika-agent/src/server/draft_pr_opened_handler.rs
+++ b/crates/mika-agent/src/server/draft_pr_opened_handler.rs
@@ -1,0 +1,462 @@
+//! Structural handler for `pull_request.opened` (draft) webhook events (mika#1849).
+//!
+//! When mika-dev/dev-pilot opens a **draft** PR closing an issue (systematically
+//! via dispatch-lib's wip-rescue path, mika#1282), the issue's `ready` label is
+//! never removed. It lingers on the issue permanently, so loop inventory reads
+//! "N ready" when only a fraction are actually dispatchable. This handler
+//! intercepts the `opened` webhook **before** the LLM turn and removes `ready`
+//! from each closing-issue of a newly-opened draft PR.
+//!
+//! Companion to the auto-pull Phase 2 reconciler (mika#1824): once a draft PR
+//! is open and its `closingIssuesReferences` is populated, Phase 2's Filter 2
+//! (`open_pr_closing`) already excludes that issue from re-drive, so the
+//! reconciler will not re-add `ready` after this handler removes it. The two
+//! mechanisms compose; no coordination flag is needed.
+//!
+//! ## Invariants
+//!
+//! - Side-effect-only injector: returns `VerdictAction::Passthrough` on every
+//!   path (mirrors `milestone_context_handler`). Never alters the mika-qa review
+//!   turn — it mutates GitHub label state as a pure side effect.
+//! - Self-selects on the `[GitHub] PR opened:` text prefix; passthrough for
+//!   every other event type. Call order is irrelevant — handlers are disjoint
+//!   on event_type.
+//! - Repo-general: the repo is parsed from the webhook text, so the handler
+//!   works for `mika`, `mika-cloud`, `mika-skills`, etc.
+//! - Fail-open on every `gh` error (missing token, `pr view` failure, per-issue
+//!   `issue view` / `issue edit` failure): log WARN and continue; never crash
+//!   the handler or the turn.
+//!
+//! See mika#1849.
+
+use tracing::{debug, info, warn};
+
+use crate::async_db::AsyncDatabase;
+use crate::tools::pr_merge_with_gate::run_gh_subprocess;
+
+use super::verdict_handler::VerdictAction;
+
+/// Prefix on PR-opened webhook messages from the gateway.
+const PR_OPENED_PREFIX: &str = "[GitHub] PR opened: ";
+
+/// The `ready` label name — the canonical positive-consent signal for mika-dev
+/// autonomous dispatch (mika#841). Case-sensitive, matches `.github/labels.yml`.
+const READY_LABEL: &str = "ready";
+
+/// Parsed fields from a gateway-formatted `PR opened` event.
+pub(crate) struct PrOpenedEvent {
+    repo: String,
+    number: u64,
+}
+
+/// Parse `[GitHub] PR opened: <repo>#<n> — <title> (branch: <b>)` → (repo, number).
+///
+/// Returns `None` for any non-`PR opened` event text.
+pub(crate) fn parse_pr_opened(text: &str) -> Option<PrOpenedEvent> {
+    let first_line = text.lines().next()?;
+    let after = first_line.strip_prefix(PR_OPENED_PREFIX)?;
+
+    // The token up to the em-dash separator is `<repo>#<number>`.
+    let token = after.split(" — ").next()?.trim();
+    let (repo, num_str) = token.rsplit_once('#')?;
+    if repo.is_empty() {
+        return None;
+    }
+    let number = num_str.trim().parse::<u64>().ok()?;
+
+    Some(PrOpenedEvent {
+        repo: repo.to_string(),
+        number,
+    })
+}
+
+/// The closing-issue numbers eligible for cleanup: `[]` unless `is_draft` AND
+/// `closing_issue_numbers` is non-empty (AC1, AC5b, AC5c).
+pub(crate) fn plan_ready_label_cleanup(is_draft: bool, closing_issue_numbers: &[u64]) -> Vec<u64> {
+    if is_draft {
+        closing_issue_numbers.to_vec()
+    } else {
+        Vec::new()
+    }
+}
+
+/// True when the issue's current label set contains `ready`
+/// (case-sensitive, matches the taxonomy).
+pub(crate) fn issue_has_ready_label(labels: &[String]) -> bool {
+    labels.iter().any(|l| l == READY_LABEL)
+}
+
+/// Parse the JSON from `gh pr view <n> --json isDraft,closingIssuesReferences`
+/// into `(is_draft, closing_issue_numbers)`.
+fn parse_pr_view_json(json: &str) -> Result<(bool, Vec<u64>), String> {
+    let v: serde_json::Value =
+        serde_json::from_str(json.trim()).map_err(|e| format!("parse pr view json: {e}"))?;
+    let is_draft = v["isDraft"].as_bool().unwrap_or(false);
+    let refs = v["closingIssuesReferences"]
+        .as_array()
+        .map(|arr| arr.iter().filter_map(|r| r["number"].as_u64()).collect())
+        .unwrap_or_default();
+    Ok((is_draft, refs))
+}
+
+/// Parse the JSON from `gh issue view <n> --json labels` into a list of label names.
+fn parse_issue_labels_json(json: &str) -> Result<Vec<String>, String> {
+    let v: serde_json::Value =
+        serde_json::from_str(json.trim()).map_err(|e| format!("parse issue labels json: {e}"))?;
+    let labels = v["labels"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|l| l["name"].as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(labels)
+}
+
+/// Fetch `isDraft` + `closingIssuesReferences` for a PR via one `gh pr view` call.
+async fn fetch_draft_and_closing_refs(
+    pr_number: u64,
+    repo: &str,
+    token: &str,
+) -> Result<(bool, Vec<u64>), String> {
+    let n = pr_number.to_string();
+    let args = vec![
+        "pr",
+        "view",
+        &n,
+        "--repo",
+        repo,
+        "--json",
+        "isDraft,closingIssuesReferences",
+    ];
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run_gh_subprocess(&args, token),
+    )
+    .await
+    .map_err(|_| "gh pr view timed out after 60s".to_string())??;
+    parse_pr_view_json(&output)
+}
+
+/// Fetch the current label names on an issue via `gh issue view --json labels`.
+async fn fetch_issue_labels(
+    issue_number: u64,
+    repo: &str,
+    token: &str,
+) -> Result<Vec<String>, String> {
+    let n = issue_number.to_string();
+    let args = vec!["issue", "view", &n, "--repo", repo, "--json", "labels"];
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run_gh_subprocess(&args, token),
+    )
+    .await
+    .map_err(|_| "gh issue view timed out after 60s".to_string())??;
+    parse_issue_labels_json(&output)
+}
+
+/// Remove the `ready` label from an issue via `gh issue edit --remove-label`.
+/// Idempotent on GitHub's side — removing an absent label is a no-op.
+async fn remove_ready_label(issue_number: u64, repo: &str, token: &str) -> Result<(), String> {
+    let n = issue_number.to_string();
+    let args = vec![
+        "issue",
+        "edit",
+        &n,
+        "--repo",
+        repo,
+        "--remove-label",
+        READY_LABEL,
+    ];
+    tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run_gh_subprocess(&args, token),
+    )
+    .await
+    .map_err(|_| "gh issue edit timed out after 60s".to_string())??;
+    Ok(())
+}
+
+/// Attempt to clean up leftover `ready` labels when a draft PR opens.
+///
+/// Returns `VerdictAction::Passthrough { enrichment: None }` on every path —
+/// this is a side-effect-only injector (mika#1849, D1).
+pub(crate) async fn try_handle_draft_pr_opened(
+    text: &str,
+    db: &AsyncDatabase,
+    github_token: Option<&str>,
+    session_id: &str,
+    trace_id: &str,
+) -> VerdictAction {
+    // 1. Self-select on the PR-opened event prefix.
+    let event = match parse_pr_opened(text) {
+        Some(e) => e,
+        None => return VerdictAction::Passthrough { enrichment: None },
+    };
+
+    // 2. Require a GitHub token — fail-open on absence.
+    let token = match github_token {
+        Some(t) => t,
+        None => {
+            warn!(
+                event = "draft_pr_ready_cleanup_no_token",
+                repo = %event.repo,
+                pr = event.number,
+                "draft_pr_opened_handler: no GitHub token — cannot clean up ready label"
+            );
+            return VerdictAction::Passthrough { enrichment: None };
+        }
+    };
+
+    // 3. Fetch isDraft + closingIssuesReferences — fail-open on error.
+    let (is_draft, closing_refs) =
+        match fetch_draft_and_closing_refs(event.number, &event.repo, token).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    event = "draft_pr_ready_cleanup_pr_view_failed",
+                    repo = %event.repo,
+                    pr = event.number,
+                    error = %e,
+                    "draft_pr_opened_handler: gh pr view failed — passthrough"
+                );
+                return VerdictAction::Passthrough { enrichment: None };
+            }
+        };
+
+    // 4. Decide which closing issues are eligible for cleanup.
+    let to_clean = plan_ready_label_cleanup(is_draft, &closing_refs);
+    if to_clean.is_empty() {
+        debug!(
+            repo = %event.repo,
+            pr = event.number,
+            is_draft = is_draft,
+            closing_refs = closing_refs.len(),
+            "draft_pr_opened_handler: no-op (non-draft or no closing refs)"
+        );
+        return VerdictAction::Passthrough { enrichment: None };
+    }
+
+    // 5. For each closing ref: read labels, remove `ready` only if present,
+    //    emit one structured event per removal. Every gh call is fail-open.
+    for issue_number in to_clean {
+        let labels = match fetch_issue_labels(issue_number, &event.repo, token).await {
+            Ok(l) => l,
+            Err(e) => {
+                warn!(
+                    event = "draft_pr_ready_cleanup_issue_view_failed",
+                    repo = %event.repo,
+                    pr = event.number,
+                    issue = issue_number,
+                    error = %e,
+                    "draft_pr_opened_handler: gh issue view failed — continuing"
+                );
+                continue;
+            }
+        };
+
+        if !issue_has_ready_label(&labels) {
+            continue;
+        }
+
+        match remove_ready_label(issue_number, &event.repo, token).await {
+            Ok(()) => {
+                info!(
+                    event = "ready_label_cleaned_up_on_draft_open",
+                    repo = %event.repo,
+                    pr = event.number,
+                    issue = issue_number,
+                    "draft_pr_opened_handler: removed ready label from closing issue"
+                );
+
+                // Operator-visible audit record (fire-and-forget).
+                if let Err(e) = db
+                    .log_audit_event(
+                        session_id,
+                        "draft_pr_ready_label_cleaned",
+                        &format!("issue:{}#{}", event.repo, issue_number),
+                        None,
+                        Some("ready_removed"),
+                        Some(&format!(
+                            "repo={} pr={} issue={}",
+                            event.repo, event.number, issue_number
+                        )),
+                        Some(trace_id),
+                    )
+                    .await
+                {
+                    warn!(
+                        event = "draft_pr_ready_cleanup_audit_failed",
+                        repo = %event.repo,
+                        issue = issue_number,
+                        error = %e,
+                        "draft_pr_opened_handler: failed to write audit event (non-fatal)"
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    event = "draft_pr_ready_cleanup_remove_failed",
+                    repo = %event.repo,
+                    pr = event.number,
+                    issue = issue_number,
+                    error = %e,
+                    "draft_pr_opened_handler: gh issue edit --remove-label failed — continuing"
+                );
+                continue;
+            }
+        }
+    }
+
+    VerdictAction::Passthrough { enrichment: None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- parse_pr_opened tests --
+
+    #[test]
+    fn parse_pr_opened_owner_repo_form() {
+        let text = "[GitHub] PR opened: senara-solutions/mika#1849 — fix: cleanup (branch: fix/1849)\nhttps://github.com/senara-solutions/mika/pull/1900";
+        let event = parse_pr_opened(text).unwrap();
+        assert_eq!(event.repo, "senara-solutions/mika");
+        assert_eq!(event.number, 1849);
+    }
+
+    #[test]
+    fn parse_pr_opened_mika_cloud_form() {
+        let text =
+            "[GitHub] PR opened: senara-solutions/mika-cloud#42 — chart bump (branch: feat/chart)";
+        let event = parse_pr_opened(text).unwrap();
+        assert_eq!(event.repo, "senara-solutions/mika-cloud");
+        assert_eq!(event.number, 42);
+    }
+
+    #[test]
+    fn parse_pr_opened_rejects_pr_closed() {
+        let text = "[GitHub] PR closed: senara-solutions/mika#1849 — fix (branch: fix/1849)";
+        assert!(parse_pr_opened(text).is_none());
+    }
+
+    #[test]
+    fn parse_pr_opened_rejects_non_pr_text() {
+        let text = "[GitHub] Issue labeled ready on senara-solutions/mika#1849 — fix";
+        assert!(parse_pr_opened(text).is_none());
+    }
+
+    #[test]
+    fn parse_pr_opened_rejects_empty() {
+        assert!(parse_pr_opened("").is_none());
+    }
+
+    #[test]
+    fn parse_pr_opened_rejects_unparsable_number() {
+        let text = "[GitHub] PR opened: senara-solutions/mika#notanumber — title (branch: b)";
+        assert!(parse_pr_opened(text).is_none());
+    }
+
+    // -- plan_ready_label_cleanup tests (AC5 a/b/c) --
+
+    #[test]
+    fn plan_cleanup_draft_with_refs_returns_refs() {
+        // AC5a: draft PR opens with closing-refs → label removal eligible.
+        assert_eq!(
+            plan_ready_label_cleanup(true, &[1849, 1850]),
+            vec![1849, 1850]
+        );
+    }
+
+    #[test]
+    fn plan_cleanup_non_draft_is_noop() {
+        // AC5b: non-draft PR opens → no-op.
+        assert!(plan_ready_label_cleanup(false, &[1849]).is_empty());
+    }
+
+    #[test]
+    fn plan_cleanup_draft_no_refs_is_noop() {
+        // AC5c: draft with no closing-refs → no-op.
+        assert!(plan_ready_label_cleanup(true, &[]).is_empty());
+    }
+
+    // -- issue_has_ready_label tests --
+
+    #[test]
+    fn issue_has_ready_label_present() {
+        let labels = vec!["bug".to_string(), "ready".to_string(), "p1".to_string()];
+        assert!(issue_has_ready_label(&labels));
+    }
+
+    #[test]
+    fn issue_has_ready_label_absent() {
+        let labels = vec!["bug".to_string(), "p1".to_string()];
+        assert!(!issue_has_ready_label(&labels));
+    }
+
+    #[test]
+    fn issue_has_ready_label_case_sensitive() {
+        // Taxonomy uses lowercase `ready`; `Ready` is not a match.
+        let labels = vec!["Ready".to_string()];
+        assert!(!issue_has_ready_label(&labels));
+    }
+
+    // -- parse_pr_view_json tests --
+
+    #[test]
+    fn parse_pr_view_json_draft_with_refs() {
+        let json = r#"{
+            "isDraft": true,
+            "closingIssuesReferences": [
+                {"number": 1849, "title": "fix"},
+                {"number": 1850, "title": "other"}
+            ]
+        }"#;
+        let (is_draft, refs) = parse_pr_view_json(json).unwrap();
+        assert!(is_draft);
+        assert_eq!(refs, vec![1849, 1850]);
+    }
+
+    #[test]
+    fn parse_pr_view_json_non_draft_empty_refs() {
+        let json = r#"{"isDraft": false, "closingIssuesReferences": []}"#;
+        let (is_draft, refs) = parse_pr_view_json(json).unwrap();
+        assert!(!is_draft);
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn parse_pr_view_json_missing_fields_defaults() {
+        let json = r#"{}"#;
+        let (is_draft, refs) = parse_pr_view_json(json).unwrap();
+        assert!(!is_draft);
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn parse_pr_view_json_invalid_errors() {
+        // AC5d seam: malformed JSON is a recoverable error, not a panic.
+        assert!(parse_pr_view_json("not json").is_err());
+    }
+
+    // -- parse_issue_labels_json tests --
+
+    #[test]
+    fn parse_issue_labels_json_extracts_names() {
+        let json = r#"{"labels": [{"name": "ready"}, {"name": "bug"}]}"#;
+        let labels = parse_issue_labels_json(json).unwrap();
+        assert_eq!(labels, vec!["ready".to_string(), "bug".to_string()]);
+    }
+
+    #[test]
+    fn parse_issue_labels_json_empty() {
+        let json = r#"{"labels": []}"#;
+        assert!(parse_issue_labels_json(json).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_issue_labels_json_invalid_errors() {
+        assert!(parse_issue_labels_json("{bad").is_err());
+    }
+}

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -1009,6 +1009,35 @@ async fn run_agent_for_message(
                 unreachable!("milestone_context handler never dispatches");
             }
         }
+
+        // Draft-PR ready-label cleanup handler (mika#1849): for
+        // `pull_request.opened` webhooks where the PR is a draft closing one or
+        // more issues, remove the leftover `ready` label from each closing
+        // issue. Side-effect-only injector — never returns Handled/Dispatched
+        // (same shape as milestone_context above). Self-selects on the
+        // `[GitHub] PR opened:` prefix; order-independent with the handlers above.
+        let draft_pr_action = super::draft_pr_opened_handler::try_handle_draft_pr_opened(
+            &req.text,
+            &a.db,
+            verdict_github_token.as_deref(),
+            &session_id,
+            &req.request_id,
+        )
+        .await;
+        match draft_pr_action {
+            VerdictAction::Passthrough {
+                enrichment: Some(e),
+            } => {
+                req.text = format!("{e}{}", req.text);
+            }
+            VerdictAction::Passthrough { enrichment: None } => {}
+            VerdictAction::Handled { .. } => {
+                unreachable!("draft_pr_opened handler never handles");
+            }
+            VerdictAction::Dispatched { .. } => {
+                unreachable!("draft_pr_opened handler never dispatches");
+            }
+        }
     }
 
     let params = agent::AgentParams {

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod ci_failure_handler;
 pub mod ci_success_handler;
 pub mod dashboard;
 pub mod dashboard_dev_runs;
+pub mod draft_pr_opened_handler;
 pub mod embedded_dashboard;
 mod handlers;
 pub mod investigate;

--- a/crates/mika-agent/tests/eval/test_verdict_handler.rs
+++ b/crates/mika-agent/tests/eval/test_verdict_handler.rs
@@ -988,7 +988,13 @@ async fn non_pr_review_event_passes_through() -> Result<()> {
 // -------------------------------------------------------------------------
 
 #[tokio::test]
-async fn verdict_pass_no_task_passes_through() -> Result<()> {
+async fn verdict_pass_no_task_perimeter_fail_closed_holds_for_operator() -> Result<()> {
+    // Post-mika#1853: perimeter check is hoisted BEFORE the task lookup, so a
+    // VERDICT: pass on a PR without an active task row still consults the
+    // forge-gate. In this test env `gh` cannot resolve → `fetch_pr_files`
+    // errors → fail-closed to DECISION-CORE → Handled (hold for operator).
+    // This is the correct new behavior: no task + fetch-error must NOT slip
+    // through to the LLM (that was the mika#1851 bypass being closed).
     let db = test_db().await;
     let text = pr_review_text(
         "approved",
@@ -1013,14 +1019,16 @@ async fn verdict_pass_no_task_passes_through() -> Result<()> {
         VerdictAction::Dispatched { .. } => {
             unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
-        VerdictAction::Passthrough { enrichment } => {
-            assert!(
-                enrichment.is_none(),
-                "pass with no task should pass through cleanly"
+        VerdictAction::Passthrough { .. } => {
+            panic!(
+                "pass with no task + fetch-error should be Handled (forge-gate fail-closed), not Passthrough"
             );
         }
-        VerdictAction::Handled { .. } => {
-            panic!("pass with no task should not be handled");
+        VerdictAction::Handled { pre_digest } => {
+            assert!(
+                pre_digest.contains("forge-gate") || pre_digest.contains("DECISION-CORE"),
+                "hold pre-digest must name the gate: {pre_digest}"
+            );
         }
     }
     Ok(())
@@ -1031,7 +1039,12 @@ async fn verdict_pass_no_task_passes_through() -> Result<()> {
 // -------------------------------------------------------------------------
 
 #[tokio::test]
-async fn verdict_pass_completed_task_passes_through() -> Result<()> {
+async fn verdict_pass_completed_task_perimeter_fail_closed_holds_for_operator() -> Result<()> {
+    // Post-mika#1853: perimeter check runs BEFORE task-status check. A completed
+    // task is no longer a passthrough exit — the gate consults the diff first.
+    // fetch_pr_files errors in test env → fail-closed to DECISION-CORE →
+    // Handled. Task-side metadata write is skipped (task is not in_progress),
+    // but the notification + audit event + hold pre-digest still fire.
     let db = test_db().await;
     let pr_url = "https://github.com/senara-solutions/mika/pull/42";
     let task_id = create_task_with_pr_url(&db, pr_url).await;
@@ -1064,14 +1077,16 @@ async fn verdict_pass_completed_task_passes_through() -> Result<()> {
         VerdictAction::Dispatched { .. } => {
             unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
-        VerdictAction::Passthrough { enrichment } => {
-            assert!(
-                enrichment.is_none(),
-                "pass with completed task should pass through cleanly"
+        VerdictAction::Passthrough { .. } => {
+            panic!(
+                "pass with completed task + fetch-error should be Handled (forge-gate fail-closed), not Passthrough"
             );
         }
-        VerdictAction::Handled { .. } => {
-            panic!("pass with completed task should not be handled");
+        VerdictAction::Handled { pre_digest } => {
+            assert!(
+                pre_digest.contains("forge-gate") || pre_digest.contains("DECISION-CORE"),
+                "hold pre-digest must name the gate: {pre_digest}"
+            );
         }
     }
     Ok(())
@@ -1082,7 +1097,7 @@ async fn verdict_pass_completed_task_passes_through() -> Result<()> {
 // -------------------------------------------------------------------------
 
 #[tokio::test]
-async fn verdict_pass_pending_task_passes_through() -> Result<()> {
+async fn verdict_pass_pending_task_perimeter_fail_closed_holds_for_operator() -> Result<()> {
     let db = test_db().await;
     let pr_url = "https://github.com/senara-solutions/mika/pull/50";
 
@@ -1146,14 +1161,19 @@ async fn verdict_pass_pending_task_passes_through() -> Result<()> {
         VerdictAction::Dispatched { .. } => {
             unreachable!("Dispatched requires resolvable tool in SkillRegistry")
         }
-        VerdictAction::Passthrough { enrichment } => {
-            assert!(
-                enrichment.is_none(),
-                "pass with pending task should pass through cleanly"
+        VerdictAction::Passthrough { .. } => {
+            panic!(
+                "pass with pending task + fetch-error should be Handled (forge-gate fail-closed), not Passthrough"
             );
         }
-        VerdictAction::Handled { .. } => {
-            panic!("pass with pending task should not be handled");
+        VerdictAction::Handled { pre_digest } => {
+            // Post-mika#1853: perimeter runs before task-status check; a pending
+            // task no longer bails to passthrough. fetch fails-closed to
+            // DECISION-CORE → Handled with hold pre-digest.
+            assert!(
+                pre_digest.contains("forge-gate") || pre_digest.contains("DECISION-CORE"),
+                "hold pre-digest must name the gate: {pre_digest}"
+            );
         }
     }
     Ok(())

--- a/docs/plans/2026-07-27-001-fix-1849-ready-label-cleanup-draft-pr-plan.md
+++ b/docs/plans/2026-07-27-001-fix-1849-ready-label-cleanup-draft-pr-plan.md
@@ -1,0 +1,257 @@
+# Plan — fix(auto_pull): clean up `ready` label when a draft PR opens for its closing-issue
+
+**Ticket:** mika#1849
+**Type:** fix (loop-state hygiene, p1-important)
+**Branch:** `fix/1849/auto-pull-clean-up-ready-label-when`
+**Target file:** `crates/mika-agent/src/server/draft_pr_opened_handler.rs` (new) + wiring in `crates/mika-agent/src/server/handlers.rs`
+
+---
+
+## Context
+
+When mika-dev/dev-pilot opens a **draft** PR closing an issue (systematically via
+dispatch-lib's wip-rescue path, mika#1282), the issue's `ready` label is never removed. It
+stays on the issue permanently, so loop inventory reads "N ready" when only a fraction are
+actually dispatchable — the operator can no longer tell "needs dispatch" from "draft is open,
+waiting on review". Frustrated Vincent 2026-07-27 morning ("11 drafts stackés + 5 ready
+ambiguës").
+
+Two contributing gaps (from the ticket root-cause):
+
+1. **No handler listens for `pull_request.opened` (draft) and removes `ready`** from the issues
+   that PR closes.
+2. The Phase 2 auto-pull reconciler (mika#1824) *correctly skips* re-driving an issue that has an
+   open PR closing it (Filter 2, `auto_pull.rs:664`), but it does **not** proactively *remove* the
+   leftover `ready` label either.
+
+**Chosen approach — Option A (webhook-driven), per the ticket recommendation.** A new structural
+handler intercepts `pull_request.opened` events **before** the LLM turn (same pattern as
+`ci_success_handler` / `ci_failure_handler` / `milestone_context_handler`) and removes `ready`
+from each closing-issue of a newly-opened **draft** PR. Webhook-driven → immediate (vs the
+10-min reconciler cadence of Option B), and cleanly separated from the auto-pull poller.
+
+### Grounding facts established during investigation
+
+- **Routing.** The gateway routes `pull_request.opened` (including draft opens) to **mika-qa**
+  (`crates/mika-gateway/src/github.rs` `route_event`; mika#1822 confirms draft PRs reach mika-qa).
+  The new handler lives in `server::handlers::handle_message`, which runs for **every**
+  github-channel message regardless of target agent, and self-selects on the `[GitHub] PR opened:`
+  text prefix — so it fires in mika-qa's session. It needs only a resolved `github_token`
+  (mika-qa carries one), not any mika-dev-specific state.
+- **Webhook text lacks the needed fields.** `format_event_text` for `pull_request`
+  (`github.rs:442`) emits `[GitHub] PR opened: {repo}#{n} — {title} (branch: {branch})` and does
+  **not** carry `isDraft` or `closingIssuesReferences`. The handler must fetch them with one
+  `gh pr view` call — exactly the pattern `ci_success_handler` already uses (`run_gh_subprocess`).
+- **Stable after removal (no thrash).** Once a draft PR is open and its `closingIssuesReferences`
+  is populated, Phase 2's Filter 2 (`open_pr_closing`) already excludes that issue from re-drive,
+  so the reconciler will **not** re-add `ready` after this handler removes it. The two mechanisms
+  compose; no coordination flag is needed. (The ticket's "reconciler re-adds" observation was the
+  *pre-draft* window — Phase 2 ran before the draft existed. Post-draft, Filter 2 holds.)
+- **Reusable idempotent primitive.** `auto_pull.rs::gh_remove_label` (mika#1824) already implements
+  an idempotent `gh issue edit --remove-label` that tolerates "label not present" as success — but
+  it is `DEFAULT_REPO`-hardcoded and private to `auto_pull`. The new handler is repo-general (parses
+  the repo from the webhook), so it uses `run_gh_subprocess` directly rather than that helper.
+
+---
+
+## Requirements
+
+- **R1** — A new `server::draft_pr_opened_handler::try_handle_draft_pr_opened` intercepts
+  `pull_request.opened` webhooks before the LLM turn. Self-selects on the `[GitHub] PR opened:`
+  text prefix; passthrough for every other event type. Returns `VerdictAction::Passthrough`
+  always (side-effect-only injector — never replaces the turn, like `milestone_context_handler`).
+- **R2** — On a matching event, fetch `isDraft` + `closingIssuesReferences` via one
+  `gh pr view <n> --repo <repo> --json isDraft,closingIssuesReferences` call.
+- **R3** — Fire the cleanup **only** when `isDraft == true` **and** `closingIssuesReferences` is
+  non-empty (AC1). Non-draft opens and draft opens with no closing-refs are no-ops (AC5b, AC5c).
+- **R4** — For each referenced closing issue, if the `ready` label is present, remove it via
+  `gh issue edit <ref> --repo <repo> --remove-label ready`. Idempotent — removing an absent label
+  is a no-op (AC2).
+- **R5** — Emit a structured `ready_label_cleaned_up_on_draft_open` INFO event per removal, with the
+  repo, PR number, and issue number (AC3).
+- **R6** — Fail-open on every `gh` error (missing token, `pr view` failure, per-issue `issue view` /
+  `issue edit` failure): log WARN and continue; never crash the handler or the turn (AC4).
+- **R7** — The repo is taken from the parsed webhook text, so the handler works for `mika`,
+  `mika-cloud`, `mika-skills`, etc. — not hardcoded to `senara-solutions/mika`.
+
+---
+
+## Design decisions
+
+### D1 — Handler shape: `VerdictAction::Passthrough`-only, side-effect injector
+
+The handler mutates GitHub state (removes a label) as a pure side effect and does **not** need to
+alter the mika-qa review turn. It returns `VerdictAction::Passthrough { enrichment: None }` on every
+path — mirroring `milestone_context_handler`, which never returns `Handled`/`Dispatched`. Wiring in
+`handlers.rs` matches only the two `Passthrough` arms and marks `Handled`/`Dispatched` as
+`unreachable!` (same as the milestone handler's match block at `handlers.rs:998`).
+
+Reusing `VerdictAction` (rather than a bespoke return type) keeps the handler uniform with the four
+existing structural handlers and lets the wiring block stay copy-shaped.
+
+### D2 — Accurate "per removal" semantics: check label presence before removing
+
+AC3 requires an event **per removal**. Unconditionally calling `--remove-label` (which is
+idempotent) would either over-emit (event on no-op removals) or under-inform. So for each closing
+ref the handler first reads the issue's current labels
+(`gh issue view <ref> --repo <repo> --json labels -q '.labels[].name'`), and only when `ready` is
+present does it call `--remove-label` and emit `ready_label_cleaned_up_on_draft_open`. This makes
+AC2 (idempotent) and AC3 (event-per-removal) both exact, at a cost of one extra read per closing
+ref (closing refs are typically 1 per PR).
+
+### D3 — Fetch fields via `gh`, not from the webhook (unavoidable)
+
+`isDraft` and `closingIssuesReferences` are not in the gateway's PR event text (Context). The
+handler issues `gh pr view <n> --repo <repo> --json isDraft,closingIssuesReferences` through the
+shared `crate::tools::pr_merge_with_gate::run_gh_subprocess` (the same 60s-timeout subprocess
+wrapper the sibling handlers use). Fail-open: any error → WARN + passthrough, no cleanup attempted.
+
+### D4 — Pure decision seams for unit-testability (AC5)
+
+Two pure functions carry the branching logic so AC5 is testable with **no network/subprocess**,
+matching how `ci_success_handler` unit-tests its parser + formatters and explicitly leaves the live
+subprocess path out of unit scope:
+
+```rust
+/// Parse `[GitHub] PR opened: <repo>#<n> — <title> (branch: <b>)` → (repo, number).
+/// Returns None for any non-`PR opened` event text.
+fn parse_pr_opened(text: &str) -> Option<PrOpenedEvent>;
+
+/// The closing-issue numbers eligible for cleanup: `[]` unless `is_draft` AND refs non-empty.
+fn plan_ready_label_cleanup(is_draft: bool, closing_issue_numbers: &[u64]) -> Vec<u64>;
+
+/// True when the issue's current label set contains `ready` (case-sensitive, matches taxonomy).
+fn issue_has_ready_label(labels: &[String]) -> bool;
+```
+
+The async `try_handle_draft_pr_opened` wires real `gh`/JSON into these predicates. AC5 (a/b/c) is
+covered directly by `plan_ready_label_cleanup` + `issue_has_ready_label`; AC5(d) is covered by the
+removal loop's per-issue fail-open structure (each `gh` call wrapped in match → WARN + continue),
+asserted at the seam level plus a JSON-parse-tolerance test. The subprocess boundary itself is
+excluded from unit scope, consistent with the existing handler tests.
+
+### D5 — Draft-only, per the ACs
+
+AC1 and AC5(b) restrict the trigger to `isDraft == true`; a non-draft open is an explicit no-op.
+(Rationale: draft opens are the systematic dispatch-lib wip-rescue shape that produces the leftover
+label; a non-draft open is a rarer, human-driven path. Widening to non-draft is out of scope — see
+Out of scope.)
+
+---
+
+## Implementation steps
+
+1. **New module** `crates/mika-agent/src/server/draft_pr_opened_handler.rs`. Declare `pub mod
+   draft_pr_opened_handler;` in `server/mod.rs` (alongside the other handler mods).
+2. **Parser** (`parse_pr_opened`, D4): strip `[GitHub] PR opened: `, take the token up to ` — `,
+   `rsplit_once('#')` into `(repo, number)`, parse `number: u64`. Reject empty repo / unparsable
+   number. Unit tests for owner/repo form, mika-cloud form, and rejection of `PR closed` / non-PR
+   text.
+3. **Pure decision fns** (`plan_ready_label_cleanup`, `issue_has_ready_label`, D4) + unit tests
+   (AC5 a/b/c).
+4. **Async handler** `try_handle_draft_pr_opened(text, github_token, session_id, trace_id, db?)`:
+   - `parse_pr_opened` → passthrough on miss.
+   - token check → WARN + passthrough on `None`.
+   - `gh pr view` for `isDraft` + `closingIssuesReferences` → WARN + passthrough on error/parse fail.
+   - `plan_ready_label_cleanup(is_draft, &refs)` → if empty, passthrough (DEBUG "no-op").
+   - For each ref: `gh issue view --json labels`; if `issue_has_ready_label` → `gh issue edit
+     --remove-label ready` + emit `ready_label_cleaned_up_on_draft_open` INFO (R5). Every `gh` call
+     fail-open (WARN + continue) (R6).
+   - Return `VerdictAction::Passthrough { enrichment: None }` (D1).
+5. **Wiring** (`handlers.rs`, inside `if req.channel == "github"`, after the `milestone_context`
+   block): resolve the same `verdict_github_token`, call `try_handle_draft_pr_opened`, match
+   `Passthrough { enrichment }` (Some → prepend; None → no-op), `Handled`/`Dispatched` →
+   `unreachable!`. Place it independent of the other handlers (self-selecting on event type).
+6. **Audit event (optional, if `db` threaded):** write a `draft_pr_ready_label_cleaned` audit row
+   per removal for operator-visible history, mirroring `ready_label_handler`'s `log_audit_event`
+   use. Fire-and-forget (WARN on DB error). *(Include only if the wiring already has `&a.db` in
+   scope — it does; keep it non-fatal.)*
+7. **Tests** (AC5): parser tests; `plan_ready_label_cleanup` truth table (draft+refs → refs;
+   non-draft+refs → []; draft+[] → []); `issue_has_ready_label` present/absent; a `gh pr view` JSON
+   parse test over a captured fixture (isDraft + closingIssuesReferences array).
+
+---
+
+## Verification contract
+
+- `cargo test -p mika-agent draft_pr_opened` — new parser + decision-seam tests green.
+- `cargo clippy -p mika-agent -- -D warnings`, `cargo fmt --check`.
+- The pure seams (`parse_pr_opened`, `plan_ready_label_cleanup`, `issue_has_ready_label`) fully cover
+  AC5 (a/b/c) with no network/subprocess; the removal loop's fail-open structure covers AC5(d).
+- No change to any existing handler's observable behavior (each self-selects on disjoint event
+  types); existing `handlers.rs` handler tests unchanged and passing.
+
+### Post-deploy verification (operator, AC6)
+
+- Open a test draft PR whose body has `Closes #<n>` for an issue carrying `ready`. Within ~5s
+  (webhook latency) confirm the label is gone (`gh issue view <n> --json labels`) and a
+  `ready_label_cleaned_up_on_draft_open` line is present:
+  `grep ready_label_cleaned_up_on_draft_open $MIKA_SPIRIT_LOG_FILE | jq 'select(.issue==<n>)'`.
+- Steady-state: the count of `ready`-labelled issues that also have an open closing PR should trend
+  to 0.
+
+---
+
+## Definition of Done
+
+- `try_handle_draft_pr_opened` fires on `pull_request.opened` with `isDraft=true` +
+  non-empty closing refs; removes `ready` from each closing issue that has it (R1–R5, AC1).
+- Idempotent — absent label is a no-op; no event emitted when nothing removed (R4, D2, AC2).
+- `ready_label_cleaned_up_on_draft_open` INFO emitted per removal (R5, AC3).
+- Fail-open on all `gh`/token errors; handler and turn never crash (R6, AC4).
+- Handler is repo-general (parses repo from the webhook) (R7).
+- Unit tests pass (AC5); clippy/fmt clean; no regression to existing structural handlers.
+- Wired into `handlers.rs` `handle_message`, order-independent with the four existing handlers.
+
+---
+
+## Acceptance criteria
+
+- AC1: New handler fires on `pull_request.opened` with `isDraft=true` AND `closingIssuesReferences` non-empty. For each referenced issue, if `ready` label present, remove it.
+- AC2: Handler is idempotent (removing an absent label is a no-op).
+- AC3: Handler emits `ready_label_cleaned_up_on_draft_open` structured INFO event per removal.
+- AC4: Handler fail-opens on gh CLI errors (warn log + continue).
+- AC5: Unit tests cover: (a) draft PR opens with closing-refs → label removed; (b) non-draft PR opens → no-op; (c) draft with no closing-refs → no-op; (d) gh CLI failure → warn but no crash.
+- AC6: Post-deploy verification — open a test draft PR closing an issue with `ready` label. Confirm label removed within 5s + structured log event emitted.
+
+---
+
+## Out of scope
+
+- **Existing backlog cleanup.** Option A is webhook-driven — it fires only on **new**
+  `pull_request.opened` events. The 5 issues already in the stuck state (their draft PRs opened in
+  the past) will **not** be cleaned by this handler. They need a one-time operator sweep
+  (`gh issue edit <n> --remove-label ready`), which is now stable because Phase 2 Filter 2 already
+  refuses to re-add `ready` while an open closing-PR exists (Context). A reconciler-side proactive
+  removal (the ticket's Option B) is a possible follow-up if backlog cleanup should be automated;
+  not needed for AC1–AC6.
+- **Non-draft PR opens.** The ACs scope the trigger to `isDraft=true` (D5); leftover `ready` on
+  non-draft opens is theoretically possible but out of scope here.
+- **`ready_for_review` (draft→ready promotion) events.** The label should already be gone by the
+  time a draft is promoted; no handler needed on that transition.
+- **Any change to the auto-pull poller (Option B).** Deliberately not touched — Option A chosen for
+  separation and immediacy.
+
+---
+
+## Risks
+
+- **R-routing** — the handler runs in mika-qa's session (that's where `pull_request.opened` lands).
+  It performs only issue-label mutation via `github_token`, agent-agnostic. Mitigated: no
+  mika-dev-specific state is read; the qa-review turn is unperturbed (Passthrough-only).
+- **R-closing-refs-lag** — GitHub may populate `closingIssuesReferences` slightly after the
+  `opened` event fires. If empty at handler time, the cleanup no-ops and the label lingers until a
+  later signal. Mitigated: the leftover is bounded and Phase 2 Filter 2 keeps it stable (no
+  re-add); backlog sweep (out of scope) covers the residue.
+- **R-extra-reads** — one `gh issue view` per closing ref (D2). Bounded (≈1 ref/PR); acceptable for
+  accurate per-removal event semantics.
+
+## References
+
+- mika#1824 (Phase 2 stuck-ready reconciler — Filter 2 skips, doesn't clean;
+  `gh_remove_label` idempotent primitive).
+- mika#1822 (draft PR `opened`/`ready_for_review` routing to mika-qa).
+- mika#1282 (dispatch-lib wip-rescue draft-PR path — the systematic producer of the leftover label).
+- Sibling structural handlers: `ci_success_handler`, `ci_failure_handler`, `milestone_context_handler`.
+- Founding diagnostic: Samidarko-CC spool
+  `2026-07-27-...engine-FROZEN-7h-restart-urgent-plus-label-bug-real.md`.


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: commit-pushed-no-pr)

<!-- rescue-pipeline-verified: no -->

This PR was created by dispatch-lib's git-workflow recovery. The pilot session committed and pushed but did not open a PR (`gh pr create` failed, or the pilot ended its turn before invoking it — mika#1383). dispatch-lib opened this PR from the existing branch.

**Auto-rescued PR.** Operator: verify pipeline completion, then either un-draft this PR or set the marker above to `yes`.

### Recovery metadata
- Recovery class: `commit-pushed-no-pr`
- Pilot session: `d3344e3a-5c3e-4d71-a74c-0d27bf848c13`
- Turns: 30
- Cost: $4.611302

Closes #1849