### PR TITLE
fix(dispatch): Q3 auth injection host-side — subscription OAuth (Voie A), sandbox blind

### DIFF
--- a/scripts/mika-pilot-egress-proxy
+++ b/scripts/mika-pilot-egress-proxy
@@ -58,12 +58,14 @@ Failure modes:
 
 import argparse
 import asyncio
+import json
 import os
 import re
 import socket
 import ssl
 import stat
 import sys
+import time
 from pathlib import Path
 
 # Sole security boundary — every entry is a decision.
@@ -95,8 +97,19 @@ BUFFER_SIZE = 65536
 CONNECT_RE = re.compile(rb"^CONNECT ([^:\s]+):(\d+) HTTP/1\.[01]\r\n", re.ASCII)
 
 # Q3 auth-injection reverse-proxy — path prefix stripped, forwarded to
-# api.anthropic.com over TLS with `Authorization: Bearer <scoped-key>`
-# injected host-side. See ANTHROPIC_PROXY_PATH_PREFIX + read_scoped_key.
+# api.anthropic.com over TLS with `Authorization: Bearer <subscription-access-token>`
+# injected host-side. Voie A (2026-08-05, Vincent-ratified): token source is
+# ~/.claude/.credentials.json (the subscription OAuth cred, refreshed by the
+# local Claude Code CLI). The proxy is read-only on that file — refresh is
+# delegated to the host CLI (natural during Vincent's use + cron keep-warm
+# for headless nights). Voie B (proxy owns refresh) is a follow-up.
+#
+# Vincent's decision (2026-08-05): pilot MUST auth via the paid subscription,
+# not a metered API key — cost is flat-and-bounded vs API bill that grows
+# with the loop. The blast-radius trade (subscription OAuth = full identity
+# vs API key = billing-only) is knowingly accepted because containment is
+# for the *pilot* (untrusted code), not the *host* (trusted zone anyway);
+# the sandbox stays blind either way.
 ANTHROPIC_UPSTREAM_HOST = "api.anthropic.com"
 ANTHROPIC_UPSTREAM_PORT = 443
 ANTHROPIC_PROXY_PATH_PREFIX = "/anthropic-proxy"
@@ -107,46 +120,79 @@ ANTHROPIC_METHOD_RE = re.compile(
     re.ASCII,
 )
 
-# Scoped Anthropic API key — held host-side, re-read on ~/.mika/.env mtime
-# change so operator rotations pick up without proxy restart. The var name
-# `MIKA_PILOT_ANTHROPIC_KEY` is dedicated to the pilot subprocess; distinct
-# from `MIKA_ANTHROPIC_API_KEY` which holds the OAuth identity token (never
-# read here — see Q3 design note in dispatch-lib.sh).
-_SCOPED_KEY_VAR = "MIKA_PILOT_ANTHROPIC_KEY"
-_MIKA_ENV_PATH = Path.home() / ".mika" / ".env"
-_scoped_key_cache = {"mtime": None, "value": None}
+# Subscription OAuth token — held host-side (never crosses bwrap boundary),
+# read from ~/.claude/.credentials.json with mtime-caching so the CLI's
+# natural refresh writes are picked up on the next request without proxy
+# restart. The proxy NEVER writes this file (Voie A: read-only).
+_CREDS_PATH = Path.home() / ".claude" / ".credentials.json"
+_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
+_token_cache = {"mtime": None, "value": None, "expires_at": None}
 
 
-def read_scoped_key() -> str | None:
-    """Return the scoped Anthropic key from ~/.mika/.env, cached by mtime.
+def _extract_oauth_token(obj) -> tuple[str | None, float | None]:
+    """Walk a JSON-decoded object looking for an OAuth access token +
+    optional expiry. Handles multiple credentials.json shapes:
 
