### PR TITLE
feat(perimeter): extend MECHANICAL allowlist for cpp — precondition for cpp#79 (mika#1860) [DECISION-CORE hand-merge]

### DIFF
--- a/crates/mika-agent/src/perimeter/rules.rs
+++ b/crates/mika-agent/src/perimeter/rules.rs
@@ -24,6 +24,8 @@
 //! For clarity and audit-trail — none of these paths appears in the rules
 //! below, so they fail-closed to DECISION-CORE via [`super::classify_path`]:
 //!
+//! ### mika (senara-solutions/mika)
+//!
 //! - `crates/mika-agent/src/perimeter/**` — the perimeter itself
 //! - `crates/mika-agent/src/server/verdict.rs` — verdict parser
 //! - `crates/mika-agent/src/server/verdict_handler.rs` — verdict-form / dispatch-authority
@@ -35,6 +37,20 @@
 //! - `.github/labels.yml` — label taxonomy (governance)
 //! - `docs/gate/perimeter.md` — the perimeter doc (self-reference at doc layer)
 //! - `docs/architecture/**`, `docs/adr/**`, `docs/design/**` — authority docs
+//!
+//! ### claude-pilot (senara-solutions/claude-pilot) — mika#1860, precondition for cpp#79
+//!
+//! - `src/claude_pilot/tier1.py` — tier-1 auto-approval classifier
+//! - `src/claude_pilot/policy.py` — tier-2 policy YAML evaluator (decision authority)
+//! - `src/claude_pilot/permissions.py` — can_use_tool orchestration + chain-safe
+//! - `src/claude_pilot/per_spawn.py` — per-spawn permission-policy evaluator (mika#1708)
+//! - `src/claude_pilot/policies/permissions.yaml` — policy rules themselves
+//! - `src/claude_pilot/policies/**` (any `.yaml` under this prefix) — any future policy file
+//! - `src/claude_pilot/policies/__init__.py` — policy loader (touches loader = touches policy)
+//!
+//! Non-security cpp python files (agent.py, cli.py, guardrails.py, inbox_writer.py,
+//! ipython/, logger.py, transport.py, types.py, ui.py) are enumerated as MECHANICAL
+//! below; anything not listed defaults to DECISION-CORE via fail-closed.
 //!
 //! ## Growth
 //!
@@ -77,6 +93,30 @@ const MECHANICAL_PREFIXES: &[&str] = &[
     // These control how versions are stamped and released, not what the
     // engine does at runtime.
     ".github/release-please/",
+    // --- claude-pilot (senara-solutions/claude-pilot) non-security python ---
+    //
+    // Precondition for cpp#79 (autonomous onboarding). Each path below is
+    // provably non-security-critical: no allowlist, no policy decision, no
+    // permission surface. DECISION-CORE cpp files (tier1.py, policy.py,
+    // permissions.py, per_spawn.py, policies/*.yaml, policies/__init__.py)
+    // are NOT in this list — they fail-closed to DECISION-CORE via the
+    // classify_path fall-through, correct semantics.
+    //
+    // The MECHANICAL classification only activates ONCE cpp webhooks flow
+    // through mika-agent (post-cpp#79). Until then this list is precondition
+    // work only. mika#1860.
+    "src/claude_pilot/agent.py", // ClaudeSDKClient wrapper — delegates to permissions.py
+    "src/claude_pilot/cli.py",   // argparse + signal handling — no policy
+    "src/claude_pilot/guardrails.py", // stall/empty/idle detection — no permission surface
+    "src/claude_pilot/inbox_writer.py", // gateway POST side-channel — no permission decision
+    "src/claude_pilot/ipython/", // optional REPL magics — opt-in `[ipython]` extra
+    "src/claude_pilot/logger.py", // stderr + file sink — no auth surface
+    "src/claude_pilot/transport.py", // asyncio subprocess wrapper — no allowlist
+    "src/claude_pilot/types.py", // Pydantic models — no runtime decision
+    "src/claude_pilot/ui.py",    // ANSI color renderer — no logic
+    // cpp tests at repo root (mika tests live under `crates/*/tests/` and are
+    // already covered by the MECHANICAL_CONTAINS `/tests/` rule below).
+    "tests/",
 ];
 
 /// Exact file paths that grant MECHANICAL.
