### PR TITLE
fix(dispatch): remove api.anthropic.com from CONNECT allowlist (force BASE_URL path)

### DIFF
--- a/scripts/mika-pilot-egress-proxy
+++ b/scripts/mika-pilot-egress-proxy
@@ -69,9 +69,26 @@ import time
 from pathlib import Path
 
 # Sole security boundary — every entry is a decision.
+#
+# NOTE: `api.anthropic.com` is deliberately ABSENT from the CONNECT allowlist
+# (2026-08-05 root-cause fix). All Anthropic API traffic MUST route through
+# the /anthropic-proxy/* reverse-proxy path where host-side OAuth injection
+# happens. Any CONNECT tunnel attempt to api.anthropic.com now fails fast
+# with a 403, converting a silent hang (SDK trying auth via CONNECT with the
+# sandbox placeholder key) into a visible fail-fast — RT#003 (silent→noisy)
+# applied at the egress layer.
+#
+# Diagnostic evidence (canary --enter, 2026-08-05): bundled claude v2.1.191
+# with HTTPS_PROXY set + BASE_URL set uses HTTPS_PROXY CONNECT for SOME API
+# paths (bypassing BASE_URL). Those calls carry the sandbox's placeholder
+# ANTHROPIC_API_KEY (proxy-managed-no-secret) as bearer → Anthropic returns
+# 401 or the SDK stalls waiting for a valid response → guardrail idle_timeout
+# 300s → PIPELINE FAILURE zero commits. Removing api.anthropic.com from
+# CONNECT allowlist forces the SDK to fall back to BASE_URL (verified in
+# canary: tool-use flow completes cleanly, tool_use → tool_result exchange
+# observed end-to-end).
 HOST_ALLOWLIST = frozenset({
-    # LLM providers used by claude-pilot / claude-agent-sdk.
-    "api.anthropic.com",
+    # LLM providers other than Anthropic (Anthropic is REVERSE-PROXIED, not tunneled).
     "api.openai.com",
     "api.z.ai",
     "openrouter.ai",


### PR DESCRIPTION
## Summary

Follow-up to #1896 (Voie A subscription OAuth via reverse-proxy). Root cause of pilot idle_timeout post-deploy isolated: bundled `claude` v2.1.191 with HTTPS_PROXY + BASE_URL both set uses HTTPS_PROXY CONNECT for SOME API paths, bypassing BASE_URL. Those calls carry the sandbox's placeholder `ANTHROPIC_API_KEY=proxy-managed-no-secret` → Anthropic 401 or SDK hang → 300s idle_timeout → PIPELINE FAILURE zero commits.

## Change

Remove `api.anthropic.com` from `HOST_ALLOWLIST` in `mika-pilot-egress-proxy`. Any CONNECT to it now fails fast (403). All Anthropic traffic MUST route via `/anthropic-proxy/*` reverse-proxy where host-side OAuth injection lives.

## Verified end-to-end (canary --enter A/B)

- **A** (HTTPS_PROXY set + api.anthropic.com in CONNECT allowlist): bundled claude tool-use HANGS 150s — mirrors exact pilot failure
- **B** (this fix): bundled claude tool-use COMPLETES cleanly — full `tool_use → tool_result` cycle for `echo HELLO_FROM_TOOL` observed

Regression:
- `CONNECT api.anthropic.com:443` → **403 Forbidden** (fix)
- `CONNECT api.github.com:443` → **200 Connection Established** (unchanged)
- Reverse-proxy `/anthropic-proxy/v1/messages` with valid OAuth → real completion (unchanged from #1896)

## Property

Strict tightening: removed one allowlist entry, added no capability. Reverse-proxy path unchanged — Anthropic remains reachable via the auth-injecting path only. Sandbox blindness to the OAuth token preserved (already established in #1896).

## RT#003 applied at egress

Silent hang → visible fast-403. Any client attempting CONNECT to api.anthropic.com now surfaces the misroute in logs instead of silently stalling.

## Test plan

- [x] python3 ast.parse on proxy
- [x] Canary A/B tool-use flow (A hangs, B completes)
- [x] CONNECT allow regression (github OK)
- [x] CONNECT deny confirmed (anthropic 403)
- [x] Reverse-proxy unchanged
- [ ] Post-merge deploy → real dispatch produces PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)