### PR TITLE
fix(forge-gate): close CI-success + verdict-handler perimeter bypasses (mika#1853) [P0 HOTFIX hors-loop]

### DIFF
--- a/crates/mika-agent/src/server/ci_failure_handler.rs
+++ b/crates/mika-agent/src/server/ci_failure_handler.rs
@@ -22,6 +22,17 @@
 //! - The handler constructs a pre-digest for the LLM — it does NOT directly invoke
 //!   `run_claude_pilot`. The dispatch-readiness guard in `executor.rs` is the
 //!   authoritative gate for long-running dispatch.
+//!
+//! ## Forge-gate perimeter (mika#1853)
+//!
+//! Audited 2026-07-27: this handler has NO `run_gh_merge` callsite — it only builds
+//! a pre-digest that suggests a claude-pilot dispatch. No perimeter check is wired in
+//! because there is no merge path to gate here. If a future refactor introduces a
+//! direct merge callsite in this handler (or its close family), the perimeter fetch +
+//! classify pattern from `verdict_handler::handle_pass_verdict` and
+//! `ci_success_handler::try_handle_ci_success` (both mika#1853) MUST be applied here
+//! too. Grep-anchor before landing: `grep -n 'run_gh_merge' server/*.rs` — every hit
+//! must consult `perimeter::classify_pr_files`.
 
 use std::sync::Arc;
 

--- a/crates/mika-agent/src/server/ci_success_handler.rs
+++ b/crates/mika-agent/src/server/ci_success_handler.rs
@@ -36,6 +36,7 @@ use tracing::{info, warn};
 
 use crate::async_db::AsyncDatabase;
 use crate::messaging::MessageSender;
+use crate::perimeter::{self, Classification};
 use crate::task_state::merge_metadata;
 use crate::tools::pr_merge_with_gate::{
     CheckClassification, classify_checks, is_behind_main, run_gh_checks, run_gh_merge,
@@ -279,6 +280,103 @@ pub async fn try_handle_ci_success(
                 "CI success handler: failed to fetch PR preflight for behind-main check — proceeding (fail-open)"
             );
         }
+    }
+
+    // 5c. Forge-gate perimeter check (mika#1853 — coupled pair with verdict_handler mika#1829).
+    //
+    // The CI-success race path was previously the load-bearing bypass: `verdict_handler`
+    // has consulted the classifier since mika#1829, but this handler called
+    // `run_gh_merge` directly — mika#1851 auto-merged 4 DECISION-CORE files
+    // (crates/mika-agent/src/task_engine/**, server/mod.rs) through this callsite on
+    // 2026-07-27T08:09:14Z because the perimeter classifier was never consulted.
+    //
+    // Fail-closed: on gh-CLI fetch error, we treat the PR as DECISION-CORE (better to
+    // hold a MECHANICAL PR than to auto-merge a DECISION-CORE PR through the CI-success
+    // race path). Behavioral, not declarative — the diff is authority; labels and PR
+    // body prose are never consulted.
+    let perimeter_verdict = match perimeter::fetch::fetch_pr_files(pr.number, &event.repo, token)
+        .await
+    {
+        Ok(files) => perimeter::classify_pr_files(&files),
+        Err(e) => {
+            warn!(
+                error = %e,
+                pr_number = pr.number,
+                repo = %event.repo,
+                "Perimeter classifier: failed to fetch PR files — fail-closed to DECISION-CORE (mika#1853)"
+            );
+            perimeter::PrClassification {
+                verdict: Classification::DecisionCore,
+                mechanical_files: Vec::new(),
+                decision_core_files: vec![format!("<fetch-error: {e}>")],
+            }
+        }
+    };
+
+    if perimeter_verdict.verdict == Classification::DecisionCore {
+        info!(
+            event = "ci_success_handler_human_gate_required",
+            pr_number = pr.number,
+            repo = %event.repo,
+            summary = %perimeter_verdict.summary(),
+            decision_core_files = ?perimeter_verdict.decision_core_files,
+            "Forge-gate: PR touches DECISION-CORE zone(s) — skipping CI-success auto-merge, operator must merge manually (mika#1853)"
+        );
+
+        // Audit event so operators can grep for gate firings independent of the merge path.
+        if let Err(e) = db
+            .log_audit_event(
+                session_id,
+                "ci_success_handler_human_gate_required",
+                &format!("pr:{}#{}", event.repo, pr.number),
+                None,
+                None,
+                Some(&format!(
+                    "trigger=check_suite_success gate=forge-gate reviewer={} decision_core_files={}",
+                    verdict_review.reviewer,
+                    perimeter_verdict.decision_core_files.join(","),
+                )),
+                Some(trace_id),
+            )
+            .await
+        {
+            warn!(error = %e, "Failed to log ci_success_handler_human_gate_required audit event");
+        }
+
+        // Notify operator with the concrete file list.
+        if let Some(sender) = message_sender {
+            let notification = format!(
+                "PR #{} on {} — CI checks all green + VERDICT: pass from @{}, but touches DECISION-CORE zone(s). \
+                 Auto-merge blocked by forge-gate (mika#1853). {}. Operator must merge manually.",
+                pr.number,
+                event.repo,
+                verdict_review.reviewer,
+                perimeter_verdict.summary(),
+            );
+            match sender.send(&notification).await {
+                Ok(crate::messaging::SendOutcome::Delivered) => {}
+                Ok(crate::messaging::SendOutcome::Failed { reason }) => {
+                    warn!(reason = %reason, "CI success DECISION-CORE hold notification delivery failed");
+                }
+                Ok(crate::messaging::SendOutcome::NoChannel) => {
+                    warn!(
+                        "CI success DECISION-CORE hold notification skipped — no reply channel (chat_id=0)"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to send CI success DECISION-CORE hold notification");
+                }
+            }
+        }
+
+        return VerdictAction::Handled {
+            pre_digest: format_decision_core_hold_pre_digest(
+                &event,
+                pr.number,
+                &verdict_review.reviewer,
+                &perimeter_verdict.summary(),
+            ),
+        };
     }
 
     // 6. All conditions met — initiate merge
@@ -628,6 +726,28 @@ fn format_error_pre_digest(event: &CheckSuiteEvent, pr_number: u64, error: &str)
     )
 }
 
