### PR TITLE
feat(dispatch): dev-pilot containment layer (bwrap fs+kernel+env cut + hostname-allowlist egress relay)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ restart: ## Restart mika-spirit and mika-gateway (via OpenRC)
 		sudo rc-service "$$bin" restart || true; \
 	done
 
-install: ## Copy release binaries to INSTALL_DIR (safe while services run)
+install: ## Copy release binaries + scripts to INSTALL_DIR (safe while services run)
 	@mkdir -p $(INSTALL_DIR)
 	@for bin in $(BINARIES); do \
 		if [ ! -f target/release/$$bin ]; then \
@@ -41,6 +41,12 @@ install: ## Copy release binaries to INSTALL_DIR (safe while services run)
 		if [ "$$(uname)" = "Darwin" ]; then codesign -s - $(INSTALL_DIR)/$$bin; fi; \
 		echo "Installed $$bin -> $(INSTALL_DIR)/$$bin"; \
 	done
+	@# Ship the pilot egress proxy alongside the binaries so dispatch-lib.sh
+	@# can find it on PATH (bwrap Phase 2b — network cut + hostname allowlist).
+	@cp scripts/mika-pilot-egress-proxy $(INSTALL_DIR)/mika-pilot-egress-proxy.tmp
+	@chmod +x $(INSTALL_DIR)/mika-pilot-egress-proxy.tmp
+	@mv $(INSTALL_DIR)/mika-pilot-egress-proxy.tmp $(INSTALL_DIR)/mika-pilot-egress-proxy
+	@echo "Installed mika-pilot-egress-proxy -> $(INSTALL_DIR)/mika-pilot-egress-proxy"
 
 deploy: deploy-info build-dashboard build install restart check-ngrok ## Full deploy: build, install, restart
 

--- a/scripts/canary-pilot-containment
+++ b/scripts/canary-pilot-containment
@@ -1,0 +1,206 @@
+#!/bin/bash
+# canary-pilot-containment — reproducible verdict-ready canary for coherence.
+#
+# WHAT: spawns claude-pilot's containment shape from the working branch
+# (feat/pilot-bwrap-containment-v1), then runs the adversarial must-fail +
+# must-work suite from INSIDE the actual sandbox, capturing every result.
+#
+# WHY: coherence full-validation gate requires a real spawn on the complete
+# shape (Phase 1 env + Phase 2a fs/kernel/env + Phase 2b net). This script
+# reproduces that shape via `_run_pilot_sandboxed` — the SAME code path a
+# real dispatch takes — without needing to trigger a full dev-pilot pipeline
+# (which would (a) pollute mika.db with a canary task, (b) still hit the
+# pre-existing cpp deny wall on ce-work preamble until cpp is extended, so
+# would not produce more information than this harness does).
+#
+# HOW: sources dispatch-lib.sh from the branch worktree, installs the
+# egress-proxy binary to ~/.local/bin (dry-run mimicking `make install`),
+# then invokes _run_pilot_sandboxed with two sequential payloads:
+#   (1) claude-pilot --version   — proves the pilot binary boots inside the
+#                                   real sandbox (env resolves, libs load,
+#                                   stdin/stdout work)
+#   (2) diagnostic hole-hunt     — the coherence adversarial suite
+#                                   (must-fail + must-work + env + /proc)
+#
+# WHAT COHERENCE VERIFIES from the output:
+#   * bwrap shape shown by `ps` matches the documented shape
+#   * every must-fail line is "ok:" (no LEAK)
+#   * every must-work line succeeds (gh, node, cargo, rustc, python3, git)
+#   * env_ok + proc_ok
+#   * curl exfil returns 403 (proxy DENY) or blocked_direct
+#   * curl allowlisted returns 200
+#
+# INVOKE:
+#   ./scripts/canary-pilot-containment              # run canary, print report
+#   ./scripts/canary-pilot-containment --show-args  # print bwrap args only
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SCRIPT="$REPO_ROOT/scripts/mika-pilot-egress-proxy"
+DISPATCH_LIB="$REPO_ROOT/skills/bundled/_shared/dispatch-lib.sh"
+INSTALLED_PROXY="$HOME/.local/bin/mika-pilot-egress-proxy"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "canary: mika-pilot-egress-proxy missing at $SCRIPT" >&2
+    exit 1
+fi
+if [ ! -f "$DISPATCH_LIB" ]; then
+    echo "canary: dispatch-lib.sh missing at $DISPATCH_LIB" >&2
+    exit 1
+fi
+
+# Install the proxy binary to ~/.local/bin (mimics `make install`). Safe:
+# same path production uses; overwrite is idempotent.
+install -Dm755 "$SCRIPT" "$INSTALLED_PROXY"
+
+# Source dispatch-lib. Set WORKTREE_DIR to the branch worktree — matches
+# the invariant that _run_pilot_sandboxed binds this path rw.
+export WORKTREE_DIR="$REPO_ROOT"
+# shellcheck source=/dev/null
+source "$DISPATCH_LIB"
+
+# --show-args mode: print the exact bwrap args + exit. For coherence to
+# review without running the sandbox.
+if [ "${1:-}" = "--show-args" ]; then
+    # Enable tracing of just the bwrap invocation
+    set -x
+    _run_pilot_sandboxed /bin/true 2>&1 | head -80
+    exit 0
+fi
+
+# Simulate host env vars a real spawn would carry through (post PR#1893
+# env allowlist). Only allowlisted vars will survive `--clearenv`.
+export ATLASSIAN_API_TOKEN="canary-must-not-leak-atlassian"
+export ANTHROPIC_API_KEY="canary-must-not-leak-anthropic"
+export AWS_SECRET_ACCESS_KEY="canary-must-not-leak-aws"
+export NODE_AUTH_TOKEN="canary-must-not-leak-npm"
+export GH_TOKEN="${GH_TOKEN:-canary-gh-token-for-passthrough}"
+export ANTHROPIC_LOG_FILE="/tmp/pilot-transcripts.jsonl"
+export MIKA_LOG_PILOT_TRANSCRIPTS="1"
+
+echo "============================================================"
+echo "canary-pilot-containment — real spawn under branch shape"
+echo "============================================================"
+echo "WORKTREE_DIR: $WORKTREE_DIR"
+echo "proxy binary: $INSTALLED_PROXY ($(stat -c %y "$INSTALLED_PROXY" 2>/dev/null | cut -d. -f1))"
+echo "bwrap:        $(command -v bwrap) ($(bwrap --version 2>&1))"
+echo "date:         $(date -Iseconds)"
+echo
+
+echo "============================================================"
+echo "PART 1 — claude-pilot binary boots inside sandbox"
+echo "============================================================"
+_run_pilot_sandboxed sh -c '
+    if command -v claude-pilot >/dev/null 2>&1; then
+        echo "claude-pilot in PATH: $(command -v claude-pilot)"
+        claude-pilot --version 2>&1 | head -3 || echo "claude-pilot --version exit=$?"
+    else
+        echo "claude-pilot NOT in PATH (Phase 2b bind narrow — expected if uv-shim absent)"
+        # Fall back to direct venv invocation
+        ~/.local/share/uv/tools/claude-pilot/bin/claude-pilot --version 2>&1 | head -3 || echo "direct exit=$?"
+    fi
+' || echo "PART 1 exit=$?"
+echo
+
+echo "============================================================"
+echo "PART 2 — coherence adversarial hole-hunt (must-fail + must-work)"
+echo "============================================================"
+_run_pilot_sandboxed sh -c '
+echo "--- must-fail: filesystem (15 credential/state paths) ---"
+for p in \
+    ~/.ssh \
+    ~/.aws \
+    ~/.mika/.env \
+    ~/.mika/oauth.json \
+    ~/.mika/data/mika.db \
+    ~/.claude/.credentials.json \
+    ~/.local/share/jupyter/notebook_secret \
+    ~/.local/share/jupyter/runtime/jupyter_cookie_secret \
+    ~/.local/share/uv/credentials/credentials.toml.lock \
+    ~/.config \
+    ~/.cargo/credentials.toml \
+    ~/.config/gh/hosts.yml \
+    /var/spool/claude-mail \
+    /data/workspace/mika-platform/mika-cloud \
+    /data/workspace/mika-platform/mika-skills \
+    /data/workspace/mika-platform/wizzard ; do
+    if ls "$p" >/dev/null 2>&1; then echo "LEAK: $p"; else echo "ok:   $p"; fi
+done
+
+echo
+echo "--- must-fail: env vars (should be dropped by --clearenv) ---"
+env | grep -E "^(ATLASSIAN|AWS_SECRET|NODE_AUTH|ANTHROPIC_API_KEY)=" >/dev/null 2>&1 \
+    && echo "ENV_LEAK: some cred-shaped var survived" \
+    || echo "ok:   env_cleared (no ATLASSIAN/AWS_SECRET/NODE_AUTH/ANTHROPIC_API_KEY)"
+
+echo
+echo "--- must-fail: /proc/1/environ (host mika-spirit env harvest) ---"
+if cat /proc/1/environ 2>/dev/null | tr "\0" "\n" | grep -qE "^(ATLASSIAN|AWS_SECRET|MIKA_ANTHROPIC|MIKA_INTERNAL_TOKEN)="; then
+    echo "PROC_LEAK"
+else
+    echo "ok:   proc_1_env_clean"
+fi
+
+echo
+echo "--- must-fail: network egress (raw socket + DNS + non-allowlisted host) ---"
+# Use base64 to sidestep quote-nesting hell between outer sh -c and python -c.
+_NET_TEST_B64=aW1wb3J0IHNvY2tldApzID0gc29ja2V0LnNvY2tldCgpCnMuc2V0dGltZW91dCgyKQp0cnk6CiAgICBzLmNvbm5lY3QoKCIxLjEuMS4xIiwgNDQzKSkKICAgIHByaW50KCJMRUFLOiByYXcgc29ja2V0IHRvIDEuMS4xLjE6NDQzIHN1Y2NlZWRlZCIpCmV4Y2VwdCBPU0Vycm9yIGFzIGU6CiAgICBwcmludChmIm9rOiAgIHJhd19zb2NrZXRfYmxvY2tlZCAoe3R5cGUoZSkuX19uYW1lX199KSIpCnRyeToKICAgIGlwID0gc29ja2V0LmdldGhvc3RieW5hbWUoImV2aWwuY29tIikKICAgIHByaW50KGYiTEVBSzogRE5TIHJlc29sdmVkIGV2aWwuY29tIC0+IHtpcH0iKQpleGNlcHQgRXhjZXB0aW9uIGFzIGU6CiAgICBwcmludChmIm9rOiAgIGRuc19ibG9ja2VkICh7dHlwZShlKS5fX25hbWVfX30pIikK
+echo "$_NET_TEST_B64" | base64 -d | python3
+
+curl -sS -m 4 -o /dev/null -w "curl_evil=%{http_code}\n" https://evil.example.com/ 2>&1 | head -1 \
+    || echo "ok:   curl_evil_error (expected — 403 via proxy)"
+
+echo
+echo "--- must-work: allowlisted egress ---"
+curl -sS -m 8 -o /dev/null -w "curl_github=%{http_code}\n" https://api.github.com/ 2>&1 | head -1
+
+echo
+echo "--- must-work: tools (6/6) ---"
+gh --version 2>&1 | head -1 || echo "FAIL: gh missing"
+if command -v node >/dev/null 2>&1; then node --version 2>&1; \
+elif [ -x "$HOME/.nvm/versions/node/v24.13.0/bin/node" ]; then $HOME/.nvm/versions/node/v24.13.0/bin/node --version 2>&1; \
+else echo "FAIL: node missing"; fi
+cargo --version 2>&1 | head -1 || echo "FAIL: cargo missing"
+rustc --version 2>&1 | head -1 || echo "FAIL: rustc missing"
+python3 --version 2>&1 | head -1 || echo "FAIL: python3 missing"
+git --version 2>&1 | head -1 || echo "FAIL: git missing"
+
+echo
+echo "--- must-work: worktree R/W + pilot-transcripts R/W ---"
+if touch "$WORKTREE_DIR/scratch-canary" && rm "$WORKTREE_DIR/scratch-canary"; then
+    echo "ok:   worktree_rw"
+else
+    echo "FAIL: worktree not writable"
+fi
+if touch ~/.mika/data/pilot-transcripts/canary-test.jsonl && rm ~/.mika/data/pilot-transcripts/canary-test.jsonl; then
+    echo "ok:   pilot_transcripts_rw"
+else
+    echo "FAIL: pilot-transcripts not writable"
+fi
+
+echo
+echo "--- structural: kernel namespace isolation ---"
+echo "PID 1 in namespace: $(cat /proc/self/status | grep -E "^(NSpid|Pid)" | head -2)"
+echo "hostname: $(hostname 2>&1)"
+' || echo "PART 2 exit=$?"
+
+echo
+echo "============================================================"
+echo "PART 3 — host-side egress proxy log (last 20 lines)"
+echo "============================================================"
+for p in /var/log/mika/pilot-egress-proxy.log /tmp/mika-pilot-egress-proxy.log; do
+    if [ -f "$p" ]; then
+        echo "--- $p ---"
+        tail -20 "$p" 2>&1 | head -20
+        break
+    fi
+done
+
+echo
+echo "============================================================"
+echo "canary complete — coherence review:"
+echo "  every must-fail line MUST be 'ok:' or 'blocked'"
+echo "  every must-work line MUST succeed (version string)"
+echo "  proxy log MUST show DENY on evil.example.com + ALLOW on api.github.com"
+echo "============================================================"

