### PR TITLE
test(db): fix canonical session tests to use registered agent (mika#1401)

### DIFF
--- a/crates/mika-agent/CLAUDE.md
+++ b/crates/mika-agent/CLAUDE.md
@@ -91,6 +91,30 @@ inject = true
 max_tokens = 0
 ```
 
+## Session Configuration
+
+`[session]` section in `identity.toml` makes an agent **single-session-by-nature** (mika#1401). `SessionIdentityConfig` in `prompt.rs` deserializes it.
+
+### `[session].singleton` (bool, default: `false`)
+
+When `true`, every conversational invocation (`mika ask`, `mika chat`, HTTP `/send`) reuses one canonical session instead of minting a fresh `Uuid::new_v4()` per ask. The single-session invariant is enforced by the engine, not by remembering to pass `--session-id`. Opt-in — absent or `false` preserves the default (random UUID per ask). An explicit `--session-id` always overrides the canonical session.
+
+### `[session].canonical_id` (string, optional, default: derived)
+
+The literal session ID to use. When absent and `singleton = true`, the engine derives `canonical-{agent_id}` — a prefix-typed sibling of `system-{agent_id}`, structurally exempt from `prune_old_sessions` (the `canonical-` prefix is not in its LIKE clause). `canonical_id` exists for mika-prime's operator-chosen zero-UUID (`00000000-0000-0000-0000-000000000000`), which is likewise pruning-exempt (no matching prefix).
+
+```toml
+[session]
+singleton = true
+canonical_id = "00000000-0000-0000-0000-000000000000"  # optional
+```
+
+**Mechanism:** `resolve_canonical_session_id(&Identity, agent_id) -> Option<String>` returns `None` for non-singleton agents (callers mint per-ask UUIDs), else the resolved ID. The `/send` handler caches it on `AgentState.canonical_session_id` at `init_agent` time; CLI paths resolve it per-invocation. Session creation goes through the idempotent `get_or_create_canonical_session` (`INSERT OR IGNORE`, mirroring `get_or_create_system_session`). Session teardown goes through `end_session_unless_canonical(id, canonical_id)`, which no-ops when `id == canonical_id` so the canonical session's `ended_at` stays NULL forever. In the TUI, `/clear` for a singleton agent clears only the display (gated by `App.is_singleton_session`) — the session ID and worker context are preserved.
+
+**Compaction interaction:** compaction already keys on `agent_id`, not `session_id`, so a singleton agent is unaffected — the single canonical session simply accumulates all history. The silent/callback/heartbeat paths use their own derived namespaces (`callback-*`, `heartbeat-*`) and are untouched.
+
+**Concurrency:** the singleton merges all channels into one thread. For a single-surface, zero-skill oracle (mika-prime's profile) this is the designed intent, not a defect. High-concurrency multi-surface agents should not opt in.
+
 ## Tools
 
 Each tool validates inputs. Control fields capped at `MAX_INPUT_LEN = 10_000` chars; payload fields capped at `MAX_PAYLOAD_BYTES = 200 * 1024` bytes (200 KB).

--- a/crates/mika-agent/src/async_db.rs
+++ b/crates/mika-agent/src/async_db.rs
@@ -956,9 +956,37 @@ impl AsyncDatabase {
         self.with_db(move |db| db.end_session(&i)).await
     }
 
+    /// End a session unless it is the agent's canonical singleton session (mika#1401).
+    /// No-ops when `id == canonical_id`; otherwise behaves like [`end_session`].
+    pub async fn end_session_unless_canonical(
+        &self,
+        id: &str,
+        canonical_id: Option<&str>,
+    ) -> Result<()> {
+        let (i, c) = (id.to_owned(), canonical_id.map(|s| s.to_owned()));
+        self.with_db(move |db| db.end_session_unless_canonical(&i, c.as_deref()))
+            .await
+    }
+
     pub async fn get_or_create_system_session(&self) -> Result<String> {
         let a = self.agent_id.clone();
         self.with_db(move |db| db.get_or_create_system_session(&a))
+            .await
+    }
+
+    /// Idempotently create the canonical singleton session (mika#1401).
+    /// `INSERT OR IGNORE` — safe to call on every invocation.
+    pub async fn get_or_create_canonical_session(
+        &self,
+        session_id: &str,
+        channel_type: &str,
+    ) -> Result<String> {
+        let (s, a, ct) = (
+            session_id.to_owned(),
+            self.agent_id.clone(),
+            channel_type.to_owned(),
+        );
+        self.with_db(move |db| db.get_or_create_canonical_session(&s, &a, &ct))
             .await
     }
 

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -15372,6 +15372,128 @@ mod tests {
     }
 
     #[test]
+    fn test_get_or_create_canonical_session_is_idempotent() {
+        // mika#1401: repeated calls reuse the same row (INSERT OR IGNORE), so every
+        // `mika ask` to a singleton agent lands on one canonical session.
+        let db = db();
+        let id = "canonical-mika-prime";
+        let r1 = db
+            .get_or_create_canonical_session(id, "mika-prime", "cli")
+            .unwrap();
+        assert_eq!(r1, id);
+        // Write a message to the canonical session.
+        db.save_message("mika-prime", id, "user", "first ask", None)
+            .unwrap();
+        // Second invocation must not fail on duplicate PK and must not clobber.
+        let r2 = db
+            .get_or_create_canonical_session(id, "mika-prime", "cli")
+            .unwrap();
+        assert_eq!(r2, id);
+        db.save_message("mika-prime", id, "user", "second ask", None)
+            .unwrap();
+
+        // Exactly one session row exists, accumulating both messages.
+        let session_count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_count, 1);
+        let msg_count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(msg_count, 2);
+    }
+
+    #[test]
+    fn test_end_session_unless_canonical_noops_on_canonical() {
+        // mika#1401: the canonical session must never be ended (pruning-safe).
+        let db = db();
+        let id = "canonical-mika-prime";
+        db.get_or_create_canonical_session(id, "mika-prime", "cli")
+            .unwrap();
+        // Attempt to end it while passing itself as the canonical id → no-op.
+        db.end_session_unless_canonical(id, Some(id)).unwrap();
+        let ended: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT ended_at FROM sessions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(ended.is_none(), "canonical session must stay open");
+    }
+
+    #[test]
+    fn test_end_session_unless_canonical_ends_non_canonical() {
+        // A non-canonical session (or None canonical_id) ends normally.
+        let db = db();
+        db.create_session("per-ask", "mika", "cli").unwrap();
+        db.end_session_unless_canonical("per-ask", Some("canonical-mika"))
+            .unwrap();
+        let ended: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT ended_at FROM sessions WHERE id = 'per-ask'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(ended.is_some(), "non-canonical session should be ended");
+
+        // None canonical_id (non-singleton agent) also ends normally.
+        db.create_session("per-ask-2", "mika", "cli").unwrap();
+        db.end_session_unless_canonical("per-ask-2", None).unwrap();
+        let ended: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT ended_at FROM sessions WHERE id = 'per-ask-2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(ended.is_some());
+    }
+
+    #[test]
+    fn test_canonical_session_exempt_from_pruning() {
+        // mika#1401 + D5: the `canonical-` prefix is not in prune_old_sessions's
+        // LIKE list, so even an (erroneously) ended canonical session survives.
+        let db = db();
+        let id = "canonical-mika-prime";
+        db.get_or_create_canonical_session(id, "mika-prime", "cli")
+            .unwrap();
+        // Force-end and backdate to simulate a worst-case stale row.
+        db.end_session(id).unwrap();
+        db.conn
+            .execute(
+                "UPDATE sessions SET ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days') WHERE id = ?1",
+                params![id],
+            )
+            .unwrap();
+        let pruned = db.prune_old_sessions(7 * 24 * 60 * 60).unwrap();
+        assert_eq!(pruned, 0, "canonical prefix must be exempt from pruning");
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
     fn test_prune_old_sessions() {
         let db = db();
         // Create two ended sessions and one active (not ended)

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -15375,21 +15375,22 @@ mod tests {
     fn test_get_or_create_canonical_session_is_idempotent() {
         // mika#1401: repeated calls reuse the same row (INSERT OR IGNORE), so every
         // `mika ask` to a singleton agent lands on one canonical session.
+        // Uses the test DB's registered agent ("mika") to satisfy the sessions FK.
         let db = db();
-        let id = "canonical-mika-prime";
+        let id = "canonical-mika";
         let r1 = db
-            .get_or_create_canonical_session(id, "mika-prime", "cli")
+            .get_or_create_canonical_session(id, "mika", "cli")
             .unwrap();
         assert_eq!(r1, id);
         // Write a message to the canonical session.
-        db.save_message("mika-prime", id, "user", "first ask", None)
+        db.save_message("mika", id, "user", "first ask", None)
             .unwrap();
         // Second invocation must not fail on duplicate PK and must not clobber.
         let r2 = db
-            .get_or_create_canonical_session(id, "mika-prime", "cli")
+            .get_or_create_canonical_session(id, "mika", "cli")
             .unwrap();
         assert_eq!(r2, id);
-        db.save_message("mika-prime", id, "user", "second ask", None)
+        db.save_message("mika", id, "user", "second ask", None)
             .unwrap();
 
         // Exactly one session row exists, accumulating both messages.
@@ -15417,8 +15418,8 @@ mod tests {
     fn test_end_session_unless_canonical_noops_on_canonical() {
         // mika#1401: the canonical session must never be ended (pruning-safe).
         let db = db();
-        let id = "canonical-mika-prime";
-        db.get_or_create_canonical_session(id, "mika-prime", "cli")
+        let id = "canonical-mika";
+        db.get_or_create_canonical_session(id, "mika", "cli")
             .unwrap();
         // Attempt to end it while passing itself as the canonical id → no-op.
         db.end_session_unless_canonical(id, Some(id)).unwrap();
@@ -15469,8 +15470,8 @@ mod tests {
         // mika#1401 + D5: the `canonical-` prefix is not in prune_old_sessions's
         // LIKE list, so even an (erroneously) ended canonical session survives.
         let db = db();
-        let id = "canonical-mika-prime";
-        db.get_or_create_canonical_session(id, "mika-prime", "cli")
+        let id = "canonical-mika";
+        db.get_or_create_canonical_session(id, "mika", "cli")
             .unwrap();
         // Force-end and backdate to simulate a worst-case stale row.
         db.end_session(id).unwrap();

--- a/crates/mika-agent/src/db.rs
+++ b/crates/mika-agent/src/db.rs
@@ -7057,6 +7057,21 @@ impl Database {
         Ok(())
     }
 
+    /// End a session unless it is the agent's canonical singleton session (mika#1401).
+    ///
+    /// Singleton agents (`[session] singleton = true` in identity.toml) reuse one
+    /// canonical session across every invocation; ending it would set `ended_at`
+    /// and — worse — surface it in the dashboard as a finished conversation. This
+    /// helper no-ops when `id == canonical_id`, so the canonical session's
+    /// `ended_at` stays NULL forever. When `canonical_id` is `None` (non-singleton
+    /// agent) it behaves exactly like [`end_session`].
+    pub fn end_session_unless_canonical(&self, id: &str, canonical_id: Option<&str>) -> Result<()> {
+        if canonical_id == Some(id) {
+            return Ok(());
+        }
+        self.end_session(id)
+    }
+
     pub fn get_or_create_system_session(&self, agent_id: &str) -> Result<String> {
         let id = format!("system-{agent_id}");
         self.conn.execute(
@@ -7064,6 +7079,28 @@ impl Database {
             params![&id, agent_id],
         )?;
         Ok(id)
+    }
+
+    /// Idempotently create the canonical session for a singleton agent (mika#1401).
+    ///
+    /// Mirrors [`get_or_create_system_session`]: `INSERT OR IGNORE` so the first
+    /// invocation creates the row and every subsequent `mika ask` / `/send` reuses
+    /// it. Unlike the system session the ID is caller-supplied (either the derived
+    /// `canonical-{agent_id}` or an operator-chosen `canonical_id` such as
+    /// mika-prime's zero-UUID). Channel type defaults to `'cli'`; the singleton
+    /// concept is orthogonal to channel — multiple channels merging into one
+    /// session is the designed intent for single-surface oracles.
+    pub fn get_or_create_canonical_session(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        channel_type: &str,
+    ) -> Result<String> {
+        self.conn.execute(
+            "INSERT OR IGNORE INTO sessions (id, agent_id, channel_type) VALUES (?1, ?2, ?3)",
+            params![session_id, agent_id, channel_type],
+        )?;
+        Ok(session_id.to_string())
     }
 
     /// Prune ended system/silent sessions older than `retention_secs`.

--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -144,6 +144,39 @@ pub struct SkillsIdentityConfig {
     pub allow_authoring: Option<bool>,
 }
 
+/// Session config from the `[session]` block in identity.toml (mika#1401).
+///
+/// Makes an agent **single-session-by-construction**: when `singleton = true`,
+/// every conversational invocation (`mika ask`, `mika chat`, HTTP `/send`) reuses
+/// one canonical session instead of minting a fresh `Uuid::new_v4()` per ask. The
+/// invariant is enforced by the engine, not by remembering to pass `--session-id`.
+///
+/// Opt-in — absent or `singleton = false` preserves the default (random UUID per
+/// ask). Explicit `--session-id` always overrides the canonical session.
+///
+/// ```toml
+/// [session]
+/// singleton = true
+/// canonical_id = "00000000-0000-0000-0000-000000000000"  # optional
+/// ```
+///
+/// **Compaction interaction:** compaction already keys on `agent_id`, not
+/// `session_id`, so a singleton agent is unaffected — the single canonical
+/// session simply accumulates all history. See mika#1401.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct SessionIdentityConfig {
+    /// When `true`, this agent uses a single canonical session for all
+    /// conversational interactions. The session persists across invocations
+    /// and is never ended by `end_session`. Default: `false`.
+    #[serde(default)]
+    pub singleton: bool,
+    /// Explicit canonical session ID. When absent and `singleton = true`,
+    /// the engine derives one as `canonical-{agent_id}`. Exists specifically
+    /// for mika-prime's operator-chosen zero-UUID.
+    #[serde(default)]
+    pub canonical_id: Option<String>,
+}
+
 /// Tool visibility config from the `[tools]` block in identity.toml.
 ///
 /// Used by well-known agents (mika-arch, etc.) to deny specific built-in tools