+/// Format the pre-digest for a DECISION-CORE hold (mika#1853 — forge-gate perimeter).
+///
+/// IMPORTANT: Avoids completion-claim guard trigger words (merged, deployed,
+/// completed, complete, shipped). Uses "blocked" / "held" / "must merge manually" phrasing.
+fn format_decision_core_hold_pre_digest(
+    event: &CheckSuiteEvent,
+    pr_number: u64,
+    reviewer: &str,
+    perimeter_summary: &str,
+) -> String {
+    format!(
+        "<ci_success_handler>\n\
+         [GitHub] Check suite success on {}#{pr_number} (branch: {})\n\
+         CI checks all green + VERDICT: pass from @{reviewer}, but this PR touches DECISION-CORE zone(s).\n\n\
+         Auto-merge BLOCKED by forge-gate (mika#1853). {perimeter_summary}. Operator must merge manually.\n\n\
+         Do NOT call pr_merge_with_gate for this PR — it will also block on the same gate. \
+         Notify the operator that a manual review-and-merge is required.\n\
+         </ci_success_handler>",
+        event.repo, event.branch
+    )
+}
+
 /// Format the enrichment message for a behind-main block.
 fn format_behind_main_enrichment(pr_base_sha: &str, current_main_sha: &str) -> String {
     format!(
@@ -728,6 +848,62 @@ mod tests {
             !COMPLETION_CLAIM_RE.is_match(&text),
             "Pre-digest contains completion-claim trigger word: {text}"
         );
+    }
+
+    // ---- DECISION-CORE hold pre-digest tests (mika#1853) ----
+
+    #[test]
+    fn decision_core_hold_pre_digest_avoids_completion_claim_words() {
+        let event = sample_event();
+        let text = format_decision_core_hold_pre_digest(
+            &event,
+            1851,
+            "mika-qa",
+            "DECISION-CORE (4 files: crates/mika-agent/src/task_engine/engine.rs, crates/mika-agent/src/task_engine/liveness.rs, crates/mika-agent/src/task_engine/mod.rs, crates/mika-agent/src/server/mod.rs)",
+        );
+        assert!(
+            !COMPLETION_CLAIM_RE.is_match(&text),
+            "Pre-digest contains completion-claim trigger word: {text}"
+        );
+    }
+
+    #[test]
+    fn decision_core_hold_pre_digest_contains_do_not_call_instruction() {
+        let event = sample_event();
+        let text = format_decision_core_hold_pre_digest(
+            &event,
+            1851,
+            "mika-qa",
+            "DECISION-CORE (1 file: foo.rs)",
+        );
+        assert!(text.contains("Do NOT call pr_merge_with_gate"));
+    }
+
+    #[test]
+    fn decision_core_hold_pre_digest_contains_operator_manual_signal() {
+        let event = sample_event();
+        let text = format_decision_core_hold_pre_digest(
+            &event,
+            1851,
+            "mika-qa",
+            "DECISION-CORE (1 file: foo.rs)",
+        );
+        assert!(text.contains("Operator must merge manually"));
+        assert!(text.contains("BLOCKED by forge-gate"));
+        assert!(text.contains("mika#1853"));
+    }
+
+    #[test]
+    fn decision_core_hold_pre_digest_contains_pr_number_and_reviewer() {
+        let event = sample_event();
+        let text = format_decision_core_hold_pre_digest(
+            &event,
+            1851,
+            "mika-qa",
+            "DECISION-CORE (1 file: foo.rs)",
+        );
+        assert!(text.contains("1851"));
+        assert!(text.contains("mika-qa"));
     }
 
     #[test]

--- a/crates/mika-agent/src/server/verdict_handler.rs
+++ b/crates/mika-agent/src/server/verdict_handler.rs
@@ -291,7 +291,139 @@ async fn handle_pass_verdict(
         }
     };
 
