### PR TITLE
feat(observability,corpus): persist claude-pilot subprocess transcripts to mika.db — instrument-first for owned-model bet (wizzard#16 finding half 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,15 @@ MIKA_ANTHROPIC_API_KEY=sk-ant-...
 # MIKA_STORE_TOOL_CALLS=true      # Store full tool call I/O in SQLite (default: true)
 # MIKA_LOG_LLM_BODIES=false       # Log full LLM request/response bodies (default: false, dev-only)
 
+# Optional: claude-pilot subprocess transcript capture (mika#1705)
+# Captures the implementation-reasoning corpus (LLM calls inside claude-pilot
+# dispatches) that the in-process llm_calls table never sees. When enabled, the
+# executor injects ANTHROPIC_LOG_FILE for dev-pilot/dev-groom subprocesses;
+# claude-pilot-py appends JSONL per LLM call; the engine tick ingests finished
+# files into the pilot_transcripts table and deletes the JSONL.
+# MIKA_LOG_PILOT_TRANSCRIPTS=true          # Capture pilot transcripts (default: true, gateable)
+# MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS=90  # Delete transcript rows older than N days (default: 90)
+
 # Optional: OpenTelemetry trace export (requires --features telemetry at build time)
 # NOTE: The endpoint must include the full path with /v1/traces — it is NOT auto-appended.
 # MIKA_TELEMETRY_ENABLED=true

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -2425,6 +2425,29 @@ impl AsyncDatabase {
             .await
     }
 
+    /// Insert a batch of pilot-transcript rows for one task atomically
+    /// (mika#1705). Bodies must already be secret-scrubbed by the caller.
+    pub async fn insert_pilot_transcripts_batch(
+        &self,
+        task_id: String,
+        rows: Vec<crate::db::PilotTranscriptRow>,
+    ) -> Result<usize> {
+        self.with_db(move |db| db.insert_pilot_transcripts_batch(&task_id, &rows))
+            .await
+    }
+
+    /// Prune pilot transcripts older than `retention_secs` (mika#1705 AC6).
+    pub async fn prune_old_pilot_transcripts(&self, retention_secs: i64) -> Result<usize> {
+        self.with_db(move |db| db.prune_old_pilot_transcripts(retention_secs))
+            .await
+    }
+
+    /// Count pilot transcripts for a task (mika#1705 idempotency guard).
+    pub async fn count_pilot_transcripts_for_task(&self, task_id: String) -> Result<i64> {
+        self.with_db(move |db| db.count_pilot_transcripts_for_task(&task_id))
+            .await
+    }
+
     pub async fn query_llm_calls_by_trace(
         &self,
         trace_id: &str,

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -27,7 +27,7 @@ pub fn init_sqlite_vec() {
     });
 }
 
-pub const CURRENT_SCHEMA_VERSION: i64 = 44;
+pub const CURRENT_SCHEMA_VERSION: i64 = 45;
 
 /// mika#1742 Problem B: refuse-to-zombie grace window for
 /// [`Database::create_recurring_task_if_absent`]. Recent same-label recurring