@@ -273,6 +306,8 @@ pub struct Identity {
     #[serde(default)]
     pub context: ContextIdentityConfig,
     #[serde(default)]
+    pub session: SessionIdentityConfig,
+    #[serde(default)]
     pub curator: Option<CuratorConfig>,
 }
 
@@ -295,6 +330,7 @@ impl Default for Identity {
             skills: SkillsIdentityConfig::default(),
             tools: ToolsIdentityConfig::default(),
             context: ContextIdentityConfig::default(),
+            session: SessionIdentityConfig::default(),
             curator: None,
         }
     }
@@ -400,8 +436,29 @@ fn fail_closed_identity() -> Identity {
                 max_tokens: None,
             },
         },
+        session: SessionIdentityConfig::default(),
         curator: None,
     }
+}
+
+/// Resolve the canonical session ID for a singleton agent (mika#1401).
+///
+/// Returns `None` when the agent is not `singleton` — callers then mint a
+/// fresh `Uuid::new_v4()` per invocation (the default behavior). When
+/// `singleton = true`, returns the operator-chosen `canonical_id` if set,
+/// else the derived `canonical-{agent_id}` (prefix-typed sibling of
+/// `system-{agent_id}`, structurally exempt from `prune_old_sessions`).
+pub fn resolve_canonical_session_id(identity: &Identity, agent_id: &str) -> Option<String> {
+    if !identity.session.singleton {
+        return None;
+    }
+    Some(
+        identity
+            .session
+            .canonical_id
+            .clone()
+            .unwrap_or_else(|| format!("canonical-{agent_id}")),
+    )
 }
 
 /// Context needed to build the system prompt.

