### PR TITLE
feat(tui): thin-client ask.rs via A2A message/send (mika#1727 first step)

### DIFF
--- a/crates/mika-cli/src/commands/ask.rs
+++ b/crates/mika-cli/src/commands/ask.rs
@@ -1,13 +1,6 @@
-use anyhow::Result;
-use secrecy::ExposeSecret;
+use anyhow::{Context, Result};
 use std::io::Read;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use uuid::Uuid;
-
-use mika_agent::agent::{self, AgentParams, check_onboarding};
-use mika_agent::skills::SkillRegistry;
-use mika_agent::tools;
 
 use crate::cli::OutputFormat;
 use crate::init;
@@ -161,15 +154,6 @@ pub async fn run(
             tracing::warn!(error = %e, "failed to create session");
         }
     }
-    let http_client = reqwest::Client::new();
-    let message_sender = crate::init::make_message_sender(
-        &ctx.settings,
-        &ctx.async_db,
-        &http_client,
-        ctx.async_db.agent_id(),
-    );
-    let embedding_client = ctx.settings.make_embedding_client();
-
     // Read message from arg, or from stdin if "-"
     let user_message = if message == "-" {
         let mut buf = String::new();
@@ -292,41 +276,26 @@ pub async fn run(
         user_message
     };
 
-    // Normal ask mode — full conversation agent
-    let mut tool_registry = tools::default_tools();
-    for tool in tools::management_tools_if_needed(
-        &ctx.global_home,
-        &ctx.settings,
-        reqwest::Client::new(),
-        ctx.github_app.clone(),
-    ) {
-        tool_registry.register(tool);
-    }
-    let tool_registry = Arc::new(tool_registry);
-    let skills_dir = ctx.home_dir.join("skills");
-    // Migrate legacy .disabled marker files to DB (one-shot, idempotent).
-    if let Err(e) = mika_agent::skills::migrate_disabled_markers_async(
-        &skills_dir,
-        &ctx.async_db,
-        &ctx.async_db.agent_id,
-    )
-    .await
-    {
-        tracing::warn!(error = %e, "failed to migrate .disabled markers");
-    }
-    let mut skill_registry = SkillRegistry::from_dir(&skills_dir);
-    // `identity` was loaded earlier for canonical-session resolution (mika#1401); reuse it.
-    if let Some(ref allowlist) = identity.skills.allowlist {
-        skill_registry.apply_identity_allowlist(allowlist);
-    }
-    if let Ok(overrides) = ctx
-        .async_db
-        .get_skill_overrides(&ctx.async_db.agent_id)
-        .await
-    {
-        skill_registry.apply_overrides(&overrides);
-    }
-    // Validate --enable-skill / --disable-skill don't conflict on the same skill name.
+    // --- #1727 TUI/CLI thin-client slice ---
+    // The one-shot agent loop no longer runs in-process here. It is delegated to
+    // the local mika-spirit daemon over A2A (`message/send`), mirroring the
+    // `--remote` cloud path in `remote_ask.rs`. mika-spirit owns skills, tools,
+    // MCP, and per-run token accounting; this process is now a thin client that
+    // ships the prompt and renders the returned Task.
+    //
+    // Deferred follow-ups (flagged for MPC review, out of scope for this slice):
+    //   * `--enable-skill` / `--disable-skill` / `--model` configure the *local*
+    //     registry/LLM, which is no longer the execution surface. Their arg-level
+    //     validation is preserved, but they do not yet reach spirit — that needs
+    //     a config channel threaded through `message/send`.
+    //   * per-run token usage (verbose `tokens.*`) is not carried by the A2A
+    //     `Task`, so it degrades to absent until threaded through the protocol.
+    //   * the local bookkeeping session created above no longer records agent
+    //     turns (spirit owns the execution session); reconciling the two is a
+    //     follow-up.
+
+    // Preserve arg-level validation: --enable-skill / --disable-skill must not
+    // conflict on the same skill name.
     for enable_name in enable_skill {
         if disable_skill
             .iter()
@@ -338,85 +307,23 @@ pub async fn run(
         }
     }
 
-    // Apply transient overrides from --enable-skill / --disable-skill CLI flags.
-    // Runs after apply_overrides() so it stacks on top of DB state.
-    // Order: disable first, enable second (matches apply_overrides Phase 0/1 pattern).
-    if !disable_skill.is_empty() {
-        let result = skill_registry.apply_transient_disable(disable_skill);
-        for name in &result.not_found {
-            eprintln!("[mika] warning: --disable-skill '{name}' did not match any loaded skill");
-        }
-    }
-    if !enable_skill.is_empty() {
-        let result = skill_registry.apply_transient_always_on(enable_skill);
-        for name in &result.disabled {
-            eprintln!(
-                "[mika] warning: --enable-skill '{name}' has no effect — \
-                 skill is disabled. Run 'mika skills enable {name}' first."
-            );
-        }
-        for name in &result.not_found {
-            eprintln!("[mika] warning: --enable-skill '{name}' did not match any loaded skill");
-        }
-    }
-    skill_registry.apply_load_safety_check();
-    // Runtime allowlist↔required_tools coherence guard (mika#1576). Runs after
-    // safety check so the effective surface reflects only surviving skills.
-    skill_registry.apply_required_tools_coherence_check(agent_name);
-    skill_registry.log_summary();
-
-    // Surface validation warnings on stderr (Unit 4: #530)
-    let warn_count = skill_registry.validated_warnings().len();
-    if warn_count > 0 {
-        eprintln!(
-            "[mika] {warn_count} skill(s) loaded with validation warnings. \
-             Run 'mika skills validate' for details."
-        );
-    }
-
-    let skill_registry = Arc::new(skill_registry);
-    let is_onboarding = check_onboarding(&ctx.async_db).await;
-    let skills_dirty = AtomicBool::new(false);
-    let mcp_manager = init::connect_mcp(&ctx.home_dir).await;
-
     let started = std::time::Instant::now();
-    let output = agent::run_agent(&AgentParams {
-        db: &ctx.async_db,
-        llm: ctx.llm.as_ref(),
-        tools: &tool_registry,
-        skills: &skill_registry,
-        user_message: &user_message,
-        channel_type: "cli",
-        session_id: &session_id,
-        home_dir: &ctx.home_dir,
-        is_onboarding,
-        message_sender,
-        skip_compaction: false,
-        embedding_client: embedding_client.as_ref(),
-        thinking: None,
-        user_images: &[],
-        brave_api_key: ctx
-            .settings
-            .brave_api_key
-            .as_ref()
-            .map(|s| s.expose_secret()),
-        github_token: ctx.settings.agent_github_token(),
-        github_app: ctx.github_app.as_deref(),
-        skills_dirty: &skills_dirty,
-        mcp_manager: mcp_manager.as_ref(),
-        global_home_dir: Some(&ctx.global_home),
-        is_callback_turn: false,
-        settings: Some(&ctx.settings),
-        trace_id: None,
-        correlated_task_id: task_id.map(|s| s.to_string()),
-        internal: task_id.is_some() && !task_complete,
-        pr_reviews_posted: None, // CLI mode: no session-scoped dedup needed
-        stream_tx: None,         // A2A-only injection point (mika#1731)
-    })
-    .await;
 
-    // End the session regardless of agent result so the dashboard shows duration.
-    // No-op for singleton agents — the canonical session is never ended (mika#1401).
+    // Dispatch to the local mika-spirit A2A endpoint: {spirit_url}/a2a/{agent_name}.
+    let spirit_endpoint = format!(
+        "{}/a2a/{}",
+        crate::commands::dashboard::spirit_url(),
+        agent_name
+    );
+    let task = mika_cli::remote_ask::send_message_to_agent(&user_message, &spirit_endpoint)
+        .await
+        .with_context(|| {
+            format!("failed to reach mika-spirit over A2A at {spirit_endpoint} (is it running?)")
+        })?;
+
+    // End the local bookkeeping session regardless of outcome so the dashboard
+    // shows duration. No-op for singleton agents — the canonical session is never
+    // ended (mika#1401).
     if let Err(e) = ctx
         .async_db
         .end_session_unless_canonical(&session_id, canonical_session_id.as_deref())
@@ -425,7 +332,17 @@ pub async fn run(
         tracing::warn!(error = %e, "failed to end session");
     }
 
-    let output = output?;
+    // Extract the assistant text from the returned Task (artifacts → agent-role
+    // history → status message), reusing remote_ask's renderer. Empty output maps
+    // to `None` to preserve the text-mode fallback and JSON `content: null`.
+    let content: Option<String> = {
+        let rendered = mika_cli::remote_ask::render_task_parts(&task);
+        if rendered.is_empty() {
+            None
+        } else {
+            Some(rendered)
+        }
+    };
 
     // Check for pending callback tasks spawned during the agent loop (#265).
     // In `mika ask` there is no TaskEngine to poll for callbacks — the user needs
@@ -469,16 +386,12 @@ pub async fn run(
             None
         },
         latency_ms: if verbose { Some(elapsed_ms) } else { None },
-        tokens: if verbose {
-            output.usage.as_ref().map(|u| TokensMetadata {
-                input: Some(u.input_tokens),
-                output: Some(u.output_tokens),
-                cache_read: u.cache_read_input_tokens,
-                cache_write: u.cache_creation_input_tokens,
-            })
-        } else {
-            None
-        },
+        // #1727: per-run token usage is not carried by the A2A `Task` returned by
+        // `message/send`, so verbose `tokens.*` degrades to absent until threaded
+        // through the protocol. mika-spirit records usage server-side in the
+        // meantime. `TokensMetadata` is retained (constructed in tests + a future
+        // slice) so the JSON envelope shape stays stable for consumers.
+        tokens: None,
     };
 
     // Emit None when all fields are absent so the top-level `metadata` key
