### PR TITLE
feat(agent-loop): stage-timing observability for team-agent pre-LLM prelude (delegation-hang diagnostic)

### DIFF
--- a/crates/mika-agent/src/agent_loop/mod.rs
+++ b/crates/mika-agent/src/agent_loop/mod.rs
@@ -4184,6 +4184,33 @@ async fn run_team_agent_inner(
         .await
 }
 
+/// Emit a stage-timing INFO event for the team-agent pre-LLM prelude.
+/// Returns the current instant so the caller can chain (`prev = emit_team_stage(...)`).
+///
+/// Delegation-hang diagnostic: when `delegate_task`'s 120s tool timeout fires
+/// with zero LLM calls in the delegate session, this trail tells the operator
+/// exactly which prelude stage stalled. Grep `event = "team_agent_stage"` in
+/// `$MIKA_SPIRIT_LOG_FILE` for stage/elapsed_ms per session.
+fn emit_team_stage(
+    stage: &'static str,
+    agent_name: &str,
+    session_id: &str,
+    prev: Instant,
+) -> Instant {
+    let now = Instant::now();
+    let elapsed_ms = now.duration_since(prev).as_millis() as u64;
+    tracing::info!(
+        target: "mika::otel",
+        event = "team_agent_stage",
+        agent = agent_name,
+        session_id = session_id,
+        stage,
+        elapsed_ms,
+        "team_agent pre-LLM stage complete"
+    );
+    now
+}
+
 async fn run_team_agent_inner_impl(
     params: &TeamAgentParams<'_>,
     deadline: Instant,
@@ -4191,7 +4218,26 @@ async fn run_team_agent_inner_impl(
     let llm = params.llm;
     let tools = params.tools;
 
+    // Pre-LLM stage-timing observability (mika delegation-hang diagnostic).
+    // The delegate_task tool has a 120s timeout; when it fires the inner
+    // `run_team_agent` future is dropped, so if the hang is in the pre-LLM
+    // prelude we see ZERO downstream events (no llm_call, no tool_call).
+    // Without checkpoints between session-create and first LLM call, the
+    // operator can't tell whether the hang was in `load_agent_context`, in
+    // `resolve_github_token` (App token exchange network), in
+    // `resolve_contexts` (per-context fetch), or in tool injection.
+    // Six checkpoints, each with elapsed_ms since the previous one, keyed
+    // on `event = "team_agent_stage"` for grep-friendly log queries.
+    let stage_start = Instant::now();
+
     let ctx = load_agent_context(params.db, params.home_dir).await?;
+    let mut stage_prev = stage_start;
+    stage_prev = emit_team_stage(
+        "load_agent_context",
+        params.agent_name,
+        params.session_id,
+        stage_prev,
+    );
 
     let prompt_ctx = prompt::PromptContext {
         soul_content: &ctx.soul_content,
@@ -4221,6 +4267,12 @@ async fn run_team_agent_inner_impl(
         system.push_str(params.team_context);
         system.push('\n');
     }
+    stage_prev = emit_team_stage(
+        "build_system_prompt",
+        params.agent_name,
+        params.session_id,
+        stage_prev,
+    );
 
     // Resolve GitHub token once: prefer GitHub App installation token, fall back to PAT.
     let team_resolved_github_token = if let Some(settings) = params.settings {
@@ -4228,6 +4280,12 @@ async fn run_team_agent_inner_impl(
     } else {
         params.github_token.map(String::from)
     };
+    stage_prev = emit_team_stage(
+        "resolve_github_token",
+        params.agent_name,
+        params.session_id,
+        stage_prev,
+    );
 
     // Match skills and resolve tool definitions
     let mut matched = params.skills.match_message(params.task_message);
@@ -4236,6 +4294,12 @@ async fn run_team_agent_inner_impl(
     review_filter::apply_review_filter(&mut matched, params.task_message);
 
     let matched_entries: Vec<&SkillEntry> = matched.iter().map(|m| m.entry).collect();
+    stage_prev = emit_team_stage(
+        "match_skills",
+        params.agent_name,
+        params.session_id,
+        stage_prev,
+    );
 
     // Resolve context requirements before LLM override
     let (resolved_context, context_exclude) = context::resolve_contexts(
@@ -4248,6 +4312,12 @@ async fn run_team_agent_inner_impl(
     for &idx in context_exclude.iter().rev() {
         matched.remove(idx);
     }
+    let _ = emit_team_stage(
+        "resolve_contexts",
+        params.agent_name,
+        params.session_id,
+        stage_prev,
+    );
     // Resolve per-skill LLM override (keyword-matched skills only — #463)
     let skill_llm_override = resolve_skill_llm_override(&matched, params.settings, llm);
     let matched_entries: Vec<&SkillEntry> = matched.iter().map(|m| m.entry).collect();


### PR DESCRIPTION
## Summary

- Add 5 stage-timing INFO events (event: `team_agent_stage`) in `run_team_agent_inner_impl` covering the pre-LLM prelude
- New helper `emit_team_stage` inline (single-consumer, agent_loop/mod.rs)
- Stages: `load_agent_context`, `build_system_prompt`, `resolve_github_token`, `match_skills`, `resolve_contexts`
- Zero behavioral change, pure observability

## Why

**Delegation Mika→Prime hangs intermittently.** Observed evidence:

| Session | Started | Ended | LLM calls | Tool calls | Notes |
|---|---|---|---|---|---|
| `delegate-7cea7d9e-*` | 2026-08-03 08:58 UTC | NULL | 0 | 0 | 120s tool timeout, pre-LLM hang |
| `delegate-bbb80d08-*` | 2026-08-03 09:32 UTC | NULL | 0 | 0 | same pattern |
| `delegate-1e9cf7b1-*` | 2026-08-03 09:59 UTC | 32s | 1 | 0 | worked (short) |
| `delegate-707cea29-*` | 2026-08-03 17:50 UTC | 18s | 1 | 0 | worked (short, sonnet) |
| `delegate-78c2d856-*` | 2026-08-03 17:56 UTC | 72s | 7 | 0 | worked (complex, sonnet) |

Hangs = ZERO downstream events. `delegate_task`'s 120s timeout fires, the future is dropped, and we lose the ability to tell which pre-LLM stage stalled.

**Suspects investigated** (all reduced by code inspection):
- KG loading with `[kg] enabled=false + docs_roots` set → `resolve_per_agent_docs_root` short-circuits at `!identity.kg.enabled` (`crates/mika-agent/src/kg/config.rs:101`).
- Singleton zero-UUID race → `resolve_canonical_session_id` returns None for non-singleton agents; Prime's identity.toml has no `[session]` block.
- Identity/allowlist race → `load_identity_async` is a straightforward tokio fs read + toml parse.

Root cause remains elusive without runtime evidence. This PR closes that visibility gap.

## Fix

`run_team_agent_inner_impl` now emits one INFO event per stage between session-create and first LLM call:

```
event = "team_agent_stage"
stage = "load_agent_context" | "build_system_prompt" | "resolve_github_token" | "match_skills" | "resolve_contexts"
agent = <agent_name>
session_id = <session_id>
elapsed_ms = <duration since previous stage>
target = "mika::otel"
```

Grep pattern for operators:

```bash
grep event.*team_agent_stage \$MIKA_SPIRIT_LOG_FILE | jq '{stage, elapsed_ms, session_id, agent}'
```

If a stage exceeds ~5s consistently or the trail STOPS mid-way, the last-emitted stage names the culprit.

## Non-fix (deliberately)

- **No timeout change.** `delegate_task`'s 120s tool timeout stays as-is. Bumping without root cause hides real hangs.
- **No behavioral change.** Same code path, same execution — just observability added.
- **No downstream L1 spec coupling** (see D7 sub-language proposal, separate track).

## Test plan

- [x] `cargo build -p mika-agent --lib` — clean
- [x] `cargo test -p mika-agent --lib agent_loop` — 277 pass
- [x] `cargo clippy -p mika-agent --lib` — clean (no new warnings)
- [x] `cargo fmt --check` — clean
- [ ] **Post-deploy (operator):** on next observed delegate timeout, grep `team_agent_stage` for the affected session and confirm the trail identifies the stall point.

## Ship path

Non-souverain — mechanism-only, no policy/decision-core surface touched. Standard PR + CI-green merge per sami-darko's ratification (mail 2026-08-03 17:47).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>