### PR TITLE
fix(dispatch): add CLAUDE_CODE_API_BASE_URL alongside ANTHROPIC_BASE_URL (Voie A completeness)

### DIFF
--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -223,8 +223,26 @@ _run_pilot_sandboxed() {
         # ANTHROPIC_API_KEY is set to a placeholder so Claude Code doesn't
         # short-circuit into "Not logged in" — the proxy overwrites the
         # Authorization header regardless of what the sandbox sent.
+        #
+        # CLAUDE_CODE_API_BASE_URL (2026-08-05 — anti-jour finding, sami-ratified):
+        # ANTHROPIC_BASE_URL covers the Anthropic SDK's message API client, but
+        # bundled `claude` v2.1.191 has INTERNAL code paths (auto-update check,
+        # session bootstrap, OAuth handshake, telemetry) that hardcode
+        # https://api.anthropic.com/... and honor a distinct CC-specific env
+        # var — CLAUDE_CODE_API_BASE_URL — for their base URL override. Setting
+        # this alongside ANTHROPIC_BASE_URL routes ALL CC-internal traffic
+        # through the /anthropic-proxy/* reverse-proxy path where host-side
+        # OAuth injection lives. Without it, those internal calls fall through
+        # to HTTPS_PROXY CONNECT tunnels (carrying the sandbox placeholder key)
+        # → Anthropic 401 / SDK stall → guardrail idle_timeout 300s → pilot
+        # dies at Turns:1 with HEAD unchanged (n=6 dispatches observed).
+        # Found via `strings` on bundled claude binary; verified end-to-end
+        # in canary (opus-4-8, stream-json, no --bare) → 1.7s clean completion.
+        # γ (MITM CONNECT tunnels) filed as long-term robustness follow-up so
+        # we're not dependent on this internal env var indefinitely.
         net_setenv_args+=(
             --setenv ANTHROPIC_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
+            --setenv CLAUDE_CODE_API_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
             --setenv ANTHROPIC_API_KEY "proxy-managed-no-secret"
         )
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,


### PR DESCRIPTION
## Summary

Follow-up to #1897 (CONNECT allowlist strip). Root-cause fix for pilot idle_timeout that persisted after #1897 deploy: bundled `claude` v2.1.191 has CC-internal code paths (auto-update, session bootstrap, OAuth handshake, telemetry) that hardcode `https://api.anthropic.com/...` and honor a **distinct** env var — `CLAUDE_CODE_API_BASE_URL` — for their base URL override. Without it, these internal calls fell through to HTTPS_PROXY CONNECT tunnels, got 403'd (fix B), and the SDK stalled → 300s idle_timeout → PIPELINE FAILURE (n=6 consecutive dispatches).

## Change

Add `--setenv CLAUDE_CODE_API_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"` alongside the existing `ANTHROPIC_BASE_URL` setenv in `dispatch-lib.sh`. Routes ALL CC-internal traffic through the reverse-proxy path where host-side OAuth injection happens.

## Anti-jour finding

Discovered via `strings` on bundled claude binary:

    strings .../claude_agent_sdk/_bundled/claude | grep '^CLAUDE_CODE_'

reveals `CLAUDE_CODE_API_BASE_URL` distinct from `ANTHROPIC_BASE_URL`.

## Verification (canary --enter, prod-shape)

Env: `ANTHROPIC_BASE_URL + CLAUDE_CODE_API_BASE_URL + HTTPS_PROXY + placeholder ANTHROPIC_API_KEY`. Bundled claude v2.1.191, model claude-opus-4-8, stream-json input, no --bare, no --dangerously-skip-permissions.

- **Without** `CLAUDE_CODE_API_BASE_URL`: HANGS 150s+
- **With** `CLAUDE_CODE_API_BASE_URL`: `duration_ms=1736, num_turns=1, result="OK", terminal_reason=completed`

## Property

Strict addition — no new bind, no new surface, no allowlist change. Routes MORE traffic through the auth-injecting reverse-proxy. Containment-neutral-to-positive.

## Follow-up

γ (MITM CONNECT tunnels via self-signed CA) remains the architecturally most robust fix — immunized against CC changing its internal env-var semantics. File as follow-up ticket, non-urgent now that this env-var approach unblocks the loop.

## Test plan

- [x] `bash -n` on dispatch-lib.sh
- [x] Canary A/B: without → hang, with → 1.7s clean
- [ ] Post-deploy: real dispatch produces PR (the strict success criterion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)