@@ -89,6 +129,11 @@ const MECHANICAL_EXACT: &[&str] = &[
     // The workspace-level README — cosmetic for humans, not consumed by
     // the engine.
     "README.md",
+    // --- claude-pilot (senara-solutions/claude-pilot) root artifacts ---
+    // Precondition for cpp#79. Python packaging + license — no security surface.
+    "pyproject.toml", // cpp deps (Dependabot-managed; visible in diff)
+    "uv.lock",        // cpp dep lock (regenerated from pyproject.toml)
+    "LICENSE",        // license file (both repos have one; universally safe)
 ];
 
 /// Path substrings that grant MECHANICAL when found anywhere in the path.

--- a/crates/mika-agent/src/perimeter/tests.rs
+++ b/crates/mika-agent/src/perimeter/tests.rs
@@ -320,3 +320,153 @@ fn summary_reports_mechanical_count() {
     assert!(summary.contains("MECHANICAL"));
     assert!(summary.contains('2'));
 }
+
+// ---------------------------------------------------------------------------
+// claude-pilot (mika#1860) — precondition for cpp#79 autonomous onboarding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cpp_non_security_python_is_mechanical() {
+    // Files enumerated in MECHANICAL_PREFIXES as cpp non-security python.
+    // Each has documented rationale (see rules.rs comment).
+    for path in [
+        "src/claude_pilot/agent.py",
+        "src/claude_pilot/cli.py",
+        "src/claude_pilot/guardrails.py",
+        "src/claude_pilot/inbox_writer.py",
+        "src/claude_pilot/logger.py",
+        "src/claude_pilot/transport.py",
+        "src/claude_pilot/types.py",
+        "src/claude_pilot/ui.py",
+    ] {
+        assert_eq!(
+            classify_path(path),
+            Classification::Mechanical,
+            "cpp non-security python must be MECHANICAL: {path} (mika#1860)"
+        );
+    }
+}
+
+#[test]
+fn cpp_ipython_subdir_is_mechanical() {
+    // `src/claude_pilot/ipython/` prefix covers all optional IPython magics.
+    for path in [
+        "src/claude_pilot/ipython/__init__.py",
+        "src/claude_pilot/ipython/magics.py",
+    ] {
+        assert_eq!(classify_path(path), Classification::Mechanical, "{path}");
+    }
+}
+
+#[test]
+fn cpp_tests_dir_is_mechanical() {
+    // cpp tests live at repo root under `tests/` (mika tests live under
+    // `crates/*/tests/` and are covered by MECHANICAL_CONTAINS).
+    for path in [
+        "tests/test_tier1.py",
+        "tests/test_policy_devpilot.py",
+        "tests/test_permissions.py",
+        "tests/replay/replay_relay_decisions.py",
+    ] {
+        assert_eq!(classify_path(path), Classification::Mechanical, "{path}");
+    }
+}
+
+#[test]
+fn cpp_root_artifacts_are_mechanical() {
+    // Python packaging + license — no security surface.
+    for path in ["pyproject.toml", "uv.lock", "LICENSE"] {
+        assert_eq!(classify_path(path), Classification::Mechanical, "{path}");
+    }
+}
+
+#[test]
+fn cpp_docs_solutions_and_plans_are_mechanical() {
+    // cpp shares `docs/solutions/` and `docs/plans/` with mika; already
+    // covered by the shared MECHANICAL_PREFIXES. Assert cpp paths get the
+    // right classification through the shared rules.
+    for path in [
+        "docs/solutions/security-issues/foo.md",
+        "docs/plans/2026-07-28-001-cpp-plan.md",
+    ] {
+        assert_eq!(classify_path(path), Classification::Mechanical, "{path}");
+    }
+}
+
+#[test]
+fn cpp_classifier_tiers_are_decision_core() {
+    // The 5 cpp files enumerated as DECISION-CORE in the rules.rs doc header.
+    // These MUST fail-closed to DecisionCore — a false MECHANICAL here would
+    // let the autonomous loop auto-merge a permission-policy widening,
+    // re-opening the mika#1853 invariant hole on cpp (mika#1860 rationale).
+    for path in [
+        "src/claude_pilot/tier1.py",
+        "src/claude_pilot/policy.py",
+        "src/claude_pilot/permissions.py",
+        "src/claude_pilot/per_spawn.py",
+        "src/claude_pilot/policies/permissions.yaml",
+    ] {
+        assert_eq!(
+            classify_path(path),
+            Classification::DecisionCore,
+            "cpp classifier tier must be DECISION-CORE: {path} (mika#1860)"
+        );
+    }
+}
+
+#[test]
+fn cpp_future_policy_files_are_decision_core() {
+    // Any new .yaml in src/claude_pilot/policies/ must fail-closed to
+    // DECISION-CORE — the fail-closed default catches unenumerated policy
+    // files (no `src/claude_pilot/policies/` prefix in the MECHANICAL
+    // allowlist, so it correctly falls through).
+    for path in [
+        "src/claude_pilot/policies/new_policy.yaml",
+        "src/claude_pilot/policies/overrides.yaml",
+        "src/claude_pilot/policies/__init__.py",
+    ] {
+        assert_eq!(
+            classify_path(path),
+            Classification::DecisionCore,
+            "unenumerated cpp policy file must fail-closed to DECISION-CORE: {path}"
+        );
+    }
+}
+
+#[test]
+fn cpp_mixed_pr_taints_to_decision_core() {
+    // Cross-repo integration invariant: a cpp PR touching ONE DECISION-CORE
+    // file (tier1.py) alongside MECHANICAL files (logger.py, tests/) must
+    // classify the whole PR as DECISION-CORE. Mirrors the mika mixed-PR
+    // taint invariant for cpp-side onboarding readiness (cpp#79 blocked
+    // by mika#1860).
+    let files = vec![
+        "src/claude_pilot/logger.py".to_string(),
+        "tests/test_tier1.py".to_string(),
+        "src/claude_pilot/tier1.py".to_string(), // DECISION-CORE taint
+    ];
+    let result = classify_pr_files(&files);
+    assert_eq!(result.verdict, Classification::DecisionCore);
+    assert_eq!(
+        result.decision_core_files,
+        vec!["src/claude_pilot/tier1.py"]
+    );
+    assert_eq!(result.mechanical_files.len(), 2);
+}
+
+#[test]
+fn cpp_all_mechanical_pr_classifies_mechanical() {
+    // Positive case: cpp PR touching only MECHANICAL cpp files auto-merges.
+    // This is the throughput case cpp#79 enables — dep bumps, doc fixes,
+    // test additions, non-security refactors flow through auto-merge.
+    let files = vec![
+        "src/claude_pilot/logger.py".to_string(),
+        "src/claude_pilot/ui.py".to_string(),
+        "tests/test_permissions.py".to_string(),
+        "pyproject.toml".to_string(),
+    ];
+    let result = classify_pr_files(&files);
+    assert_eq!(result.verdict, Classification::Mechanical);
+    assert!(result.decision_core_files.is_empty());
+    assert_eq!(result.mechanical_files.len(), 4);
+}