@@ -495,7 +408,7 @@ pub async fn run(
 
     match format {
         OutputFormat::Text => {
-            match output.text {
+            match content {
                 Some(text) => println!("{text}"),
                 None => eprintln!("{}", mika_agent::agent::EMPTY_RESPONSE_FALLBACK),
             }
@@ -547,7 +460,7 @@ pub async fn run(
         OutputFormat::Json => {
             let response = AskJsonResponse {
                 role: "assistant",
-                content: output.text,
+                content,
                 task_id: task_id.map(|s| s.to_string()),
                 pending_tasks: pending_callbacks,
                 metadata,
@@ -557,18 +470,13 @@ pub async fn run(
         OutputFormat::Yaml => {
             let response = AskJsonResponse {
                 role: "assistant",
-                content: output.text,
+                content,
                 task_id: task_id.map(|s| s.to_string()),
                 pending_tasks: pending_callbacks,
                 metadata,
             };
             print!("{}", serde_yaml::to_string(&response)?);
         }
-    }
-
-    // Gracefully shut down MCP server connections
-    if let Some(mcp) = mcp_manager {
-        mcp.shutdown().await;
     }
 
     // Database shutdown happens automatically via Drop on ctx

--- a/crates/mika-cli/src/remote_ask.rs
+++ b/crates/mika-cli/src/remote_ask.rs
@@ -105,39 +105,30 @@ fn build_send_params(message: &str) -> MessageSendParams {
     }
 }
 
-/// Dispatch a `mika ask` invocation in remote mode and return the rendered output.
+/// Send a single user message to an agent's A2A endpoint via `message/send` and
+/// return the terminal `Task`.
 ///
-/// Validates `remote_url`, sends the prompt via `A2aClient::send_message`, and
-/// renders the returned `Task` to a string in the requested format. Returns the
-/// rendered string rather than printing it so integration tests can assert on the
-/// output without capturing stdout. `run_remote` wraps this with a print.
+/// Shared core for both the `--remote` cloud path (`dispatch_remote`) and the
+/// local mika-spirit thin-client path (`commands::ask`, mika#1727). Handles auth,
+/// dispatch, and terminal-state validation; rendering is left to the caller so
+/// each surface can apply its own output shape.
 ///
-/// Errors are surfaced as `anyhow` failures with single-line prefixes per
-/// `A2aError` variant so the caller can `eprintln!("Error: {e}")` and exit non-zero.
-pub async fn dispatch_remote(
-    message: &str,
-    remote_url: &str,
-    format: OutputFormat,
-    verbose: bool,
-) -> Result<String> {
-    // Fail-fast URL validation. A2aClient itself doesn't pre-parse, so an invalid
-    // URL would surface as a reqwest send error — a less actionable message.
-    reqwest::Url::parse(remote_url)
-        .with_context(|| format!("invalid --remote URL: {remote_url}"))?;
-
-    // Filter out an empty MIKA_INTERNAL_TOKEN — set-but-empty (common with a
-    // misconfigured .env) would otherwise forward `Authorization: Bearer `, which
-    // the gateway 401s with no diagnostic hint. Treating empty as unset surfaces
-    // the same 401 but at least matches the no-auth diagnostic shape.
-    // Note on secrets discipline: `mika/CLAUDE.md` mandates `secrecy::SecretString`
-    // at the `Settings` accessor boundary, with downstream types using plain `String`.
-    // `A2aClient::new` takes `Option<String>` — its API IS the downstream boundary,
-    // so a plain-String read here is consistent with the convention. `A2aClient`
-    // does not derive `Debug`, so accidental log leakage is constrained.
+/// Auth is bearer-token via `MIKA_INTERNAL_TOKEN`. An empty value is treated as
+/// unset — set-but-empty (common with a misconfigured `.env`) would otherwise
+/// forward `Authorization: Bearer `, which the server 401s with no diagnostic
+/// hint; treating empty as unset surfaces the same 401 but matches the no-auth
+/// diagnostic shape. Per `mika/CLAUDE.md`, `secrecy::SecretString` guards the
+/// `Settings` accessor boundary; `A2aClient::new` takes `Option<String>` as the
+/// downstream boundary, so a plain-String read here is consistent, and
+/// `A2aClient` does not derive `Debug`, so accidental log leakage is constrained.
+///
+/// The caller is responsible for URL validation with a surface-appropriate error
+/// message (e.g. `--remote` vs. the local spirit endpoint).
+pub async fn send_message_to_agent(message: &str, url: &str) -> Result<Task> {
     let auth_token = std::env::var("MIKA_INTERNAL_TOKEN")
         .ok()
         .filter(|t| !t.is_empty());
-    let client = A2aClient::new(remote_url, auth_token);
+    let client = A2aClient::new(url, auth_token);
 
     let task = match client.send_message(build_send_params(message)).await {
         Ok(task) => task,
@@ -152,12 +143,11 @@ pub async fn dispatch_remote(
     // Inspect the terminal Task state. Per A2A v0.3 §6, a synchronous
     // `message/send` returns a Task in one of: Completed, Failed, Canceled,
     // Rejected, InputRequired, AuthRequired (terminal-or-pending). Submitted /
-    // Working are async-dispatch states the gateway should not return here.
+    // Working are async-dispatch states the server should not return here.
     //
-    // Render output for Completed and the pending-input states (the latter
-    // carry meaningful text content the user needs to see). Surface terminal-bad
-    // states and async-in-progress states as errors so the shell exit code
-    // matches the local `mika ask` contract.
+    // Completed and the pending-input states carry meaningful text the user needs
+    // to see. Surface terminal-bad and async-in-progress states as errors so the
+    // shell exit code matches the local `mika ask` contract.
     match task.status.state {
         TaskState::Completed | TaskState::InputRequired | TaskState::AuthRequired => {}
         TaskState::Failed | TaskState::Canceled | TaskState::Rejected => {
@@ -176,6 +166,30 @@ pub async fn dispatch_remote(
         }
     }
 
+    Ok(task)
+}
+
+/// Dispatch a `mika ask` invocation in remote mode and return the rendered output.
+///
+/// Validates `remote_url`, sends the prompt via `send_message_to_agent`, and
+/// renders the returned `Task` to a string in the requested format. Returns the
+/// rendered string rather than printing it so integration tests can assert on the
+/// output without capturing stdout. `run_remote` wraps this with a print.
+///
+/// Errors are surfaced as `anyhow` failures with single-line prefixes per
+/// `A2aError` variant so the caller can `eprintln!("Error: {e}")` and exit non-zero.
+pub async fn dispatch_remote(
+    message: &str,
+    remote_url: &str,
+    format: OutputFormat,
+    verbose: bool,
+) -> Result<String> {
+    // Fail-fast URL validation. A2aClient itself doesn't pre-parse, so an invalid
+    // URL would surface as a reqwest send error — a less actionable message.
+    reqwest::Url::parse(remote_url)
+        .with_context(|| format!("invalid --remote URL: {remote_url}"))?;
+
+    let task = send_message_to_agent(message, remote_url).await?;
     render(&task, format, verbose)
 }
 


### PR DESCRIPTION
## First step of #1727 (TUI/CLI thin-client refactor) — DRAFT, for MPC review

This is the **first concrete, self-contained slice** of the #1727 thin-client refactor. It turns `mika ask`'s one-shot execution into a thin HTTP client, modeled on the existing `--remote` precedent in `remote_ask.rs`.

### What changed
- **`remote_ask.rs`**: extracted a shared `send_message_to_agent(message, url) -> Task` (auth + A2A `message/send` dispatch + terminal-state validation). `dispatch_remote` now delegates to it. **No behavior change** to the `--remote` cloud path — its integration tests are unchanged and green.
- **`ask.rs`**: replaced the in-process `agent::run_agent(&AgentParams{...})` call (plus the tool/skill/MCP/embedding setup that only fed it) with an A2A dispatch to the **local mika-spirit** endpoint `{spirit_url}/a2a/{agent_name}`. Output extraction reuses `render_task_parts`. Local session/task bookkeeping, callback checks, and all output shapes (Text trailer / JSON `AskJsonResponse` / YAML) are preserved.

The server side already runs the real agent loop on `message/send` (`run_a2a_agent` → `agent::run_agent`), so the core `mika ask "..."` path is behavior-equivalent.

### Scope discipline
Only `ask.rs` and `remote_ask.rs` touched. `chat.rs`, `tui/app.rs`, and `mika-agent/src/lib.rs` untouched.

### Deferred (flagged for review — NOT in this slice)
- `--enable-skill` / `--disable-skill` / `--model` configure the *local* registry/LLM, which is no longer the execution surface. Their arg-level validation is preserved, but they don't yet reach spirit — needs a config channel through `message/send`.
- Verbose `tokens.*` degrades to absent (the A2A `Task` carries no per-run usage; spirit records it server-side).
- The local bookkeeping session no longer records agent turns (spirit owns the execution session); reconciling the two is a follow-up.

### Verification
- `cargo build -p mika-cli` — clean.
- `cargo test -p mika-cli` — 367 unit + 3 + 8 remote_ask integration, all green.
- clippy + fmt clean (pre-commit hooks passed).
- **mika-spirit is stopped**, so this is compile + unit/integration only. Live integration test pending spirit restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZi7tq7pLq3MiyLXtf8KKc