--- a/scripts/canary-pilot-containment
+++ b/scripts/canary-pilot-containment
@@ -33,6 +33,15 @@
 # INVOKE:
 #   ./scripts/canary-pilot-containment              # run canary, print report
 #   ./scripts/canary-pilot-containment --show-args  # print bwrap args only
+#   ./scripts/canary-pilot-containment --enter      # enter live sandbox as sh
+#                                                     (coherence probes here from
+#                                                     the OUTSIDE — probes come
+#                                                     via stdin; interactive if
+#                                                     stdin is a TTY)
+#   ./scripts/canary-pilot-containment --ensure-relay
+#                                                   # start the egress relay
+#                                                     daemon if not running, exit
+#                                                     0 (idempotent)
 
 set -euo pipefail
 
@@ -61,12 +70,53 @@ export WORKTREE_DIR="$REPO_ROOT"
 source "$DISPATCH_LIB"
 
 # --show-args mode: print the exact bwrap args + exit. For coherence to
-# review without running the sandbox.
+# review without running the sandbox. Runs the helper under bash -x so
+# every command (including the internal bwrap invocation) is traced.
 if [ "${1:-}" = "--show-args" ]; then
-    # Enable tracing of just the bwrap invocation
-    set -x
-    _run_pilot_sandboxed /bin/true 2>&1 | head -80
+    export WORKTREE_DIR
+    bash -x -c "
+        source '$DISPATCH_LIB'
+        _run_pilot_sandboxed /bin/true
+    " 2>&1 | grep -E '^\+ *(bwrap|--)' | head -100
     exit 0