-    Returns None if the file or key is absent — caller must handle the
-    no-key case (return 401 upstream-style, don't inject a bogus header).
+      * flat:   {"accessToken": "...", "expiresAt": 1234567890}
+      * nested: {"claudeAiOauth": {"accessToken": "...", "expiresAt": ...}}
+      * snake:  {"access_token": "...", "expires_at": ...}
+      * any other nested variant
+
+    The heuristic: first string value that starts with `sk-ant-oat` wins;
+    expiry is picked from any sibling `expiresAt`/`expires_at`/`exp` key.
+    Returns (token, expires_at_seconds) or (None, None).
+    """
+    def _walk(node, expiry_hint):
+        if isinstance(node, dict):
+            local_expiry = expiry_hint
+            for k, v in node.items():
+                if isinstance(v, (int, float)) and k in (
+                    "expiresAt", "expires_at", "exp"
+                ):
+                    # Some sources use ms epoch, some seconds. Detect and
+                    # normalize: values > 10^12 are ms since epoch.
+                    local_expiry = v / 1000 if v > 1e12 else float(v)
+            for k, v in node.items():
+                if isinstance(v, str) and v.startswith(_OAUTH_TOKEN_PREFIX):
+                    return v, local_expiry
+            for v in node.values():
+                found = _walk(v, local_expiry)
+                if found[0] is not None:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = _walk(item, expiry_hint)
+                if found[0] is not None:
+                    return found
+        return None, None
+    return _walk(obj, None)
+
+
+def read_subscription_token() -> tuple[str | None, float | None]:
+    """Return (access_token, expires_at) from ~/.claude/.credentials.json,
+    cached by file mtime. Returns (None, None) if the file/token is absent.
+
+    The Claude Code CLI refreshes this file periodically (on user interaction
+    or before expiry). The proxy READS it on each Anthropic-bound request;
+    mtime-cache avoids re-parsing on every hit but picks up refreshes as
+    soon as the CLI writes them.
     """
     try:
-        st = _MIKA_ENV_PATH.stat()
+        st = _CREDS_PATH.stat()
     except OSError:
-        return None
-    if _scoped_key_cache["mtime"] == st.st_mtime:
-        return _scoped_key_cache["value"]
-    # Re-read + last-win parse (matches dotenvy semantics).
-    latest: str | None = None
+        return None, None
+    if _token_cache["mtime"] == st.st_mtime:
+        return _token_cache["value"], _token_cache["expires_at"]
     try:
-        with _MIKA_ENV_PATH.open("r", encoding="utf-8", errors="replace") as fh:
-            prefix = f"{_SCOPED_KEY_VAR}="
-            for line in fh:
-                if line.startswith(prefix):
-                    val = line[len(prefix):].rstrip("\r\n")
-                    # Strip surrounding quotes (single or double), best-effort.
-                    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-                        val = val[1:-1]
-                    if val:
-                        latest = val
-    except OSError:
-        return None
-    _scoped_key_cache["mtime"] = st.st_mtime
-    _scoped_key_cache["value"] = latest
-    return latest
+        with _CREDS_PATH.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None, None
+    token, expires_at = _extract_oauth_token(data)
+    _token_cache["mtime"] = st.st_mtime
+    _token_cache["value"] = token
+    _token_cache["expires_at"] = expires_at
+    return token, expires_at
 
 
 async def pipe_bytes(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -174,18 +220,26 @@ async def handle_anthropic_reverse_proxy(
     method: bytes,
     path: bytes,
 ) -> None:
-    """Q3 host-side auth injection.
+    """Q3 host-side auth injection (Voie A — subscription OAuth).
 
     Sandbox client sends an HTTP request to <method> /anthropic-proxy/<rest>.
     We strip the prefix, rewrite Host and Authorization headers with the
-    scoped key from ~/.mika/.env (never crosses sandbox boundary), open TLS
-    to api.anthropic.com:443, forward request, and stream response back.
+    subscription OAuth access token from ~/.claude/.credentials.json
+    (host-side, never crosses sandbox boundary), open TLS to
+    api.anthropic.com:443, forward request, and stream response back.
+
+    Refresh: delegated to the local Claude Code CLI. When the CLI refreshes
+    its token, the file mtime changes and the proxy picks up the new value
+    on the next request. If expired without a refresh (marathon-nights with
+    no CLI activity), Anthropic responds 401 → pilot fails visibly → cron
+    keep-warm covers this case (see docs/solutions/).
     """
-    scoped_key = read_scoped_key()
-    if scoped_key is None:
+    token, expires_at = read_subscription_token()
+    if token is None:
         body = (
-            f"mika-pilot-egress: scoped key {_SCOPED_KEY_VAR} not set in "
-            f"{_MIKA_ENV_PATH} — operator must provision before dispatch\n"
+            f"mika-pilot-egress: subscription OAuth token not found in "
+            f"{_CREDS_PATH}. Vincent must be logged in to Claude Code on "
+            f"the host for the pilot to authenticate.\n"
         ).encode("utf-8")
         writer.write(
             b"HTTP/1.1 503 Service Unavailable\r\n"
@@ -195,9 +249,18 @@ async def handle_anthropic_reverse_proxy(
             b"\r\n" + body
         )
         await writer.drain()
-        print(f"[anthropic-proxy] DENY no-key path={path.decode('ascii', 'replace')}",
+        print(f"[anthropic-proxy] DENY no-token path={path.decode('ascii', 'replace')}",
               file=sys.stderr, flush=True)
         return
+    # Soft-warn if the token appears expired — Anthropic will 401 anyway,
+    # this makes debugging easier from the proxy log.
+    if expires_at is not None and expires_at < time.time():
+        print(
+            f"[anthropic-proxy] WARN token appears expired "
+            f"({int(time.time() - expires_at)}s ago) — Anthropic will 401. "
+            f"Refresh via a Claude Code CLI call on the host.",
+            file=sys.stderr, flush=True,
+        )
 
     # Split request into request-line + headers. body follows blank line.
     try:
@@ -236,7 +299,7 @@ async def handle_anthropic_reverse_proxy(
     new_request = (
         method + b" " + new_path + b" HTTP/1.1\r\n"
         + b"Host: " + ANTHROPIC_UPSTREAM_HOST.encode("ascii") + b"\r\n"
-        + b"Authorization: Bearer " + scoped_key.encode("ascii") + b"\r\n"
+        + b"Authorization: Bearer " + token.encode("ascii") + b"\r\n"
         + b"Connection: close\r\n"  # force one-shot, avoid keepalive complexity
         + b"\r\n".join(filtered_headers)
         + b"\r\n\r\n"

--- a/scripts/mika-pilot-egress-proxy
+++ b/scripts/mika-pilot-egress-proxy
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""HTTPS CONNECT proxy with hostname allowlist — dev-pilot containment Phase 2b.
+"""HTTPS CONNECT proxy with hostname allowlist + Anthropic auth reverse-proxy
+— dev-pilot containment Phase 2b.
 
 Two invocation modes:
 
   mika-pilot-egress-proxy --host-unix
       Listens on `/tmp/mika-pilot-egress.sock` (unix socket).
-      Accepts HTTP CONNECT, filters by hostname allowlist, forwards to upstream.
-      This is the SECURITY BOUNDARY — only the allowlisted hosts reachable.
+      Two request shapes accepted on the same endpoint (dispatched by method
+      + path on the request line):
+
+        (1) CONNECT <host>:<port>  — HTTPS tunnel via allowlist. Existing.
+        (2) <METHOD> /anthropic-proxy/...  — HTTP reverse-proxy to
+            api.anthropic.com/... with Authorization: Bearer <scoped-key>
+            injected host-side. The sandbox NEVER sees the key
+            (Q3 shape, sami+coherence-ratified 2026-08-05).
+
       Runs as long-lived daemon on the host (spawned by dispatch-lib.sh).
 
   mika-pilot-egress-proxy --sandbox-tcp <PORT>
@@ -14,7 +22,9 @@ Two invocation modes:
       Forwards each connection verbatim to `/tmp/mika-pilot-egress.sock`
       (which is bind-mounted from host by bwrap). No filtering here — the
       host side is the gate. This exists ONLY because most HTTP clients
-      (reqwest, node fetch, cargo) don't accept `HTTPS_PROXY=unix:///path`.
+      (reqwest, node fetch, cargo) don't accept `HTTPS_PROXY=unix:///path`,
+      AND because ANTHROPIC_BASE_URL points at this loopback port for the
+      auth-injection reverse-proxy flow.
 
 Design rationale (see coherence audit 2026-08-04 + Phase 2b design):
 
@@ -51,6 +61,7 @@ import asyncio
 import os
 import re
 import socket
+import ssl
 import stat
 import sys
 from pathlib import Path
@@ -83,6 +94,60 @@ DEFAULT_UNIX_SOCK = "/tmp/mika-pilot-egress.sock"
 BUFFER_SIZE = 65536
 CONNECT_RE = re.compile(rb"^CONNECT ([^:\s]+):(\d+) HTTP/1\.[01]\r\n", re.ASCII)
 
+# Q3 auth-injection reverse-proxy — path prefix stripped, forwarded to
+# api.anthropic.com over TLS with `Authorization: Bearer <scoped-key>`
+# injected host-side. See ANTHROPIC_PROXY_PATH_PREFIX + read_scoped_key.
+ANTHROPIC_UPSTREAM_HOST = "api.anthropic.com"
+ANTHROPIC_UPSTREAM_PORT = 443
+ANTHROPIC_PROXY_PATH_PREFIX = "/anthropic-proxy"
+ANTHROPIC_METHOD_RE = re.compile(
+    rb"^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) "
+    rb"(" + re.escape(ANTHROPIC_PROXY_PATH_PREFIX.encode("ascii")) + rb"[^\s]*)"
+    rb" HTTP/1\.[01]\r\n",
+    re.ASCII,
+)
+
+# Scoped Anthropic API key — held host-side, re-read on ~/.mika/.env mtime
+# change so operator rotations pick up without proxy restart. The var name
+# `MIKA_PILOT_ANTHROPIC_KEY` is dedicated to the pilot subprocess; distinct
+# from `MIKA_ANTHROPIC_API_KEY` which holds the OAuth identity token (never
+# read here — see Q3 design note in dispatch-lib.sh).
+_SCOPED_KEY_VAR = "MIKA_PILOT_ANTHROPIC_KEY"
+_MIKA_ENV_PATH = Path.home() / ".mika" / ".env"
+_scoped_key_cache = {"mtime": None, "value": None}
+
+
+def read_scoped_key() -> str | None:
+    """Return the scoped Anthropic key from ~/.mika/.env, cached by mtime.
+
+    Returns None if the file or key is absent — caller must handle the
+    no-key case (return 401 upstream-style, don't inject a bogus header).
+    """
+    try:
+        st = _MIKA_ENV_PATH.stat()
+    except OSError:
+        return None
+    if _scoped_key_cache["mtime"] == st.st_mtime:
+        return _scoped_key_cache["value"]
+    # Re-read + last-win parse (matches dotenvy semantics).
+    latest: str | None = None
+    try:
+        with _MIKA_ENV_PATH.open("r", encoding="utf-8", errors="replace") as fh:
+            prefix = f"{_SCOPED_KEY_VAR}="
+            for line in fh:
+                if line.startswith(prefix):
+                    val = line[len(prefix):].rstrip("\r\n")
+                    # Strip surrounding quotes (single or double), best-effort.
+                    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+                        val = val[1:-1]
+                    if val:
+                        latest = val
+    except OSError:
+        return None
+    _scoped_key_cache["mtime"] = st.st_mtime
+    _scoped_key_cache["value"] = latest
+    return latest
+
 
 async def pipe_bytes(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
     """Forward reader → writer until either side closes. Silent on error."""
@@ -102,11 +167,145 @@ async def pipe_bytes(reader: asyncio.StreamReader, writer: asyncio.StreamWriter)
             pass
 
 
+async def handle_anthropic_reverse_proxy(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request: bytes,
+    method: bytes,
+    path: bytes,
+) -> None:
+    """Q3 host-side auth injection.
+
+    Sandbox client sends an HTTP request to <method> /anthropic-proxy/<rest>.
+    We strip the prefix, rewrite Host and Authorization headers with the
+    scoped key from ~/.mika/.env (never crosses sandbox boundary), open TLS
+    to api.anthropic.com:443, forward request, and stream response back.
+    """
+    scoped_key = read_scoped_key()
+    if scoped_key is None:
+        body = (
+            f"mika-pilot-egress: scoped key {_SCOPED_KEY_VAR} not set in "
+            f"{_MIKA_ENV_PATH} — operator must provision before dispatch\n"
+        ).encode("utf-8")
+        writer.write(
+            b"HTTP/1.1 503 Service Unavailable\r\n"
+            b"Content-Type: text/plain; charset=utf-8\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"Connection: close\r\n"
+            b"\r\n" + body
+        )
+        await writer.drain()
+        print(f"[anthropic-proxy] DENY no-key path={path.decode('ascii', 'replace')}",
+              file=sys.stderr, flush=True)
+        return
+
+    # Split request into request-line + headers. body follows blank line.
+    try:
+        head, _sep, _ = request.partition(b"\r\n\r\n")
+    except Exception:
+        writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+        await writer.drain()
+        return
+    lines = head.split(b"\r\n")
+    header_lines = lines[1:]  # skip request line
+    new_path = path[len(ANTHROPIC_PROXY_PATH_PREFIX.encode("ascii")):]
+    if not new_path or not new_path.startswith(b"/"):
+        new_path = b"/" + new_path
+    # Drop Host, Authorization, X-API-Key, X-Api-Key from client headers —
+    # we re-write them. Drop Proxy-Authorization defensively. Preserve
+    # everything else (Content-Type, Content-Length, Transfer-Encoding,
+    # Accept, User-Agent, anthropic-version, anthropic-beta, etc.).
+    drop_re = re.compile(
+        rb"^(host|authorization|x-api-key|proxy-authorization)\s*:",
+        re.IGNORECASE,
+    )
+    filtered_headers = [h for h in header_lines if not drop_re.match(h)]
+    # Detect body length. Support Content-Length (fixed) and
+    # Transfer-Encoding: chunked (streaming).
+    content_length = 0
+    is_chunked = False
+    for h in filtered_headers:
+        if re.match(rb"^content-length\s*:", h, re.IGNORECASE):
+            try:
+                content_length = int(h.split(b":", 1)[1].strip())
+            except (ValueError, IndexError):
+                content_length = 0
+        elif re.match(rb"^transfer-encoding\s*:.*chunked", h, re.IGNORECASE):
+            is_chunked = True
+    # Build new request line + injected headers.
+    new_request = (
+        method + b" " + new_path + b" HTTP/1.1\r\n"
+        + b"Host: " + ANTHROPIC_UPSTREAM_HOST.encode("ascii") + b"\r\n"
+        + b"Authorization: Bearer " + scoped_key.encode("ascii") + b"\r\n"
+        + b"Connection: close\r\n"  # force one-shot, avoid keepalive complexity
+        + b"\r\n".join(filtered_headers)
+        + b"\r\n\r\n"
+    )
+    # Open TLS upstream.
+    try:
+        ssl_ctx = ssl.create_default_context()
+        up_reader, up_writer = await asyncio.wait_for(
+            asyncio.open_connection(
+                ANTHROPIC_UPSTREAM_HOST, ANTHROPIC_UPSTREAM_PORT,
+                ssl=ssl_ctx, server_hostname=ANTHROPIC_UPSTREAM_HOST,
+            ),
+            timeout=15.0,
+        )
+    except (asyncio.TimeoutError, OSError, ssl.SSLError) as exc:
+        writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+        await writer.drain()
+        print(f"[anthropic-proxy] UPSTREAM_FAIL: {exc}",
+              file=sys.stderr, flush=True)
+        return
+
+    try:
+        # Send request head.
+        up_writer.write(new_request)
+        await up_writer.drain()
+        # Forward request body from client → upstream.
+        if is_chunked:
+            # Stream chunked body verbatim until 0-length chunk terminator.
+            while True:
+                chunk = await reader.read(BUFFER_SIZE)
+                if not chunk:
+                    break
+                up_writer.write(chunk)
+                await up_writer.drain()
+                if b"0\r\n\r\n" in chunk:
+                    break
+        elif content_length > 0:
+            remaining = content_length
+            while remaining > 0:
+                chunk = await reader.read(min(BUFFER_SIZE, remaining))
+                if not chunk:
+                    break
+                up_writer.write(chunk)
+                await up_writer.drain()
+                remaining -= len(chunk)
+        # Stream response upstream → client until upstream closes.
+        while True:
+            chunk = await up_reader.read(BUFFER_SIZE)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+        print(
+            f"[anthropic-proxy] ALLOW {method.decode('ascii')} "
+            f"{new_path.decode('ascii', 'replace')}",
+            file=sys.stderr, flush=True,
+        )
+    finally:
+        try:
+            up_writer.close()
+        except OSError:
+            pass
+
+
 async def handle_host_client(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
 ) -> None:
-    """Host-side handler: parse CONNECT, filter hostname, bridge to upstream."""
+    """Host-side handler: dispatch by request-line to CONNECT or reverse-proxy."""
     peer = "unknown"
     try:
         # Read request line + headers (up to blank line).
@@ -117,6 +316,16 @@ async def handle_host_client(
         except (asyncio.TimeoutError, asyncio.IncompleteReadError):
             writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
             await writer.drain()
+            return
+
+        # Dispatch: CONNECT vs anthropic-proxy HTTP reverse-proxy.
+        anthropic_match = ANTHROPIC_METHOD_RE.match(request)
+        if anthropic_match:
+            method = anthropic_match.group(1)
+            path = anthropic_match.group(2)
+            await handle_anthropic_reverse_proxy(
+                reader, writer, request, method, path,
+            )
             return
 
         match = CONNECT_RE.match(request)

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -198,44 +198,35 @@ _run_pilot_sandboxed() {
             # does NOT set this — safe-exec stays denied, invariant preserved.
             --setenv MIKA_PILOT_CONTAINED "1"
         )
-        # Anthropic auth passthrough (2026-08-05, Option C — sami-ratified).
-        # The Phase 2a fs cut hides ~/.claude/.credentials.json (Anthropic OAuth
-        # identity token — cred-invariant "no cred in HOME binds"). Without an
-        # alternate auth path, Claude Code inside the sandbox prints "Not logged
-        # in" and exits at 1 turn / $0.
+        # Anthropic auth via HOST-SIDE proxy injection (2026-08-05 — Q3 shape,
+        # sami+coherence-ratified). The Phase 2a fs cut hides
+        # ~/.claude/.credentials.json (Anthropic OAuth identity token —
+        # cred-invariant "no cred in HOME binds"). Without an alternate auth
+        # path Claude Code inside the sandbox prints "Not logged in" and
+        # exits at 1 turn / $0.
         #
-        # CRITICAL: we read MIKA_PILOT_ANTHROPIC_KEY (a DEDICATED, revocable,
-        # rate-limited API key created by the operator specifically for the
-        # pilot subprocess). We do NOT read MIKA_ANTHROPIC_API_KEY — that
-        # variable holds the same OAuth identity token as .credentials.json
-        # (`sk-ant-oat01-...`), and injecting it here would re-expose exactly
-        # what the round-2 fs cut protects (readable via `cat /proc/self/environ`
-        # + exfiltrable via the sanctioned api.anthropic.com channel). Blast
-        # radius: pilot-scoped key = billing/rate-limit + independent revocation;
-        # OAuth token = full Claude Code identity impersonation. The whole
-        # containment point is minimal-scope credentials.
+        # Q3 approach: the sandbox NEVER holds an Anthropic secret. Instead:
+        #   * mika-pilot-egress-proxy (host-side, outside bwrap) reads the
+        #     scoped key MIKA_PILOT_ANTHROPIC_KEY from ~/.mika/.env directly.
+        #   * The sandbox points ANTHROPIC_BASE_URL at the proxy's HTTP
+        #     reverse-proxy endpoint (localhost / not-CONNECT).
+        #   * Claude Code sends unauthenticated HTTP requests to that URL;
+        #     the proxy injects `Authorization: Bearer <scoped-key>`
+        #     host-side and forwards over TLS to api.anthropic.com.
         #
-        # Silent no-op if MIKA_PILOT_ANTHROPIC_KEY is absent: dispatch proceeds
-        # without ANTHROPIC_API_KEY set, pilot hits "Not logged in" and exits
-        # visibly at 1 turn. This is the correct fail-mode until the operator
-        # provisions the scoped key — no fallback to the OAuth token.
+        # Property: `cat /proc/self/environ` inside the sandbox reveals NO
+        # Anthropic secret material, EVER — the key never crosses the bwrap
+        # boundary. A pilot fully compromised by a malicious dep cannot
+        # exfiltrate the key; the worst case is unauthorized API calls
+        # bounded by the scoped key's rate/spend limits.
         #
-        # Last-win semantics via `tail -n1` — matches dotenvy: if the .env file
-        # has multiple entries (e.g. after a key rotation where the operator
-        # appended rather than replaced), the latest wins. Quotes stripped
-        # best-effort.
-        local _mika_env_file="$HOME/.mika/.env"
-        if [ -f "$_mika_env_file" ]; then
-            local _anthropic_key
-            _anthropic_key=$(grep '^MIKA_PILOT_ANTHROPIC_KEY=' "$_mika_env_file" 2>/dev/null \
-                | tail -n1 \
-                | sed -e 's/^MIKA_PILOT_ANTHROPIC_KEY=//' \
-                      -e 's/^"\(.*\)"$/\1/' \
-                      -e "s/^'\(.*\)'$/\1/")
-            if [ -n "$_anthropic_key" ]; then
-                net_setenv_args+=(--setenv ANTHROPIC_API_KEY "$_anthropic_key")
-            fi
-        fi
+        # ANTHROPIC_API_KEY is set to a placeholder so Claude Code doesn't
+        # short-circuit into "Not logged in" — the proxy overwrites the
+        # Authorization header regardless of what the sandbox sent.
+        net_setenv_args+=(
+            --setenv ANTHROPIC_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
+            --setenv ANTHROPIC_API_KEY "proxy-managed-no-secret"
+        )
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,
         # cleans up on exit. `exec` in the final position ensures the pilot's
         # exit status becomes the sh's.

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -200,25 +200,36 @@ _run_pilot_sandboxed() {
         )
         # Anthropic auth passthrough (2026-08-05, Option C — sami-ratified).
         # The Phase 2a fs cut hides ~/.claude/.credentials.json (Anthropic OAuth
-        # token — cred-invariant "no cred in HOME binds"). Without an alternate
-        # auth path, Claude Code inside the sandbox prints "Not logged in" and
-        # exits at 1 turn / $0. Fix: extract MIKA_ANTHROPIC_API_KEY from
-        # ~/.mika/.env (mika-spirit's dotenvy source) — a project-scoped API key
-        # (rotatable, revocable, blast-radius = billing) rather than the OAuth
-        # token (blast-radius = full Claude Code identity impersonation). Set as
-        # ANTHROPIC_API_KEY in the sandbox env allowlist so claude-agent-sdk
-        # picks it up without needing the credentials.json file at all.
+        # identity token — cred-invariant "no cred in HOME binds"). Without an
+        # alternate auth path, Claude Code inside the sandbox prints "Not logged
+        # in" and exits at 1 turn / $0.
+        #
+        # CRITICAL: we read MIKA_PILOT_ANTHROPIC_KEY (a DEDICATED, revocable,
+        # rate-limited API key created by the operator specifically for the
+        # pilot subprocess). We do NOT read MIKA_ANTHROPIC_API_KEY — that
+        # variable holds the same OAuth identity token as .credentials.json
+        # (`sk-ant-oat01-...`), and injecting it here would re-expose exactly
+        # what the round-2 fs cut protects (readable via `cat /proc/self/environ`
+        # + exfiltrable via the sanctioned api.anthropic.com channel). Blast
+        # radius: pilot-scoped key = billing/rate-limit + independent revocation;
+        # OAuth token = full Claude Code identity impersonation. The whole
+        # containment point is minimal-scope credentials.
+        #
+        # Silent no-op if MIKA_PILOT_ANTHROPIC_KEY is absent: dispatch proceeds
+        # without ANTHROPIC_API_KEY set, pilot hits "Not logged in" and exits
+        # visibly at 1 turn. This is the correct fail-mode until the operator
+        # provisions the scoped key — no fallback to the OAuth token.
         #
         # Last-win semantics via `tail -n1` — matches dotenvy: if the .env file
-        # has multiple MIKA_ANTHROPIC_API_KEY entries (e.g. after a key rotation
-        # where the operator appended rather than replaced), the latest wins.
-        # Quotes stripped best-effort. Silent no-op if the file/key is absent.
+        # has multiple entries (e.g. after a key rotation where the operator
+        # appended rather than replaced), the latest wins. Quotes stripped
+        # best-effort.
         local _mika_env_file="$HOME/.mika/.env"
         if [ -f "$_mika_env_file" ]; then
             local _anthropic_key
-            _anthropic_key=$(grep '^MIKA_ANTHROPIC_API_KEY=' "$_mika_env_file" 2>/dev/null \
+            _anthropic_key=$(grep '^MIKA_PILOT_ANTHROPIC_KEY=' "$_mika_env_file" 2>/dev/null \
                 | tail -n1 \
-                | sed -e 's/^MIKA_ANTHROPIC_API_KEY=//' \
+                | sed -e 's/^MIKA_PILOT_ANTHROPIC_KEY=//' \
                       -e 's/^"\(.*\)"$/\1/' \
                       -e "s/^'\(.*\)'$/\1/")
             if [ -n "$_anthropic_key" ]; then

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -198,6 +198,33 @@ _run_pilot_sandboxed() {
             # does NOT set this — safe-exec stays denied, invariant preserved.
             --setenv MIKA_PILOT_CONTAINED "1"
         )
+        # Anthropic auth passthrough (2026-08-05, Option C — sami-ratified).
+        # The Phase 2a fs cut hides ~/.claude/.credentials.json (Anthropic OAuth
+        # token — cred-invariant "no cred in HOME binds"). Without an alternate
+        # auth path, Claude Code inside the sandbox prints "Not logged in" and
+        # exits at 1 turn / $0. Fix: extract MIKA_ANTHROPIC_API_KEY from
+        # ~/.mika/.env (mika-spirit's dotenvy source) — a project-scoped API key
+        # (rotatable, revocable, blast-radius = billing) rather than the OAuth
+        # token (blast-radius = full Claude Code identity impersonation). Set as
+        # ANTHROPIC_API_KEY in the sandbox env allowlist so claude-agent-sdk
+        # picks it up without needing the credentials.json file at all.
+        #
+        # Last-win semantics via `tail -n1` — matches dotenvy: if the .env file
+        # has multiple MIKA_ANTHROPIC_API_KEY entries (e.g. after a key rotation
+        # where the operator appended rather than replaced), the latest wins.
+        # Quotes stripped best-effort. Silent no-op if the file/key is absent.
+        local _mika_env_file="$HOME/.mika/.env"
+        if [ -f "$_mika_env_file" ]; then
+            local _anthropic_key
+            _anthropic_key=$(grep '^MIKA_ANTHROPIC_API_KEY=' "$_mika_env_file" 2>/dev/null \
+                | tail -n1 \
+                | sed -e 's/^MIKA_ANTHROPIC_API_KEY=//' \
+                      -e 's/^"\(.*\)"$/\1/' \
+                      -e "s/^'\(.*\)'$/\1/")
+            if [ -n "$_anthropic_key" ]; then
+                net_setenv_args+=(--setenv ANTHROPIC_API_KEY "$_anthropic_key")
+            fi
+        fi
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,
         # cleans up on exit. `exec` in the final position ensures the pilot's
         # exit status becomes the sh's.


### PR DESCRIPTION
## Status: READY for coherence re-sonde → sami merge

Vincent's decision (2026-08-05): pilot auth = paid subscription, NOT metered
API key. sami+coherence-ratified Voie A (proxy read-only on
`~/.claude/.credentials.json`, refresh delegated to local Claude Code CLI).

## Design (unchanged from Q3 architecture)

`mika-pilot-egress-proxy` dual-flow (same endpoint):

- Request line matches `<METHOD> /anthropic-proxy/... HTTP/1.1` →
  reverse-proxy: strip prefix, drop client Host/Auth headers, inject
  `Host: api.anthropic.com` + `Authorization: Bearer <subscription-token>`,
  open TLS to `api.anthropic.com:443`, stream response back.
- Everything else → existing CONNECT hostname-allowlist tunnel.

`dispatch-lib.sh` Phase 2b setenv (unchanged from Q3):

    --setenv ANTHROPIC_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
    --setenv ANTHROPIC_API_KEY "proxy-managed-no-secret"

Only the SOURCE of the injected token changes: from a scoped API key in
`~/.mika/.env` (Q3-initial) → subscription OAuth `accessToken` from
`~/.claude/.credentials.json` (Voie A).

## Robust token extraction

`_extract_oauth_token()` walks the JSON defensively — handles nested
(`claudeAiOauth.accessToken`), flat (`accessToken`), and snake_case
(`access_token`) shapes. Picks first `sk-ant-oat*` string; sibling
`expiresAt`/`expires_at`/`exp` picked (ms-epoch auto-detected) for a soft
expiry warning in logs.

## Refresh strategy (Voie A)

Proxy is READ-ONLY on `.credentials.json`. Refresh happens through the
local Claude Code CLI's natural writes (which the mtime-cache picks up on
the next request). If token expires without CLI activity, Anthropic
returns 401 → pilot fails visibly.

**Keep-warm for headless nights**: cron

    */6 * * * * claude -p "ok" --model claude-haiku-4-5 >/dev/null 2>&1

`claude auth status` is local-only (no refresh side-effect — verified).
A real prompt call is required to trigger a refresh if near expiry.
Cost: ~50 tokens / 6h = negligible.

Voie B (proxy owns refresh) filed as follow-up — not required for the
1st loop PR.

## Property (coherence-target unchanged)

`cat /proc/self/environ` inside the sandbox reveals NO Anthropic secret
material — ever. The token never crosses the bwrap boundary. Compromised
pilot cannot exfiltrate the subscription cred; worst-case bounded by
subscription rate limits + any Anthropic anti-abuse throttle.

## Live verification (isolated fake HOME)

Nested shape (production shape):

```
$ echo '{"claudeAiOauth":{"accessToken":"sk-ant-oat01-DUMMY"}}' \
    > /tmp/fake/.claude/.credentials.json
$ HOME=/tmp/fake mika-pilot-egress-proxy --host-unix \
    --socket /tmp/test.sock &
$ curl --unix-socket /tmp/test.sock \
    -X POST 'http://localhost/anthropic-proxy/v1/messages' \
    -H 'Content-Type: application/json' \
    -d '{"model":"claude-opus-4","max_tokens":10,
         "messages":[{"role":"user","content":"hi"}]}'
HTTP=401
{"type":"error","error":{"type":"authentication_error",
 "message":"OAuth access token is invalid."},"request_id":null}
```

Anthropic's `"OAuth access token is invalid"` (vs `"Invalid bearer token"`
for an API-key test) confirms: proxy walked JSON → extracted OAuth token
→ injected → TLS forward → Anthropic recognized as OAuth attempt.

Flat shape → same 401 (walker handles both). No-token → 503 with helpful
error message.

CONNECT regression (Q3 shipped): allow api.anthropic.com:443 → 200;
deny evil.example.com → 403.

## Merge sequence

1. Coherence re-sondes via `./scripts/canary-pilot-containment --enter`:
   - `ls ~/.claude/.credentials.json` → still `No such file` (invariant intact)
   - `env | grep ANTHROPIC` → `BASE_URL` set, `API_KEY=proxy-managed-no-secret`
   - `cat /proc/self/environ | tr '\0' '\n' | grep -i anthropic` → same, ZERO secret
   - Pilot boots, LLM calls succeed via reverse-proxy (subscription auth)
2. sami merges + `make -C mika deploy` (dispatch-lib + proxy binary).
3. Next real dispatch → first REAL loop PR.

Vincent's token is warm (he's active) → merge → 1st PR can drop immediately.

## Rate/ToS notes

- Programmatic use of subscription OAuth = same auth path claude-agent-sdk
  uses. No known "no bots" clause.
- Max tier: high ceiling. Loop is sequential (1 pilot at a time per
  mika-dev), well below abuse thresholds.
- 429 with `retry-after` is non-fatal; pilot retries naturally.
- Cost: flat (subscription) vs variable-explosive (API key). Vincent's
  explicit trade-off.

## Test plan

- [x] `python3 -c 'ast.parse(...)'` on proxy
- [x] Nested shape → 401 OAuth invalid (correct injection)
- [x] Flat shape → 401 OAuth invalid (walker robust)
- [x] Empty file → 503 with visible error (no silent fallback)
- [x] CONNECT allow regression: api.anthropic.com:443 → 200
- [x] CONNECT deny regression: evil.example.com:443 → 403
- [ ] Coherence re-sonde PASSE via `--enter` (invariant + auth via proxy)
- [ ] Post-deploy: real dispatch produces Turns > 1 via subscription auth

## Related

- Follow-up: Voie B (proxy owns OAuth refresh — autonomous nights, no cron)
- Follow-up: rotate the previously-leaked OAuth token (sami's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)