-    // Look up the task by PR URL
+    // Forge-gate perimeter check (mika#1829, hoisted before task lookup by mika#1853).
+    //
+    // The perimeter check MUST run before the task lookup gate — otherwise a PR filed
+    // hors-loop (no `tasks` row) bypasses the classifier entirely and falls through to
+    // the LLM (empirically observed on mika#1851, 2026-07-27T08:06:28Z).
+    //
+    // Non-negotiable (b): the diff is authority. Labels and PR body prose are
+    // never consulted here — only what the PR ACTUALLY touches.
+    // Fail-closed: on gh-CLI fetch error, we assume DECISION-CORE (better
+    // to hold a mechanical PR than to auto-merge a decision-core PR).
+    let perimeter_verdict = match perimeter::fetch::fetch_pr_files(
+        event.pr_number,
+        &event.repo,
+        token,
+    )
+    .await
+    {
+        Ok(files) => perimeter::classify_pr_files(&files),
+        Err(e) => {
+            warn!(
+                error = %e,
+                pr_number = event.pr_number,
+                repo = %event.repo,
+                "Perimeter classifier: failed to fetch PR files — fail-closed to DECISION-CORE (mika#1829/#1853)"
+            );
+            // Synthesize a DECISION-CORE result so downstream logic gates.
+            perimeter::PrClassification {
+                verdict: Classification::DecisionCore,
+                mechanical_files: Vec::new(),
+                decision_core_files: vec![format!("<fetch-error: {e}>")],
+            }
+        }
+    };
+
+    if perimeter_verdict.verdict == Classification::DecisionCore {
+        // Best-effort task lookup for metadata write. NOT required — a hors-loop PR
+        // without a `tasks` row still triggers the notification + audit event + hold
+        // pre-digest. Task-side metadata write happens only when a task exists in a
+        // writable state (in_progress).
+        let task_for_metadata = match db.find_active_task_by_pr_url(&pr_url).await {
+            Ok(Some(t)) if t.status == "in_progress" => Some(t),
+            _ => None,
+        };
+        let task_id_label = task_for_metadata
+            .as_ref()
+            .map(|t| t.id.as_str())
+            .unwrap_or("<no-active-task>");
+
+        info!(
+            event = "verdict_handler_human_gate_required",
+            pr_number = event.pr_number,
+            repo = %event.repo,
+            task_id = %task_id_label,
+            summary = %perimeter_verdict.summary(),
+            decision_core_files = ?perimeter_verdict.decision_core_files,
+            "Forge-gate: PR touches DECISION-CORE zone(s) — skipping auto-merge, operator must merge manually (mika#1829/#1853)"
+        );
+
+        // Update task metadata only when a writable in_progress task exists.
+        if let Some(ref task) = task_for_metadata
+            && let Err(e) = update_hold_metadata(
+                db,
+                &task.id,
+                &task.metadata,
+                &event.review_url,
+                &format!(
+                    "[forge-gate mika#1829] Auto-merge blocked: {}. Operator must merge manually.\n\n{}",
+                    perimeter_verdict.summary(),
+                    truncate_body(&event.body)
+                ),
+            )
+            .await
+        {
+            warn!(error = %e, task_id = %task.id, "Failed to update hold metadata after forge-gate block");
+        }
+
+        // Audit event — distinct tool_name so operators can grep for
+        // gate firings independent of hold[review] noise.
+        let target_key = task_for_metadata
+            .as_ref()
+            .map(|t| format!("task:{}", t.id))
+            .unwrap_or_else(|| format!("pr:{}#{}", event.repo, event.pr_number));
+        if let Err(e) = db
+            .log_audit_event(
+                session_id,
+                "verdict_handler_human_gate_required",
+                &target_key,
+                task_for_metadata.as_ref().map(|_| "in_progress"),
+                None,
+                Some(&format!(
+                    "verdict=pass gate=forge-gate pr_url={pr_url} decision_core_files={}",
+                    perimeter_verdict.decision_core_files.join(",")
+                )),
+                Some(trace_id),
+            )
+            .await
+        {
+            warn!(error = %e, "Failed to log verdict_handler_human_gate_required audit event");
+        }
+
+        // Notify operator with the concrete file list.
+        if let Some(sender) = message_sender {
+            send_notification(
+                sender,
+                &format!(
+                    "PR #{} on {} — VERDICT: pass from @{}, but touches DECISION-CORE zone(s). \
+                     Auto-merge blocked by forge-gate (mika#1829/#1853). {}. \
+                     Operator must merge manually. Task: {}",
+                    event.pr_number,
+                    event.repo,
+                    event.reviewer,
+                    perimeter_verdict.summary(),
+                    task_id_label
+                ),
+            )
+            .await;
+        }
+
+        return VerdictAction::Handled {
+            pre_digest: format!(
+                "[verdict_handler] Structural: VERDICT: pass on PR #{n} — auto-merge BLOCKED by \
+                 forge-gate (mika#1829/#1853). {summary}. Operator must merge manually. Do NOT call \
+                 pr_merge_with_gate for this PR — it will also block on the same gate. Task: {task_id_label}.\n\n",
+                n = event.pr_number,
+                summary = perimeter_verdict.summary(),
+            ),
+        };
+    }
+
+    // Perimeter cleared — MECHANICAL PR, proceed to task lookup + merge flow.
+    // Task lookup is required past this point: MECHANICAL auto-merge writes task
+    // metadata and updates task state, so a missing task row means we cannot
+    // book-keep the merge — pass through to the LLM.
     let task = match db.find_active_task_by_pr_url(&pr_url).await {
         Ok(Some(t)) => t,
         Ok(None) => {
@@ -299,7 +431,7 @@ async fn handle_pass_verdict(
                 pr_number = event.pr_number,
                 repo = %event.repo,
                 pr_url = %pr_url,
-                "VERDICT: pass but no active task found for PR — passing through to LLM"
+                "VERDICT: pass (MECHANICAL) but no active task found for PR — passing through to LLM"
             );
             return VerdictAction::Passthrough { enrichment: None };
         }
@@ -319,7 +451,7 @@ async fn handle_pass_verdict(
             task_id = %task.id,
             status = %task.status,
             pr_url = %pr_url,
-            "VERDICT: pass but task not in_progress (status: {}) — skipping structural merge",
+            "VERDICT: pass (MECHANICAL) but task not in_progress (status: {}) — skipping structural merge",
             task.status
         );
         return VerdictAction::Passthrough { enrichment: None };
@@ -327,121 +459,6 @@ async fn handle_pass_verdict(
 
     let task_id = task.id.clone();
 
-    // Forge-gate perimeter check (mika#1829).
-    //
-    // Fetch the actual touched-file set from GitHub and classify. If the PR
-    // touches ANY DECISION-CORE zone (permission-policy, verdict-form, gate
-    // logic, dispatch authority, perimeter itself), skip the auto-merge path
-    // and hand over to the operator with hold[review] semantics.
-    //
-    // Non-negotiable (b): the diff is authority. Labels and PR body prose are
-    // never consulted here — only what the PR ACTUALLY touches.
-    // Fail-closed: on gh-CLI fetch error, we assume DECISION-CORE (better
-    // to hold a mechanical PR than to auto-merge a decision-core PR).
-    let perimeter_verdict = match perimeter::fetch::fetch_pr_files(
-        event.pr_number,
-        &event.repo,
-        token,
-    )
-    .await
-    {
-        Ok(files) => perimeter::classify_pr_files(&files),
-        Err(e) => {
-            warn!(
-                error = %e,
-                pr_number = event.pr_number,
-                repo = %event.repo,
-                task_id = %task_id,
-                "Perimeter classifier: failed to fetch PR files — fail-closed to DECISION-CORE (mika#1829)"
-            );
-            // Synthesize a DECISION-CORE result so downstream logic gates.
-            perimeter::PrClassification {
-                verdict: Classification::DecisionCore,
-                mechanical_files: Vec::new(),
-                decision_core_files: vec![format!("<fetch-error: {e}>")],
-            }
-        }
-    };
-
-    if perimeter_verdict.verdict == Classification::DecisionCore {
-        info!(
-            event = "verdict_handler_human_gate_required",
-            pr_number = event.pr_number,
-            repo = %event.repo,
-            task_id = %task_id,
-            summary = %perimeter_verdict.summary(),
-            decision_core_files = ?perimeter_verdict.decision_core_files,
-            "Forge-gate: PR touches DECISION-CORE zone(s) — skipping auto-merge, operator must merge manually (mika#1829)"
-        );
-
-        // Update task metadata with hold-review shape so the operator
-        // dashboard surfaces the block.
-        if let Err(e) = update_hold_metadata(
-            db,
-            &task_id,
-            &task.metadata,
-            &event.review_url,
-            &format!(
-                "[forge-gate mika#1829] Auto-merge blocked: {}. Operator must merge manually.\n\n{}",
-                perimeter_verdict.summary(),
-                truncate_body(&event.body)
-            ),
-        )
-        .await
-        {
-            warn!(error = %e, task_id = %task_id, "Failed to update hold metadata after forge-gate block");
-        }
-
-        // Audit event — distinct tool_name so operators can grep for
-        // gate firings independent of hold[review] noise.
-        if let Err(e) = db
-            .log_audit_event(
-                session_id,
-                "verdict_handler_human_gate_required",
-                &format!("task:{task_id}"),
-                Some("in_progress"),
-                None,
-                Some(&format!(
-                    "verdict=pass gate=forge-gate pr_url={pr_url} decision_core_files={}",
-                    perimeter_verdict.decision_core_files.join(",")
-                )),
-                Some(trace_id),
-            )
-            .await
-        {
-            warn!(error = %e, "Failed to log verdict_handler_human_gate_required audit event");
-        }
-
-        // Notify operator with the concrete file list.
-        if let Some(sender) = message_sender {
-            send_notification(
-                sender,
-                &format!(
-                    "PR #{} on {} — VERDICT: pass from @{}, but touches DECISION-CORE zone(s). \
-                     Auto-merge blocked by forge-gate (mika#1829). {}. \
-                     Operator must merge manually. Task: {}",
-                    event.pr_number,
-                    event.repo,
-                    event.reviewer,
-                    perimeter_verdict.summary(),
-                    task_id
-                ),
-            )
-            .await;
-        }
-
-        return VerdictAction::Handled {
-            pre_digest: format!(
-                "[verdict_handler] Structural: VERDICT: pass on PR #{n} — auto-merge BLOCKED by \
-                 forge-gate (mika#1829). {summary}. Operator must merge manually. Do NOT call \
-                 pr_merge_with_gate for this PR — it will also block on the same gate. Task: {task_id}.\n\n",
-                n = event.pr_number,
-                summary = perimeter_verdict.summary(),
-            ),
-        };
-    }
-
-    // Perimeter cleared — proceed with existing merge flow.
     info!(
         event = "verdict_handler_perimeter_cleared",
         pr_number = event.pr_number,


### PR DESCRIPTION
Closes senara-solutions/mika#1853

## Empirical bypass this PR closes

`crates/mika-agent/src/perimeter/rules.rs` fail-closes any path not on the MECHANICAL allowlist. Yet mika#1851 (touching 4 files — `crates/mika-agent/src/task_engine/{engine,liveness,mod}.rs` + `server/mod.rs`, ALL DECISION-CORE per the classifier) auto-merged 2026-07-27T08:09:14Z by `mika-platform-dev`.

Server log confirms the classifier was never consulted for that merge:

- `verdict_handler` fired at 08:06:28Z: `"VERDICT: pass but no active task found for PR — passing through to LLM"` — the `find_task_for_verdict` bail happens BEFORE the perimeter fetch, so hors-loop PRs (no `tasks` row) bypass the classifier entirely.
- `ci_success_handler` fired at 08:07:42Z + 08:09:26Z: `"CI success handler: evaluating merge eligibility"` → `run_gh_merge` direct. Zero perimeter events in the log. mika#1829 wired the classifier into `verdict_handler` + `pr_merge_with_gate` but overlooked this sibling callsite.

## Fix — 3 coupled changes

### AC1 — `ci_success_handler.rs`

Perimeter fetch + classify inserted between step 5b (behind-main) and step 6 (`run_gh_merge`). Fail-closed on gh-CLI fetch error. If DECISION-CORE: audit event `ci_success_handler_human_gate_required`, notify operator, return `VerdictAction::Handled` with hold pre-digest that explicitly says `"Do NOT call pr_merge_with_gate"` + `"Operator must merge manually"`.

### AC2 — `verdict_handler.rs::handle_pass_verdict`

Perimeter check hoisted BEFORE task lookup. If DECISION-CORE + no active task → still fires audit + notification + hold pre-digest (task metadata write becomes best-effort — only fires when a writable `in_progress` task exists). Audit `target_key` falls back to `pr:<repo>#<n>` when no task exists. MECHANICAL branch preserves the existing task-lookup + bail-if-none semantics.

### AC3 — `ci_failure_handler.rs`

Audited: no `run_gh_merge` callsite. Doc-comment added referencing mika#1853 with grep-anchor discipline for future refactors (`grep -n 'run_gh_merge' server/*.rs` — every hit must consult `perimeter::classify_pr_files`).

## Verification

- **Full lib**: 3468 passed, 0 failed, 0 regression.
- **Focused subset** (`server::ci_success_handler::tests server::verdict_handler::tests perimeter`): 120 pass.
- **4 new unit tests** on `ci_success_handler` for the DECISION-CORE hold pre-digest (no completion-claim trigger words, contains "Do NOT call pr_merge_with_gate", contains "Operator must merge manually" + `mika#1853`, surfaces PR number + reviewer).
- **clippy + fmt clean.**

## Post-deploy verification (AC5)

Grep server.log after deploy:
```bash
# CI-success DECISION-CORE holds — should fire on next matching PR
grep 'ci_success_handler_human_gate_required' /var/log/mika/server.log

# verdict_handler hors-loop DECISION-CORE holds — new coverage path
grep 'verdict_handler_human_gate_required' /var/log/mika/server.log | jq 'select(.target_key | startswith("pr:"))'

# MECHANICAL PRs should log the perimeter-cleared event and auto-merge normally
grep 'verdict_handler_perimeter_cleared\|CI success handler: merge initiated' /var/log/mika/server.log
```

Synthetic test PRs to fire after deploy:
- **MECHANICAL-only** (touches only `docs/logs/` or `crates/mika-agent/tests/`) → expect auto-merge + `perimeter_cleared` log.
- **DECISION-CORE** (touches `crates/mika-agent/src/task_engine/`) → expect NO merge + hold-review notification + audit event.

## Pipeline-Exempt — hors-loop hotfix

This PR is itself DECISION-CORE (it modifies verdict_handler + ci_success_handler = gate-logic per `perimeter/rules.rs`). Sending it through the normal loop would auto-merge it through the very bypass it fixes. Built hors-loop, deployed via samidarko-claude carve-out to close the trou live, then Vincent hand-merge (per RT#004 AC5 STRICT).

## Impact on RT#004 auto-restart pre-condition

Vincent + Prime ratified RT#004 (2026-07-27): watchdog auto-restart armament requires the forge-gate proven loop-resistant (mika#1827). This PR is a necessary step toward that proof. Once deployed + AC5 verification passes on live traffic, mika#1827 can close and auto-restart can be armed behind an env flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HcGVyb827JZd9KV7s784