### PR DESCRIPTION
Closes senara-solutions/mika#1860. Blocks-precondition-for senara-solutions/claude-pilot#79.

## Fix
- 10 cpp-unique MECHANICAL_PREFIXES + 3 MECHANICAL_EXACT entries
- Grep-anchored DECISION-CORE comment: tier1.py, policy.py, permissions.py, per_spawn.py, policies/**
- Zero mika-side regression

## Tests
Perimeter suite 36/36 pass (was 27; +9 new). Full lib 3507/3507. verify-bundled-skills clean.

## Activation
No behavior change today — cpp webhooks don't reach mika-agent until cpp#79 lands. Precondition work: classifier READY so cpp#79 activation happens with proven loop-resistance BEFORE App installs (point-of-no-return).

## Post-deploy AC5 (before cpp#79 App installs)
Verify via audit_events (NOT log grep per mika#1853 lesson):
1. Deploy this PR
2. Synthetic MECHANICAL cpp PR → audit_events.tool_name IN ('ci_success_merge', 'verdict_handled')
3. Synthetic DECISION-CORE cpp PR → audit_events.tool_name IN ('ci_success_handler_human_gate_required', 'verdict_handler_human_gate_required')
4. Both pass → Vincent may install cpp GH Apps

## DECISION-CORE — Vincent hand-merge
Touches perimeter/rules.rs — DECISION-CORE by construction. Same discipline as mika#1855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)