### PR TITLE
fix(ci): restore main baseline — docs sync + advisory-db bump (#1903+#1904)

### DIFF
--- a/crates/mika-agent/docs/runtime-structure.md
+++ b/crates/mika-agent/docs/runtime-structure.md
@@ -43,7 +43,7 @@ Home directory: `$MIKA_HOME` (default `~/.mika/`).
 ├── agents/
 │   └── mika/                         # Default agent (same structure per agent)
 │       ├── config.toml               # Per-agent config overrides (0600)
-│       ├── identity.toml             # Agent name + emoji (0600)
+│       ├── identity.toml             # Agent name + emoji + [kg]/[skills]/[tools]/[context]/[session] blocks (0600)
 │       ├── soul.md                   # Personality definition (0600)
 │       ├── heartbeat.md              # Heartbeat checklist (0600)
 │       ├── user.md                   # User info seed (0600)
@@ -114,7 +114,7 @@ Durable changes to bundled skills must go through the source tree at `skills/bun
 
 **agents** — `id TEXT PK`, `name TEXT NOCASE`, `home_dir TEXT`, `active BOOLEAN DEFAULT 1`, `last_seen TEXT`, `created_at TEXT`
 
-**sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`
+**sessions** — `id TEXT PK`, `agent_id TEXT FK→agents`, `channel_type TEXT DEFAULT 'cli'`, `parent_session_id TEXT`, `task_id TEXT` (reverse link to triggering task, partial index), `started_at TEXT`, `ended_at TEXT`, `metadata TEXT`. Session IDs are prefix-typed: random UUID (per-ask default), `system-{agent_id}` (compaction summaries), `canonical-{agent_id}` (single-session-by-nature agents, mika#1401), plus derived namespaces `heartbeat-*`, `callback-*`, `skill-*`, `reflection-*`, `team-*`, `delegate-*`, `reminder-*`. `prune_old_sessions` only deletes the derived-namespace prefixes; `canonical-*`, `system-*`, and bare UUIDs are exempt. Agents opt into a single canonical session via `[session] singleton = true` in `identity.toml` (see `crates/mika-agent/CLAUDE.md` § Session Configuration).
 
 **messages** — `id INTEGER PK AUTO`, `session_id TEXT FK→sessions`, `agent_id TEXT FK→agents`, `role TEXT CHECK(user|assistant|system|summary|tool_result)`, `content TEXT`, `metadata TEXT`, `trace_id TEXT`, `compacted_through_id INTEGER`, `created_at TEXT`, `internal INTEGER NOT NULL DEFAULT 0` (agent-to-agent messages hidden from TUI inbox mode)
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,16 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 
 [[advisories.ignore]]
-id = "RUSTSEC-2024-0436"
-reason = "paste is unmaintained but has no security impact; widely used transitive dependency with no drop-in replacement yet."
+id = "RUSTSEC-2026-0253"
+reason = "lru LruCache::pop panic-safety (unsound); transitive dep only, we do not pass panicking Drop keys to pop()."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0221"
+reason = "event-listener !Send tags via StackSlot (unsound); transitive dep only, we do not share listeners across threads on custom !Send types."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0205"
+reason = "scc Array::insert exception safety (unsound); transitive dep only, we do not pass panicking compare fns."
 
 [licenses]
 allow = [


### PR DESCRIPTION
## Summary

Restores main CI baseline (red since 08-05). Two orthogonal drift fixes bundled:

- **Docs Sync** (#1903): runs `bash scripts/sync-agent-docs.sh` — canonical `docs/runtime-structure.md` had session prefix-types + identity block content added (likely from mika#1401), sync to `crates/mika-agent/docs/` was missed.
- **Security** (#1904): bumps `deny.toml` for 3 new `unsound` advisories published between 08-05 and 08-16 (`RUSTSEC-2026-0253` lru, `RUSTSEC-2026-0221` event-listener, `RUSTSEC-2026-0205` scc). Drops now-orphaned `RUSTSEC-2024-0436` paste ignore.

## Evidence

See mika#1903 and mika#1904 bodies for CI log excerpts + advisory dates.

## Test plan

- [x] `bash scripts/sync-agent-docs.sh` — no additional file drift after run
- [x] `cargo deny check advisories` locally returns `ok`
- [ ] CI green on this PR (validates both fixes work in CI env)

Closes #1903
Closes #1904

🤖 Generated with [Claude Code](https://claude.com/claude-code)