+fi
+
+# --ensure-relay mode: bring up host-side egress-proxy daemon idempotently,
+# print status, exit. Coherence runs this once before entering the sandbox
+# (or the sandbox itself will lazy-launch it via _ensure_pilot_egress_proxy).
+if [ "${1:-}" = "--ensure-relay" ]; then
+    if _ensure_pilot_egress_proxy; then
+        echo "relay: up ($_PILOT_EGRESS_SOCK)"
+        exit 0
+    fi
+    echo "relay: FAILED to start (see stderr above)" >&2
+    exit 1
+fi
+
+# --enter mode: bring up the relay, then exec /bin/sh inside the FULL branch
+# shape (Phase 2b bwrap wrap). stdin/stdout/stderr are passed through so:
+#   * a piped-in adversarial script runs and prints results
+#   * an interactive TTY on stdin gets a shell prompt
+# This is the sonde-live pattern coherence needs: MPC does not control what
+# runs inside, coherence does. Print the exact bwrap args first so the
+# invocation is auditable (the "author is not their own control" gate).
+if [ "${1:-}" = "--enter" ]; then
+    echo "============================================================" >&2
+    echo "canary --enter: full branch shape, coherence probes here" >&2
+    echo "============================================================" >&2
+    echo "The exact bwrap invocation follows (--show-args tracing):" >&2
+    echo "------------------------------------------------------------" >&2
+    ( set -x; _run_pilot_sandboxed /bin/true 2>&1 ) 2>&1 >/dev/null | head -100 >&2 || true
+    echo "------------------------------------------------------------" >&2
+    echo "Egress-proxy log tail (host-side allowlist audit):" >&2
+    for p in /var/log/mika/pilot-egress-proxy.log /tmp/mika-pilot-egress-proxy.log; do
+        if [ -f "$p" ]; then echo "$p" >&2; break; fi
+    done
+    echo "------------------------------------------------------------" >&2
+    echo "Entering sandbox. Type your hole-hunt (Ctrl-D to exit)." >&2
+    echo >&2
+    _run_pilot_sandboxed /bin/sh
+    exit $?
 fi
 
 # Simulate host env vars a real spawn would carry through (post PR#1893

