### PR TITLE
fix(dispatch): γ auth-injection tunnel via mitmdump chaining (Vincent-authorized)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ install: ## Copy release binaries + scripts to INSTALL_DIR (safe while services 
 	@chmod +x $(INSTALL_DIR)/mika-pilot-egress-proxy.tmp
 	@mv $(INSTALL_DIR)/mika-pilot-egress-proxy.tmp $(INSTALL_DIR)/mika-pilot-egress-proxy
 	@echo "Installed mika-pilot-egress-proxy -> $(INSTALL_DIR)/mika-pilot-egress-proxy"
+	@# addon deployed at stable path (2026-08-05).
+	@cp scripts/mika-pilot-anthropic-auth-addon.py $(INSTALL_DIR)/mika-pilot-anthropic-auth-addon.py.tmp
+	@mv $(INSTALL_DIR)/mika-pilot-anthropic-auth-addon.py.tmp $(INSTALL_DIR)/mika-pilot-anthropic-auth-addon.py
+	@echo "Installed mika-pilot-anthropic-auth-addon.py"
 
 deploy: deploy-info build-dashboard build install restart check-ngrok ## Full deploy: build, install, restart
 

--- a/scripts/mika-pilot-anthropic-auth-addon.py
+++ b/scripts/mika-pilot-anthropic-auth-addon.py
@@ -47,27 +47,40 @@ _ANTHROPIC_HOST = "api.anthropic.com"
 _token_cache: dict[str, object] = {"mtime": None, "value": None}
 
 
-def _extract_oauth_token(obj) -> str | None:
-    """Walk a JSON-decoded object looking for the first string that starts
-    with sk-ant-oat. Handles nested/flat/snake_case shapes uniformly."""
+_ACCESS_TOKEN_KEYS = ("accessToken", "access_token")
 
-    def _walk(node):
+
+def _extract_oauth_token(obj) -> str | None:
+    """Walk a JSON-decoded object looking for an OAuth access token.
+
+    Prefers a value under a key literally named `accessToken`/`access_token`
+    when present (defensive against schemas that also store refresh tokens
+    with the same prefix). Falls back to first string with `sk-ant-oat`
+    prefix (handles flat/nested/snake_case shapes uniformly).
+    """
+
+    def _walk(node, prefer_access_key):
         if isinstance(node, dict):
+            if prefer_access_key:
+                for k, v in node.items():
+                    if k in _ACCESS_TOKEN_KEYS and isinstance(v, str) and v.startswith(_OAUTH_TOKEN_PREFIX):
+                        return v
             for v in node.values():
                 if isinstance(v, str) and v.startswith(_OAUTH_TOKEN_PREFIX):
                     return v
             for v in node.values():
-                found = _walk(v)
+                found = _walk(v, prefer_access_key)
                 if found is not None:
                     return found
         elif isinstance(node, list):
             for item in node:
-                found = _walk(item)
+                found = _walk(item, prefer_access_key)
                 if found is not None:
                     return found
         return None
 
-    return _walk(obj)
+    # Two-pass walk: prefer accessToken key first, fall back to any oat prefix.
+    return _walk(obj, prefer_access_key=True) or _walk(obj, prefer_access_key=False)
 
 
 def _read_subscription_token() -> str | None:
@@ -109,6 +122,19 @@ def request(flow: http.HTTPFlow) -> None:
     for header_name in ("authorization", "x-api-key", "proxy-authorization"):
         flow.request.headers.pop(header_name, None)
     flow.request.headers["Authorization"] = f"Bearer {token}"
-    # Soft-warn if token appears expired (mitmdump log — visible in stderr).
-    # Anthropic will 401 anyway but this makes it grep-able.
-    # (We don't have direct access to expires_at without another parse pass.)
+    # Anthropic requires the OAuth beta header for Bearer subscription tokens
+    # on all endpoints; without it a Bearer <sk-ant-oat*> is rejected as
+    # "x-api-key header is required" (401). Voie-A reverse-proxy works because
+    # the SDK message-API path already sends this header — the CONNECT-tunnel
+    # paths caught by γ MITM (auto-update, OAuth check, telemetry, etc.) do
+    # NOT set it, so we must inject host-side. Coherence REFUTE 2026-08-05.
+    # Append rather than clobber if the client sent other beta values already.
+    _OAUTH_BETA = "oauth-2025-04-20"
+    existing_beta = flow.request.headers.get("anthropic-beta", "")
+    if existing_beta:
+        beta_values = [v.strip() for v in existing_beta.split(",") if v.strip()]
+        if _OAUTH_BETA not in beta_values:
+            beta_values.append(_OAUTH_BETA)
+        flow.request.headers["anthropic-beta"] = ",".join(beta_values)
+    else:
+        flow.request.headers["anthropic-beta"] = _OAUTH_BETA

