### PR TITLE
fix(mika-dev): mika-dev auto-un-drafts wip-rescue PRs — layer-2 bypass of mika#1613 operator-review contract

### DIFF
--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -7175,7 +7175,8 @@ mod tests {
     #[test]
     fn test_validate_pr_ready_undraft_blocks_wip_rescue_label() {
         // Shape detection: `gh pr ready 1681` is a ready-promote call.
-        let pr = detect_ready_promote_pr(&str_args(&["pr", "ready", "1681"]));
+        let args = str_args(&["pr", "ready", "1681"]);
+        let pr = detect_ready_promote_pr(&args);
         assert_eq!(pr, Some("1681"));
         // Decision on a wip-rescue-labelled PR rejects.
         let view = wip_rescue_label_view();
@@ -7215,13 +7216,14 @@ mod tests {
     #[test]
     fn test_validate_pr_edit_title_blocks_rename_on_wip_rescue() {
         // The captured attack shape: `gh pr edit 1681 --title "fix(...)"`.
-        let pr = detect_ready_promote_pr(&str_args(&[
+        let args = str_args(&[
             "pr",
             "edit",
             "1681",
             "--title",
             "fix(mika#1663): skill-review variant path",
-        ]));
+        ]);
+        let pr = detect_ready_promote_pr(&args);
         assert_eq!(pr, Some("1681"));
         let view = wip_rescue_label_view();
         let result = decide_pr_ready_undraft("1681", Some(&view));
@@ -7231,7 +7233,8 @@ mod tests {
     #[test]
     fn test_validate_passes_pr_ready_undo() {
         // `gh pr ready 1681 --undo` converts TO draft — not a promote, allowed.
-        let pr = detect_ready_promote_pr(&str_args(&["pr", "ready", "1681", "--undo"]));
+        let args = str_args(&["pr", "ready", "1681", "--undo"]);
+        let pr = detect_ready_promote_pr(&args);
         assert_eq!(pr, None);
     }
 
@@ -7260,17 +7263,19 @@ mod tests {
     #[test]
     fn test_extract_pr_number_skips_numeric_title_value() {
         // A numeric `--title 123` value must not be mistaken for the PR number.
-        let pr = detect_ready_promote_pr(&str_args(&["pr", "edit", "1681", "--title", "123"]));
+        let args = str_args(&["pr", "edit", "1681", "--title", "123"]);
+        let pr = detect_ready_promote_pr(&args);
         assert_eq!(pr, Some("1681"));
     }
 
     #[test]
     fn test_detect_ready_promote_normalizes_pr_url() {
-        let pr = detect_ready_promote_pr(&str_args(&[
+        let args = str_args(&[
             "pr",
             "ready",
             "https://github.com/senara-solutions/mika/pull/1681",
-        ]));
+        ]);
+        let pr = detect_ready_promote_pr(&args);
         assert_eq!(pr, Some("1681"));
     }
 

--- a/crates/mika-agent/src/skills/builtin_handlers.rs
+++ b/crates/mika-agent/src/skills/builtin_handlers.rs
@@ -2077,6 +2077,241 @@ fn extract_api_path(args: &[String]) -> &str {
     ""
 }
 
+/// Parsed subset of `gh pr view --json isDraft,labels,commits` output used to
+/// detect the wip-rescue signature (mika#1682).
+#[derive(Debug, Clone)]
+struct PrWipRescueView {
+    is_draft: bool,
+    labels: Vec<String>,
+    /// Head commit headline = `commits[-1].messageHeadline` (last commit on the PR).
+    head_commit_headline: Option<String>,
+}
+
+/// Structured rejection message for un-drafting / renaming a wip-rescue PR.
+/// References mika#1613's operator-review contract so the LLM (and operator
+/// reading audit logs) understands why the tool call was blocked.
+fn wip_rescue_rejection_message(pr_num: &str) -> String {
+    format!(
+        "Cannot un-draft / rename wip-rescue PR #{pr_num}. This PR was opened by \
+         dispatch-lib's post-flight recovery (mika#1282 or mika#1383). The wip-rescue \
+         draft state is the operator-review gate per mika#1613 — the operator must \
+         un-draft this PR manually after reviewing the rescued work.\n\n\
+         To proceed: leave the PR draft. The operator will review and promote it. \
+         Source: builtin_handlers.rs::validate_pr_ready_undraft_scope (mika#1682)."
+    )
+}
+
+/// Detect a ready-promoting `gh` call and extract its target PR number (mika#1682).
+///
+/// Returns `Some(pr_num)` when the argv is one of the two un-draft / rename shapes:
+/// - `gh pr ready <N>` (without `--undo`) — explicit un-draft. (`--undo` converts
+///   TO draft and is allowed.)
+/// - `gh pr edit <N> --title <T>` — title rename (the captured `wip(...)` → `fix(...)`
+///   promotion shape).
+///
+/// Returns `None` for any other call, or when no PR number can be parsed from a
+/// positional argument (fail-open: e.g. current-branch `gh pr ready`).
+fn detect_ready_promote_pr(args: &[String]) -> Option<&str> {
+    let subcommand = args.first().map(String::as_str)?;
+    if subcommand != "pr" {
+        return None;
+    }
+    let verb = args.get(1).map(String::as_str)?;
+
+    let is_ready_promote = verb == "ready" && !args.iter().any(|a| a == "--undo");
+    let is_edit_title = verb == "edit" && args.iter().any(|a| a == "--title");
+    if !is_ready_promote && !is_edit_title {
+        return None;
+    }
+
+    extract_pr_number_positional(args)
+}
+
+/// Extract the first positional PR number from a `gh pr <verb> ...` argv.
+///
+/// Scans args after the subcommand+verb (index 2+), skipping value-consuming flags
+/// and their values so a numeric `--title 123` is not mistaken for the PR number.
+/// Normalizes GitHub PR URLs to bare numbers via `normalize_pr_identifier`.
+fn extract_pr_number_positional(args: &[String]) -> Option<&str> {
+    /// Flags on `gh pr ready`/`gh pr edit` that consume the next argument as a value.
+    const VALUE_FLAGS: &[&str] = &[
+        "--title",
+        "-t",
+        "--body",
+        "-b",
+        "--body-file",
+        "-F",
+        "--add-label",
+        "--remove-label",
+        "--add-assignee",
+        "--remove-assignee",
+        "--add-reviewer",
+        "--remove-reviewer",
+        "--add-project",
+        "--remove-project",
+        "--milestone",
+        "-m",
+        "--base",
+        "-B",
+        "--repo",
+        "-R",
+    ];
+
+    let mut iter = args.iter().skip(2);
+    while let Some(arg) = iter.next() {
+        if arg.starts_with('-') {
+            if VALUE_FLAGS.contains(&arg.as_str()) {
+                let _ = iter.next(); // consume the flag's value
+            }
+            continue;
+        }
+        let normalized = normalize_pr_identifier(arg);
+        if normalized.parse::<u32>().is_ok() {
+            return Some(normalized);
+        }
+    }
+    None
+}
+
+/// Pure wip-rescue signature check (mika#1682 / mika#1613).
+///
+/// A PR matches when EITHER:
+/// - it carries the `wip-rescue` label (case-insensitive), OR
+/// - it is a draft AND its head commit headline starts with `wip(` (the marker
+///   prefix written by dispatch-lib's post-flight recovery, mika#1282/#1383).
+fn pr_matches_wip_rescue(view: &PrWipRescueView) -> bool {
+    if view
+        .labels
+        .iter()
+        .any(|l| l.eq_ignore_ascii_case("wip-rescue"))
+    {
+        return true;
+    }
+    view.is_draft
+        && view
+            .head_commit_headline
+            .as_deref()
+            .map(|h| h.starts_with("wip("))
+            .unwrap_or(false)
+}
+
+/// Pure decision for a detected ready-promote call (mika#1682).
+///
+/// `view` is `None` when the `gh pr view` fetch failed — fail-open (allow), per the
+/// existing scope-validator pattern, so a transient GitHub error never blocks
+/// legitimate PR flows. Rejects only when the fetched view matches the wip-rescue
+/// signature.
+fn decide_pr_ready_undraft(pr_num: &str, view: Option<&PrWipRescueView>) -> Result<(), ToolOutput> {
+    match view {
+        Some(v) if pr_matches_wip_rescue(v) => {
+            Err(ToolOutput::error(wip_rescue_rejection_message(pr_num)))
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Parse `gh pr view --json isDraft,labels,commits` JSON output into a
+/// `PrWipRescueView`. Returns `None` on any parse failure (fail-open).
+fn parse_pr_wip_rescue_view(json: &str) -> Option<PrWipRescueView> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    let is_draft = value
+        .get("isDraft")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let labels = value
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|l| l.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    // Head commit = last entry in the commits array.
+    let head_commit_headline = value
+        .get("commits")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.last())
+        .and_then(|c| c.get("messageHeadline"))
+        .and_then(|h| h.as_str())
+        .map(String::from);
+    Some(PrWipRescueView {
+        is_draft,
+        labels,
+        head_commit_headline,
+    })
+}
+
+/// Fetch the wip-rescue-relevant view of a PR via `gh pr view`. Fail-open: any
+/// spawn / non-zero-exit / parse error returns `None` so the caller allows the call.
+async fn fetch_pr_wip_rescue_view(
+    pr_num: &str,
+    repo: Option<&str>,
+    ctx: &ToolContext<'_>,
+) -> Option<PrWipRescueView> {
+    let mut cmd = tokio::process::Command::new("gh");
+    cmd.args(["pr", "view", pr_num, "--json", "isDraft,labels,commits"]);
+    if let Some(repo) = repo {
+        cmd.arg("--repo").arg(repo);
+    }
+    cmd.env("GH_PROMPT_DISABLED", "1");
+    super::executor::scrub_mika_env_vars(&mut cmd);
+    if let Some(token) = ctx.github_token {
+        cmd.env("GH_TOKEN", token);
+    }
+
+    let output = spawn_and_collect(cmd, "gh", "Is the GitHub CLI installed?").await;
+    if output.is_error
+        || output.content.starts_with("Exit code:")
+        || output.content.starts_with("Killed by signal:")
+    {
+        // Fail-open: don't block legitimate flows on a transient GitHub error.
+        return None;
+    }
+    parse_pr_wip_rescue_view(&output.content)
+}
+
+/// Validate `gh pr ready` / `gh pr edit --title` against the wip-rescue
+/// operator-review contract (mika#1682, layer-2 companion of mika#1679).
+///
+/// mika#1613 requires that dispatch-lib post-flight rescue draft PRs stay draft
+/// until the operator manually un-drafts them after review. This engine-side
+/// tool-boundary guard — mirroring `validate_dispatch_readiness()` (mika#525) and
+/// the `validate_gh_api_scope` (mika#1167) / `validate_qa_review_gh_scope`
+/// (mika#1196) chain — rejects un-draft / rename calls targeting a wip-rescue PR
+/// before the subprocess spawns. Prompt-only contracts don't bind across model
+/// classes (per `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate`),
+/// so this structural guard is the load-bearing fix.
+///
+/// Fail-open on `gh pr view` errors and on non-promote calls (pass-through).
+async fn validate_pr_ready_undraft_scope(
+    args: &[String],
+    repo: Option<&str>,
+    ctx: &ToolContext<'_>,
+) -> Result<(), ToolOutput> {
+    let Some(pr_num) = detect_ready_promote_pr(args) else {
+        return Ok(());
+    };
+
+    let view = fetch_pr_wip_rescue_view(pr_num, repo, ctx).await;
+    let decision = decide_pr_ready_undraft(pr_num, view.as_ref());
+
+    if decision.is_err() {
+        // Audit event mirroring `gh_api_invocation` shape (mika#1682 AC3).
+        tracing::info!(
+            event = "pr_ready_undraft_blocked",
+            agent_id = %ctx.db.agent_id(),
+            session_id = %ctx.session_id,
+            pr_number = %pr_num,
+            reason = "wip_rescue_contract",
+            repo = %repo.unwrap_or("unknown"),
+            "blocked un-draft / rename of wip-rescue PR per mika#1613 contract"
+        );
+    }
+
+    decision
+}
+
 /// Execute a GitHub CLI (`gh`) command with safe argument passing.
 ///
 /// Input: `{"command": ["pr", "list", "--state", "open"], "repo": "owner/repo"}`
@@ -2092,6 +2327,15 @@ async fn run_gh(input: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolOutput 
     // Skill-scoped scope check (mika#1196): when qa-review is in the active
     // skill set, restrict to the narrow allowlist before any side effects.
     if let Err(err) = validate_qa_review_gh_scope(&gh_args.args, ctx) {
+        return err;
+    }
+
+    // Wip-rescue ready-promote gate (mika#1682): reject `gh pr ready` / `gh pr
+    // edit --title` on PRs matching the wip-rescue signature, restoring mika#1613's
+    // operator-review contract that mika-dev was silently bypassing (layer-2).
+    if let Err(err) =
+        validate_pr_ready_undraft_scope(&gh_args.args, gh_args.repo.as_deref(), ctx).await
+    {
         return err;
     }
 
@@ -6895,5 +7139,163 @@ mod tests {
         let ctx = harness.ctx(); // active_skill_paths: &[]
         let result = validate_qa_review_gh_scope(&str_args(&["pr", "merge", "123"]), &ctx);
         assert!(result.is_ok());
+    }
+
+    // -- validate_pr_ready_undraft_scope tests (mika#1682) --
+    //
+    // The network-fetch boundary (`fetch_pr_wip_rescue_view`) is separated from
+    // the pure detection (`detect_ready_promote_pr`) and decision
+    // (`decide_pr_ready_undraft`) logic, so these tests exercise the full guard
+    // semantics without hitting GitHub.
+
+    fn wip_rescue_label_view() -> PrWipRescueView {
+        PrWipRescueView {
+            is_draft: true,
+            labels: vec!["wip-rescue".to_string()],
+            head_commit_headline: Some("fix(mika#1663): skill-review variant path".to_string()),
+        }
+    }
+
+    fn wip_commit_view() -> PrWipRescueView {
+        PrWipRescueView {
+            is_draft: true,
+            labels: vec![],
+            head_commit_headline: Some("wip(mika#1663): impl staged by recovery".to_string()),
+        }
+    }
+
+    fn normal_pr_view() -> PrWipRescueView {
+        PrWipRescueView {
+            is_draft: false,
+            labels: vec!["bug".to_string()],
+            head_commit_headline: Some("fix(mika#1700): correct edge case".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_validate_pr_ready_undraft_blocks_wip_rescue_label() {
+        // Shape detection: `gh pr ready 1681` is a ready-promote call.
+        let pr = detect_ready_promote_pr(&str_args(&["pr", "ready", "1681"]));
+        assert_eq!(pr, Some("1681"));
+        // Decision on a wip-rescue-labelled PR rejects.
+        let view = wip_rescue_label_view();
+        let result = decide_pr_ready_undraft("1681", Some(&view));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.content.contains("wip-rescue PR #1681"));
+        assert!(err.content.contains("mika#1613"));
+        assert!(err.content.contains("mika#1682"));
+    }
+
+    #[test]
+    fn test_validate_pr_ready_undraft_blocks_wip_commit() {
+        // Draft PR whose head commit starts with `wip(` matches even without a label.
+        let view = wip_commit_view();
+        assert!(pr_matches_wip_rescue(&view));
+        let result = decide_pr_ready_undraft("1681", Some(&view));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_pr_ready_undraft_allows_normal_pr() {
+        // Non-draft, no wip-rescue label, conventional commit → allowed.
+        let view = normal_pr_view();
+        assert!(!pr_matches_wip_rescue(&view));
+        let result = decide_pr_ready_undraft("1700", Some(&view));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_pr_ready_undraft_fail_open_on_api_error() {
+        // `gh pr view` failed → view is None → fail-open (allow).
+        let result = decide_pr_ready_undraft("1681", None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_pr_edit_title_blocks_rename_on_wip_rescue() {
+        // The captured attack shape: `gh pr edit 1681 --title "fix(...)"`.
+        let pr = detect_ready_promote_pr(&str_args(&[
+            "pr",
+            "edit",
+            "1681",
+            "--title",
+            "fix(mika#1663): skill-review variant path",
+        ]));
+        assert_eq!(pr, Some("1681"));
+        let view = wip_rescue_label_view();
+        let result = decide_pr_ready_undraft("1681", Some(&view));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_passes_pr_ready_undo() {
+        // `gh pr ready 1681 --undo` converts TO draft — not a promote, allowed.
+        let pr = detect_ready_promote_pr(&str_args(&["pr", "ready", "1681", "--undo"]));
+        assert_eq!(pr, None);
+    }
+
+    #[test]
+    fn test_detect_ready_promote_ignores_non_pr_and_other_verbs() {
+        // Non-`pr` subcommands and non-promote verbs are pass-through.
+        assert_eq!(
+            detect_ready_promote_pr(&str_args(&["issue", "view", "1"])),
+            None
+        );
+        assert_eq!(
+            detect_ready_promote_pr(&str_args(&["pr", "view", "1681"])),
+            None
+        );
+        assert_eq!(
+            detect_ready_promote_pr(&str_args(&["pr", "diff", "1681"])),
+            None
+        );
+        // `pr edit` WITHOUT `--title` (e.g. label change) is not a rename-promote.
+        assert_eq!(
+            detect_ready_promote_pr(&str_args(&["pr", "edit", "1681", "--add-label", "x"])),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_pr_number_skips_numeric_title_value() {
+        // A numeric `--title 123` value must not be mistaken for the PR number.
+        let pr = detect_ready_promote_pr(&str_args(&["pr", "edit", "1681", "--title", "123"]));
+        assert_eq!(pr, Some("1681"));
+    }
+
+    #[test]
+    fn test_detect_ready_promote_normalizes_pr_url() {
+        let pr = detect_ready_promote_pr(&str_args(&[
+            "pr",
+            "ready",
+            "https://github.com/senara-solutions/mika/pull/1681",
+        ]));
+        assert_eq!(pr, Some("1681"));
+    }
+
+    #[test]
+    fn test_parse_pr_wip_rescue_view_reads_last_commit() {
+        let json = r#"{
+            "isDraft": true,
+            "labels": [{"name": "wip-rescue"}, {"name": "bug"}],
+            "commits": [
+                {"messageHeadline": "first commit"},
+                {"messageHeadline": "wip(mika#1663): impl staged by recovery"}
+            ]
+        }"#;
+        let view = parse_pr_wip_rescue_view(json).expect("parses");
+        assert!(view.is_draft);
+        assert_eq!(view.labels, vec!["wip-rescue", "bug"]);
+        assert_eq!(
+            view.head_commit_headline.as_deref(),
+            Some("wip(mika#1663): impl staged by recovery")
+        );
+        assert!(pr_matches_wip_rescue(&view));
+    }
+
+    #[test]
+    fn test_parse_pr_wip_rescue_view_malformed_returns_none() {
+        assert!(parse_pr_wip_rescue_view("Exit code: 1\nnot found").is_none());
     }
 }

--- a/docs/plans/2026-06-30-017-fix-1682-mika-1613-layer2-bypass-plan.md
+++ b/docs/plans/2026-06-30-017-fix-1682-mika-1613-layer2-bypass-plan.md
@@ -1,0 +1,187 @@
+---
+issue: 1682
+type: fix
+date: 2026-06-30
+---
+
+# Plan — fix(mika-dev): mika-dev auto-un-drafts wip-rescue PRs (mika#1613 layer-2 bypass) (mika#1682)
+
+## Problem
+
+mika#1613's qa-webhook guard chain (Guard 1 metadata flag, Guard 2 `isDraft AND ^wip\(`) enforces an operator-review contract on dispatch-lib rescue draft PRs: they stay draft until the operator un-drafts. This contract is being silently bypassed in production by a separate autonomous-loop step where mika-dev (the LLM) auto-promotes the rescue PR — renames the title from `wip(...)` to `fix(...)` AND un-drafts — likely as part of its webhook-event handling.
+
+**Live evidence captured 2026-06-30 ~15:07Z on mika#PR1681:**
+
+- `15:03:43Z` PR opened by dispatch-lib (mika#1383 path, non-draft per mika#1679's documented bypass)
+- `15:06:32Z` operator-CC `convert_to_draft` + added `wip-rescue` label (restore mika#1613 contract)
+- `15:07:55Z` `mika-platform-dev` (mika-dev agent) **renamed** title `wip(mika#1663): impl staged...` → `fix(mika#1663): skill-review variant path uses provider naming`
+- `15:07:56Z` `mika-platform-dev` **ready_for_review** (un-drafted)
+
+The two operations are 1 second apart = single mika-dev LLM turn calling `gh pr edit --title` + `gh pr ready` in succession. Grep of `skills/bundled/` for `gh pr ready` / `--undo` returns zero hardcoded calls — confirming this is LLM-driven, not a hardcoded skill step. Per `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate`, prompt-only contracts don't bind across model classes — confirming why mika#1613's prompt-level guards aren't holding.
+
+## Architectural lineage
+
+- mika#1613 (CLOSED, PR#1677) — original wip-rescue operator-review contract; this issue documents its layer-2 bypass.
+- mika#1679 (GROOMED + ready) — sibling fix at dispatch-lib level (closes layer-1 bypass: mika#1383 path opens non-draft).
+- mika#525 — tool-boundary guard pattern (`validate_dispatch_readiness`) — the architectural precedent this fix mirrors.
+- mika#1196 — `validate_qa_review_gh_scope` — skill-scoped `run_gh` validator (the engine-side validation pattern).
+- mika#1167 — `validate_gh_api_scope` — `gh api` per-method gating matrix (same engine-side gating shape).
+- `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate` — why this fix MUST be structural, not prompt-only.
+
+## Fix shape (engine-side tool-boundary guard)
+
+Add a new validator `validate_pr_ready_undraft_scope` in `crates/mika-agent/src/skills/builtin_handlers.rs` (alongside the existing `validate_qa_review_gh_scope` + `validate_gh_api_scope`), called from `run_gh` before subprocess spawn.
+
+**Detection:**
+1. Identify ready-promoting `run_gh` calls:
+   - `gh pr ready <N>` (without `--undo`) — explicit un-draft.
+   - `gh pr edit <N> --title <T>` paired with rename FROM `wip(...)` (heuristic: hard to detect post-rename, but we can check the PR's CURRENT title is `wip(...)` and reject the rename).
+2. For each detected call, extract the PR number from args (positional or via `--head` flag).
+3. Call `gh pr view <N> --json isDraft,labels,commits` (synchronous, 30s timeout, reuses `ctx.github_token`).
+4. Check if the PR matches the wip-rescue signature:
+   - `isDraft: true` AND `commits[-1].messageHeadline` matches `^wip\(` (commit-prefix check), OR
+   - Has `wip-rescue` label.
+5. If wip-rescue: reject with structured error referencing mika#1613's operator-review contract.
+6. If not wip-rescue (or PR fetch failed — fail-open per existing pattern): allow.
+
+**Rejection error shape (matches `validate_qa_review_gh_scope` style):**
+
+```
+Cannot un-draft / rename wip-rescue PR #<N>. This PR was opened by dispatch-lib's
+post-flight recovery (mika#1282 or mika#1383). The wip-rescue draft state is the
+operator-review gate per mika#1613 — the operator must un-draft this PR manually
+after reviewing the rescued work.
+
+To proceed: leave the PR draft. The operator will review and promote it.
+```
+
+**Composition with mika#1679:** mika#1679 closes the layer-1 bypass (dispatch-lib opening non-draft). This fix (mika#1682) closes the layer-2 bypass (mika-dev re-undrafting). Both fixes together restore mika#1613's contract.
+
+**Composition with mika#1196 / mika#1167:** runs in the same chain as the existing scope validators. Order: global allowlist → qa-review skill-scope → gh-api method matrix → **wip-rescue ready-promote scope (new)**. The new validator only fires on `pr ready` / specific `pr edit` shapes; pass-through for all other calls.
+
+## Implementation outline
+
+1. **New constant + validator function** in `crates/mika-agent/src/skills/builtin_handlers.rs` near line 1904 (alongside `validate_qa_review_gh_scope`):
+
+   ```rust
+   /// Validate `gh pr ready` / `gh pr edit --title` against wip-rescue contract (mika#1682).
+   /// Rejects un-draft attempts on PRs whose head commit is `wip(...)` or whose labels
+   /// include `wip-rescue` — mika#1613's operator-review contract requires manual un-draft.
+   fn validate_pr_ready_undraft_scope(args: &[String], ctx: &ToolContext<'_>) -> Result<(), ToolOutput> {
+       // Detect ready-promoting shapes
+       let is_ready_promote = matches!(
+           (args.first().map(String::as_str), args.get(1).map(String::as_str)),
+           (Some("pr"), Some("ready"))
+       ) && !args.contains(&"--undo".to_string());
+
+       let is_pr_edit_title = matches!(
+           (args.first().map(String::as_str), args.get(1).map(String::as_str)),
+           (Some("pr"), Some("edit"))
+       ) && args.iter().any(|a| a == "--title");
+
+       if !is_ready_promote && !is_pr_edit_title { return Ok(()); }
+
+       // Extract PR number (positional arg after subcommand+verb)
+       let pr_num = args.iter().skip(2).find(|a| a.parse::<u32>().is_ok());
+       let Some(pr_num) = pr_num else { return Ok(()); };  // fail-open if no PR num parseable
+
+       // Synchronous gh pr view to fetch isDraft, labels, head commit headline
+       // (reuses ctx.github_token; 30s timeout; fail-open on API error)
+       let wip_rescue = check_wip_rescue_status(pr_num, ctx);
+       match wip_rescue {
+           Ok(true) => Err(ToolOutput::error(/* structured error per §Fix shape */)),
+           Ok(false) | Err(_) => Ok(()),  // not wip-rescue OR fail-open on fetch error
+       }
+   }
+   ```
+
+   `check_wip_rescue_status` helper: synchronous `gh pr view` shell-out, parse JSON, return `Ok(true)` if (isDraft=true AND head-commit matches `^wip\(`) OR labels contain `wip-rescue`.
+
+2. **Wire into `run_gh`** (line 2025 area). Add the call alongside existing validators:
+
+   ```rust
+   if let Err(err) = validate_qa_review_gh_scope(&gh_args.args, ctx) { return err; }
+   if let Err(err) = validate_pr_ready_undraft_scope(&gh_args.args, ctx) { return err; }  // NEW
+   // ... existing gh_api_invocation logic unchanged
+   ```
+
+3. **Audit event emission** — on rejection, emit `pr_ready_undraft_blocked` audit event mirroring `gh_api_invocation` shape:
+
+   ```rust
+   info!(
+       target: "audit",
+       event = "pr_ready_undraft_blocked",
+       agent_id = %ctx.agent_id(),
+       pr_number = pr_num,
+       reason = "wip_rescue_contract",
+       repo = %extract_repo_from_args(&args).unwrap_or("unknown"),
+   );
+   ```
+
+4. **Unit tests** in the existing test mod near line 6647:
+   - `test_validate_pr_ready_undraft_blocks_wip_rescue_label` — PR has wip-rescue label → reject.
+   - `test_validate_pr_ready_undraft_blocks_wip_commit` — head commit `^wip\(` → reject.
+   - `test_validate_pr_ready_undraft_allows_normal_pr` — non-draft, no label, normal commit → pass.
+   - `test_validate_pr_ready_undraft_fail_open_on_api_error` — gh pr view fails → pass (don't break legitimate flows).
+   - `test_validate_pr_edit_title_blocks_rename_on_wip_rescue` — `pr edit <N> --title <T>` on wip-rescue PR → reject.
+   - `test_validate_passes_pr_ready_undo` — explicit `--undo` (convert TO draft) → pass.
+
+5. **Defense-in-depth — skill prompt instruction (Layer B)**: add explicit instruction to `self-dev-webhook-qa/system_prompt.md`:
+
+   ```
+   ## Wip-rescue contract (mika#1613 / mika#1682)
+   Do NOT call `gh pr ready` or `gh pr edit --title` on any PR matching the
+   wip-rescue signature: `wip-rescue` label OR head commit starts with `wip(`.
+   The operator must un-draft these PRs manually after reviewing the rescued
+   work. Engine-side guard mika#1682 will reject the tool call if attempted —
+   this instruction is a prompt-level reinforcement to avoid hitting the guard.
+   ```
+
+   Prompt-only won't bind across model classes (per `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate`), but adds context for the model to make the right decision when the engine guard fires.
+
+## Acceptance criteria
+
+- **AC1** — Hard evidence captured in issue body (DONE — mika#PR1681 timeline).
+
+- **AC2** — Engine-side validator `validate_pr_ready_undraft_scope` implemented in `crates/mika-agent/src/skills/builtin_handlers.rs`, wired into `run_gh` after the existing `validate_qa_review_gh_scope` chain. Rejects `gh pr ready <N>` (without `--undo`) AND `gh pr edit <N> --title <T>` when target PR matches wip-rescue signature (isDraft=true + head commit `^wip\(` OR `wip-rescue` label). Structured error references mika#1613 contract. Fail-open on `gh pr view` API errors.
+
+- **AC3** — `pr_ready_undraft_blocked` audit event emitted on rejection with `agent_id`, `pr_number`, `reason`, `repo` fields.
+
+- **AC4** — Unit tests (6 cases per §Implementation outline §4) cover happy path + label match + commit match + fail-open + edit-title path + explicit-undo pass-through.
+
+- **AC5 (architect F1 expanded)** — Skill prompt instruction (defense-in-depth Layer B per §Implementation §5) added to **all webhook-handler skill prompts**, not just qa: `self-dev-webhook-qa/system_prompt.md`, `self-dev-webhook-ci/system_prompt.md`, `self-dev-webhook-ready-label/system_prompt.md`, and `self-dev-callback/system_prompt.md`. The offending un-draft turn could fire from any webhook-event handler; covering one skill leaves the others exposed.
+
+- **AC6** — Post-deploy smoke: the next 3 dispatch-lib-rescue PRs (mika#PR1681 itself + any new ones from queue) should NOT be auto-un-drafted by mika-dev. Verified via `gh api repos/.../issues/<N>/timeline` filtered for `ready_for_review` events from `mika-platform-dev` actor — count should be 0 across the smoke window.
+
+## Out of scope
+
+- **Auto-promote of non-wip-rescue PRs.** mika-dev legitimately un-drafts its own non-rescue PRs after CI green. The guard discriminates on the wip-rescue signature; only those are blocked.
+- **mika#1679 dispatch-lib fix.** That's layer-1; this is layer-2. Composes cleanly — both needed for full contract restoration.
+- **Reverting glm-5.2 swap.** Calibration-discipline-gated; orthogonal axis.
+- **Broader autonomous-loop PR-state management policy reform.** This ticket scopes to closing the specific wip-rescue contract bypass.
+
+## Files involved
+
+- `crates/mika-agent/src/skills/builtin_handlers.rs` — validator function + wire-in + tests
+- `skills/bundled/self-dev-webhook-qa/system_prompt.md` — Layer B defense-in-depth (architect F1)
+- `skills/bundled/self-dev-webhook-ci/system_prompt.md` — Layer B defense-in-depth (architect F1)
+- `skills/bundled/self-dev-webhook-ready-label/system_prompt.md` — Layer B defense-in-depth (architect F1)
+- `skills/bundled/self-dev-callback/system_prompt.md` — Layer B defense-in-depth (architect F1)
+- No schema migration; no skill manifest changes
+
+## Verification
+
+- **Static:** `cargo clippy -p mika-agent` clean. `cargo test -p mika-agent builtin_handlers::tests::validate_pr_ready_undraft*` covers all 6 unit-test cases.
+- **Integration:** existing `qa-review`/`run_gh` integration tests stay green (no regression on legitimate `gh pr` calls).
+- **Live (AC6):** post-deploy, the next 3 wip-rescue PRs hold draft state. Confirmed by timeline query.
+
+## References
+
+- mika#1613 (CLOSED) — original wip-rescue operator-review contract
+- mika#1679 (GROOMED + ready) — sibling fix at dispatch-lib level (layer 1)
+- mika#1196 — `validate_qa_review_gh_scope` pattern
+- mika#1167 — `validate_gh_api_scope` matrix pattern
+- mika#525 — tool-boundary guard pattern precedent
+- `feedback_prompt_enforcement_empirically_confirmed_at_loop_substrate.md` — why this fix is structural
+- mika#PR1681 — live evidence of layer-2 bypass (timeline above)
+- Operator screenshot / push notification 2026-06-30 ~15:09Z

--- a/skills/bundled/self-dev-callback/system_prompt.md
+++ b/skills/bundled/self-dev-callback/system_prompt.md
@@ -155,3 +155,9 @@ If the callback text contains the line `RECOVERY_PENDING: true` (emitted by disp
 **Step 5 — (removed: QA is webhook-driven)**
 
 QA review triggers automatically on PR open/update/review_requested. Verdicts arrive via `pull_request_review.submitted` webhook, handled by the `self-dev-webhook-qa` skill. After claude-pilot creates a PR, proceed directly to Step 6 with `in_progress`.
+
+---
+
+## Wip-rescue contract (mika#1613 / mika#1682)
+
+Do NOT call `gh pr ready` or `gh pr edit --title` on any PR matching the wip-rescue signature: `wip-rescue` label OR head commit starts with `wip(`. The operator must un-draft these PRs manually after reviewing the rescued work. Engine-side guard mika#1682 will reject the tool call if attempted — this instruction is a prompt-level reinforcement to avoid hitting the guard.

--- a/skills/bundled/self-dev-webhook-ci/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-ci/system_prompt.md
@@ -43,3 +43,9 @@ Never call `run_gh("pr merge ...")` or `run_gh("gh pr merge ...")` to merge a PR
 `run_gh` takes TWO SEPARATE INPUTS: `"command"` (array of gh subcommand arguments) and `"repo"` (string, `owner/repo` target). `--repo` is a **sibling parameter to `command`**, NOT a flag inside the array. Any shorthand example like `run_gh("pr list --repo senara-solutions/mika ...")` is **not literal** — split it: put every token EXCEPT `--repo VALUE` into `command`, pull `VALUE` into `repo`. Including `--repo` inside `command` causes the wrapper to reject the call. If that happens, **move `--repo` out of the array** — do NOT drop it (you will silently query the wrong repo). Permitted: `pr, issue, run, workflow, release, repo, search, label, api`. Use `gh api` for milestone/project mutations and arbitrary REST/GraphQL operations (e.g., `gh api --method PATCH /repos/owner/repo/milestones/N -f state=closed`).
 
 **Incident:** session `4cbc6de7-...` on 2026-04-17 — milestone #12 dispatch failed because `--repo` was passed inside `command`, wrapper rejected it, agent dropped `--repo` on retry and falsely concluded milestone didn't exist.
+
+---
+
+## Wip-rescue contract (mika#1613 / mika#1682)
+
+Do NOT call `gh pr ready` or `gh pr edit --title` on any PR matching the wip-rescue signature: `wip-rescue` label OR head commit starts with `wip(`. The operator must un-draft these PRs manually after reviewing the rescued work. Engine-side guard mika#1682 will reject the tool call if attempted — this instruction is a prompt-level reinforcement to avoid hitting the guard.

--- a/skills/bundled/self-dev-webhook-qa/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-qa/system_prompt.md
@@ -268,3 +268,9 @@ For milestone and project workflows (see self-dev skill), child tasks are linked
 3. If still no match, check if any task has this PR's issue as its `parent_task_id` (milestone/project child lookup)
 
 Child tasks use the same PR review webhook path — their QA verdict handling is identical to standalone issues.
+
+---
+
+## Wip-rescue contract (mika#1613 / mika#1682)
+
+Do NOT call `gh pr ready` or `gh pr edit --title` on any PR matching the wip-rescue signature: `wip-rescue` label OR head commit starts with `wip(`. The operator must un-draft these PRs manually after reviewing the rescued work. Engine-side guard mika#1682 will reject the tool call if attempted — this instruction is a prompt-level reinforcement to avoid hitting the guard.

--- a/skills/bundled/self-dev-webhook-ready-label/system_prompt.md
+++ b/skills/bundled/self-dev-webhook-ready-label/system_prompt.md
@@ -59,3 +59,9 @@ When the message starts with `[GitHub] Issue labeled ready on <repo>#<n>`, the o
 
 **Other label-add events** (`bug`, `enhancement`, `p1-important`, etc.) — any `[GitHub] Issue labeled <name> on ...` where `<name>` is NOT `ready` — match the Webhook Fallthrough scope rule below: acknowledge, do NOT dispatch.
 
+
+---
+
+## Wip-rescue contract (mika#1613 / mika#1682)
+
+Do NOT call `gh pr ready` or `gh pr edit --title` on any PR matching the wip-rescue signature: `wip-rescue` label OR head commit starts with `wip(`. The operator must un-draft these PRs manually after reviewing the rescued work. Engine-side guard mika#1682 will reject the tool call if attempted — this instruction is a prompt-level reinforcement to avoid hitting the guard.


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: dirty-worktree)

<!-- rescue-pipeline-verified: no -->

This PR was created by dispatch-lib's git-workflow recovery. The pilot session wrote file changes but never committed. dispatch-lib auto-committed with `wip()` prefix.

**Auto-rescued PR.** Operator: verify pipeline completion, then either un-draft this PR or set the marker above to `yes`.

### Recovery metadata
- Recovery class: `dirty-worktree`
- Pilot session: `2c77b258-62e9-4da8-8afd-762c0dd90edd`
- Turns: 27
- Cost: $2.9551395

Closes #1682