@@ -134,6 +134,21 @@ pub struct TeamRow {
     pub name: String,
     pub config_path: String,
     pub created_at: String,
+}
+
+/// One parsed pilot-transcript row awaiting insert (mika#1705). Bodies are
+/// secret-scrubbed by the ingestion tick before construction. All fields are
+/// optional because a claude-pilot JSONL entry may omit any of them.
+#[derive(Debug, Clone, Default)]
+pub struct PilotTranscriptRow {
+    pub timestamp: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub request_body: Option<String>,
+    pub response_body: Option<String>,
+    pub tokens_in: Option<i64>,
+    pub tokens_out: Option<i64>,
+    pub latency_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -1045,6 +1060,11 @@ impl Database {
         if (3..=43).contains(&version) {
             self.migrate_v43_to_v44()?;
             info!(version = 44, "database migrated to v44");
+        }
+
+        if (3..=44).contains(&version) {
+            self.migrate_v44_to_v45()?;
+            info!(version = 45, "database migrated to v45");
         }
 
         Ok(())
@@ -4438,6 +4458,117 @@ impl Database {
             ],
         )?;
         Ok(())
+    }
+
+    /// v44→v45: additive `pilot_transcripts` table (mika#1705).
+    ///
+    /// Captures the LLM-call transcripts emitted by claude-pilot subprocesses
+    /// (the implementation-reasoning corpus, ~90% of the trajectory that the
+    /// in-process `llm_calls` table never sees). Rows are ingested by the
+    /// engine tick from `~/.mika/data/pilot-transcripts/<task-id>.jsonl` files
+    /// written by claude-pilot-py and linked back to the dispatching callback
+    /// `task_id`. Additive-only — no rebuild of existing tables. Two indexes
+    /// support the two query shapes: per-task correlation and time-window
+    /// retention scans.
+    fn migrate_v44_to_v45(&mut self) -> Result<()> {
+        let version = self.schema_version()?;
+        if version >= 45 {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS pilot_transcripts (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                timestamp TEXT,
+                provider TEXT,
+                model TEXT,
+                request_body TEXT,
+                response_body TEXT,
+                tokens_in INTEGER,
+                tokens_out INTEGER,
+                latency_ms INTEGER,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_pilot_transcripts_task_id
+                ON pilot_transcripts(task_id);
+            CREATE INDEX IF NOT EXISTS idx_pilot_transcripts_created_at
+                ON pilot_transcripts(created_at DESC);",
+        )?;
+
+        tx.execute("INSERT INTO schema_version (version) VALUES (45)", [])?;
+        tx.commit()?;
+
+        info!("v44→v45: added pilot_transcripts table (mika#1705)");
+
+        Ok(())
+    }
+
+    /// Insert a batch of pilot-transcript rows for one task in a single
+    /// transaction (mika#1705). Atomic per source JSONL file: either every row
+    /// commits or none does, so a crash mid-import never leaves a half-imported
+    /// file that the ingestion tick would then delete (idempotency contract).
+    /// `request_body`/`response_body` are already secret-scrubbed by the caller.
+    /// A fresh UUID is minted per row — JSONL entries carry no stable id.
+    pub fn insert_pilot_transcripts_batch(
+        &mut self,
+        task_id: &str,
+        rows: &[PilotTranscriptRow],
+    ) -> Result<usize> {
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO pilot_transcripts (
+                    id, task_id, timestamp, provider, model,
+                    request_body, response_body, tokens_in, tokens_out, latency_ms
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            )?;
+            for r in rows {
+                let id = uuid::Uuid::new_v4().to_string();
+                stmt.execute(params![
+                    id,
+                    task_id,
+                    r.timestamp,
+                    r.provider,
+                    r.model,
+                    r.request_body,
+                    r.response_body,
+                    r.tokens_in,
+                    r.tokens_out,
+                    r.latency_ms,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(rows.len())
+    }
+
+    /// Prune pilot transcripts older than `retention_secs` (mika#1705 AC6).
+    /// Retention keys off `created_at` (import time, guaranteed ISO 8601) so
+    /// the scan is a simple lexicographic comparison, matching the
+    /// `prune_old_llm_calls` shape.
+    pub fn prune_old_pilot_transcripts(&self, retention_secs: i64) -> Result<usize> {
+        let cutoff = timestamp::now_minus(Duration::seconds(retention_secs));
+        let n = self.conn.execute(
+            "DELETE FROM pilot_transcripts WHERE created_at < ?1",
+            params![cutoff],
+        )?;
+        Ok(n)
+    }
+
+    /// Count pilot transcripts for a given task (mika#1705). Used by the
+    /// ingestion tick's idempotency guard and by tests.
+    pub fn count_pilot_transcripts_for_task(&self, task_id: &str) -> Result<i64> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM pilot_transcripts WHERE task_id = ?1",
+            params![task_id],
+            |r| r.get(0),
+        )?;
+        Ok(n)
     }
 
     /// Check if a column exists on a table within a transaction scope.
@@ -16797,6 +16928,7 @@ mod tests {
         db2.migrate_v41_to_v42().unwrap();
         db2.migrate_v42_to_v43().unwrap();
         db2.migrate_v43_to_v44().unwrap();
+        db2.migrate_v44_to_v45().unwrap();
 
         let final_version: i64 = db2
             .conn

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -1121,7 +1121,7 @@ impl Database {
                 version INTEGER NOT NULL,
                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
             );
-            INSERT INTO schema_version (version) VALUES (44);
+            INSERT INTO schema_version (version) VALUES (45);
 
             -- Schema meta table for migration state tracking (v27+).
             CREATE TABLE schema_meta (
@@ -1770,6 +1770,28 @@ impl Database {
                 ON permission_decisions(request_id);
             CREATE INDEX idx_permission_decisions_created_at
                 ON permission_decisions(created_at DESC);
+
+            -- v45: pilot_transcripts (mika#1705). Must be in v1 DDL so fresh installs
+            -- get the table without depending on the v44→v45 migration chain (which is
+            -- skipped on fresh install because migrate() captures version BEFORE
+            -- migrate_v1 runs and the (3..=44).contains(&0) guard fails).
+            CREATE TABLE pilot_transcripts (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                timestamp TEXT,
+                provider TEXT,
+                model TEXT,
+                request_body TEXT,
+                response_body TEXT,
+                tokens_in INTEGER,
+                tokens_out INTEGER,
+                latency_ms INTEGER,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            );
+            CREATE INDEX idx_pilot_transcripts_task_id
+                ON pilot_transcripts(task_id);
+            CREATE INDEX idx_pilot_transcripts_created_at
+                ON pilot_transcripts(created_at DESC);
 
             -- Pre-register the default 'mika' agent
             INSERT INTO agents (id, name, home_dir) VALUES ('mika', 'Mika', '');

--- a/crates/mika-agent/src/skills/executor.rs
+++ b/crates/mika-agent/src/skills/executor.rs
@@ -65,6 +65,67 @@ pub(crate) fn scrub_mika_env_vars_std(cmd: &mut std::process::Command) {
     }
 }
 
+/// Environment variable claude-pilot-py honors to append a per-LLM-call JSONL
+/// transcript (mika#1705). Deliberately non-`MIKA_*` so it survives the
+/// child-env scrub in [`scrub_mika_env_vars`] and flows through dispatch-lib.sh
+/// into the claude-pilot subprocess.
+const PILOT_TRANSCRIPT_ENV: &str = "ANTHROPIC_LOG_FILE";
+
+/// Read the `MIKA_LOG_PILOT_TRANSCRIPTS` gate from mika-spirit's own environment
+/// (mika#1705 committed position 4 — default ON once shipped, gateable). Reads
+/// the parent process env directly, before the child-command scrub. `0`,
+/// `false`, `no`, `off` (case-insensitive) disable; any other value or absence
+/// enables.
+pub(crate) fn pilot_transcripts_enabled() -> bool {
+    match std::env::var("MIKA_LOG_PILOT_TRANSCRIPTS") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => true,
+    }
+}
+
+/// Inject `ANTHROPIC_LOG_FILE` for claude-pilot dispatch skills so the
+/// subprocess appends its LLM-call corpus to
+/// `{home}/data/pilot-transcripts/<task-id>.jsonl` (mika#1705). The engine
+/// ingestion tick imports finished files into the `pilot_transcripts` table.
+///
+/// MUST be called AFTER [`scrub_mika_env_vars`] so the injected var is not
+/// stripped. Best-effort: feature-off, non-pilot skill, home resolution failure,
+/// or dir-create failure are all silent no-ops — transcript capture must never
+/// block or fail a dispatch.
+fn inject_pilot_transcript_env(
+    cmd: &mut tokio::process::Command,
+    skill_dir: &std::path::Path,
+    task_id: &str,
+) {
+    if !pilot_transcripts_enabled() {
+        return;
+    }
+    // Only the two claude-pilot dispatch skills produce subprocess LLM
+    // trajectories worth capturing (both source `_shared/dispatch-lib.sh`).
+    let is_pilot_skill = skill_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n == "dev-pilot" || n == "dev-groom");
+    if !is_pilot_skill {
+        return;
+    }
+    let Ok(home) = mika_common::home::resolve_home_dir() else {
+        warn!(task_id = %task_id, "mika#1705: could not resolve home dir; skipping transcript capture");
+        return;
+    };
+    let dir = home.join("data").join("pilot-transcripts");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        warn!(task_id = %task_id, error = %e, "mika#1705: failed to create pilot-transcripts dir; skipping capture");
+        return;
+    }
+    let path = dir.join(format!("{task_id}.jsonl"));
+    cmd.env(PILOT_TRANSCRIPT_ENV, &path);
+    debug!(task_id = %task_id, path = %path.display(), "mika#1705: pilot transcript capture enabled");
+}
+
 /// Maximum raw image file size (5 MB).
 const MAX_IMAGE_SIZE: u64 = 5 * 1024 * 1024;
 
@@ -2186,6 +2247,9 @@ pub(crate) fn spawn_long_running_exec(
         if let Some(ref token) = github_token {
             cmd.env("GH_TOKEN", token);
         }
+        // mika#1705: enable claude-pilot subprocess LLM-transcript capture.
+        // Injected AFTER the MIKA_* scrub so the non-MIKA var survives.
+        inject_pilot_transcript_env(&mut cmd, &skill_dir, &task_id);
         let mut child = match cmd.spawn() {
             Ok(child) => child,
             Err(e) => {

--- a/crates/mika-agent/src/task_engine/engine.rs
+++ b/crates/mika-agent/src/task_engine/engine.rs
@@ -43,6 +43,17 @@ const CHILDLESS_PARENT_REAPER_GRACE_DEFAULT_SECS: i64 = 1800;
 /// Env var overriding [`CHILDLESS_PARENT_REAPER_GRACE_DEFAULT_SECS`].
 const CHILDLESS_PARENT_REAPER_GRACE_ENV: &str = "MIKA_CHILDLESS_PARENT_REAPER_GRACE_SECS";
 
+/// Ticks between pilot-transcript retention sweeps (mika#1705 AC6). At the 1s
+/// tick cadence, 86_400 ticks ≈ 24h — a daily prune, matching the plan's
+/// "daily tick deletes rows older than N days". Startup also runs one sweep.
+const PILOT_TRANSCRIPT_RETENTION_INTERVAL_TICKS: u64 = 86_400;
+
+/// Env var overriding the pilot-transcript retention window (mika#1705 AC6).
+const PILOT_TRANSCRIPT_RETENTION_ENV: &str = "MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS";
+
+/// Default pilot-transcript retention window in days (mika#1705 AC6).
+const PILOT_TRANSCRIPT_RETENTION_DEFAULT_DAYS: i64 = 90;
+
 /// The two currently-defined dispatch classes (per `derive_dispatch_class` at
 /// `skills/executor.rs`). Iteration order is `implement` first because pre-v34
 /// NULL-class wrappers fall into this bucket via `COALESCE` — promote those
@@ -51,6 +62,36 @@ const CHILDLESS_PARENT_REAPER_GRACE_ENV: &str = "MIKA_CHILDLESS_PARENT_REAPER_GR
 /// test in this crate pins this slice against `derive_dispatch_class` to catch
 /// drift when a new class is added to the executor (mika#1175).
 const DISPATCH_CLASSES: &[&str] = &["implement", "groom"];
+
+/// Parse one claude-pilot transcript JSONL object into a [`crate::db::PilotTranscriptRow`]
+/// (mika#1705). Missing fields become `None`; body fields are secret-scrubbed.
+/// Body values that are JSON objects/arrays are serialized to their compact
+/// string form before scrubbing (claude-pilot may emit either shape).
+fn parse_pilot_transcript_line(v: &serde_json::Value) -> crate::db::PilotTranscriptRow {
+    let str_field = |key: &str| v.get(key).and_then(|x| x.as_str()).map(str::to_owned);
+    let i64_field = |key: &str| v.get(key).and_then(serde_json::Value::as_i64);
+    let scrubbed_body = |key: &str| -> Option<String> {
+        match v.get(key) {
+            None | Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(s)) => {
+                Some(crate::secret_scrubber::scrub_secrets(s).into_owned())
+            }
+            Some(other) => {
+                Some(crate::secret_scrubber::scrub_secrets(&other.to_string()).into_owned())
+            }
+        }
+    };
+    crate::db::PilotTranscriptRow {
+        timestamp: str_field("timestamp"),
+        provider: str_field("provider"),
+        model: str_field("model"),
+        request_body: scrubbed_body("request_body"),
+        response_body: scrubbed_body("response_body"),
+        tokens_in: i64_field("tokens_in"),
+        tokens_out: i64_field("tokens_out"),
+        latency_ms: i64_field("latency_ms"),
+    }
+}
 
 /// The unified task engine: a min-heap BinaryHeap backed by SQLite, driven by a
 /// 1-second tick loop that fires tasks whose `next_fire_at <= now`.
@@ -184,6 +225,9 @@ impl TaskEngine {
             Err(e) => warn!(error = %e, "failed to prune old tool_calls"),
         }
 
+        // 6. Prune pilot transcripts past the retention window (mika#1705 AC6).
+        self.prune_old_pilot_transcripts().await;
+
         debug!(
             loaded = count,
             queue_len = self.queue.len(),
@@ -302,6 +346,19 @@ impl TaskEngine {
             // the parent-task reaper above, for the `team_runs` lifecycle:
             // frees team slots held by runs whose finalizer never executed.
             crate::teams::engine::reap_orphaned_team_runs(&self.db).await;
+
+            // mika#1705: ingest finished claude-pilot transcript JSONL files
+            // into the pilot_transcripts table (the implementation-reasoning
+            // corpus for the owned-model bet).
+            self.ingest_pilot_transcripts().await;
+        }
+
+        // mika#1705 AC6: daily pilot-transcript retention sweep.
+        if self
+            .tick_count
+            .is_multiple_of(PILOT_TRANSCRIPT_RETENTION_INTERVAL_TICKS)
+        {
+            self.prune_old_pilot_transcripts().await;
         }
 
         let now = crate::timestamp::now();
@@ -702,6 +759,146 @@ impl TaskEngine {
     /// Any new writers of `callback_delivered_without_pr_url` must respect
     /// the groom-class filter. SOLE WRITER: this method is the only site
     /// that writes `callback_delivered_without_pr_url` to `tasks.result`.
+    /// mika#1705: ingest finished claude-pilot transcript JSONL files into the
+    /// `pilot_transcripts` table, then delete each imported file.
+    ///
+    /// Runs on the periodic DB scan. Files live in a single shared directory
+    /// (`{home}/data/pilot-transcripts/<callback-task-id>.jsonl`); because
+    /// [`AsyncDatabase::get_task`] is agent-scoped, each file resolves to
+    /// exactly one engine (the dispatching agent's), so N engines scanning the
+    /// same directory never double-import — non-owners see `None` and skip.
+    ///
+    /// Race safety (mika#1705 Risk 5): a file is only imported once its owning
+    /// callback task has left `in_progress`/`pending` — by then the pilot
+    /// subprocess has exited (dispatch-lib's EXIT trap completes the task only
+    /// after `claude-pilot` returns), so the JSONL is fully written. Import is
+    /// transactional (all rows or none) and the file is deleted only after a
+    /// successful commit; a pre-existing row count short-circuits to delete,
+    /// giving idempotency when a prior commit succeeded but the unlink failed.
+    async fn ingest_pilot_transcripts(&self) {
+        if !crate::skills::executor::pilot_transcripts_enabled() {
+            return;
+        }
+        let dir = self
+            .dispatcher
+            .settings
+            .home_dir
+            .join("data")
+            .join("pilot-transcripts");
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            // Dir absent = nothing dispatched with capture yet. Not an error.
+            Err(_) => return,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(task_id) = path.file_stem().and_then(|s| s.to_str()).map(str::to_owned) else {
+                continue;
+            };
+
+            // Agent-scoped lookup routes each file to exactly one engine.
+            let task = match self.db.get_task(&task_id).await {
+                Ok(Some(t)) => t,
+                Ok(None) => continue, // not this agent's task — leave for owner
+                Err(e) => {
+                    warn!(task_id = %task_id, error = %e, "mika#1705: task lookup failed; skipping transcript file");
+                    continue;
+                }
+            };
+
+            // Only import once the pilot subprocess has exited (task no longer
+            // pending/in_progress) so we never read a partially-written file.
+            if matches!(
+                task.status.as_str(),
+                task_status::PENDING | task_status::IN_PROGRESS
+            ) {
+                continue;
+            }
+
+            // Idempotency: rows already present ⇒ a prior import committed but
+            // the unlink failed. Just delete the file and move on.
+            match self
+                .db
+                .count_pilot_transcripts_for_task(task_id.clone())
+                .await
+            {
+                Ok(n) if n > 0 => {
+                    if let Err(e) = std::fs::remove_file(&path) {
+                        warn!(task_id = %task_id, error = %e, "mika#1705: failed to delete already-imported transcript file");
+                    }
+                    continue;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(task_id = %task_id, error = %e, "mika#1705: transcript count check failed; skipping");
+                    continue;
+                }
+            }
+
+            let contents = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(task_id = %task_id, error = %e, "mika#1705: failed to read transcript file");
+                    continue;
+                }
+            };
+
+            let rows: Vec<crate::db::PilotTranscriptRow> = contents
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+                .map(|v| parse_pilot_transcript_line(&v))
+                .collect();
+
+            if rows.is_empty() {
+                // Empty or all-unparseable file: delete so it doesn't linger.
+                if let Err(e) = std::fs::remove_file(&path) {
+                    warn!(task_id = %task_id, error = %e, "mika#1705: failed to delete empty transcript file");
+                }
+                continue;
+            }
+
+            match self
+                .db
+                .insert_pilot_transcripts_batch(task_id.clone(), rows)
+                .await
+            {
+                Ok(imported) => {
+                    if let Err(e) = std::fs::remove_file(&path) {
+                        warn!(task_id = %task_id, error = %e, "mika#1705: import committed but file delete failed (idempotent next tick)");
+                    }
+                    info!(task_id = %task_id, imported, "mika#1705: ingested pilot transcript");
+                }
+                Err(e) => {
+                    // Leave the file in place — retried on the next scan.
+                    warn!(task_id = %task_id, error = %e, "mika#1705: transcript import failed; will retry");
+                }
+            }
+        }
+    }
+
+    /// mika#1705 AC6: delete `pilot_transcripts` rows older than the retention
+    /// window (`MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS`, default 90). Called at
+    /// startup and once per [`PILOT_TRANSCRIPT_RETENTION_INTERVAL_TICKS`].
+    async fn prune_old_pilot_transcripts(&self) {
+        let days = std::env::var(PILOT_TRANSCRIPT_RETENTION_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse::<i64>().ok())
+            .filter(|d| *d > 0)
+            .unwrap_or(PILOT_TRANSCRIPT_RETENTION_DEFAULT_DAYS);
+        let retention_secs = days * 24 * 60 * 60;
+        match self.db.prune_old_pilot_transcripts(retention_secs).await {
+            Ok(n) if n > 0 => info!(count = n, days, "mika#1705: pruned old pilot transcripts"),
+            Ok(_) => {}
+            Err(e) => warn!(error = %e, "mika#1705: failed to prune old pilot transcripts"),
+        }
+    }
+
     async fn reap_orphaned_parent_tasks(&self) {
         let candidates = match self
             .db

--- a/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
+++ b/crates/mika-agent/tests/eval/kg_fixtures/mod.rs
@@ -23,7 +23,7 @@ use mika_agent::db::{CURRENT_SCHEMA_VERSION, Database};
 /// Current schema version this fixture module is pinned to.
 /// Bump this when updating fixtures for a new schema version.
 /// Type is i64 to match db.rs::CURRENT_SCHEMA_VERSION source of truth.
-const PINNED_SCHEMA_VERSION: i64 = 44;
+const PINNED_SCHEMA_VERSION: i64 = 45;
 
 const _: () = assert!(
     CURRENT_SCHEMA_VERSION == PINNED_SCHEMA_VERSION,

--- a/docs/plans/2026-07-01-006-feat-1705-pilot-transcript-capture-plan.md
+++ b/docs/plans/2026-07-01-006-feat-1705-pilot-transcript-capture-plan.md
@@ -1,0 +1,116 @@
+---
+type: feat
+issue: 1705
+title: Persist claude-pilot subprocess transcripts to mika.db — instrument-first Part 2 for owned-model bet
+status: draft
+---
+
+# Plan — mika#1705 pilot-transcript capture (instrument-first Part 2)
+
+## Ticket
+
+mika#1705 — capture claude-pilot subprocess LLM call transcripts so they're queryable. **Critical path for Vincent's owned-model bet 2026-07-01** ("my money is on it"). Part 1 (MIKA_LOG_LLM_BODIES=true) enabled 2026-07-01 ~08:50Z — captures in-process ~10% of trajectory. Part 2 (this ticket) captures the other 90% (implementation reasoning inside claude-pilot subprocess).
+
+## Problem
+
+`run_claude_pilot` spawns claude-pilot-py subprocess. Inside that subprocess, claude-pilot-py calls Claude Code CLI which makes LLM calls to Anthropic/OpenRouter. **None of those subprocess LLM calls are persisted anywhere queryable.** They land in claude-pilot's stdout log at best, discarded at worst.
+
+Per wizzard-CC 2026-07-01 finding: the corpus we HAVE (in `llm_calls` table, orchestration verbs like `update_task_status`, `send_message`) is not what a 7B tool-use model needs. The implementation reasoning — grep-then-edit patterns, debug-then-fix cycles, plan-then-implement traces — lives in claude-pilot's subprocess. Missing.
+
+Vincent's ships-yesterday motto: this is the load-bearing missing piece. Ship v1 today if possible.
+
+## Scope
+
+**In scope (v1 ships fast — motto-aligned):**
+
+Option 3 from ticket body — **filesystem-only capture with mika-side ingestion tick**. Ships fastest:
+
+1. **claude-pilot-py side** — add `ANTHROPIC_LOG_FILE` (or similar) env var support. When set, claude-pilot-py appends JSONL entries per LLM call. dispatch-lib.sh sets this env var to `~/.mika/data/pilot-transcripts/<task-id>.jsonl` at spawn time.
+2. **mika-spirit side** — new tick (piggyback on existing 60s watchdog tick) scans `~/.mika/data/pilot-transcripts/*.jsonl`, imports finished files into a new `pilot_transcripts` table linked to `tasks.id`, deletes the JSONL file after successful import.
+3. **New table** — `pilot_transcripts(id, task_id, timestamp, provider, model, request_body TEXT, response_body TEXT, tokens_in INTEGER, tokens_out INTEGER, latency_ms INTEGER)`. Schema v40. Async DB write.
+4. **Env-var gated** — `MIKA_LOG_PILOT_TRANSCRIPTS=true` (default: on once shipped, but gateable).
+5. **Retention** — 3 months default via nightly cron/tick. `MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS=90`.
+
+**Out of scope (v1):**
+- HTTP push from claude-pilot to mika-spirit (Option 2 from ticket body — proper, but multi-repo scope creep).
+- Structured labeling/filtering of trajectories (feeds owned-model training; separate ticket).
+- Cross-agent aggregation (multi-user containers).
+
+## Committed positions
+
+1. **Filesystem + tick shape** (Option 3) — fastest to ship, matches motto. If wizzard-side training ever needs realtime streaming (Option 2), that's a v2 follow-up.
+2. **JSONL not JSON** — append-only, no lock contention if multiple pilot subprocesses run in parallel. Line-per-call.
+3. **Delete after import** — no double-storage. Tick is idempotent (import + delete atomic per file).
+4. **DB schema v40** — new bump. Migration is additive (new table only, no ALTER on existing).
+5. **claude-pilot-py side change is minimal** — 30-line env-var-driven append handler in the SDK wrapper. No refactor.
+
+## Acceptance criteria
+
+- **AC1** — `MIKA_LOG_PILOT_TRANSCRIPTS=true` env var recognized by mika-spirit. When set, dispatch-lib.sh exports `ANTHROPIC_LOG_FILE=~/.mika/data/pilot-transcripts/<task-id>.jsonl` for each claude-pilot subprocess spawn.
+- **AC2** — claude-pilot-py (fork or PR upstream) writes JSONL entry per LLM call when `ANTHROPIC_LOG_FILE` is set. Entry: `{timestamp, provider, model, request_body, response_body, tokens_in, tokens_out, latency_ms}`.
+- **AC3** — New `pilot_transcripts` table (schema v40) with the columns above + `task_id` FK. Additive migration.
+- **AC4** — Ingestion tick: 60s cadence, scans `~/.mika/data/pilot-transcripts/*.jsonl`, imports rows + deletes file. Idempotent (same file processed twice = no duplicates).
+- **AC5** — Query: `SELECT COUNT(*) FROM pilot_transcripts WHERE task_id IN (SELECT id FROM tasks WHERE created_at > date('now', '-1 day'))` returns non-zero within 24h of ship.
+- **AC6** — Retention: `MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS=90` (default 90). Daily tick deletes rows older than N days.
+- **AC7** — `docs/observability/pilot-transcript-growth.md` — weekly growth measurement doc. Reports row count + disk usage. Feeds wizzard's accumulation-rate estimate.
+- **AC8** — `cargo test -p mika-agent` clean. Regression: existing dispatches work unchanged when `MIKA_LOG_PILOT_TRANSCRIPTS=false`.
+
+## Implementation steps (dispatch order)
+
+**Phase 1 — schema + ingestion tick (mika side, ~2h):**
+- Add v40 migration for `pilot_transcripts` table in `crates/mika-agent/src/db.rs`.
+- Add ingestion loop in engine tick (alongside callback watchdog, per mika#959 pattern).
+- Env-var wiring for `MIKA_LOG_PILOT_TRANSCRIPTS` + `MIKA_PILOT_TRANSCRIPT_RETENTION_DAYS`.
+
+**Phase 2 — dispatch-lib env-var passthrough (~30min):**
+- In `skills/bundled/_shared/dispatch-lib.sh` claude-pilot invocation: if `MIKA_LOG_PILOT_TRANSCRIPTS=true`, set `ANTHROPIC_LOG_FILE=~/.mika/data/pilot-transcripts/${TASK_ID}.jsonl` in the child env.
+- Ensure `~/.mika/data/pilot-transcripts/` directory exists (dispatch-lib creates on demand).
+
+**Phase 3 — claude-pilot-py side (~1-2h):**
+- In `claude-pilot-py/src/claude_pilot/`, add per-LLM-call hook that appends JSONL to `ANTHROPIC_LOG_FILE` if env var set.
+- Handle atomic append (`open('a')` + fsync per line).
+- Unit test with a mock LLM provider.
+
+**Phase 4 — retention tick + docs (~30min):**
+- Daily retention tick.
+- Growth doc + weekly measurement script.
+
+**Phase 5 — deploy + verify:**
+- `make deploy` from meta-repo. Verify one dispatch produces a JSONL file that gets imported.
+- Query the new table. Confirm non-zero after next real dispatch.
+
+## Verification
+
+- Manual test: set `MIKA_LOG_PILOT_TRANSCRIPTS=true`, dispatch a fast task. After 60s, `sqlite3 ~/.mika/data/mika.db "SELECT COUNT(*) FROM pilot_transcripts WHERE task_id = '<id>'"` returns non-zero.
+- File cleanup: JSONL file exists during subprocess, deleted after import.
+- Regression: set `MIKA_LOG_PILOT_TRANSCRIPTS=false`, dispatch a task; no JSONL file created; existing behavior unchanged.
+- `cargo test -p mika-agent` clean.
+- No perceptible latency increase on dispatched tasks (append is async).
+
+## Risks
+
+1. **claude-pilot-py fork vs upstream PR.** If we fork, we own maintenance. If we upstream PR, waits on Anthropic's review cadence. Recommendation: **fork first for v1, upstream PR after we validate the shape.** Ships-yesterday motto.
+2. **Disk growth.** JSONL files during dispatch + persistent DB rows. Cap: retention default 90 days. Weekly measurement doc catches runaway growth.
+3. **Schema bump v40.** Additive; no data loss risk. But every mika instance needs migration to run cleanly. Standard pattern.
+4. **claude-pilot subprocess doesn't honor ANTHROPIC_LOG_FILE.** Some env-var patterns need explicit SDK support. If Anthropic SDK doesn't have this hook, we need a wrapper layer. Verify Phase 3 step 1.
+5. **Race on JSONL import.** If pilot is still writing when ingestion tick fires, tick reads partial. Mitigation: only import files whose corresponding task is in terminal state (completed/failed/blocked), not in_progress.
+6. **Secret leakage in request bodies.** LLM request bodies may contain code with secrets. Reuse existing `secret_scrubber::scrub_secrets()` before insert.
+
+## Out of scope (repeated)
+
+- HTTP push from claude-pilot to mika-spirit — v2.
+- Trajectory labeling/filtering pipeline — separate wizzard-side ticket.
+- Cross-agent aggregation.
+
+## References
+
+- mika#1705 — this ticket
+- wizzard#16 finding — `wizzard/docs/brainstorms/2026-07-01-trajectory-corpus-feasibility.md` (commit 1d7f880)
+- [[project-mika-owned-model-dev-qa-quality-first]] — the decision framework
+- MIKA_LOG_LLM_BODIES=true enabled 2026-07-01 ~08:50Z (Part 1 corpus, in-process)
+- Vincent direction 2026-07-01: "my money is on it (glm fine tuning)"
+- `crates/mika-agent/src/tools/claude_pilot.rs` — subprocess spawn point
+- `skills/bundled/_shared/dispatch-lib.sh` — env-var pass-through point
+- `crates/mika-agent/src/db.rs` — schema location (currently v39; this bumps to v40)
+- `crates/mika-common/src/secret_scrubber.rs` — for AC scrub step
+- mika#959 callback watchdog tick — precedent for the 60s ingestion tick pattern

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -676,6 +676,14 @@ _run_claude_pilot() {
     if [ "${CLAUDE_PILOT_TRACE:-}" = "1" ] || [ "${CLAUDE_PILOT_TRACE:-}" = "true" ]; then
         TRACE_FLAG="--trace"
     fi
+    # mika#1705: pilot-transcript capture. When MIKA_LOG_PILOT_TRANSCRIPTS is on,
+    # the mika-spirit executor injects ANTHROPIC_LOG_FILE into this handler's env
+    # (AFTER its MIKA_* scrub, since this handler cannot read MIKA_* itself), and
+    # points it at ~/.mika/data/pilot-transcripts/<task-id>.jsonl. claude-pilot
+    # inherits our env, so ANTHROPIC_LOG_FILE flows through to the subprocess,
+    # where claude-pilot-py appends one JSONL line per LLM call. The mika engine
+    # tick then ingests finished files into the pilot_transcripts table. Nothing
+    # to do here except NOT clobber the inherited env before the run below.
     set +e
     # CWD_ARGS is intentionally word-split (multiple flags)
     # shellcheck disable=SC2086


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: dirty-worktree)

<!-- rescue-pipeline-verified: no -->

This PR was created by dispatch-lib's git-workflow recovery. The pilot session wrote file changes but never committed. dispatch-lib auto-committed with `wip()` prefix.

**Auto-rescued PR.** Operator: verify pipeline completion, then either un-draft this PR or set the marker above to `yes`.

### Recovery metadata
- Recovery class: `dirty-worktree`
- Pilot session: `c0754236-6a97-4da7-ba2a-ec2633f333f0`
- Turns: 83
- Cost: $9.286201499999997

Closes #1705