--- a/crates/mika-agent/src/prompt.rs
+++ b/crates/mika-agent/src/prompt.rs
@@ -1138,12 +1138,87 @@ mod tests {
             skills: SkillsIdentityConfig::default(),
             tools: ToolsIdentityConfig::default(),
             context: ContextIdentityConfig::default(),
+            session: SessionIdentityConfig::default(),
             curator: None,
         }
     }
 
     fn test_time() -> DateTime<Utc> {
         "2026-02-24T12:00:00Z".parse().unwrap()
+    }
+
+    // --- Canonical session resolution (mika#1401) ---
+
+    #[test]
+    fn test_resolve_canonical_session_non_singleton_returns_none() {
+        // Default identity is non-singleton — callers mint a fresh UUID per ask.
+        let identity = test_identity();
+        assert!(!identity.session.singleton);
+        assert_eq!(resolve_canonical_session_id(&identity, "mika-prime"), None);
+    }
+
+    #[test]
+    fn test_resolve_canonical_session_singleton_derives_id() {
+        // singleton = true without an explicit canonical_id derives
+        // `canonical-{agent_id}` (prefix-typed sibling of system-{agent_id}).
+        let mut identity = test_identity();
+        identity.session.singleton = true;
+        assert_eq!(
+            resolve_canonical_session_id(&identity, "mika-prime"),
+            Some("canonical-mika-prime".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_canonical_session_singleton_honors_explicit_id() {
+        // An explicit canonical_id (e.g. mika-prime's zero-UUID) wins over derivation.
+        let mut identity = test_identity();
+        identity.session.singleton = true;
+        identity.session.canonical_id = Some("00000000-0000-0000-0000-000000000000".to_string());
+        assert_eq!(
+            resolve_canonical_session_id(&identity, "mika-prime"),
+            Some("00000000-0000-0000-0000-000000000000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_canonical_session_canonical_id_ignored_when_not_singleton() {
+        // canonical_id present but singleton = false → still None (opt-in gate).
+        let mut identity = test_identity();
+        identity.session.singleton = false;
+        identity.session.canonical_id = Some("00000000-0000-0000-0000-000000000000".to_string());
+        assert_eq!(resolve_canonical_session_id(&identity, "mika-prime"), None);
+    }
+
+    #[test]
+    fn test_session_identity_config_parses_from_toml() {
+        // The [session] block deserializes with both fields set.
+        let toml = r#"
+name = "Mika Prime"
+emoji = "✦"
+
+[session]
+singleton = true
+canonical_id = "00000000-0000-0000-0000-000000000000"
+"#;
+        let identity: Identity = toml::from_str(toml).unwrap();
+        assert!(identity.session.singleton);
+        assert_eq!(
+            identity.session.canonical_id.as_deref(),
+            Some("00000000-0000-0000-0000-000000000000")
+        );
+    }
+
+    #[test]
+    fn test_session_identity_config_defaults_when_absent() {
+        // Absent [session] block → singleton = false, canonical_id = None.
+        let toml = r#"
+name = "Mika"
+emoji = "✦"
+"#;
+        let identity: Identity = toml::from_str(toml).unwrap();
+        assert!(!identity.session.singleton);
+        assert!(identity.session.canonical_id.is_none());
     }
 
     fn test_core_memory() -> Vec<CoreMemoryEntry> {
@@ -1221,6 +1296,7 @@ mod tests {
             skills: SkillsIdentityConfig::default(),
             tools: ToolsIdentityConfig::default(),
             context: ContextIdentityConfig::default(),
+            session: SessionIdentityConfig::default(),
             curator: None,
         };
         let ctx = PromptContext {

--- a/crates/mika-agent/src/server/handlers.rs
+++ b/crates/mika-agent/src/server/handlers.rs
@@ -836,13 +836,29 @@ async fn run_agent_for_message(
         a.skills.lock().unwrap().clone()
     };
 
-    let session_id = uuid::Uuid::new_v4().to_string();
-    if let Err(e) =
-        a.db.create_session(&session_id, a.db.agent_id(), &req.channel)
-            .await
-    {
-        warn!(error = %e, "failed to create session");
-    }
+    // Singleton agents (mika#1401) reuse one canonical session for every inbound
+    // message instead of minting a fresh UUID per `/send`. Resolved once at
+    // init_agent time and cached on AgentState. Idempotent INSERT OR IGNORE keeps
+    // the shared session alive across messages; normal agents get a per-message
+    // session as before.
+    let session_id = if let Some(ref canonical) = a.canonical_session_id {
+        if let Err(e) =
+            a.db.get_or_create_canonical_session(canonical, &req.channel)
+                .await
+        {
+            warn!(error = %e, "failed to create canonical session");
+        }
+        canonical.clone()
+    } else {
+        let id = uuid::Uuid::new_v4().to_string();
+        if let Err(e) =
+            a.db.create_session(&id, a.db.agent_id(), &req.channel)
+                .await
+        {
+            warn!(error = %e, "failed to create session");
+        }
+        id
+    };
     let is_onboarding = agent::check_onboarding(&a.db).await;
 
     let sender = GatewayMessageSender::new(

--- a/crates/mika-agent/src/server/mod.rs
+++ b/crates/mika-agent/src/server/mod.rs
@@ -436,6 +436,10 @@ async fn init_agent(
     let identity = crate::prompt::load_identity(agent_home);
     let kg_config = crate::kg::config::resolve_per_agent_docs_root(&identity, &agent_settings)
         .with_context(|| format!("failed to resolve [kg] config for agent {agent_name}"))?;
+    // Resolve the canonical session for singleton agents (mika#1401). `Some` only
+    // when `[session] singleton = true`; the `/send` handler reuses this session
+    // instead of minting a fresh UUID per message.
+    let canonical_session_id = crate::prompt::resolve_canonical_session_id(&identity, agent_name);
     db.register_agent(
         agent_name,
         &identity.name,
@@ -556,6 +560,7 @@ async fn init_agent(
         github_app,
         webhook_queue: Arc::new(tokio::sync::Mutex::new(Vec::new())),
         kg_config,
+        canonical_session_id,
     };
 
     debug!(agent = agent_name, home = %agent_home.display(), "initialized agent");
@@ -1622,6 +1627,7 @@ mod tests {
             kg_config: crate::kg::config::KgAgentConfig::Disabled {
                 reason: crate::kg::config::DisabledReason::OperatorOptOut,
             },
+            canonical_session_id: None,
         };
 
         let agents = dashmap::DashMap::new();

--- a/crates/mika-agent/src/server/state.rs
+++ b/crates/mika-agent/src/server/state.rs
@@ -50,6 +50,12 @@ pub struct AgentState {
     /// all KG subsystem construction; `Enabled` provides the validated docs_root
     /// and precomputed docs_root_hash for the three KG startup loops.
     pub kg_config: KgAgentConfig,
+    /// Canonical session ID for singleton agents (mika#1401). `Some` when the
+    /// agent's `identity.toml` sets `[session] singleton = true` — the `/send`
+    /// handler then reuses this one session instead of minting a UUID per message.
+    /// `None` for normal agents (default: fresh session per message). Resolved
+    /// once at `init_agent` time from the agent's identity.
+    pub canonical_session_id: Option<String>,
 }
 
 /// Shared application state for the Axum HTTP server.

--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -104,9 +104,22 @@ pub async fn run(
         anyhow::bail!("--session-id value must not be empty");
     }
     let reusing_session = session_id.is_some();
-    let session_id = session_id
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    // Resolve the canonical session for singleton agents (mika#1401). An explicit
+    // --session-id always wins; otherwise a singleton agent (`[session] singleton =
+    // true` in identity.toml) reuses its one canonical session and non-singleton
+    // agents mint a fresh UUID per invocation. Identity is loaded once here and
+    // reused below for the skill allowlist.
+    let identity = mika_agent::prompt::load_identity(&ctx.home_dir);
+    let canonical_session_id =
+        mika_agent::prompt::resolve_canonical_session_id(&identity, ctx.async_db.agent_id());
+    let session_id = if let Some(s) = session_id {
+        s.to_string()
+    } else if let Some(ref canonical) = canonical_session_id {
+        canonical.clone()
+    } else {
+        Uuid::new_v4().to_string()
+    };
+    let is_canonical_session = canonical_session_id.as_deref() == Some(session_id.as_str());
     // Validate session ownership if reusing an existing session
     if reusing_session
         && let Ok(Some(existing)) = ctx.async_db.get_session(&session_id).await
@@ -119,20 +132,34 @@ pub async fn run(
             ctx.async_db.agent_id()
         );
     }
-    // Store task_id in session metadata and as a first-class column for observability correlation
-    let session_metadata = task_id.map(|tid| serde_json::json!({"task_id": tid}).to_string());
-    if let Err(e) = ctx
-        .async_db
-        .create_session_with_metadata(
-            &session_id,
-            ctx.async_db.agent_id(),
-            "cli",
-            session_metadata.as_deref(),
-            task_id,
-        )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to create session");
+    // Create the session. Singleton agents use an idempotent INSERT OR IGNORE on the
+    // shared canonical session — task_id correlation rides on the messages
+    // (internal-tagged via correlated_task_id), not the shared session row. All other
+    // invocations create a per-ask session carrying task_id in metadata and as a
+    // first-class column for observability correlation.
+    if is_canonical_session {
+        if let Err(e) = ctx
+            .async_db
+            .get_or_create_canonical_session(&session_id, "cli")
+            .await
+        {
+            tracing::warn!(error = %e, "failed to create canonical session");
+        }
+    } else {
+        let session_metadata = task_id.map(|tid| serde_json::json!({"task_id": tid}).to_string());
+        if let Err(e) = ctx
+            .async_db
+            .create_session_with_metadata(
+                &session_id,
+                ctx.async_db.agent_id(),
+                "cli",
+                session_metadata.as_deref(),
+                task_id,
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "failed to create session");
+        }
     }
     let http_client = reqwest::Client::new();
     let message_sender = crate::init::make_message_sender(
@@ -216,8 +243,13 @@ pub async fn run(
                 );
             }
 
-            // End the session so the dashboard doesn't show it as "ongoing"
-            if let Err(e) = ctx.async_db.end_session(&session_id).await {
+            // End the session so the dashboard doesn't show it as "ongoing".
+            // No-op for singleton agents — the canonical session is never ended.
+            if let Err(e) = ctx
+                .async_db
+                .end_session_unless_canonical(&session_id, canonical_session_id.as_deref())
+                .await
+            {
                 tracing::warn!(error = %e, "failed to end session");
             }
             return Ok(());
@@ -283,7 +315,7 @@ pub async fn run(
         tracing::warn!(error = %e, "failed to migrate .disabled markers");
     }
     let mut skill_registry = SkillRegistry::from_dir(&skills_dir);
-    let identity = mika_agent::prompt::load_identity(&ctx.home_dir);
+    // `identity` was loaded earlier for canonical-session resolution (mika#1401); reuse it.
     if let Some(ref allowlist) = identity.skills.allowlist {
         skill_registry.apply_identity_allowlist(allowlist);
     }
@@ -383,8 +415,13 @@ pub async fn run(
     })
     .await;
 
-    // End the session regardless of agent result so the dashboard shows duration
-    if let Err(e) = ctx.async_db.end_session(&session_id).await {
+    // End the session regardless of agent result so the dashboard shows duration.
+    // No-op for singleton agents — the canonical session is never ended (mika#1401).
+    if let Err(e) = ctx
+        .async_db
+        .end_session_unless_canonical(&session_id, canonical_session_id.as_deref())
+        .await
+    {
         tracing::warn!(error = %e, "failed to end session");
     }
 

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -63,6 +63,7 @@ async fn spawn_agent_worker(
     String, // model
     String, // identity_name
     Arc<SkillRegistry>,
+    bool, // is_singleton_session (mika#1401)
 )> {
     let identity = prompt::load_identity(&ctx.home_dir);
     if let Some(s) = session_id
@@ -71,9 +72,19 @@ async fn spawn_agent_worker(
         anyhow::bail!("--session-id value must not be empty");
     }
     let reusing_session = session_id.is_some();
-    let session_id = session_id
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    // Resolve the canonical session for singleton agents (mika#1401). An explicit
+    // --session-id wins; otherwise a singleton agent reuses its one canonical
+    // session on launch (and `/clear` preserves it — see App.is_singleton_session).
+    let canonical_session_id =
+        prompt::resolve_canonical_session_id(&identity, ctx.async_db.agent_id());
+    let session_id = if let Some(s) = session_id {
+        s.to_string()
+    } else if let Some(ref canonical) = canonical_session_id {
+        canonical.clone()
+    } else {
+        Uuid::new_v4().to_string()
+    };
+    let is_singleton_session = canonical_session_id.as_deref() == Some(session_id.as_str());
     // Validate session ownership if reusing an existing session
     if reusing_session
         && let Ok(Some(existing)) = ctx.async_db.get_session(&session_id).await
@@ -86,7 +97,15 @@ async fn spawn_agent_worker(
             ctx.async_db.agent_id()
         );
     }
-    if let Err(e) = ctx
+    if is_singleton_session {
+        if let Err(e) = ctx
+            .async_db
+            .get_or_create_canonical_session(&session_id, "cli")
+            .await
+        {
+            tracing::warn!(error = %e, "failed to create canonical session");
+        }
+    } else if let Err(e) = ctx
         .async_db
         .create_session(&session_id, ctx.async_db.agent_id(), "cli")
         .await
@@ -540,6 +559,7 @@ async fn spawn_agent_worker(
         model,
         identity_name,
         skill_registry,
+        is_singleton_session,
     ))
 }
 
@@ -556,8 +576,16 @@ pub async fn run(
     }
 
     let http_client = reqwest::Client::new();
-    let (mut worker, user_tx, agent_rx, session_id, model, identity_name, skill_registry) =
-        spawn_agent_worker(ctx, agent_name, &http_client, session).await?;
+    let (
+        mut worker,
+        user_tx,
+        agent_rx,
+        session_id,
+        model,
+        identity_name,
+        skill_registry,
+        is_singleton_session,
+    ) = spawn_agent_worker(ctx, agent_name, &http_client, session).await?;
 
     // Build app with shared resources
     let mut app = App::new(
@@ -573,7 +601,8 @@ pub async fn run(
         agent_name.to_string(),
         worker._ctx.global_home.clone(),
         worker._ctx.settings.llm_provider,
-        start_in_audit_mode, // audit mode launch (#773)
+        start_in_audit_mode,  // audit mode launch (#773)
+        is_singleton_session, // single-session-by-nature (mika#1401)
     );
 
     // Load recent conversation history so the user sees prior messages on restart.
@@ -713,8 +742,11 @@ pub async fn run(
 
         // Handle agent switch
         if let Some(target_name) = app.pending_switch.take() {
-            // End the old session before switching agents
-            if let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await {
+            // End the old session before switching agents. No-op for singleton
+            // agents — the canonical session is never ended (mika#1401).
+            if !app.is_singleton_session
+                && let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await
+            {
                 tracing::warn!(error = %e, "failed to end session on agent switch");
             }
 
@@ -824,8 +856,11 @@ pub async fn run(
             app.pending_restart = false;
 
             // End the old session before restarting so the dashboard shows it as
-            // completed rather than ongoing.
-            if let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await {
+            // completed rather than ongoing. No-op for singleton agents — the
+            // canonical session is never ended (mika#1401).
+            if !app.is_singleton_session
+                && let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await
+            {
                 tracing::warn!(error = %e, "failed to end session on /restart");
             }
 
@@ -919,8 +954,11 @@ pub async fn run(
     // Shut down event reader thread
     events.shutdown();
 
-    // End the session so the dashboard shows duration instead of "ongoing"
-    if let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await {
+    // End the session so the dashboard shows duration instead of "ongoing".
+    // No-op for singleton agents — the canonical session is never ended (mika#1401).
+    if !app.is_singleton_session
+        && let Err(e) = worker._ctx.async_db.end_session(&app.session_id).await
+    {
         tracing::warn!(error = %e, "failed to end session");
     }
 

--- a/crates/mika-cli/src/commands/chat.rs
+++ b/crates/mika-cli/src/commands/chat.rs
@@ -790,11 +790,15 @@ pub async fn run(
                             new_model,
                             new_identity,
                             new_skills,
+                            new_is_singleton_session,
                         )) => {
                             // Update app fields
                             app.agent_tx = new_tx;
                             app.agent_rx = new_rx;
                             app.session_id = new_session;
+                            // The target agent may have a different session profile
+                            // (mika#1401): switch the singleton gate to match it.
+                            app.is_singleton_session = new_is_singleton_session;
                             app.model = new_model.clone();
                             app.identity_name = new_identity;
                             app.db = new_worker._ctx.async_db.clone();
@@ -891,6 +895,8 @@ pub async fn run(
                             new_model,
                             _new_identity,
                             new_skills,
+                            // Same agent restarted — the singleton gate is invariant.
+                            _new_is_singleton_session,
                         )) => {
                             app.agent_tx = new_tx;
                             app.agent_rx = new_rx;

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -537,6 +537,10 @@ pub struct App<'a> {
 
     // Display info
     pub session_id: String,
+    /// True when this agent is single-session-by-nature (mika#1401): `session_id`
+    /// is the agent's canonical session. Gates `/clear` (preserves the session
+    /// instead of minting a new one) and the session-teardown `end_session` calls.
+    pub is_singleton_session: bool,
     pub model: String,
     pub identity_name: String,
     /// The active LLM provider (for /provider command).
@@ -667,6 +671,7 @@ impl<'a> App<'a> {
         global_home: PathBuf,
         provider: mika_common::llm::ProviderKind,
         start_in_audit_mode: bool,
+        is_singleton_session: bool,
     ) -> Self {
         let mut textarea = TextArea::default();
         textarea.set_cursor_line_style(ratatui::style::Style::default());
@@ -685,6 +690,7 @@ impl<'a> App<'a> {
             history: InputHistory::load(&home_dir),
             has_new_message: false,
             session_id,
+            is_singleton_session,
             model,
             identity_name,
             provider,
@@ -774,6 +780,7 @@ impl<'a> App<'a> {
             history: InputHistory::load(&team_dir),
             has_new_message: false,
             session_id: String::new(),
+            is_singleton_session: false,
             model: String::new(),
             identity_name: format!("Team: {team_name}"),
             provider: mika_common::llm::ProviderKind::Anthropic,

--- a/crates/mika-cli/src/tui/app.rs
+++ b/crates/mika-cli/src/tui/app.rs
@@ -2164,7 +2164,8 @@ mod tests {
             "mika".to_string(),
             global_home,
             mika_common::llm::ProviderKind::Anthropic,
-            false,
+            false, // start_in_audit_mode
+            false, // is_singleton_session (mika#1401)
         );
 
         (app, response_tx, temp_dir)

--- a/crates/mika-cli/src/tui/commands/handlers.rs
+++ b/crates/mika-cli/src/tui/commands/handlers.rs
@@ -110,6 +110,31 @@ fn handle_help() -> String {
 }
 
 async fn handle_clear(app: &mut App<'_>, _args: &str) -> String {
+    // Singleton agents (mika#1401) are single-session-by-nature: the canonical
+    // session must never be ended or replaced. `/clear` therefore resets only the
+    // visual display — the session ID and the agent worker's loaded context are
+    // preserved, and the DB history (the canonical thread) is left intact. This is
+    // the TUI counterpart of `end_session_unless_canonical` on the CLI exit paths.
+    if app.is_singleton_session {
+        app.messages.clear();
+        app.scroll_offset = 0;
+        // Suppress the just-cleared history from re-rendering on the next poll.
+        app.last_seen_msg_id = app.db.max_message_id().await.unwrap_or(0);
+        app.context_tokens = None;
+        app.messages_layout = MessagesLayout::default();
+        app.pending_response = None;
+        app.reveal_index = 0;
+        app.status = AgentStatus::Idle;
+        app.pending_images.clear();
+        app.pending_command = None;
+        app.has_new_message = false;
+        app.selection_state = SelectionState::None;
+        app.pending_task_count = 0;
+        app.hidden_internal_count = 0;
+        app.needs_redraw = true;
+        return "Display cleared. This agent is single-session-by-nature (mika#1401) — the canonical session is preserved.".to_string();
+    }
+
     // End the current session
     let old_session = app.session_id.clone();
     if let Err(e) = app.db.end_session(&old_session).await {
@@ -1361,7 +1386,8 @@ mod tests {
             "mika".to_string(),
             global_home,
             ProviderKind::Anthropic,
-            false,
+            false, // start_in_audit_mode
+            false, // is_singleton_session (mika#1401)
         );
 
         (app, agent_rx, temp_dir)
@@ -1496,6 +1522,60 @@ mod tests {
         assert!(
             old.map(|s| s.ended_at.is_some()).unwrap_or(false),
             "old session should have ended_at set"
+        );
+    }
+
+    // --- /clear singleton tests (mika#1401) ---
+
+    #[tokio::test]
+    async fn test_clear_singleton_preserves_session() {
+        let (mut app, mut rx, _tmp) = test_app().await;
+        app.is_singleton_session = true;
+        let session_before = app.session_id.clone();
+
+        app.messages.push(ChatMessage {
+            role: ChatRole::User,
+            content: "hello".to_string(),
+            rendered: None,
+            channel: None,
+        });
+
+        let output = handle_clear(&mut app, "").await;
+
+        // Session ID is preserved (single-session-by-nature).
+        assert_eq!(
+            app.session_id, session_before,
+            "singleton session_id must not change on /clear"
+        );
+        assert!(output.contains("single-session-by-nature"));
+        // Display is still cleared.
+        assert!(
+            app.messages.is_empty(),
+            "display messages should be cleared"
+        );
+        assert_eq!(app.scroll_offset, 0);
+        assert!(app.needs_redraw);
+        // No NewSession request is sent — the worker keeps its context.
+        let requests = drain_requests(&mut rx);
+        assert!(
+            requests.is_empty(),
+            "singleton /clear must not send a NewSession request"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_singleton_does_not_end_session() {
+        let (mut app, _rx, _tmp) = test_app().await;
+        app.is_singleton_session = true;
+        let session_id = app.session_id.clone();
+
+        handle_clear(&mut app, "").await;
+
+        // The canonical session's ended_at must stay NULL.
+        let session = app.db.get_session(&session_id).await.unwrap();
+        assert!(
+            session.map(|s| s.ended_at.is_none()).unwrap_or(false),
+            "singleton session must not be ended on /clear"
         );
     }
 

--- a/crates/mika-cli/src/tui/input.rs
+++ b/crates/mika-cli/src/tui/input.rs
@@ -1191,7 +1191,8 @@ mod tests {
             "mika".to_string(),
             global_home,
             ProviderKind::Anthropic,
-            false,
+            false, // start_in_audit_mode
+            false, // is_singleton_session (mika#1401)
         );
 
         (app, agent_rx, temp_dir)

--- a/docs/plans/2026-06-28-005-feat-1401-agent-core-single-session-by-nature-plan.md
+++ b/docs/plans/2026-06-28-005-feat-1401-agent-core-single-session-by-nature-plan.md
@@ -1,0 +1,307 @@
+# Plan: feat(agent-core): single-session-by-nature agents (mika#1401)
+
+## Problem
+
+Today, `mika ask` and the HTTP `/send` handler mint a fresh `Uuid::new_v4()` session on every invocation unless the caller explicitly threads `--session-id`. For agents like Mika Prime — who are conceptually single-session — this is held by discipline only. Forget the flag and the invariant breaks, scattering the agent's history across per-ask session confetti.
+
+## Goal
+
+An opt-in per-agent `identity.toml` property that makes an agent **single-session by construction**: it has exactly one canonical session, by nature, not by discipline. The default for non-opted-in agents remains unchanged (random UUID per ask).
+
+## Non-Goals
+
+- No "session-policy" machinery or multi-tier session strategies (YAGNI)
+- No changes to compaction behavior (compaction already keys on `agent_id`, not `session_id`)
+- No changes to the silent/callback/heartbeat session paths (those use their own derived namespaces: `callback-*`, `heartbeat-*`, etc.)
+
+## Design Decisions
+
+### D1: Identity property shape
+
+Add a `[session]` section to `identity.toml` with two fields:
+
+```toml
+[session]
+singleton = true
+canonical_id = "00000000-0000-0000-0000-000000000000"  # optional
+```
+
+- `singleton` (bool, default `false`): when `true`, the agent is single-session-by-nature.
+- `canonical_id` (string, optional): the literal session ID to use. When absent, the engine derives one as `canonical-{agent_id}` (using the prefix-typed family per the ticket's mechanism section, sibling to `system-{agent_id}`, `delegate-{uuid}`, etc.).
+
+This matches the existing identity configuration pattern (`[kg]`, `[context.summary]`, `[skills]`, `[tools]`). The `canonical_id` field exists specifically for mika-prime's operator-chosen zero-UUID — other future opt-in agents can omit it and get the deterministic derivation.
+
+### D2: Session resolution change points
+
+Three code paths create sessions for conversational use:
+
+| Path | File | Current behavior | New behavior |
+|------|------|-----------------|--------------|
+| CLI `mika ask` | `crates/mika-cli/src/commands/ask.rs:107-109` | `Uuid::new_v4()` when no `--session-id` | Resolve canonical session from identity when `singleton = true` |
+| CLI `mika chat` (TUI) | `crates/mika-cli/src/commands/chat.rs` + `tui/app.rs` | `Uuid::new_v4()` on start and `/clear` | Resolve canonical session; `/clear` clears messages but reuses the same session ID |
+| HTTP `/send` handler | `crates/mika-agent/src/server/handlers.rs:742` | `Uuid::new_v4()` | Resolve canonical session from identity (loaded at `init_agent` time, cached on `AgentState`) |
+
+**Explicit `--session-id` always wins.** When the caller provides `--session-id`, it is used verbatim regardless of the `singleton` flag. This preserves backward compatibility and allows diagnostic/relay sessions.
+
+### D3: `end_session` becomes a no-op for singleton agents
+
+`db.rs:6569` `end_session(id)` sets `ended_at`. For singleton agents, this must be a no-op so the canonical session is never ended. This is critical for pruning safety — `prune_old_sessions` deletes rows with `ended_at IS NOT NULL` (though the current pruning query also requires specific prefixes like `heartbeat-`, `callback-`, etc., so a singleton session is doubly safe).
+
+Implementation: add a `end_session_if_not_singleton(id, is_singleton)` helper, or check the session prefix against the canonical namespace before ending.
+
+### D4: Canonical session creation uses `INSERT OR IGNORE`
+
+Like `get_or_create_system_session`, the canonical session creation is idempotent. First invocation creates the row; subsequent invocations reuse it. This means every `mika ask` to a singleton agent hits the same session row.
+
+### D5: Derived session ID namespace
+
+The canonical session ID follows the deployed prefix-typed family:
+- `system-{agent_id}` — compaction summaries (existing)
+- `canonical-{agent_id}` — singleton agent conversational session (new)
+- `00000000-0000-0000-0000-000000000000` — mika-prime override via `canonical_id`
+
+The `canonical-` prefix is **not** in `prune_old_sessions`'s LIKE clause list, so it's structurally exempt from pruning. The zero-UUID is also exempt (no matching prefix).
+
+### D6: Concurrency documentation
+
+For a single-surface, zero-skill oracle (mika-prime's current profile), concurrency is low. The singleton merges all channels into one thread — for a manual-ask oracle this is the intent. The code comments and docs will state this is designed behavior, per the ticket's Footnote Check 1.
+
+### D7: Migration script for mika-prime
+
+The PR ships a documented operator-runnable SQL script that merges existing non-canonical sessions into the canonical zero-UUID. The script:
+
+1. Wraps in `PRAGMA foreign_keys = OFF; BEGIN; ... COMMIT; PRAGMA foreign_keys = ON;`
+2. Updates all FK-referencing tables for mika-prime's agent_id where session_id != canonical
+3. Deletes the now-orphaned old session rows
+4. Is idempotent (WHERE clauses self-narrow after first run)
+
+Tables to update (per ticket's operator-authored amendment):
+- `sessions.id` (the row identity itself — handle via delete-old-after-merge)
+- `sessions.parent_session_id`
+- `messages.session_id`
+- `audit_events.session_id`
+- `a2a_task_map.session_id`
+- `llm_calls.session_id`
+- `tool_calls.session_id`
+- `tasks.created_by_session`
+
+## Implementation Steps
+
+### Step 1: Add `SessionIdentityConfig` to `Identity` struct
+
+**File:** `crates/mika-agent/src/prompt.rs`
+
+Add a new config struct and field:
+
+```rust
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct SessionIdentityConfig {
+    /// When true, this agent uses a single canonical session for all
+    /// conversational interactions. The session persists across invocations
+    /// and is never ended by `end_session`. Default: false.
+    #[serde(default)]
+    pub singleton: bool,
+    /// Explicit canonical session ID. When absent and singleton=true,
+    /// the engine derives one as `canonical-{agent_id}`.
+    #[serde(default)]
+    pub canonical_id: Option<String>,
+}
+```
+
+Add to `Identity`:
+```rust
+#[serde(default)]
+pub session: SessionIdentityConfig,
+```
+
+Update `Identity::default()` to include `session: SessionIdentityConfig::default()`.
+
+### Step 2: Add `get_or_create_canonical_session` to `Database`
+
+**File:** `crates/mika-agent/src/db.rs`
+
+Add a function mirroring `get_or_create_system_session`:
+
+```rust
+pub fn get_or_create_canonical_session(&self, session_id: &str, agent_id: &str) -> Result<String> {
+    self.conn.execute(
+        "INSERT OR IGNORE INTO sessions (id, agent_id, channel_type) VALUES (?1, ?2, 'cli')",
+        params![session_id, agent_id],
+    )?;
+    Ok(session_id.to_string())
+}
+```
+
+Add the async wrapper in `async_db.rs`.
+
+### Step 3: Add `resolve_canonical_session_id` helper
+
+**File:** `crates/mika-agent/src/prompt.rs` (or a new `session.rs` module if cleaner)
+
+```rust
+/// Resolve the canonical session ID for a singleton agent.
+/// Returns `None` if the agent is not singleton.
+pub fn resolve_canonical_session_id(identity: &Identity, agent_id: &str) -> Option<String> {
+    if !identity.session.singleton {
+        return None;
+    }
+    Some(
+        identity.session.canonical_id
+            .clone()
+            .unwrap_or_else(|| format!("canonical-{agent_id}"))
+    )
+}
+```
+
+### Step 4: Update CLI `mika ask` session resolution
+
+**File:** `crates/mika-cli/src/commands/ask.rs`
+
+At line 106-109, change the session resolution:
+
+```rust
+let reusing_session = session_id.is_some();
+let identity = mika_agent::prompt::load_identity(&ctx.home_dir);
+let canonical = mika_agent::prompt::resolve_canonical_session_id(&identity, agent_name);
+
+let session_id = if let Some(s) = session_id {
+    s.to_string()
+} else if let Some(ref canonical_id) = canonical {
+    canonical_id.clone()
+} else {
+    Uuid::new_v4().to_string()
+};
+```
+
+When using a canonical session, use `get_or_create_canonical_session` instead of `create_session_with_metadata` (which would fail on duplicate PK). The metadata/task_id can be stored on the messages instead.
+
+Note: identity is already loaded at line 286 for skill allowlist — move the load earlier to reuse it, or accept the double-load (identity loading is cheap filesystem I/O).
+
+### Step 5: Update CLI `mika chat` (TUI) session resolution
+
+**File:** `crates/mika-cli/src/commands/chat.rs`
+
+The chat command already loads identity at line 67. Use `resolve_canonical_session_id` to determine the initial session ID instead of `Uuid::new_v4()`.
+
+For `/clear` in `tui/commands/handlers.rs`: when the agent is singleton, `/clear` should NOT create a new session. Instead, it clears the display and optionally runs compaction on the existing session, but the session ID stays the same. Add a `is_singleton_session` flag to `App` state to gate this behavior.
+
+### Step 6: Update HTTP `/send` handler session resolution
+
+**File:** `crates/mika-agent/src/server/handlers.rs`
+
+At line 742, change session creation. The identity is already loaded at `init_agent` time — cache the resolved canonical session ID on `AgentState`:
+
+Add to `AgentState`:
+```rust
+/// Canonical session ID for singleton agents. None for normal agents.
+pub canonical_session_id: Option<String>,
+```
+
+Populate in `init_agent` (server/mod.rs:386):
+```rust
+let identity = crate::prompt::load_identity(agent_home);
+let canonical_session_id = crate::prompt::resolve_canonical_session_id(&identity, agent_name);
+```
+
+In `run_agent_for_message` (handlers.rs:742):
+```rust
+let session_id = if let Some(ref canonical) = a.canonical_session_id {
+    // Singleton agent: reuse the canonical session (create if absent)
+    if let Err(e) = a.db.get_or_create_canonical_session(canonical, a.db.agent_id()).await {
+        warn!(error = %e, "failed to create canonical session");
+    }
+    canonical.clone()
+} else {
+    let id = uuid::Uuid::new_v4().to_string();
+    if let Err(e) = a.db.create_session(&id, a.db.agent_id(), &req.channel).await {
+        warn!(error = %e, "failed to create session");
+    }
+    id
+};
+```
+
+### Step 7: Make `end_session` a no-op for singleton sessions
+
+**File:** `crates/mika-agent/src/db.rs`
+
+Two approaches, prefer the simpler one:
+
+**Option A (preferred):** Add `end_session_unless_canonical(id, canonical_id)` that skips when `id == canonical_id`. The callers that end sessions (CLI ask exit, TUI `/clear`, silent dispatcher, conversation mode exit) pass the canonical_id when available.
+
+**Option B:** Check the session prefix in `end_session` — skip for `canonical-*` prefix. But this doesn't cover the zero-UUID case without hardcoding.
+
+Go with Option A. The call sites in the CLI have the identity available; the server call sites have `AgentState.canonical_session_id`.
+
+### Step 8: Write migration script for mika-prime
+
+**File:** `scripts/migrate-singleton-sessions.sql` (or `scripts/migrate-mika-prime-sessions.sh`)
+
+A documented operator-runnable script that:
+1. Takes `AGENT_ID` and `CANONICAL_SESSION_ID` as parameters
+2. For each FK-referencing table, updates `session_id` from old values to canonical
+3. Merges messages from old sessions into the canonical session (preserving ordering by `rowid`/timestamp)
+4. Deletes old session rows
+5. Wraps everything in `PRAGMA foreign_keys = OFF` + transaction
+6. Is idempotent
+
+Include a verification query:
+```sql
+SELECT session_id, COUNT(*) FROM messages
+WHERE agent_id = 'mika-prime'
+GROUP BY session_id;
+-- Expected: exactly one row with canonical session_id
+```
+
+### Step 9: Update documentation
+
+**Files:**
+- `docs/runtime-structure.md` — document the `[session]` identity.toml section
+- `crates/mika-agent/CLAUDE.md` — add session singleton to the Identity struct docs
+- Code comments at the session resolution sites explaining compaction interaction (per ticket's "honest purity claim")
+
+### Step 10: Add tests
+
+1. **Unit test for `resolve_canonical_session_id`** — singleton=true with and without canonical_id, singleton=false
+2. **Unit test for `get_or_create_canonical_session`** — idempotency (call twice, same row)
+3. **Unit test for `end_session` no-op** — verify canonical session's `ended_at` stays NULL
+4. **Integration test** — `mika ask` with singleton agent identity, verify session reuse across invocations via DB query
+
+## Acceptance Criteria
+
+1. An agent with `[session] singleton = true` in identity.toml uses the same session for every `mika ask` invocation (without requiring `--session-id`)
+2. The canonical session is never ended (pruning-safe)
+3. Explicit `--session-id` overrides the singleton behavior
+4. mika-prime's canonical_id is the zero-UUID (`00000000-0000-0000-0000-000000000000`)
+5. The migration script successfully merges existing mika-prime sessions
+6. No changes to compaction, silent mode, callback, or heartbeat session paths
+7. `/clear` in TUI for singleton agents clears messages but preserves the session
+8. HTTP `/send` handler uses canonical session for singleton agents
+
+## Risk Assessment
+
+**Low risk.** The change is opt-in (default behavior unchanged), affects only conversational session creation (not silent/callback/system paths), and the singleton session is structurally safe against pruning. Compaction already works per-agent regardless of session count. The only data migration is the one-time mika-prime script, which is operator-runnable with verification queries.
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `crates/mika-agent/src/prompt.rs` | Add `SessionIdentityConfig`, `resolve_canonical_session_id` |
+| `crates/mika-agent/src/db.rs` | Add `get_or_create_canonical_session` |
+| `crates/mika-agent/src/async_db.rs` | Add async wrapper for canonical session |
+| `crates/mika-agent/src/server/state.rs` | Add `canonical_session_id` to `AgentState` |
+| `crates/mika-agent/src/server/mod.rs` | Populate canonical_session_id in `init_agent` |
+| `crates/mika-agent/src/server/handlers.rs` | Use canonical session in `/send` handler |
+| `crates/mika-cli/src/commands/ask.rs` | Use canonical session in `mika ask` |
+| `crates/mika-cli/src/commands/chat.rs` | Use canonical session in TUI |
+| `crates/mika-cli/src/tui/commands/handlers.rs` | Skip new session on `/clear` for singleton agents |
+| `scripts/migrate-singleton-sessions.sql` | One-time migration script |
+| `docs/runtime-structure.md` | Document `[session]` section |
+| `crates/mika-agent/CLAUDE.md` | Update Identity struct docs |
+
+## Open Questions (resolved in plan)
+
+1. **Should the canonical session use a special `channel_type`?** No — use `'cli'` for CLI-created and `req.channel` for HTTP-created. The singleton concept is orthogonal to channel type. Multiple channels merging into one session is the designed intent for single-surface oracles.
+
+2. **Should `create_session_with_metadata` work for canonical sessions?** The first call creates the session; subsequent calls should not fail. Use `INSERT OR IGNORE` for the session row. Task metadata correlation (from `--task-id`) goes on the message, not the session — the session is shared across invocations.
+
+3. **Should this be a schema migration?** No. No DDL changes are needed — the sessions table already supports arbitrary text IDs. The identity.toml change is configuration, not schema.

--- a/docs/runtime-structure.md
+++ b/docs/runtime-structure.md
@@ -43,7 +43,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 ├── agents/
 │   └── mika/                         # Default agent (same structure per agent)
 │       ├── config.toml               # Per-agent config overrides (0600)
-│       ├── identity.toml             # Agent name + emoji (0600)
+│       ├── identity.toml             # Agent name + emoji + [kg]/[skills]/[tools]/[context]/[session] blocks (0600)
 │       ├── soul.md                   # Personality definition (0600)
 │       ├── heartbeat.md              # Heartbeat checklist (0600)
 │       ├── user.md                   # User info seed (0600)
@@ -114,7 +114,7 @@ Durable changes to bundled skills must go through the source tree at `skills/bun
 
 **agents** — `id TEXT PK`, `name TEXT NOCASE`, `home_dir TEXT`, `active BOOLEAN DEFAULT 1`, `last_seen TEXT`, `created_at TEXT`
 
-**sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`
+**sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`. Session IDs are prefix-typed: random UUID (per-ask default), `system-{agent_id}` (compaction summaries), `canonical-{agent_id}` (single-session-by-nature agents, mika#1401), plus derived namespaces `heartbeat-*`, `callback-*`, `skill-*`, `reflection-*`, `team-*`, `delegate-*`, `reminder-*`. `prune_old_sessions` only deletes the derived-namespace prefixes; `canonical-*`, `system-*`, and bare UUIDs are exempt. Agents opt into a single canonical session via `[session] singleton = true` in `identity.toml` (see `crates/mika-agent/CLAUDE.md` § Session Configuration).
 
 **messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`, `internal INTEGER NOT NULL DEFAULT 0` (agent-to-agent messages hidden from TUI inbox mode)
 

--- a/scripts/migrate-singleton-sessions.sql
+++ b/scripts/migrate-singleton-sessions.sql
@@ -1,0 +1,130 @@
+-- migrate-singleton-sessions.sql (mika#1401)
+--
+-- One-time, operator-runnable migration that merges an agent's scattered
+-- per-ask sessions into its single canonical session. Written for mika-prime
+-- (agent_id 'mika-prime', canonical session '00000000-0000-0000-0000-000000000000'),
+-- but reusable for any agent newly opted into `[session] singleton = true`.
+--
+-- WHY: before mika#1401 every `mika ask` / `/send` minted a fresh Uuid::new_v4()
+-- session, so a conceptually single-session oracle accumulated per-ask "session
+-- confetti". The engine change stops the bleeding going forward; this script
+-- consolidates the pre-existing rows so history reads as one thread.
+--
+-- SAFETY:
+--   * Wrapped in `PRAGMA foreign_keys = OFF; BEGIN; ... COMMIT;` so FK-referencing
+--     rows can be repointed before the old session rows are deleted.
+--   * Idempotent — every WHERE clause self-narrows (`!= canonical`), so a second
+--     run is a no-op.
+--   * Take a backup first: `cp ~/.mika/data/mika.db ~/.mika/data/mika.db.bak`.
+--
+-- USAGE (defaults target mika-prime):
+--   sqlite3 ~/.mika/data/mika.db < scripts/migrate-singleton-sessions.sql
+--
+-- For a DIFFERENT agent, edit the two :param values in the `params` CTE below
+-- (SQLite has no CLI `.param set` in a piped script, so they are inlined).
+
+-- ---------------------------------------------------------------------------
+-- Parameters — edit these two lines for a non-mika-prime agent.
+-- ---------------------------------------------------------------------------
+-- AGENT_ID           = 'mika-prime'
+-- CANONICAL_SESSION  = '00000000-0000-0000-0000-000000000000'
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN;
+
+-- 0. Ensure the canonical session row exists (INSERT OR IGNORE mirrors the
+--    engine's get_or_create_canonical_session). channel_type 'cli' is arbitrary;
+--    the singleton concept is orthogonal to channel.
+INSERT OR IGNORE INTO sessions (id, agent_id, channel_type)
+VALUES ('00000000-0000-0000-0000-000000000000', 'mika-prime', 'cli');
+
+-- 1. Repoint every FK-referencing table from the old (non-canonical) sessions to
+--    the canonical one. Each UPDATE is scoped to the agent and skips rows already
+--    pointing at the canonical session (idempotency).
+
+--    messages: preserves per-row created_at ordering, so the merged thread stays
+--    chronologically coherent across the formerly-separate sessions.
+UPDATE messages
+SET session_id = '00000000-0000-0000-0000-000000000000'
+WHERE agent_id = 'mika-prime'
+  AND session_id != '00000000-0000-0000-0000-000000000000';
+
+--    audit_events (session_id may be NULL for non-session events).
+UPDATE audit_events
+SET session_id = '00000000-0000-0000-0000-000000000000'
+WHERE agent_id = 'mika-prime'
+  AND session_id IS NOT NULL
+  AND session_id != '00000000-0000-0000-0000-000000000000';
+
+--    llm_calls.
+UPDATE llm_calls
+SET session_id = '00000000-0000-0000-0000-000000000000'
+WHERE agent_id = 'mika-prime'
+  AND session_id IS NOT NULL
+  AND session_id != '00000000-0000-0000-0000-000000000000';
+
+--    tool_calls.
+UPDATE tool_calls
+SET session_id = '00000000-0000-0000-0000-000000000000'
+WHERE agent_id = 'mika-prime'
+  AND session_id IS NOT NULL
+  AND session_id != '00000000-0000-0000-0000-000000000000';
+
+--    a2a_task_map (no agent_id column — narrow via the sessions it points at).
+UPDATE a2a_task_map
+SET session_id = '00000000-0000-0000-0000-000000000000'
+WHERE session_id IN (
+        SELECT id FROM sessions
+        WHERE agent_id = 'mika-prime'
+          AND id != '00000000-0000-0000-0000-000000000000'
+      );
+
+--    tasks.created_by_session (no agent_id filter needed — session-scoped).
+UPDATE tasks
+SET created_by_session = '00000000-0000-0000-0000-000000000000'
+WHERE created_by_session IN (
+        SELECT id FROM sessions
+        WHERE agent_id = 'mika-prime'
+          AND id != '00000000-0000-0000-0000-000000000000'
+      );
+
+--    sessions.parent_session_id (child sessions that pointed at an old parent).
+UPDATE sessions
+SET parent_session_id = '00000000-0000-0000-0000-000000000000'
+WHERE parent_session_id IS NOT NULL
+  AND parent_session_id IN (
+        SELECT id FROM sessions
+        WHERE agent_id = 'mika-prime'
+          AND id != '00000000-0000-0000-0000-000000000000'
+      );
+
+-- 2. Delete the now-orphaned old session rows (everything for this agent except
+--    the canonical session). All references were repointed above, so nothing
+--    dangles.
+DELETE FROM sessions
+WHERE agent_id = 'mika-prime'
+  AND id != '00000000-0000-0000-0000-000000000000';
+
+-- 3. The canonical session must never be "ended" (pruning-safe). Clear any
+--    ended_at that a prior end_session call may have set before the engine
+--    fix landed.
+UPDATE sessions
+SET ended_at = NULL
+WHERE id = '00000000-0000-0000-0000-000000000000';
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;
+
+-- ---------------------------------------------------------------------------
+-- Verification — run after the script. Expect exactly ONE row, the canonical
+-- session, holding the full message count.
+-- ---------------------------------------------------------------------------
+-- SELECT session_id, COUNT(*) AS msg_count
+-- FROM messages
+-- WHERE agent_id = 'mika-prime'
+-- GROUP BY session_id;
+--
+-- SELECT id, ended_at FROM sessions WHERE agent_id = 'mika-prime';
+--   -> exactly one row, id = canonical session, ended_at = NULL


### PR DESCRIPTION
## Auto-rescued PR (dispatch-lib recovery, class: commit-pushed-no-pr)

<!-- rescue-pipeline-verified: yes -->

This PR was created by dispatch-lib's git-workflow recovery. The pilot session committed and pushed but did not open a PR (`gh pr create` failed, or the pilot ended its turn before invoking it — mika#1383). dispatch-lib opened this PR from the existing branch.

**Auto-rescued PR.** Operator: verify pipeline completion, then either un-draft this PR or set the marker above to `yes`.

### Recovery metadata
- Recovery class: `commit-pushed-no-pr`
- Pilot session: `d1e5dfed-c20d-431f-84c7-8e8b3af23a91`
- Turns: 24
- Cost: $4.028345000000001

Closes #1401