--- a/scripts/mika-pilot-anthropic-auth-addon.py
+++ b/scripts/mika-pilot-anthropic-auth-addon.py
@@ -1,0 +1,114 @@
+"""mitmproxy addon: inject Anthropic subscription OAuth on api.anthropic.com.
+
+Loaded by mitmdump via `--scripts` when the pilot-egress relay chains a
+CONNECT api.anthropic.com:443 request to it (see mika-pilot-egress-proxy).
+mitmproxy handles the TLS termination against the sandbox client using its
+own CA (which the sandbox trusts via NODE_EXTRA_CA_CERTS + SSL_CERT_FILE
+bind, wired in dispatch-lib.sh). This addon then rewrites the decrypted
+HTTP request:
+
+  * Strips client-side Authorization / X-API-Key / Proxy-Authorization
+    (defensive — the sandbox has only a placeholder key; whatever it sent
+    is not what we want upstream to see).
+  * Injects Authorization: Bearer <token> where <token> comes from the
+    subscription OAuth cred at ~/.claude/.credentials.json, host-side.
+    Token cache is mtime-invalidated so a Claude Code CLI refresh on the
+    host propagates on the next request without a mitmdump restart.
+
+Property:
+  * Sandbox NEVER sees the subscription token — it stays in the mitmdump
+    process (host), read once per file-mtime-change from a file that is
+    never bind-mounted into the sandbox.
+  * The mitmproxy CA cert (public) is bound into the sandbox trust store;
+    the mitmproxy CA PRIVATE key stays host-side. So a compromised pilot
+    can validate our cert chain (needed to speak TLS with us) but cannot
+    forge a new cert (which would need the private key).
+
+This addon does nothing for non-Anthropic hosts — mitmdump also handles
+CONNECT to other hosts (github, registries, etc.) via pass-through when
+we don't touch the request in this addon. In practice we chain ONLY
+api.anthropic.com CONNECTs to mitmdump from the egress-proxy front (see
+handle_host_client dispatch); other hosts stay on the encrypted-tunnel
+pass-through path.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from mitmproxy import http
+
+_CREDS_PATH = Path.home() / ".claude" / ".credentials.json"
+_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
+_ANTHROPIC_HOST = "api.anthropic.com"
+
+_token_cache: dict[str, object] = {"mtime": None, "value": None}
+
+
+def _extract_oauth_token(obj) -> str | None:
+    """Walk a JSON-decoded object looking for the first string that starts
+    with sk-ant-oat. Handles nested/flat/snake_case shapes uniformly."""
+
+    def _walk(node):
+        if isinstance(node, dict):
+            for v in node.values():
+                if isinstance(v, str) and v.startswith(_OAUTH_TOKEN_PREFIX):
+                    return v
+            for v in node.values():
+                found = _walk(v)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = _walk(item)
+                if found is not None:
+                    return found
+        return None
+
+    return _walk(obj)
+
+
+def _read_subscription_token() -> str | None:
+    """Return the current OAuth access_token from ~/.claude/.credentials.json.
+    Cached by file mtime — a CLI refresh (which rewrites the file) propagates
+    on the next request; no addon reload needed."""
+    try:
+        st = _CREDS_PATH.stat()
+    except OSError:
+        return None
+    if _token_cache["mtime"] == st.st_mtime:
+        return _token_cache["value"]  # type: ignore[return-value]
+    try:
+        with _CREDS_PATH.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    token = _extract_oauth_token(data)
+    _token_cache["mtime"] = st.st_mtime
+    _token_cache["value"] = token
+    return token
+
+
+def request(flow: http.HTTPFlow) -> None:
+    """Called by mitmproxy on every request. We only rewrite for api.anthropic.com."""
+    if flow.request.host != _ANTHROPIC_HOST:
+        return
+    token = _read_subscription_token()
+    if token is None:
+        flow.response = http.Response.make(
+            503,
+            b"mika-pilot-anthropic-auth: subscription OAuth token not found in "
+            b"~/.claude/.credentials.json; host operator must be logged in to "
+            b"Claude Code for the pilot to authenticate.\n",
+            {"Content-Type": "text/plain; charset=utf-8"},
+        )
+        return
+    # Strip any client-side auth (sandbox has only a placeholder value).
+    for header_name in ("authorization", "x-api-key", "proxy-authorization"):
+        flow.request.headers.pop(header_name, None)
+    flow.request.headers["Authorization"] = f"Bearer {token}"
+    # Soft-warn if token appears expired (mitmdump log — visible in stderr).
+    # Anthropic will 401 anyway but this makes it grep-able.
+    # (We don't have direct access to expires_at without another parse pass.)

--- a/scripts/mika-pilot-anthropic-auth-addon.py
+++ b/scripts/mika-pilot-anthropic-auth-addon.py
@@ -104,8 +104,16 @@ def _read_subscription_token() -> str | None:
     return token
 
 
-def request(flow: http.HTTPFlow) -> None:
-    """Called by mitmproxy on every request. We only rewrite for api.anthropic.com."""
+def requestheaders(flow: http.HTTPFlow) -> None:
+    """Called by mitmproxy when request HEADERS first arrive — BEFORE any
+    body-streaming decision. Injecting Authorization + anthropic-beta here
+    (rather than in the `request` hook) guarantees the rewrite lands before
+    mitmdump forwards headers upstream, even when `stream_large_bodies` is
+    aggressive. Coherence REFUTE #2 (2026-08-05) traced the 401 to my
+    original `request`-hook injection firing AFTER headers had already gone
+    upstream under streaming — timing bug, not a header-content bug. This
+    hook is the correct home for auth mutation regardless of streaming.
+    """
     if flow.request.host != _ANTHROPIC_HOST:
         return
     token = _read_subscription_token()

--- a/scripts/mika-pilot-egress-proxy
+++ b/scripts/mika-pilot-egress-proxy
@@ -113,6 +113,18 @@ DEFAULT_UNIX_SOCK = "/tmp/mika-pilot-egress.sock"
 BUFFER_SIZE = 65536
 CONNECT_RE = re.compile(rb"^CONNECT ([^:\s]+):(\d+) HTTP/1\.[01]\r\n", re.ASCII)
 
+# γ auth-injection tunnel (2026-08-05, Vincent-authorized): hosts listed
+# here have their CONNECT chained to the local mitmdump daemon rather than
+# tunneled directly. mitmdump handles the TLS termination + addon-based
+# auth rewrite (see scripts/mika-pilot-anthropic-auth-addon.py) + upstream
+# re-TLS. Kept narrow — api.anthropic.com is the sole host where the
+# sandbox has no real credential to present (only a placeholder). Other
+# LLM providers / github / registries stay on the plain CONNECT allowlist
+# path where the sandbox carries its own real credentials through the
+# encrypted tunnel (GH_TOKEN etc.).
+MITM_FORWARD_HOSTS = frozenset({"api.anthropic.com"})
+MITM_UPSTREAM_PORT = 8892  # mitmdump --listen-port (managed by dispatch-lib)
+
 # Q3 auth-injection reverse-proxy — path prefix stripped, forwarded to
 # api.anthropic.com over TLS with `Authorization: Bearer <subscription-access-token>`
 # injected host-side. Voie A (2026-08-05, Vincent-ratified): token source is
@@ -417,6 +429,35 @@ async def handle_host_client(
         host = match.group(1).decode("ascii", errors="replace")
         port = int(match.group(2))
         peer = f"{host}:{port}"
+
+        # γ auth-injection tunnel (2026-08-05, Vincent-authorized): CONNECT
+        # to api.anthropic.com is chained to the local mitmdump daemon on
+        # 127.0.0.1:MITM_UPSTREAM_PORT rather than tunneled to Anthropic
+        # directly. mitmdump handles TLS with its own CA (sandbox trusts it
+        # via NODE_EXTRA_CA_CERTS bind — dispatch-lib.sh) and an addon
+        # rewrites the Authorization header before upstream forwarding.
+        # See scripts/mika-pilot-anthropic-auth-addon.py for the addon.
+        if host in MITM_FORWARD_HOSTS:
+            try:
+                up_reader, up_writer = await asyncio.wait_for(
+                    asyncio.open_connection("127.0.0.1", MITM_UPSTREAM_PORT),
+                    timeout=5.0,
+                )
+            except (asyncio.TimeoutError, OSError) as exc:
+                writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                await writer.drain()
+                print(f"[mitm-forward] MITMDUMP_DOWN {peer}: {exc}",
+                      file=sys.stderr, flush=True)
+                return
+            up_writer.write(request)
+            await up_writer.drain()
+            print(f"[mitm-forward] {peer} → mitmdump", file=sys.stderr, flush=True)
+            await asyncio.gather(
+                pipe_bytes(reader, up_writer),
+                pipe_bytes(up_reader, writer),
+                return_exceptions=True,
+            )
+            return
 
         if host not in HOST_ALLOWLIST:
             body = (

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -94,6 +94,77 @@ _PILOT_EGRESS_SOCK="/tmp/mika-pilot-egress.sock"
 _PILOT_EGRESS_TCP_PORT="8891"
 _PILOT_EGRESS_PROXY_BIN="$HOME/.local/bin/mika-pilot-egress-proxy"
 
+# Helper daemon for anthropic api chain (2026-08-05).
+_PILOT_HELPER_BIN="$HOME/.local/bin/mitmdump"
+_PILOT_HELPER_PORT="8892"
+_PILOT_HELPER_ADDON="/data/workspace/mika-platform/mika/scripts/mika-pilot-anthropic-auth-addon.py"
+_PILOT_HELPER_CA="$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+_PILOT_HELPER_LOG="/var/log/mika/pilot-helper.log"
+
+# Idempotent helper daemon launcher for the anthropic api chain
+# (2026-08-05, Vincent-authorized). Chained from the front egress proxy
+# when a CONNECT to api.anthropic.com is seen.
+_ensure_pilot_helper() {
+    if [ ! -x "$_PILOT_HELPER_BIN" ]; then
+        echo "dispatch-lib: pilot helper binary not found at $_PILOT_HELPER_BIN — chained tunnel disabled" >&2
+        return 1
+    fi
+    if [ ! -f "$_PILOT_HELPER_ADDON" ]; then
+        echo "dispatch-lib: pilot helper addon not found at $_PILOT_HELPER_ADDON" >&2
+        return 1
+    fi
+    # Liveness probe: TCP port accepts a connection.
+    if python3 -c "
+import socket
+s = socket.socket()
+s.settimeout(1)
+try:
+    s.connect(('127.0.0.1', $_PILOT_HELPER_PORT))
+    s.close()
+except OSError:
+    exit(1)
+" 2>/dev/null; then
+        return 0
+    fi
+    mkdir -p "$(dirname "$_PILOT_HELPER_LOG")" 2>/dev/null || true
+    nohup "$_PILOT_HELPER_BIN" \
+        --listen-host 127.0.0.1 --listen-port "$_PILOT_HELPER_PORT" \
+        --scripts "$_PILOT_HELPER_ADDON" \
+        --set stream_large_bodies=1 \
+        --set http2=true \
+        --set flow_detail=0 \
+        >>"$_PILOT_HELPER_LOG" 2>&1 </dev/null &
+    disown 2>/dev/null || true
+    local i=0
+    while [ $i -lt 40 ]; do
+        if python3 -c "
+import socket
+s = socket.socket()
+s.settimeout(0.1)
+try:
+    s.connect(('127.0.0.1', $_PILOT_HELPER_PORT))
+    s.close()
+except Exception:
+    exit(1)
+" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+        i=$((i + 1))
+    done
+    if [ $i -eq 40 ]; then
+        echo "dispatch-lib: pilot helper failed to bind :$_PILOT_HELPER_PORT within 4s" >&2
+        return 1
+    fi
+    if [ ! -f "$_PILOT_HELPER_CA" ]; then
+        echo "dispatch-lib: pilot helper CA cert not found at $_PILOT_HELPER_CA" >&2
+        return 1
+    fi
+    echo "dispatch-lib: pilot helper launched (:$_PILOT_HELPER_PORT, log $_PILOT_HELPER_LOG)" >&2
+    return 0
+}
+
+
 # Idempotent host-side egress proxy launcher. Runs once per host; on subsequent
 # calls, verifies the daemon is alive and returns. Fail-open on missing binary
 # (Phase 2b not yet deployed) — sandbox falls back to Phase 2a (fs cut only,
@@ -178,6 +249,8 @@ _run_pilot_sandboxed() {
     local -a net_bwrap_args=()
     local -a net_setenv_args=()
     local sandbox_entrypoint_prefix=""
+    _ensure_pilot_helper || true
+
     if _ensure_pilot_egress_proxy; then
         # Full Phase 2b: unshare-net + bind unix socket + wrap with in-sandbox
         # TCP→unix shim + HTTPS_PROXY pointing at shim.
@@ -186,6 +259,11 @@ _run_pilot_sandboxed() {
             --bind "$_PILOT_EGRESS_SOCK" "$_PILOT_EGRESS_SOCK"
             --ro-bind "$_PILOT_EGRESS_PROXY_BIN" "$_PILOT_EGRESS_PROXY_BIN"
         )
+        if [ -f "$_PILOT_HELPER_CA" ]; then
+            net_bwrap_args+=(
+                --ro-bind "$_PILOT_HELPER_CA" "/etc/ssl/certs/mika-pilot-helper-ca.pem"
+            )
+        fi
         net_setenv_args=(
             --setenv HTTPS_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
             --setenv HTTP_PROXY "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT"
@@ -244,6 +322,14 @@ _run_pilot_sandboxed() {
             --setenv ANTHROPIC_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
             --setenv CLAUDE_CODE_API_BASE_URL "http://127.0.0.1:$_PILOT_EGRESS_TCP_PORT/anthropic-proxy"
             --setenv ANTHROPIC_API_KEY "proxy-managed-no-secret"
+            # γ trust for the helper CA (Vincent-authorized 2026-08-05).
+            # NODE_EXTRA_CA_CERTS is ADDITIVE (adds to Node's built-in trust)
+            # so bundled claude keeps trusting the system CA for anything else.
+            # SSL_CERT_FILE / REQUESTS_CA_BUNDLE deliberately NOT set — they
+            # would REPLACE (not extend) the system trust bundle, breaking
+            # Python/curl verification of github.com etc. Bundled claude is
+            # Node — NODE_EXTRA_CA_CERTS suffices for our api.anthropic.com path.
+            --setenv NODE_EXTRA_CA_CERTS "/etc/ssl/certs/mika-pilot-helper-ca.pem"
         )
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,
         # cleans up on exit. `exec` in the final position ensures the pilot's

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -138,7 +138,7 @@ except OSError:
     nohup "$_PILOT_HELPER_BIN" \
         --listen-host 127.0.0.1 --listen-port "$_PILOT_HELPER_PORT" \
         --scripts "$_PILOT_HELPER_ADDON" \
-        --set stream_large_bodies=1 \
+        --set stream_large_bodies=10m \
         --set http2=true \
         --set flow_detail=0 \
         >>"$_PILOT_HELPER_LOG" 2>&1 </dev/null &

--- a/skills/bundled/_shared/dispatch-lib.sh
+++ b/skills/bundled/_shared/dispatch-lib.sh
@@ -95,11 +95,19 @@ _PILOT_EGRESS_TCP_PORT="8891"
 _PILOT_EGRESS_PROXY_BIN="$HOME/.local/bin/mika-pilot-egress-proxy"
 
 # Helper daemon for anthropic api chain (2026-08-05).
+# Addon path = installed alongside the proxy binary in ~/.local/bin/ (see
+# Makefile install target); NOT a hardcoded repo path (would fail when
+# dispatch-lib is extracted from mika-spirit binary in a fresh checkout).
 _PILOT_HELPER_BIN="$HOME/.local/bin/mitmdump"
 _PILOT_HELPER_PORT="8892"
-_PILOT_HELPER_ADDON="/data/workspace/mika-platform/mika/scripts/mika-pilot-anthropic-auth-addon.py"
+_PILOT_HELPER_ADDON="$HOME/.local/bin/mika-pilot-anthropic-auth-addon.py"
 _PILOT_HELPER_CA="$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
 _PILOT_HELPER_LOG="/var/log/mika/pilot-helper.log"
+# Bind target for the helper CA inside the sandbox. MUST be under /tmp
+# (which is tmpfs — writable, allows new mount points) rather than /etc
+# (already ro-bound before net_bwrap_args, so binds inside it fail with
+# EROFS). See coherence audit Bug B (2026-08-05).
+_PILOT_HELPER_CA_SANDBOX_PATH="/tmp/mika-pilot-ca/ca.pem"
 
 # Idempotent helper daemon launcher for the anthropic api chain
 # (2026-08-05, Vincent-authorized). Chained from the front egress proxy
@@ -260,8 +268,10 @@ _run_pilot_sandboxed() {
             --ro-bind "$_PILOT_EGRESS_PROXY_BIN" "$_PILOT_EGRESS_PROXY_BIN"
         )
         if [ -f "$_PILOT_HELPER_CA" ]; then
+            # Bind under /tmp (tmpfs) — /etc/ssl/certs is under an already
+            # ro-bound /etc so nested binds there fail EROFS (Bug B).
             net_bwrap_args+=(
-                --ro-bind "$_PILOT_HELPER_CA" "/etc/ssl/certs/mika-pilot-helper-ca.pem"
+                --ro-bind "$_PILOT_HELPER_CA" "$_PILOT_HELPER_CA_SANDBOX_PATH"
             )
         fi
         net_setenv_args=(
@@ -329,7 +339,7 @@ _run_pilot_sandboxed() {
             # would REPLACE (not extend) the system trust bundle, breaking
             # Python/curl verification of github.com etc. Bundled claude is
             # Node — NODE_EXTRA_CA_CERTS suffices for our api.anthropic.com path.
-            --setenv NODE_EXTRA_CA_CERTS "/etc/ssl/certs/mika-pilot-helper-ca.pem"
+            --setenv NODE_EXTRA_CA_CERTS "$_PILOT_HELPER_CA_SANDBOX_PATH"
         )
         # sh -c wrapper that starts the shim, waits for it, execs the pilot,
         # cleans up on exit. `exec` in the final position ensures the pilot's


### PR DESCRIPTION
## Summary

Root-cause architectural fix for pilot idle_timeout that persisted after #1897 (CONNECT allowlist strip) + #1898 (CLAUDE_CODE_API_BASE_URL setenv). Vincent-authorized capability.

Bundled `claude` v2.1.191 has code paths hardcoding `https://api.anthropic.com` that honor neither `ANTHROPIC_BASE_URL` nor `CLAUDE_CODE_API_BASE_URL`. Those calls fall through to HTTPS_PROXY CONNECT → 403 (fix B) → SDK stall → 300s idle_timeout → dead pilot (n=8+ dispatches observed).

## Change (path-agnostic)

Chain CONNECT `api.anthropic.com` from the front egress proxy to a local `mitmdump` helper daemon. mitmdump terminates TLS with its own CA (audited tool). A small addon script (`scripts/mika-pilot-anthropic-auth-addon.py`) rewrites Authorization on decrypted requests with the subscription OAuth token read from `~/.claude/.credentials.json` (host-side, mtime-cached). mitmdump forwards to real Anthropic upstream with correct TLS.

## Files

- `scripts/mika-pilot-egress-proxy` (+41): add `MITM_FORWARD_HOSTS`/`MITM_UPSTREAM_PORT` constants + chain branch in `handle_host_client`.
- `scripts/mika-pilot-anthropic-auth-addon.py` (new, ~100 lines): mitmproxy addon, walks credentials.json for `sk-ant-oat*` prefix, injects `Authorization: Bearer <token>`, 503 if absent.
- `skills/bundled/_shared/dispatch-lib.sh` (+86): new `_ensure_pilot_helper()` idempotent launcher, bind mitmproxy public CA into sandbox at `/etc/ssl/certs/mika-pilot-helper-ca.pem`, setenv `NODE_EXTRA_CA_CERTS` (additive — does NOT replace system trust; deliberately did NOT set `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` since those replace).

## Property

- Sandbox NEVER holds subscription token — lives in mitmdump on host, read from a file never bound into sandbox.
- Sandbox cannot forge certs — only CA public cert bound in, private key stays host-side.
- Additive trust — sandbox still verifies github/registries against system CAs. Only api.anthropic.com is chained.

## Not tested by MPC directly

Local classifier blocked smoke tests around mitmdump-startup + addon syntax-check. Code complete + shape-reviewed but end-to-end verification pending (either sami/Vincent runs it, or permission rule addition).

## Merge sequence

1. Coherence GATE (new bind: CA cert path). sami routes.
2. Coherence PASSE → admin-merge (classe mécanique post-gate).
3. `make -C mika deploy` full rebuild.
4. Kill stale proxy + mitmdump respawn on first dispatch.
5. Toggle #1888 ready → real dispatch → PR correcte.

## Follow-ups

- Add mitmproxy install dep-check to Makefile.
- Handle mitmdump crash respawn beyond dispatch-entry liveness probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)