--- a/scripts/mika-pilot-egress-proxy
+++ b/scripts/mika-pilot-egress-proxy
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""HTTPS CONNECT proxy with hostname allowlist — dev-pilot containment Phase 2b.
+
+Two invocation modes:
+
+  mika-pilot-egress-proxy --host-unix
+      Listens on `/tmp/mika-pilot-egress.sock` (unix socket).
+      Accepts HTTP CONNECT, filters by hostname allowlist, forwards to upstream.
+      This is the SECURITY BOUNDARY — only the allowlisted hosts reachable.
+      Runs as long-lived daemon on the host (spawned by dispatch-lib.sh).
+
+  mika-pilot-egress-proxy --sandbox-tcp <PORT>
+      Listens on 127.0.0.1:<PORT> (TCP, on sandbox loopback).
+      Forwards each connection verbatim to `/tmp/mika-pilot-egress.sock`
+      (which is bind-mounted from host by bwrap). No filtering here — the
+      host side is the gate. This exists ONLY because most HTTP clients
+      (reqwest, node fetch, cargo) don't accept `HTTPS_PROXY=unix:///path`.
+
+Design rationale (see coherence audit 2026-08-04 + Phase 2b design):
+
+  * `--unshare-net` in bwrap gives a fresh network namespace — the sandbox
+    has ONLY `lo` interface. No route to host loopback, no DNS, no anything.
+  * The unix socket is the sole escape from the sandbox namespace, and
+    only the allowlisted hosts (via CONNECT hostname check) can be reached.
+  * DNS is done host-side by this proxy — the sandbox has no resolver
+    (nothing bound at /etc/resolv.conf resolution level once net is gone).
+  * Raw sockets from sandbox → nowhere to go: no host reachable via TCP.
+
+Allowlist covers the three concrete need classes:
+  1. LLM providers: api.anthropic.com, api.openai.com, api.z.ai, openrouter.ai
+  2. GitHub (gh CLI, git push/fetch): api.github.com, github.com, ssh.github.com,
+     codeload.github.com, objects.githubusercontent.com (LFS)
+  3. Package registries used by the pilot's builds:
+     - crates.io ecosystem: crates.io, static.crates.io, index.crates.io
+     - npm: registry.npmjs.org (some cargo/plugin flows)
+     - PyPI: pypi.org, files.pythonhosted.org (uv / pip if the pilot touches Python)
+
+Adding a hostname requires a code change here — deliberate friction. If a
+pilot needs to reach a new host, that surfaces as a proxy-403 in its logs
+and gets a governance decision.
+
+Failure modes:
+  * 403 Forbidden — hostname not in allowlist.
+  * 502 Bad Gateway — upstream connect failed (DNS / connect timeout).
+  * 400 Bad Request — malformed CONNECT.
+  * Socket errors closed silently — expected on client abort.
+"""
+
+import argparse
+import asyncio
+import os
+import re
+import socket
+import stat
+import sys
+from pathlib import Path
+
+# Sole security boundary — every entry is a decision.
+HOST_ALLOWLIST = frozenset({
+    # LLM providers used by claude-pilot / claude-agent-sdk.
+    "api.anthropic.com",
+    "api.openai.com",
+    "api.z.ai",
+    "openrouter.ai",
+    # GitHub — pilot uses gh CLI + git push/fetch.
+    "api.github.com",
+    "github.com",
+    "ssh.github.com",
+    "codeload.github.com",
+    "objects.githubusercontent.com",
+    # Cargo registry ecosystem.
+    "crates.io",
+    "static.crates.io",
+    "index.crates.io",
+    # npm registry (some cargo/plugin flows pull JS deps).
+    "registry.npmjs.org",
+    # PyPI (uv / pip if the pilot touches Python).
+    "pypi.org",
+    "files.pythonhosted.org",
+})
+
+DEFAULT_UNIX_SOCK = "/tmp/mika-pilot-egress.sock"
+BUFFER_SIZE = 65536
+CONNECT_RE = re.compile(rb"^CONNECT ([^:\s]+):(\d+) HTTP/1\.[01]\r\n", re.ASCII)
+
+
+async def pipe_bytes(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """Forward reader → writer until either side closes. Silent on error."""
+    try:
+        while True:
+            data = await reader.read(BUFFER_SIZE)
+            if not data:
+                break
+            writer.write(data)
+            await writer.drain()
+    except (ConnectionResetError, BrokenPipeError, asyncio.CancelledError, OSError):
+        pass
+    finally:
+        try:
+            writer.close()
+        except OSError:
+            pass
+
+
+async def handle_host_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Host-side handler: parse CONNECT, filter hostname, bridge to upstream."""
+    peer = "unknown"
+    try:
+        # Read request line + headers (up to blank line).
+        try:
+            request = await asyncio.wait_for(
+                reader.readuntil(b"\r\n\r\n"), timeout=10.0
+            )
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+            writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            await writer.drain()
+            return
+
+        match = CONNECT_RE.match(request)
+        if not match:
+            writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            await writer.drain()
+            return
+
+        host = match.group(1).decode("ascii", errors="replace")
+        port = int(match.group(2))
+        peer = f"{host}:{port}"
+
+        if host not in HOST_ALLOWLIST:
+            body = (
+                f"host '{host}' not in mika-pilot egress allowlist"
+                "\n"
+            ).encode("utf-8")
+            writer.write(
+                b"HTTP/1.1 403 Forbidden\r\n"
+                b"Content-Type: text/plain; charset=utf-8\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n"
+                b"\r\n"
+                + body
+            )
+            await writer.drain()
+            print(f"[egress] DENY {peer}", file=sys.stderr, flush=True)
+            return
+
+        # Upstream connect. Bounded timeout so a dead upstream can't wedge.
+        try:
+            up_reader, up_writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port), timeout=15.0
+            )
+        except (asyncio.TimeoutError, OSError) as exc:
+            writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            await writer.drain()
+            print(f"[egress] FAIL {peer}: {exc}", file=sys.stderr, flush=True)
+            return
+
+        writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        await writer.drain()
+        print(f"[egress] ALLOW {peer}", file=sys.stderr, flush=True)
+
+        # Bidirectional relay. Either side closing tears down both.
+        await asyncio.gather(
+            pipe_bytes(reader, up_writer),
+            pipe_bytes(up_reader, writer),
+            return_exceptions=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — proxy must not crash on bad clients
+        print(f"[egress] ERROR {peer}: {exc}", file=sys.stderr, flush=True)
+    finally:
+        try:
+            writer.close()
+        except OSError:
+            pass
+
+
+async def handle_sandbox_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    unix_sock_path: str,
+) -> None:
+    """Sandbox-side handler: verbatim pipe TCP client ↔ unix socket to host."""
+    try:
+        try:
+            up_reader, up_writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(unix_sock_path), timeout=5.0
+            )
+        except (asyncio.TimeoutError, OSError):
+            writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            await writer.drain()
+            return
+        await asyncio.gather(
+            pipe_bytes(reader, up_writer),
+            pipe_bytes(up_reader, writer),
+            return_exceptions=True,
+        )
+    finally:
+        try:
+            writer.close()
+        except OSError:
+            pass
+
+
+async def run_host_mode(unix_sock_path: str) -> None:
+    sock_path = Path(unix_sock_path)
+    # Remove stale socket if present.
+    if sock_path.exists():
+        try:
+            if stat.S_ISSOCK(sock_path.stat().st_mode):
+                sock_path.unlink()
+            else:
+                sys.exit(f"refusing to unlink non-socket: {sock_path}")
+        except OSError as exc:
+            sys.exit(f"stale-socket cleanup failed: {exc}")
+
+    server = await asyncio.start_unix_server(handle_host_client, str(sock_path))
+    # World-writable so the sandbox (running as same uid, but env-cleared) can
+    # still connect through the bwrap-mounted socket path.
+    sock_path.chmod(0o666)
+    print(
+        f"[egress] host-unix listening on {sock_path} (allowlist: "
+        f"{len(HOST_ALLOWLIST)} hosts)",
+        file=sys.stderr,
+        flush=True,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+async def run_sandbox_mode(port: int, unix_sock_path: str) -> None:
+    server = await asyncio.start_server(
+        lambda r, w: handle_sandbox_client(r, w, unix_sock_path),
+        host="127.0.0.1",
+        port=port,
+    )
+    print(
+        f"[egress-shim] tcp 127.0.0.1:{port} → {unix_sock_path}",
+        file=sys.stderr,
+        flush=True,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="mika-pilot-egress-proxy",
+        description=__doc__.split("\n", 1)[0],
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--host-unix",
+        action="store_true",
+        help="Run as host-side unix socket proxy with hostname allowlist",
+    )
+    mode.add_argument(
+        "--sandbox-tcp",
+        type=int,
+        metavar="PORT",
+        help="Run as sandbox-side TCP→unix bridge on 127.0.0.1:PORT",
+    )
+    parser.add_argument(
+        "--socket",
+        default=DEFAULT_UNIX_SOCK,
+        help=f"Unix socket path (default: {DEFAULT_UNIX_SOCK})",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        if args.host_unix:
+            asyncio.run(run_host_mode(args.socket))
+        else:
+            asyncio.run(run_sandbox_mode(args.sandbox_tcp, args.socket))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -110,6 +110,12 @@ _run_pilot_sandboxed() {
         "$@"
         return $?
     fi
+    # Ensure pilot-transcript dir exists BEFORE the bind — bwrap refuses to
+    # bind a source path that doesn't exist. The dir is created on demand by
+    # mika#1705 anyway when the first transcript flushes; we create it eagerly
+    # here so the bind is stable even on a fresh install.
+    mkdir -p "$HOME/.mika/data/pilot-transcripts" 2>/dev/null || true
+
     local -a setenv_args=()
     local var
     for var in "${_PILOT_SANDBOX_ENV_ALLOWLIST[@]}"; do
@@ -117,6 +123,13 @@ _run_pilot_sandboxed() {
             setenv_args+=(--setenv "$var" "${!var}")
         fi
     done
+    # HOME bind property: EACH bind-in HOME must not carry any credential
+    # or session token. Enforced by narrow subpaths per family — never bind
+    # a whole family directory (~/.claude, ~/.local, ~/.mika) because those
+    # roots hold .credentials.json / share/jupyter/*_secret /
+    # share/uv/credentials/ / .env respectively. Adding a new bind requires
+    # confirming its subtree carries no cred-shaped file (see
+    # coherence audit 2026-08-04).
     bwrap \
         --as-pid-1 \
         --unshare-user \
@@ -141,13 +154,18 @@ _run_pilot_sandboxed() {
         --tmpfs /run \
         --tmpfs /home \
         --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
-        --ro-bind-try "$HOME/.local" "$HOME/.local" \
-        --ro-bind-try "$HOME/.claude" "$HOME/.claude" \
-        --ro-bind-try "$HOME/.nvm" "$HOME/.nvm" \
+        --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
+        --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
+        --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
+        --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
+        --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \
+        --ro-bind-try "$HOME/.claude/hooks" "$HOME/.claude/hooks" \
+        --ro-bind-try "$HOME/.nvm/versions" "$HOME/.nvm/versions" \
         --ro-bind-try "$HOME/.cargo/registry" "$HOME/.cargo/registry" \
         --ro-bind-try "$HOME/.cargo/config.toml" "$HOME/.cargo/config.toml" \
         --ro-bind-try "$HOME/.cargo/bin" "$HOME/.cargo/bin" \
-        --bind "$HOME/.mika/data" "$HOME/.mika/data" \
+        --ro-bind-try "$HOME/.rustup" "$HOME/.rustup" \
+        --bind "$HOME/.mika/data/pilot-transcripts" "$HOME/.mika/data/pilot-transcripts" \
         "${setenv_args[@]}" \
         --chdir "$WORKTREE_DIR" \
         -- "$@"

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -190,6 +190,13 @@ _run_pilot_sandboxed() {
             --setenv HTTPS_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
             --setenv HTTP_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
             --setenv NO_PROXY "localhost,127.0.0.1"
+            # Exec-si-contenu attestation for cpp (Vincent-ratified 2026-08-04).
+            # Only set in Phase 2b full mode (fs+net+kernel cut ALL active).
+            # cpp reads this env at classify-time and enables the safe-exec
+            # tier1 primitives (node/python3/cargo/npm) SOLELY when this
+            # attestation is present. Phase 2a fallback (net open) intentionally
+            # does NOT set this — safe-exec stays denied, invariant preserved.
+            --setenv MIKA_PILOT_CONTAINED "1"
         )
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,
         # cleans up on exit. `exec` in the final position ensures the pilot's

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -242,6 +242,7 @@ _run_pilot_sandboxed() {
             --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
             --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
             --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
+            --ro-bind-try "/data/workspace/mika-platform/claude-pilot/src" "/data/workspace/mika-platform/claude-pilot/src" \
             --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
             --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
             --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \
@@ -306,6 +307,7 @@ $quoted_argv
             --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
             --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
             --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
+            --ro-bind-try "/data/workspace/mika-platform/claude-pilot/src" "/data/workspace/mika-platform/claude-pilot/src" \
             --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
             --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
             --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -27,6 +27,69 @@
 
 # --- Internal helpers (underscore-prefixed, not part of the API contract) ---
 
+# mika#TBD (containment Phase 2a): fs-cut sandbox for the pilot subprocess.
+# Prepends bwrap to the claude-pilot invocation so the process runs with a
+# minimal-visibility filesystem — ~/.ssh, ~/.aws, ~/.mika/.env, and other
+# operator-home secrets become invisible (tmpfs /home covers them; explicit
+# binds re-expose only what the pilot legitimately needs).
+#
+# Design (Phase 2a, fs-only):
+#   * `--ro-bind / /`     : root fs read-only baseline (bins, libs, /etc, …)
+#   * `--tmpfs /home`     : blanks the operator home — key protection
+#   * bind narrow subset  : ~/.local, ~/.claude, ~/.nvm, ~/.config/gh, ~/.mika/data
+#                           (writable — pilot needs to log/read/execute here)
+#   * `--bind $WORKTREE`  : the branch worktree, writable (git-plumbing target)
+#   * `--dev /dev --proc /proc --tmpfs /tmp` : minimal virtual filesystems
+#   * `--chdir $WORKTREE_DIR --setenv HOME $HOME` : preserve invocation semantics
+#
+# NOT included in Phase 2a: network cut (`--unshare-net` or nftables egress).
+# Phase 2b tracks that separately — until it lands, an in-sandbox process
+# still has full outbound network access. Env-scrub (PR#1893) is the
+# orthogonal defense reducing what the process sees at all.
+#
+# Opt-out: `MIKA_PILOT_SANDBOX=0` (or any of `false`/`no`/`off`, case-insensitive)
+# reverts to direct invocation. Default: enabled (Phase 2a is safe fallback —
+# fs cut hides secrets, never breaks legitimate reads of allowlisted paths).
+#
+# The helper prints its resolved bwrap prefix to stdout; callers use it via
+# command substitution:  eval "$(_pilot_sandbox_prefix) claude-pilot …"
+# Empty output when sandbox disabled — callers can invoke claude-pilot direct.
+_pilot_sandbox_enabled() {
+    local mode="${MIKA_PILOT_SANDBOX:-1}"
+    case "$(echo "$mode" | tr '[:upper:]' '[:lower:]')" in
+        0|false|no|off|disabled) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+_run_pilot_sandboxed() {
+    # Runs "$@" (the full claude-pilot invocation) under bwrap when enabled,
+    # or direct-exec otherwise. Preserves stdin/stdout/stderr semantics.
+    if ! _pilot_sandbox_enabled; then
+        "$@"
+        return $?
+    fi
+    if ! command -v bwrap >/dev/null 2>&1; then
+        echo "dispatch-lib: MIKA_PILOT_SANDBOX enabled but bwrap not installed on PATH — falling back to direct invocation" >&2
+        "$@"
+        return $?
+    fi
+    bwrap \
+        --ro-bind / / \
+        --tmpfs /home \
+        --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
+        --bind "$HOME/.local" "$HOME/.local" \
+        --bind "$HOME/.claude" "$HOME/.claude" \
+        --bind "$HOME/.config/gh" "$HOME/.config/gh" \
+        --bind "$HOME/.nvm" "$HOME/.nvm" \
+        --bind "$HOME/.mika/data" "$HOME/.mika/data" \
+        --dev /dev --proc /proc --tmpfs /tmp \
+        --chdir "$WORKTREE_DIR" \
+        --setenv HOME "$HOME" \
+        --setenv PATH "$PATH" \
+        -- "$@"
+}
+
 # mika#749: TERM trap writes cancel discriminator before exit.
 # Convention: reason file at /tmp/mika-cancel-reason-$$ (PID-based).
 # cancel_task pre-writes CANCELLED_BY_OPERATOR before SIGTERM; this trap
@@ -687,7 +750,7 @@ _run_claude_pilot() {
     set +e
     # CWD_ARGS is intentionally word-split (multiple flags)
     # shellcheck disable=SC2086
-    claude-pilot --verbose --log-dir --task-id "$LOG_ID" --command "$ENTRY_COMMAND" $TRACE_FLAG $CWD_ARGS -- "$PROMPT" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+    _run_pilot_sandboxed claude-pilot --verbose --log-dir --task-id "$LOG_ID" --command "$ENTRY_COMMAND" $TRACE_FLAG $CWD_ARGS -- "$PROMPT" >"$STDOUT_FILE" 2>"$STDERR_FILE"
     PILOT_EXIT=$?
     # Persist stderr to durable file before any processing (mika#1097).
     # Scrub secrets from the persistent copy to prevent durable secret retention (mika#903).
@@ -1970,7 +2033,7 @@ _launch_revise_pilot() {
     set +e
     # CWD_ARGS is intentionally word-split (multiple flags)
     # shellcheck disable=SC2086
-    claude-pilot --verbose --log-dir --task-id "$revise_log_id" \
+    _run_pilot_sandboxed claude-pilot --verbose --log-dir --task-id "$revise_log_id" \
         --command "/mika-revise-plan" $CWD_ARGS \
         -- "@${findings_file}" \
         >"$revise_stdout" 2>"$revise_stderr"

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -29,31 +29,55 @@
 
 # mika#TBD (containment Phase 2a): fs-cut sandbox for the pilot subprocess.
 # Prepends bwrap to the claude-pilot invocation so the process runs with a
-# minimal-visibility filesystem — ~/.ssh, ~/.aws, ~/.mika/.env, and other
-# operator-home secrets become invisible (tmpfs /home covers them; explicit
-# binds re-expose only what the pilot legitimately needs).
+# minimal-visibility filesystem AND a clean environment AND fresh kernel
+# namespaces (pid/ipc/uts/cgroup/user). Combined with the caller's env
+# scrub (see executor.rs `sandboxed_pilot_env`), the pilot cannot see or
+# exfiltrate operator-home secrets, cross-repo worktrees, other host
+# processes' env vars, or host IPC channels.
 #
-# Design (Phase 2a, fs-only):
-#   * `--ro-bind / /`     : root fs read-only baseline (bins, libs, /etc, …)
-#   * `--tmpfs /home`     : blanks the operator home — key protection
-#   * bind narrow subset  : ~/.local, ~/.claude, ~/.nvm, ~/.config/gh, ~/.mika/data
-#                           (writable — pilot needs to log/read/execute here)
-#   * `--bind $WORKTREE`  : the branch worktree, writable (git-plumbing target)
-#   * `--dev /dev --proc /proc --tmpfs /tmp` : minimal virtual filesystems
-#   * `--chdir $WORKTREE_DIR --setenv HOME $HOME` : preserve invocation semantics
+# Design (Phase 2a, fs-only — Phase 2b adds `--unshare-net` + egress relay):
 #
-# NOT included in Phase 2a: network cut (`--unshare-net` or nftables egress).
+#   Kernel isolation:
+#     * `--as-pid-1`           make the pilot PID 1 in the namespace (removes
+#                              the bwrap reaper whose /proc/1/environ would
+#                              leak the mika-spirit host env with API keys)
+#     * `--unshare-user/pid/ipc/uts/cgroup` — no cross-process channel back
+#                              to host, /proc shows only sandbox processes
+#     * `--new-session --die-with-parent` — no controlling tty, sandbox dies
+#                              with parent
+#     * `--clearenv` + `--setenv ...` — env allowlist (no ANTHROPIC_API_KEY /
+#                              AWS_* / NPM_TOKEN inheritance)
+#
+#   Filesystem allowlist (no `--ro-bind / /` — that would expose /var, /srv,
+#                        cross-worktree /data/workspace paths):
+#     * ro binds : /usr, /bin, /sbin, /lib, /lib64, /etc, /opt
+#                   (toolchain, ca-certs, resolver config, rust runtime)
+#     * tmpfs   : /home, /tmp, /var/tmp, /run
+#                   (blanks operator-home + host tempdirs)
+#     * ro binds under /home (must come AFTER `--tmpfs /home`) :
+#                 ~/.local (uv + claude-pilot binary), ~/.claude (plugin cache),
+#                 ~/.nvm (node runtime), ~/.cargo/{registry,config.toml,bin}
+#                 (crate cache + config — NOT credentials.toml)
+#     * rw binds: $WORKTREE_DIR (branch worktree), ~/.mika/data (transcripts)
+#
+#   NOT bound (per coherence threat-model review):
+#     * ~/.ssh, ~/.aws, ~/.config, ~/.mika (except /data), /var/spool/*
+#     * ~/.cargo/credentials.toml (cargo publish secret — dev-pilot never
+#                                  publishes; safe to omit)
+#     * ~/.config/gh (contains hosts.yml with gh token) — gh CLI uses the
+#                     GH_TOKEN env var re-injected below
+#     * $SSH_AUTH_SOCK, docker.sock, dbus, cm/NATS unix sockets
+#     * /data/workspace outside the branch worktree (other worktrees + repos)
+#
+# NOT included in Phase 2a: network cut (`--unshare-net` + egress relay).
 # Phase 2b tracks that separately — until it lands, an in-sandbox process
-# still has full outbound network access. Env-scrub (PR#1893) is the
-# orthogonal defense reducing what the process sees at all.
+# still has full outbound network access (can exfil via HTTP, DNS, SNI).
+# The invariant "Exec-si-contenu" holds only after Phase 2a + 2b ship.
 #
-# Opt-out: `MIKA_PILOT_SANDBOX=0` (or any of `false`/`no`/`off`, case-insensitive)
-# reverts to direct invocation. Default: enabled (Phase 2a is safe fallback —
-# fs cut hides secrets, never breaks legitimate reads of allowlisted paths).
-#
-# The helper prints its resolved bwrap prefix to stdout; callers use it via
-# command substitution:  eval "$(_pilot_sandbox_prefix) claude-pilot …"
-# Empty output when sandbox disabled — callers can invoke claude-pilot direct.
+# Opt-out: `MIKA_PILOT_SANDBOX=0` (or `false`/`no`/`off`/`disabled`,
+# case-insensitive) reverts to direct invocation. Default: enabled. Also
+# degrades gracefully to direct invocation if `bwrap` is not on PATH
+# (WARN-logged) — first-rollout deployment tolerance.
 _pilot_sandbox_enabled() {
     local mode="${MIKA_PILOT_SANDBOX:-1}"
     case "$(echo "$mode" | tr '[:upper:]' '[:lower:]')" in
@@ -61,6 +85,18 @@ _pilot_sandbox_enabled() {
         *) return 0 ;;
     esac
 }
+
+# Passthrough env allowlist: after `--clearenv`, these vars are re-injected
+# via `--setenv` when present in the parent env. Deliberately narrow — any
+# non-listed var (AWS_*, NPM_TOKEN, ATLASSIAN_API_TOKEN, non-MIKA_
+# OPENAI_/ANTHROPIC_, etc.) is DROPPED by --clearenv and does not reach the
+# sandbox. `GH_TOKEN` is passed through so `gh` works without needing
+# ~/.config/gh (which stays hidden). `ANTHROPIC_LOG_FILE` is the pilot
+# transcript hook (mika#1705). `MIKA_LOG_PILOT_TRANSCRIPTS` gates transcript.
+_PILOT_SANDBOX_ENV_ALLOWLIST=(
+    HOME PATH USER LOGNAME SHELL TERM LANG LC_ALL TMPDIR HOSTNAME
+    GH_TOKEN ANTHROPIC_LOG_FILE MIKA_LOG_PILOT_TRANSCRIPTS
+)
 
 _run_pilot_sandboxed() {
     # Runs "$@" (the full claude-pilot invocation) under bwrap when enabled,
@@ -74,19 +110,46 @@ _run_pilot_sandboxed() {
         "$@"
         return $?
     fi
+    local -a setenv_args=()
+    local var
+    for var in "${_PILOT_SANDBOX_ENV_ALLOWLIST[@]}"; do
+        if [ -n "${!var:-}" ]; then
+            setenv_args+=(--setenv "$var" "${!var}")
+        fi
+    done
     bwrap \
-        --ro-bind / / \
+        --as-pid-1 \
+        --unshare-user \
+        --unshare-pid \
+        --unshare-ipc \
+        --unshare-uts \
+        --unshare-cgroup \
+        --new-session \
+        --die-with-parent \
+        --clearenv \
+        --ro-bind /usr /usr \
+        --ro-bind-try /lib /lib \
+        --ro-bind-try /lib64 /lib64 \
+        --ro-bind /bin /bin \
+        --ro-bind-try /sbin /sbin \
+        --ro-bind /etc /etc \
+        --ro-bind-try /opt /opt \
+        --dev /dev \
+        --proc /proc \
+        --tmpfs /tmp \
+        --tmpfs /var/tmp \
+        --tmpfs /run \
         --tmpfs /home \
         --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
-        --bind "$HOME/.local" "$HOME/.local" \
-        --bind "$HOME/.claude" "$HOME/.claude" \
-        --bind "$HOME/.config/gh" "$HOME/.config/gh" \
-        --bind "$HOME/.nvm" "$HOME/.nvm" \
+        --ro-bind-try "$HOME/.local" "$HOME/.local" \
+        --ro-bind-try "$HOME/.claude" "$HOME/.claude" \
+        --ro-bind-try "$HOME/.nvm" "$HOME/.nvm" \
+        --ro-bind-try "$HOME/.cargo/registry" "$HOME/.cargo/registry" \
+        --ro-bind-try "$HOME/.cargo/config.toml" "$HOME/.cargo/config.toml" \
+        --ro-bind-try "$HOME/.cargo/bin" "$HOME/.cargo/bin" \
         --bind "$HOME/.mika/data" "$HOME/.mika/data" \
-        --dev /dev --proc /proc --tmpfs /tmp \
+        "${setenv_args[@]}" \
         --chdir "$WORKTREE_DIR" \
-        --setenv HOME "$HOME" \
-        --setenv PATH "$PATH" \
         -- "$@"
 }
 

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -86,6 +86,62 @@ _pilot_sandbox_enabled() {
     esac
 }
 
+# Phase 2b (network cut): egress-proxy unix socket path + sandbox-side TCP
+# bridge port. The proxy script is installed to ~/.local/bin by `make install`
+# and speaks HTTP CONNECT with a hostname allowlist. See
+# scripts/mika-pilot-egress-proxy for the allowlist + threat model.
+_PILOT_EGRESS_SOCK="/tmp/mika-pilot-egress.sock"
+_PILOT_EGRESS_TCP_PORT="8891"
+_PILOT_EGRESS_PROXY_BIN="$HOME/.local/bin/mika-pilot-egress-proxy"
+
+# Idempotent host-side egress proxy launcher. Runs once per host; on subsequent
+# calls, verifies the daemon is alive and returns. Fail-open on missing binary
+# (Phase 2b not yet deployed) — sandbox falls back to Phase 2a (fs cut only,
+# network open) so the pilot still functions during the deploy window.
+_ensure_pilot_egress_proxy() {
+    if [ ! -x "$_PILOT_EGRESS_PROXY_BIN" ]; then
+        echo "dispatch-lib: mika-pilot-egress-proxy not found at $_PILOT_EGRESS_PROXY_BIN — Phase 2b network cut disabled (falling back to fs-only)" >&2
+        return 1
+    fi
+    # Liveness probe: socket exists + accepts a connection.
+    if [ -S "$_PILOT_EGRESS_SOCK" ] && python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_UNIX)
+s.settimeout(1)
+try:
+    s.connect('$_PILOT_EGRESS_SOCK')
+    s.close()
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+" 2>/dev/null; then
+        return 0  # already alive
+    fi
+    # Launch as detached daemon. Log to /var/log/mika/ if writable, else stderr.
+    local log_dir="/var/log/mika"
+    local log_file
+    if [ -w "$log_dir" ] || mkdir -p "$log_dir" 2>/dev/null; then
+        log_file="$log_dir/pilot-egress-proxy.log"
+    else
+        log_file="/tmp/mika-pilot-egress-proxy.log"
+    fi
+    nohup "$_PILOT_EGRESS_PROXY_BIN" --host-unix --socket "$_PILOT_EGRESS_SOCK" \
+        >>"$log_file" 2>&1 </dev/null &
+    disown 2>/dev/null || true
+    # Wait for socket to appear (bounded).
+    local i=0
+    while [ $i -lt 20 ] && [ ! -S "$_PILOT_EGRESS_SOCK" ]; do
+        sleep 0.1
+        i=$((i + 1))
+    done
+    if [ ! -S "$_PILOT_EGRESS_SOCK" ]; then
+        echo "dispatch-lib: pilot-egress-proxy failed to bind $_PILOT_EGRESS_SOCK within 2s — falling back to fs-only" >&2
+        return 1
+    fi
+    echo "dispatch-lib: pilot-egress-proxy launched (pid $!, log $log_file)" >&2
+    return 0
+}
+
 # Passthrough env allowlist: after `--clearenv`, these vars are re-injected
 # via `--setenv` when present in the parent env. Deliberately narrow — any
 # non-listed var (AWS_*, NPM_TOKEN, ATLASSIAN_API_TOKEN, non-MIKA_
@@ -116,6 +172,31 @@ _run_pilot_sandboxed() {
     # here so the bind is stable even on a fresh install.
     mkdir -p "$HOME/.mika/data/pilot-transcripts" 2>/dev/null || true
 
+    # Phase 2b: launch host-side egress proxy (idempotent). If it's not
+    # available (binary missing, first deploy), returns non-zero and we run
+    # in Phase 2a mode (fs cut only, network open) — degraded but functional.
+    local -a net_bwrap_args=()
+    local -a net_setenv_args=()
+    local sandbox_entrypoint_prefix=""
+    if _ensure_pilot_egress_proxy; then
+        # Full Phase 2b: unshare-net + bind unix socket + wrap with in-sandbox
+        # TCP→unix shim + HTTPS_PROXY pointing at shim.
+        net_bwrap_args=(
+            --unshare-net
+            --bind "$_PILOT_EGRESS_SOCK" "$_PILOT_EGRESS_SOCK"
+            --ro-bind "$_PILOT_EGRESS_PROXY_BIN" "$_PILOT_EGRESS_PROXY_BIN"
+        )
+        net_setenv_args=(
+            --setenv HTTPS_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
+            --setenv HTTP_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
+            --setenv NO_PROXY "localhost,127.0.0.1"
+        )
+        # sh -c wrapper that starts the shim, waits for it, execs the pilot,
+        # cleans up on exit. `exec` in the final position ensures the pilot's
+        # exit status becomes the sh's.
+        sandbox_entrypoint_prefix="/bin/sh"
+    fi
+
     local -a setenv_args=()
     local var
     for var in "${_PILOT_SANDBOX_ENV_ALLOWLIST[@]}"; do
@@ -130,45 +211,115 @@ _run_pilot_sandboxed() {
     # share/uv/credentials/ / .env respectively. Adding a new bind requires
     # confirming its subtree carries no cred-shaped file (see
     # coherence audit 2026-08-04).
-    bwrap \
-        --as-pid-1 \
-        --unshare-user \
-        --unshare-pid \
-        --unshare-ipc \
-        --unshare-uts \
-        --unshare-cgroup \
-        --new-session \
-        --die-with-parent \
-        --clearenv \
-        --ro-bind /usr /usr \
-        --ro-bind-try /lib /lib \
-        --ro-bind-try /lib64 /lib64 \
-        --ro-bind /bin /bin \
-        --ro-bind-try /sbin /sbin \
-        --ro-bind /etc /etc \
-        --ro-bind-try /opt /opt \
-        --dev /dev \
-        --proc /proc \
-        --tmpfs /tmp \
-        --tmpfs /var/tmp \
-        --tmpfs /run \
-        --tmpfs /home \
-        --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
-        --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
-        --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
-        --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
-        --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
-        --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \
-        --ro-bind-try "$HOME/.claude/hooks" "$HOME/.claude/hooks" \
-        --ro-bind-try "$HOME/.nvm/versions" "$HOME/.nvm/versions" \
-        --ro-bind-try "$HOME/.cargo/registry" "$HOME/.cargo/registry" \
-        --ro-bind-try "$HOME/.cargo/config.toml" "$HOME/.cargo/config.toml" \
-        --ro-bind-try "$HOME/.cargo/bin" "$HOME/.cargo/bin" \
-        --ro-bind-try "$HOME/.rustup" "$HOME/.rustup" \
-        --bind "$HOME/.mika/data/pilot-transcripts" "$HOME/.mika/data/pilot-transcripts" \
-        "${setenv_args[@]}" \
-        --chdir "$WORKTREE_DIR" \
-        -- "$@"
+    if [ -n "$sandbox_entrypoint_prefix" ]; then
+        # Phase 2b mode: quote the original argv so the sh -c can re-exec it
+        # verbatim. Uses `printf '%q'` for shell-safe re-quoting.
+        local quoted_argv
+        quoted_argv=$(printf ' %q' "$@")
+        bwrap \
+            --as-pid-1 \
+            --unshare-user \
+            --unshare-pid \
+            --unshare-ipc \
+            --unshare-uts \
+            --unshare-cgroup \
+            --new-session \
+            --die-with-parent \
+            --clearenv \
+            --ro-bind /usr /usr \
+            --ro-bind-try /lib /lib \
+            --ro-bind-try /lib64 /lib64 \
+            --ro-bind /bin /bin \
+            --ro-bind-try /sbin /sbin \
+            --ro-bind /etc /etc \
+            --ro-bind-try /opt /opt \
+            --dev /dev \
+            --proc /proc \
+            --tmpfs /tmp \
+            --tmpfs /var/tmp \
+            --tmpfs /run \
+            --tmpfs /home \
+            --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
+            --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
+            --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
+            --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
+            --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
+            --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \
+            --ro-bind-try "$HOME/.claude/hooks" "$HOME/.claude/hooks" \
+            --ro-bind-try "$HOME/.nvm/versions" "$HOME/.nvm/versions" \
+            --ro-bind-try "$HOME/.cargo/registry" "$HOME/.cargo/registry" \
+            --ro-bind-try "$HOME/.cargo/config.toml" "$HOME/.cargo/config.toml" \
+            --ro-bind-try "$HOME/.cargo/bin" "$HOME/.cargo/bin" \
+            --ro-bind-try "$HOME/.rustup" "$HOME/.rustup" \
+            --bind "$HOME/.mika/data/pilot-transcripts" "$HOME/.mika/data/pilot-transcripts" \
+            "${net_bwrap_args[@]}" \
+            "${setenv_args[@]}" \
+            "${net_setenv_args[@]}" \
+            --chdir "$WORKTREE_DIR" \
+            -- "$sandbox_entrypoint_prefix" -c "
+python3 '$_PILOT_EGRESS_PROXY_BIN' --sandbox-tcp $_PILOT_EGRESS_TCP_PORT --socket '$_PILOT_EGRESS_SOCK' >&2 &
+_shim_pid=\$!
+# Bounded wait for shim to listen (max ~1s).
+_i=0
+while [ \$_i -lt 20 ]; do
+    if python3 -c 'import socket
+s=socket.socket()
+s.settimeout(0.1)
+try:
+    s.connect((\"127.0.0.1\", $_PILOT_EGRESS_TCP_PORT))
+    s.close()
+except Exception:
+    exit(1)' 2>/dev/null; then
+        break
+    fi
+    sleep 0.05
+    _i=\$((_i + 1))
+done
+trap 'kill \$_shim_pid 2>/dev/null' EXIT
+$quoted_argv
+"
+    else
+        # Phase 2a fallback: fs cut only, network unrestricted.
+        bwrap \
+            --as-pid-1 \
+            --unshare-user \
+            --unshare-pid \
+            --unshare-ipc \
+            --unshare-uts \
+            --unshare-cgroup \
+            --new-session \
+            --die-with-parent \
+            --clearenv \
+            --ro-bind /usr /usr \
+            --ro-bind-try /lib /lib \
+            --ro-bind-try /lib64 /lib64 \
+            --ro-bind /bin /bin \
+            --ro-bind-try /sbin /sbin \
+            --ro-bind /etc /etc \
+            --ro-bind-try /opt /opt \
+            --dev /dev \
+            --proc /proc \
+            --tmpfs /tmp \
+            --tmpfs /var/tmp \
+            --tmpfs /run \
+            --tmpfs /home \
+            --bind "$WORKTREE_DIR" "$WORKTREE_DIR" \
+            --ro-bind-try "$HOME/.local/bin/claude-pilot" "$HOME/.local/bin/claude-pilot" \
+            --ro-bind-try "$HOME/.local/share/uv/tools/claude-pilot" "$HOME/.local/share/uv/tools/claude-pilot" \
+            --ro-bind-try "$HOME/.claude/plugins" "$HOME/.claude/plugins" \
+            --ro-bind-try "$HOME/.claude/settings.json" "$HOME/.claude/settings.json" \
+            --ro-bind-try "$HOME/.claude/commands" "$HOME/.claude/commands" \
+            --ro-bind-try "$HOME/.claude/hooks" "$HOME/.claude/hooks" \
+            --ro-bind-try "$HOME/.nvm/versions" "$HOME/.nvm/versions" \
+            --ro-bind-try "$HOME/.cargo/registry" "$HOME/.cargo/registry" \
+            --ro-bind-try "$HOME/.cargo/config.toml" "$HOME/.cargo/config.toml" \
+            --ro-bind-try "$HOME/.cargo/bin" "$HOME/.cargo/bin" \
+            --ro-bind-try "$HOME/.rustup" "$HOME/.rustup" \
+            --bind "$HOME/.mika/data/pilot-transcripts" "$HOME/.mika/data/pilot-transcripts" \
+            "${setenv_args[@]}" \
+            --chdir "$WORKTREE_DIR" \
+            -- "$@"
+    fi
 }
 
 # mika#749: TERM trap writes cancel discriminator before exit.


### PR DESCRIPTION
## Summary

Complete dev-pilot containment layer. Wraps `claude-pilot` in `dispatch-lib.sh` with `bwrap` so the pilot subprocess runs against:

1. **Minimal-visibility filesystem** — narrow bind-allowlist per family, tmpfs everywhere else. `~/.ssh`, `~/.aws`, `~/.mika/.env`, `~/.claude/.credentials.json`, `~/.local/share/jupyter/*_secret`, `~/.config/gh/hosts.yml` all invisible.
2. **Cleared environment** — `--clearenv` + narrow setenv allowlist. `ATLASSIAN_API_TOKEN`, `AWS_*`, non-`MIKA_` `OPENAI_/ANTHROPIC_`, `NODE_AUTH_TOKEN` dropped.
3. **Fresh kernel namespaces** — `--unshare-user/pid/ipc/uts/cgroup/net` + `--as-pid-1`. /proc shows only sandbox, no host env harvest.
4. **Network egress filtered to a 15-host allowlist** — via unix-socket HTTP CONNECT proxy. Raw sockets fail (no route), DNS fails (no resolver), non-allowlisted hosts return 403.

Grounds Prime bearing (B) — **Exec-si-contenu invariant**. Ready to unblock cpp's tier1 extension for `<safe-exec>` primitives (`node`, `python3`, `cargo`) once Vincent ratifies.

## Companion PR

- **PR#1893** — Phase 1 env allowlist in Rust spawn layer (`sandboxed_pilot_env` in `executor.rs`). Composes with `--clearenv` here — defense-in-depth at both layers.

## Three-phase design

### Phase 2a — fs + kernel + env cut (bwrap in `dispatch-lib.sh`)

`_run_pilot_sandboxed` prepends bwrap with:
- `--as-pid-1 --unshare-user --unshare-pid --unshare-ipc --unshare-uts --unshare-cgroup --new-session --die-with-parent --clearenv`
- **Bind-allowlist** (not `--ro-bind / /` — that would expose cross-worktrees, /var, /root):
  ro: `/usr /lib /lib64 /bin /sbin /etc /opt`
  tmpfs: `/home /tmp /var/tmp /run`
  rw: `$WORKTREE_DIR`, `~/.mika/data/pilot-transcripts` (transcript sink only, mika.db invisible)
  ro narrow per family: `~/.local/bin/claude-pilot`, `~/.local/share/uv/tools/claude-pilot`, `~/.claude/plugins`, `~/.claude/settings.json`, `~/.claude/commands`, `~/.claude/hooks`, `~/.nvm/versions`, `~/.cargo/{registry,config.toml,bin}`, `~/.rustup`
- setenv allowlist: HOME/PATH/USER/SHELL/TERM/LANG/LC_ALL/TMPDIR + GH_TOKEN/ANTHROPIC_LOG_FILE/MIKA_LOG_PILOT_TRANSCRIPTS (conditional)

**Property invariant** (per coherence audit): no bind-in HOME may carry any credential. Comment in helper for future bind additions.

### Phase 2b — network cut via unix-socket egress relay

- `--unshare-net` in bwrap — sandbox gets fresh network namespace, only `lo` (up)
- Host-side daemon `mika-pilot-egress-proxy --host-unix` (new Python script, ~200 lines) listens on `/tmp/mika-pilot-egress.sock`, parses HTTP CONNECT, filters against 15-host allowlist, forwards to real upstream
- Sandbox-side shim (same script, `--sandbox-tcp 8891`) bridges 127.0.0.1:8891 → unix socket (required because `HTTPS_PROXY` doesn't accept `unix://` in most clients)
- `HTTPS_PROXY`/`HTTP_PROXY` in sandbox set to `http://127.0.0.1:8891`
- Idempotent host-daemon launch by `_ensure_pilot_egress_proxy` (checks socket liveness, spawns if missing)
- **Fail-open to Phase 2a**: if `mika-pilot-egress-proxy` binary is missing (deployment window), skip `--unshare-net` and run with network open + WARN

### Allowlist (15 hosts — deliberate friction to add)

| Class | Hosts |
|---|---|
| LLM | `api.anthropic.com`, `api.openai.com`, `api.z.ai`, `openrouter.ai` |
| GitHub | `api.github.com`, `github.com`, `ssh.github.com`, `codeload.github.com`, `objects.githubusercontent.com` |
| Cargo | `crates.io`, `static.crates.io`, `index.crates.io` |
| npm | `registry.npmjs.org` |
| PyPI | `pypi.org`, `files.pythonhosted.org` |

## E2E verification (integrated helper, live-tested on gentux)

```
=== E2E integrated ===
[egress-shim] tcp 127.0.0.1:8891 → /tmp/mika-pilot-egress.sock

net-must-fail:
curl: (7) CONNECT tunnel failed, response 403      # allowlist DENY on evil.example.com
exfil=000
blocked_direct:OSError                             # raw socket direct → OSError (no route)

net-must-work:
github=200                                         # allowlisted host succeeds via proxy

fs-spot:
ls: cannot access '/home/samidarko/.claude/.credentials.json': No such file or directory
```

Host proxy log:
```
[egress] host-unix listening on /tmp/mika-pilot-egress.sock (allowlist: 15 hosts)
[egress] DENY evil.example.com:443
[egress] ALLOW api.github.com:443
```

Prior test rounds (pre-Phase 2b) already validated 15/15 file must-fail + env-cleared + /proc/1 clean + 6/6 tools (gh, node, cargo, rustc, python3, git).

## Coherence audit response (2 rounds, 8 gaps closed)

**Round 1 threat-model** — 6 gaps in the initial naive shape (`--ro-bind / /` + `--tmpfs /home` + narrow binds + `--unshare-net + relay`):
- Filesystem too wide (crossworktrees exposed) → bind-allowlist
- /proc harvest of host env → `--as-pid-1` + `--unshare-pid`
- Env-tokens inherited → `--clearenv` + narrow allowlist
- DNS-exfil → `--unshare-net` (no resolver in sandbox)
- CDN-IP-allowlist → hostname-based CONNECT allowlist
- Host unix sockets → none bound

**Round 2 property audit** — 2 residual leaks (whack-a-mole class):
- `~/.claude/.credentials.json` (Anthropic OAuth) → narrow `~/.claude` binds, credentials.json unreachable
- `~/.local/share/jupyter/*_secret` + uv credentials → narrow `~/.local` binds
- cargo regression (missing `.rustup`) → `--ro-bind-try ~/.rustup`

**Property invariant established**: "no bind-in HOME may carry any credential" — commented in helper for future bind additions.

## Opt-out + fallback

- `MIKA_PILOT_SANDBOX=0` (or `false`/`no`/`off`/`disabled`) → direct invocation (no bwrap)
- `bwrap` missing on PATH → WARN + direct invocation
- `mika-pilot-egress-proxy` missing → Phase 2a only (fs cut, network open) + WARN

## Ship + verification checklist

- [ ] CI green
- [ ] Post-deploy: dispatch a canary dev-groom on a small ticket, verify bwrap process visible in `ps`, dispatch completes normally
- [ ] Grep `$MIKA_SPIRIT_LOG_FILE` for `dispatch-lib: mika-pilot-egress-proxy not found` — should be zero after `make deploy`
- [ ] Grep `/var/log/mika/pilot-egress-proxy.log` for `DENY` events — expected zero from legitimate pilot activity
- [ ] Coherence full validation on real dev-pilot spawn: conjunction (fs+env+kernel+net breach ALL fail + LLM+gh+cargo+node ALL work)

## Coherence residual (must be named — NOT closed by bwrap)

Even with perfect allowlist: the pilot can still write a secret INTO a github PR/issue/commit body (sanctioned channel) or a prompt logged to Anthropic. bwrap = "no arbitrary egress", NOT "exfil-proof". **Forge-gate** (merge/push review) + content review remain load-bearing.

## Follow-ups (out-of-scope)

- **GH_TOKEN scope tightening**: current token is the mika-spirit shared PAT/App. Per-pilot-repo scoping requires GitHub App installation-scope work — separate PR.
- **Deployment**: bwrap already installed on gentux (v0.11.2). `make install` now copies `mika-pilot-egress-proxy` to `~/.local/bin/`. First `make deploy` spawns the daemon on first dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)